### PR TITLE
Seed members from local file on local db reset

### DIFF
--- a/dali-api/package.json
+++ b/dali-api/package.json
@@ -11,7 +11,7 @@
     "typecheck": "react-router typegen && tsc",
     "db:reset": "PRISMA_USER_CONSENT_FOR_DANGEROUS_AI_ACTION=yes prisma migrate reset --force && prisma db seed",
     "db:reset:local": "PRISMA_USER_CONSENT_FOR_DANGEROUS_AI_ACTION=yes DATABASE_URL=postgresql://dali:dali@localhost:5432/dali prisma migrate reset --force && DATABASE_URL=postgresql://dali:dali@localhost:5432/dali prisma db seed",
-    "db:fetch:members": "tsx prisma/fetch-members.ts",
+    "db:fetch:members": "tsx --env-file .env prisma/fetch-members.ts",
     "db:seed:members": "tsx prisma/seed-members.ts"
   },
   "dependencies": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     build:
       context: ./dali-api
       target: deps
-    command: sh -c "npx prisma generate && npx prisma db push --force-reset && npx prisma db seed && npm run dev & npx prisma studio --port 5555 --browser none & wait"
+    command: sh -c "npx prisma generate && npx prisma db push --force-reset && npx prisma db seed && npm run db:seed:members && npm run dev & npx prisma studio --port 5555 --browser none & wait"
     working_dir: /app
     ports:
       - "3001:3001"


### PR DESCRIPTION
## Summary
- `docker-compose.yml`: runs `npm run db:seed:members` after the standard seed on every local db reset
- `dali-api/package.json`: adds `--env-file .env` to `db:fetch:members` so `NOTION_TOKEN` is loaded automatically

## Test plan
- [ ] `docker compose up` resets and seeds the DB, then runs `seed-members` against `prisma/data/members.json`
- [ ] `npm run db:fetch:members` picks up `NOTION_TOKEN` from `.env` without manual export

🤖 Generated with [Claude Code](https://claude.com/claude-code)