### PR TITLE
Reset Neon dev branch from prod on every dev deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,8 +7,29 @@ on:
       - prod
 
 jobs:
+  reset-neon-dev:
+    name: Reset Neon dev branch from prod
+    runs-on: ubuntu-latest
+    if: github.ref_name == 'dev'
+    steps:
+      - name: Restore development branch from production
+        env:
+          NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
+          PROJECT_ID: falling-morning-15858013
+        run: |
+          BRANCHES=$(curl -sf "https://console.neon.tech/api/v2/projects/$PROJECT_ID/branches" \
+            -H "Authorization: Bearer $NEON_API_KEY")
+          DEV_ID=$(echo "$BRANCHES" | jq -r '.branches[] | select(.name=="development") | .id')
+          PROD_ID=$(echo "$BRANCHES" | jq -r '.branches[] | select(.name=="production") | .id')
+          curl -sf -X POST "https://console.neon.tech/api/v2/projects/$PROJECT_ID/branches/$DEV_ID/restore" \
+            -H "Authorization: Bearer $NEON_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d "{\"source_branch_id\": \"$PROD_ID\"}"
+
   deploy-api:
     name: Deploy API (${{ github.ref_name }})
+    needs: [reset-neon-dev]
+    if: always() && (needs.reset-neon-dev.result == 'success' || needs.reset-neon-dev.result == 'skipped')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Adds a `reset-neon-dev` job that calls the Neon Restore API to reset the `development` branch to match `production` before each dev deployment
- `deploy-api` now depends on `reset-neon-dev` so migrations run on a fresh, prod-like database every time
- On prod pushes, `reset-neon-dev` is skipped and `deploy-api` still runs normally

## Required setup

Add a `NEON_API_KEY` secret to the GitHub repo (Settings → Secrets and variables → Actions). Get the key from the Neon console under Account → API Keys.

## Test plan

- [ ] Add `NEON_API_KEY` GitHub secret
- [ ] Merge to `dev` and confirm `reset-neon-dev` runs before `deploy-api` in Actions
- [ ] Check Neon console — `development` branch history should show a restore from `production`
- [ ] Push to `prod` and confirm `reset-neon-dev` is skipped but `deploy-api` still runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)