### PR TITLE
Fix DALIMember login crash for seeded members

### DIFF
--- a/dali-api/app/routes/auth.callback.google.ts
+++ b/dali-api/app/routes/auth.callback.google.ts
@@ -85,12 +85,24 @@ export async function loader({ request }: Route.LoaderArgs) {
     },
   });
 
-  // Ensure a DALIMember record exists for this DALI user
-  await prisma.dALIMember.upsert({
-    where: { userId: user.id },
-    update: {},
-    create: { userId: user.id, daliEmail: googleUser.email },
+  // Ensure a DALIMember record exists for this DALI user.
+  // Seeded members have a row keyed by daliEmail but no userId yet — attach
+  // the userId to that row rather than trying to create a duplicate.
+  const existingMember = await prisma.dALIMember.findFirst({
+    where: { OR: [{ userId: user.id }, { daliEmail: googleUser.email }] },
   });
+  if (existingMember) {
+    if (!existingMember.userId) {
+      await prisma.dALIMember.update({
+        where: { id: existingMember.id },
+        data: { userId: user.id },
+      });
+    }
+  } else {
+    await prisma.dALIMember.create({
+      data: { userId: user.id, daliEmail: googleUser.email },
+    });
+  }
 
   // Issue tokens and set cookies
   const tokens = await issueTokens(user.id, "member");


### PR DESCRIPTION
## Summary
- Google OAuth login was returning 500 for any member seeded via `seed-members.ts`
- The `DALIMember.upsert({ where: { userId } })` call found no row (seed records have no `userId`), then tried to create one — colliding on the `daliEmail` unique constraint (Prisma P2002)
- Fix: look up by `userId` OR `daliEmail` first; if a seeded row is found without a `userId`, attach it; only create a fresh record if truly no match exists

## Test plan
- [ ] Log in via Google as a user whose email matches a seeded `DALIMember` — should succeed and link the record
- [ ] Log in as a new user with no seed record — should create a fresh `DALIMember`
- [ ] Log in a second time as either — should be a no-op (already linked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)