### PR TITLE
Add Google OAuth login to dali-api

### DIFF
--- a/dali-api/app/components/Layout.tsx
+++ b/dali-api/app/components/Layout.tsx
@@ -7,12 +7,12 @@ import {
   Trophy,
   ClipboardList,
 } from 'lucide-react'
-import { currentUser, adminUser } from '~/mockData'
 import type { ViewMode } from '~/types'
 interface LayoutProps {
   children: React.ReactNode
   viewMode: ViewMode
   setViewMode: (val: ViewMode) => void
+  user: { firstName: string; lastName: string; email: string }
 }
 const viewRoutes: Record<ViewMode, string> = {
   applicant: '/',
@@ -21,10 +21,9 @@ const viewRoutes: Record<ViewMode, string> = {
   admin: '/admin',
 }
 
-export function Layout({ children, viewMode, setViewMode }: LayoutProps) {
+export function Layout({ children, viewMode, setViewMode, user }: LayoutProps) {
   const location = useLocation()
   const navigate = useNavigate()
-  const user = viewMode === 'applicant' ? currentUser : adminUser
   const [showViewMenu, setShowViewMenu] = useState(false)
   const viewLabels: Record<ViewMode, string> = {
     applicant: 'Applicant View',
@@ -151,7 +150,7 @@ export function Layout({ children, viewMode, setViewMode }: LayoutProps) {
                     {user.firstName} {user.lastName}
                   </div>
                   <div className="text-xs text-gray-500">
-                    {user.daliEmail || user.dartmouthEmail}
+                    {user.email}
                   </div>
                 </div>
                 <div className="w-9 h-9 rounded-full bg-blue-100 text-blue-700 flex items-center justify-center font-bold">

--- a/dali-api/app/routes.ts
+++ b/dali-api/app/routes.ts
@@ -18,6 +18,10 @@ export default [
     route("admin/rubrics/:id", "routes/admin.rubrics.$id.tsx"),
   ]),
 
+  // Login (no layout)
+  route("login", "routes/login.tsx"),
+  route("auth/callback/google", "routes/auth.callback.google.ts"),
+
   // OAuth endpoints (no layout)
   route("oauth/authorize", "routes/oauth.authorize.ts"),
   route("oauth/callback/google", "routes/oauth.callback.google.ts"),

--- a/dali-api/app/routes/admin.tsx
+++ b/dali-api/app/routes/admin.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Form, Link, redirect, useLoaderData } from "react-router";
 import type { Route } from "./+types/admin";
 import { prisma } from "~/lib/db";
+import { requireAuth } from "~/lib/auth";
 import { ChevronRight, Plus, X } from "lucide-react";
 
 const STATUS_LABELS: Record<string, string> = {
@@ -36,9 +37,10 @@ export async function action({ request }: Route.ActionArgs) {
   const name = (formData.get("name") as string)?.trim();
   if (!name) return { error: "Name is required" };
 
-  // TODO: replace with session user once login flow is built
-  const adminUser = await prisma.user.findFirstOrThrow({
-    where: { daliEmail: "admin@dali.dartmouth.edu" },
+  const auth = await requireAuth(request);
+  if (!auth.ok) return auth.response;
+  const adminUser = await prisma.user.findUniqueOrThrow({
+    where: { id: auth.user.sub },
   });
 
   const cycle = await prisma.applicationCycle.create({

--- a/dali-api/app/routes/auth.callback.google.ts
+++ b/dali-api/app/routes/auth.callback.google.ts
@@ -1,0 +1,96 @@
+import type { Route } from "./+types/auth.callback.google";
+import { prisma } from "~/lib/db";
+import { exchangeGoogleCode, issueTokens } from "~/lib/oauth";
+import { setTokenCookies } from "~/lib/cookies";
+
+const OAUTH_STATE_COOKIE = "__dali_oauth_state";
+
+function parseCookies(request: Request): Record<string, string> {
+  const header = request.headers.get("Cookie") ?? "";
+  const entries: Record<string, string> = {};
+  for (const part of header.split(";")) {
+    const [k, ...rest] = part.split("=");
+    if (k) entries[k.trim()] = rest.join("=").trim();
+  }
+  return entries;
+}
+
+export async function action() {
+  return new Response("Method not allowed", { status: 405 });
+}
+
+export async function loader({ request }: Route.LoaderArgs) {
+  const url = new URL(request.url);
+  const apiBase = process.env.API_BASE_URL ?? "http://localhost:3001";
+
+  const code = url.searchParams.get("code");
+  const state = url.searchParams.get("state");
+  const googleError = url.searchParams.get("error");
+
+  if (googleError || !code || !state) {
+    return new Response(null, {
+      status: 302,
+      headers: { Location: "/login?error=google_auth_failed" },
+    });
+  }
+
+  // CSRF validation
+  const cookies = parseCookies(request);
+  const savedState = cookies[OAUTH_STATE_COOKIE];
+  const clearStateCookie = `${OAUTH_STATE_COOKIE}=; Path=/auth/callback/google; Max-Age=0; HttpOnly; SameSite=Lax`;
+
+  if (!savedState || savedState !== state) {
+    return new Response(null, {
+      status: 302,
+      headers: {
+        "Set-Cookie": clearStateCookie,
+        Location: "/login?error=server_error",
+      },
+    });
+  }
+
+  // Exchange Google code for user info
+  let googleUser;
+  try {
+    googleUser = await exchangeGoogleCode(code, `${apiBase}/auth/callback/google`);
+  } catch {
+    return new Response(null, {
+      status: 302,
+      headers: {
+        "Set-Cookie": clearStateCookie,
+        Location: "/login?error=server_error",
+      },
+    });
+  }
+
+  // Enforce DALI domain
+  if (!googleUser.email.endsWith("@dali.dartmouth.edu")) {
+    return new Response(null, {
+      status: 302,
+      headers: {
+        "Set-Cookie": clearStateCookie,
+        Location: "/login?error=access_denied",
+      },
+    });
+  }
+
+  // Upsert user
+  const user = await prisma.user.upsert({
+    where: { daliEmail: googleUser.email },
+    update: { firstName: googleUser.firstName, lastName: googleUser.lastName },
+    create: {
+      daliEmail: googleUser.email,
+      firstName: googleUser.firstName,
+      lastName: googleUser.lastName,
+    },
+  });
+
+  // Issue tokens and set cookies
+  const tokens = await issueTokens(user.id, "member");
+  const headers = new Headers();
+  headers.append("Set-Cookie", clearStateCookie);
+  setTokenCookies(headers, tokens.access_token, tokens.refresh_token);
+  headers.set("Location", "/admin");
+
+  return new Response(null, { status: 302, headers });
+}

--- a/dali-api/app/routes/layout.tsx
+++ b/dali-api/app/routes/layout.tsx
@@ -1,8 +1,16 @@
 import { useState } from 'react'
-import { Outlet, useLocation } from 'react-router'
+import { Outlet, useLocation, redirect, useLoaderData } from 'react-router'
 import { Layout } from '~/components/Layout'
 import { FormsProvider } from '~/context/FormsContext'
 import type { ViewMode } from '~/types'
+import { requireAuth } from '~/lib/auth'
+import type { Route } from './+types/layout'
+
+export async function loader({ request }: Route.LoaderArgs) {
+  const auth = await requireAuth(request);
+  if (!auth.ok) return redirect("/login");
+  return { user: auth.user };
+}
 
 function viewModeFromPath(pathname: string): ViewMode {
   if (pathname.startsWith('/mentor')) return 'mentor'
@@ -12,12 +20,13 @@ function viewModeFromPath(pathname: string): ViewMode {
 }
 
 export default function AppLayoutRoute() {
+  const { user } = useLoaderData<typeof loader>()
   const location = useLocation()
   const [viewMode, setViewMode] = useState<ViewMode>(() => viewModeFromPath(location.pathname))
 
   return (
     <FormsProvider>
-      <Layout viewMode={viewMode} setViewMode={setViewMode}>
+      <Layout viewMode={viewMode} setViewMode={setViewMode} user={user}>
         <Outlet />
       </Layout>
     </FormsProvider>

--- a/dali-api/app/routes/login.tsx
+++ b/dali-api/app/routes/login.tsx
@@ -1,0 +1,97 @@
+import { randomBytes } from "node:crypto";
+import { Form, redirect, useSearchParams } from "react-router";
+import type { Route } from "./+types/login";
+import { requireAuth } from "~/lib/auth";
+
+const OAUTH_STATE_COOKIE = "__dali_oauth_state";
+
+export async function loader({ request }: Route.LoaderArgs) {
+  const auth = await requireAuth(request);
+  if (auth.ok) return redirect("/admin");
+  return {};
+}
+
+export async function action({ request }: Route.ActionArgs) {
+  const state = randomBytes(32).toString("base64url");
+  const apiBase = process.env.API_BASE_URL ?? "http://localhost:3001";
+
+  const stateCookie = [
+    `${OAUTH_STATE_COOKIE}=${state}`,
+    "Path=/auth/callback/google",
+    "Max-Age=600",
+    "HttpOnly",
+    "SameSite=Lax",
+    ...(process.env.NODE_ENV === "production" ? ["Secure"] : []),
+  ].join("; ");
+
+  const googleParams = new URLSearchParams({
+    client_id: process.env.GOOGLE_CLIENT_ID!,
+    redirect_uri: `${apiBase}/auth/callback/google`,
+    response_type: "code",
+    scope: "openid email profile",
+    hd: "dali.dartmouth.edu",
+    state,
+  });
+
+  return new Response(null, {
+    status: 302,
+    headers: {
+      "Set-Cookie": stateCookie,
+      Location: `https://accounts.google.com/o/oauth2/v2/auth?${googleParams}`,
+    },
+  });
+}
+
+export default function Login() {
+  const [searchParams] = useSearchParams();
+  const error = searchParams.get("error");
+
+  const errorMessages: Record<string, string> = {
+    access_denied: "Only @dali.dartmouth.edu accounts are allowed.",
+    google_auth_failed: "Google sign-in failed. Please try again.",
+    session_expired: "Session expired. Please try again.",
+    server_error: "Something went wrong. Please try again.",
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      <div className="w-full max-w-sm bg-white rounded-2xl shadow-sm border border-gray-100 p-8">
+        <h1 className="text-2xl font-bold text-gray-900 mb-1">DALI Admin</h1>
+        <p className="text-sm text-gray-500 mb-8">Sign in with your DALI Google account.</p>
+
+        {error && (
+          <p className="mb-6 text-sm text-red-600 bg-red-50 rounded-lg px-4 py-3">
+            {errorMessages[error] ?? "Sign-in failed. Please try again."}
+          </p>
+        )}
+
+        <Form method="post">
+          <button
+            type="submit"
+            className="w-full flex items-center justify-center gap-3 px-4 py-3 rounded-xl bg-gray-900 text-white text-sm font-semibold hover:bg-gray-700 transition"
+          >
+            <svg viewBox="0 0 24 24" className="w-5 h-5" aria-hidden="true">
+              <path
+                fill="#fff"
+                d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+              />
+              <path
+                fill="#fff"
+                d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+              />
+              <path
+                fill="#fff"
+                d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l3.66-2.84z"
+              />
+              <path
+                fill="#fff"
+                d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+              />
+            </svg>
+            Sign in with Google
+          </button>
+        </Form>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a `/login` page to `dali-api` with a "Sign in with Google" button, restricted to `@dali.dartmouth.edu` accounts
- Implements server-side OAuth callback at `/auth/callback/google` — no PKCE needed since both endpoints are on the same server; CSRF protection via a short-lived httpOnly state cookie
- Adds auth guard to the layout route, redirecting unauthenticated users to `/login`
- Replaces hardcoded `admin@dali.dartmouth.edu` user lookup in the admin action with the real session user
- Removes mock user from Layout header; displays the actual logged-in user's name and email

## Test plan
- [ ] Visit `/admin` with no cookies → redirected to `/login`
- [ ] Click "Sign in with Google" → Google OAuth, accepts only `@dali.dartmouth.edu`
- [ ] After auth → redirected to `/admin`, header shows real name and email
- [ ] Creating a hiring cycle attributes it to the logged-in user
- [ ] Non-DALI Google account → rejected, redirected to `/login?error=access_denied`

🤖 Generated with [Claude Code](https://claude.com/claude-code)