### PR TITLE
Enforce single active cycle and anchor mentor view on it

### DIFF
--- a/dali-api/app/lib/cycles.ts
+++ b/dali-api/app/lib/cycles.ts
@@ -1,0 +1,44 @@
+import { prisma } from "~/lib/db";
+
+// A cycle is "active" when its latest status is Open or Closed — those are the
+// stages where applicants are submitting and reviewers are reading/interviewing.
+// Draft and DecisionsReleased are not active. By convention we enforce at most
+// one active cycle at a time (see api.cycles.$cycleId.status.ts).
+export const ACTIVE_STATUSES = ["Open", "Closed"] as const;
+export type ActiveStatus = (typeof ACTIVE_STATUSES)[number];
+
+/**
+ * Find the single currently-active cycle, or null if none.
+ *
+ * If the invariant is somehow violated (multiple cycles active at once),
+ * returns the most recently created one and the caller can ignore the rest.
+ */
+export async function getActiveCycle() {
+  const cycles = await prisma.applicationCycle.findMany({
+    include: {
+      statusUpdates: { orderBy: { createdAt: "desc" }, take: 1 },
+    },
+    orderBy: { createdAt: "desc" },
+  });
+
+  for (const cycle of cycles) {
+    const latest = cycle.statusUpdates[0]?.newStatus;
+    if (latest && (ACTIVE_STATUSES as readonly string[]).includes(latest)) {
+      return { ...cycle, currentStatus: latest as ActiveStatus };
+    }
+  }
+  return null;
+}
+
+/**
+ * Returns the id of any *other* cycle (i.e. not `excludingCycleId`) that is
+ * currently active, or null if none. Used to enforce single-active-cycle when
+ * advancing a cycle into Open.
+ */
+export async function findOtherActiveCycleId(
+  excludingCycleId: string,
+): Promise<string | null> {
+  const active = await getActiveCycle();
+  if (!active || active.id === excludingCycleId) return null;
+  return active.id;
+}

--- a/dali-api/app/routes/admin.cycle.$id.tsx
+++ b/dali-api/app/routes/admin.cycle.$id.tsx
@@ -215,6 +215,7 @@ export default function AdminCycleDetails() {
   // ── Cycle status ──
   const [cycleStatus, setCycleStatus] = useState<string>('Draft')
   const [statusUpdating, setStatusUpdating] = useState(false)
+  const [statusError, setStatusError] = useState<string | null>(null)
 
   const STATUS_FLOW = ['Draft', 'Open', 'Closed', 'DecisionsReleased'] as const
   const STATUS_LABELS: Record<string, string> = {
@@ -231,13 +232,24 @@ export default function AdminCycleDetails() {
     if (idx < 0 || idx >= STATUS_FLOW.length - 1) return
     const next = STATUS_FLOW[idx + 1]
     setStatusUpdating(true)
+    setStatusError(null)
     try {
       const res = await fetch(`/api/cycles/${cycleId}/status`, {
         method: 'POST', credentials: 'include',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ newStatus: next }),
       })
-      if (res.ok) setCycleStatus(next)
+      if (res.ok) {
+        setCycleStatus(next)
+      } else {
+        const body = await res.json().catch(() => ({}))
+        setStatusError(
+          body.error ??
+            `Couldn't advance to ${STATUS_LABELS[next] ?? next} (HTTP ${res.status}).`,
+        )
+      }
+    } catch (e: any) {
+      setStatusError(e?.message ?? 'Network error advancing status.')
     } finally {
       setStatusUpdating(false)
     }
@@ -366,6 +378,25 @@ export default function AdminCycleDetails() {
           </button>
         )}
       </div>
+
+      {statusError && (
+        <div
+          role="alert"
+          className="bg-red-50 border border-red-200 rounded-xl p-4 flex items-start gap-3"
+        >
+          <AlertTriangle className="w-5 h-5 text-red-600 flex-shrink-0 mt-0.5" />
+          <div className="flex-1">
+            <p className="text-sm font-bold text-red-900">Couldn't advance cycle status</p>
+            <p className="text-sm text-red-800 mt-0.5">{statusError}</p>
+          </div>
+          <button
+            onClick={() => setStatusError(null)}
+            className="text-red-600 hover:text-red-800 text-xs font-medium"
+          >
+            Dismiss
+          </button>
+        </div>
+      )}
 
       {/* Tabs */}
       <div className="flex gap-1 bg-gray-100 rounded-lg p-1">

--- a/dali-api/app/routes/api.cycles.$cycleId.status.ts
+++ b/dali-api/app/routes/api.cycles.$cycleId.status.ts
@@ -1,5 +1,6 @@
 import { prisma } from "~/lib/db";
 import { requireAuth } from "~/lib/auth";
+import { findOtherActiveCycleId } from "~/lib/cycles";
 import type { Route } from "./+types/api.cycles.$cycleId.status";
 
 const STATUS_ORDER = ["Draft", "Open", "Closed", "DecisionsReleased"] as const;
@@ -24,6 +25,24 @@ export async function action({ request, params }: Route.ActionArgs) {
   const { newStatus } = await request.json();
   if (!STATUS_ORDER.includes(newStatus)) {
     return Response.json({ error: "Invalid status" }, { status: 400 });
+  }
+
+  // Single-active-cycle invariant: only one cycle can be Open or Closed at a
+  // time. Block any transition that would activate this cycle while another
+  // is already active. Transitioning Open → Closed within the same cycle is
+  // fine — both are "active" and only one cycle is involved.
+  if (newStatus === "Open" || newStatus === "Closed") {
+    const otherActiveId = await findOtherActiveCycleId(params.cycleId!);
+    if (otherActiveId) {
+      return Response.json(
+        {
+          error:
+            "Another cycle is already active. Only one cycle can be Open or Closed at a time. Move the existing active cycle to DecisionsReleased first.",
+          activeCycleId: otherActiveId,
+        },
+        { status: 409 },
+      );
+    }
   }
 
   await prisma.applicationCycleStatusUpdate.create({

--- a/dali-api/app/routes/mentor.tsx
+++ b/dali-api/app/routes/mentor.tsx
@@ -16,15 +16,15 @@ import type { CycleStage } from '~/types'
 import CalendarGrid from '~/components/CalendarGrid'
 import { prisma } from '~/lib/db'
 import { requireAuth } from '~/lib/auth'
+import { getActiveCycle } from '~/lib/cycles'
 import type { Route } from './+types/mentor'
 
-// Map DB cycle status → mentor-facing stage
+// Map DB cycle status → mentor-facing stage. Only Open/Closed are reachable
+// here because getActiveCycle() filters out Draft and DecisionsReleased.
 function cycleStatusToStage(status: string): CycleStage {
   switch (status) {
-    case 'Draft': return 'challengeSetup'
     case 'Open': return 'collectingAvailability'
     case 'Closed': return 'interviews'
-    case 'DecisionsReleased': return 'finalDelibs'
     default: return 'challengeSetup'
   }
 }
@@ -40,16 +40,26 @@ export async function loader({ request }: Route.LoaderArgs) {
   const auth = await requireAuth(request)
   if (!auth.ok) return empty
 
-  // Find the cycle this mentor is actually assigned to as a reviewer
+  // Anchor on the single currently-active cycle (Open or Closed). If none is
+  // active, the mentor sees the empty state — even if they have stale reviewer
+  // assignments on past cycles.
+  const active = await getActiveCycle()
+  if (!active) return { ...empty, mentorUserId: auth.user.sub }
+
+  // The mentor must be assigned as a reviewer on THAT specific cycle.
   const member = await prisma.dALIMember.findFirst({ where: { userId: auth.user.sub } })
   if (!member) return { ...empty, mentorUserId: auth.user.sub }
 
-  const reviewer = await prisma.cycleReviewer.findFirst({
-    where: { daliMemberId: member.id },
+  const reviewer = await prisma.cycleReviewer.findUnique({
+    where: {
+      daliMemberId_applicationCycleId: {
+        daliMemberId: member.id,
+        applicationCycleId: active.id,
+      },
+    },
     include: {
       applicationCycle: {
         include: {
-          statusUpdates: { orderBy: { createdAt: 'desc' }, take: 1 },
           applications: {
             include: {
               user: true,
@@ -63,13 +73,11 @@ export async function loader({ request }: Route.LoaderArgs) {
         },
       },
     },
-    orderBy: { applicationCycle: { createdAt: 'desc' } },
   })
 
   if (!reviewer) return { ...empty, mentorUserId: auth.user.sub }
 
   const cycle = reviewer.applicationCycle
-  const status = cycle.statusUpdates[0]?.newStatus ?? 'Draft'
 
   // Only submitted (non-draft) applications are visible to mentors.
   const allCycleApps = cycle.applications.filter((a) => {
@@ -79,7 +87,7 @@ export async function loader({ request }: Route.LoaderArgs) {
 
   return {
     activeCycle: { id: cycle.id, name: cycle.name },
-    currentStage: cycleStatusToStage(status),
+    currentStage: cycleStatusToStage(active.currentStatus),
     mentorUserId: auth.user.sub,
     allCycleApps,
   }

--- a/dali-api/prisma/seed.ts
+++ b/dali-api/prisma/seed.ts
@@ -552,10 +552,12 @@ async function main() {
           { challengeVersionId: pmCv.id },
         ],
       },
+      // Winter 2028 stays in Draft so it doesn't violate the single-active-
+      // cycle invariant (Fall 2026 is Closed = active). An admin would advance
+      // this one to Open after Fall 2026 reaches DecisionsReleased.
       statusUpdates: {
         create: [
-          { newStatus: "Draft", userId: admin.id, createdAt: ts(-2000) },
-          { newStatus: "Open", userId: admin.id, createdAt: ts(-1000) },
+          { newStatus: "Draft", userId: admin.id, createdAt: ts(-1000) },
         ],
       },
     },
@@ -749,8 +751,8 @@ async function main() {
   console.log("Seed complete:");
   console.log(`  Admin: ${admin.firstName} ${admin.lastName}`);
   console.log(`  Domains: ${[designDomain, engDomain, pmDomain].map((d) => d.name).join(", ")}`);
-  console.log(`  Cycle: ${cycle.name} (Closed)`);
-  console.log(`  Cycle: ${cycle2028.name} (Open)`);
+  console.log(`  Cycle: ${cycle.name} (Closed) ← active`);
+  console.log(`  Cycle: ${cycle2028.name} (Draft)`);
   console.log(
     `  Applications: ${aliceApp.id} (submitted), ${bobApp.id} (submitted), ${carolApp.id} (draft)`,
   );


### PR DESCRIPTION
## Summary

Right now nothing prevents two hiring cycles from being in active states (Open or Closed) simultaneously, and the mentor dashboard just picks "the most recent cycle the mentor has any reviewer assignment on" — which gets confusing once a second cycle is set up. This PR introduces a clear single-active-cycle invariant and rewires the mentor loader around it.

## What "active" means

A cycle is **active** when its latest status is **Open** or **Closed** — these are the stages where applicants are submitting and reviewers are reading/interviewing. **Draft** and **DecisionsReleased** are not active. The invariant: **at most one cycle can be active at a time.**

## Changes

### `app/lib/cycles.ts` (new)
Two helpers:
- **`getActiveCycle()`** — returns the single currently-active cycle (latest status in {Open, Closed}) along with its `currentStatus`, or `null`.
- **`findOtherActiveCycleId(excludingCycleId)`** — returns the id of any *other* active cycle, used to enforce the invariant on transitions.

### `api.cycles.$cycleId.status.ts` — transition guard
When advancing a cycle into **Open** or **Closed**, the action now checks whether any *other* cycle is currently active. If so it returns **409 Conflict** with a structured error:

```json
{
  "error": "Another cycle is already active. Only one cycle can be Open or Closed at a time. Move the existing active cycle to DecisionsReleased first.",
  "activeCycleId": "cycle-fall-2026"
}
```

Open → Closed within the **same** cycle is still allowed (only one cycle is involved). DecisionsReleased frees the slot for the next cycle.

### `mentor.tsx` loader — anchor on active cycle
Previously: `prisma.cycleReviewer.findFirst({ where: { daliMemberId }, orderBy: applicationCycle.createdAt desc })` — returned the latest cycle the mentor had any assignment on, regardless of whether that cycle was actually running.

Now:
1. Call `getActiveCycle()`. If null → empty state.
2. Look up the mentor's `cycleReviewer` row scoped to **that specific cycle** via the `daliMemberId_applicationCycleId` unique index. If none → empty state (mentor has no role in the active cycle).
3. Use the active cycle's `currentStatus` for the stage mapping.

Side effect: I dropped `Draft` and `DecisionsReleased` from `cycleStatusToStage` since those statuses can no longer reach this loader.

### Seed update
The previous seed left **Winter 2028 in Open** while **Fall 2026 was Closed** — that's two active cycles, violating the new invariant. Winter 2028 now stays in **Draft** in the seed; an admin would advance it to Open after Fall 2026 reaches DecisionsReleased. Log line updated to highlight which cycle is active.

## Verification

End-to-end against the dev server, all four scenarios behave correctly:

```
─── 1. Riley (Eng reviewer, Fall 2026) fetches mentor view ───
"activeCycle": cycle-fall-2026, "currentStage": "interviews"  ✓

─── 2. Try to advance Winter 2028 (Draft) → Open while Fall 2026 is Closed ───
{"error":"Another cycle is already active...","activeCycleId":"cycle-fall-2026"}
HTTP 409  ✓

─── 3. Advance Fall 2026 Closed → DecisionsReleased ───
{"currentStatus":"DecisionsReleased"}  ✓

─── 4. Now advance Winter 2028 → Open ───
{"currentStatus":"Open"}  ✓

─── 5. Riley (no reviewer assignment on Winter 2028) re-fetches mentor view ───
"activeCycle": null, "currentStage": "challengeSetup", "allCycleApps": []  ✓
```

- `npm run typecheck` — clean for files I touched
- `npm test` — 58/58 pass

## Tradeoff (also discussed when scoping)

This is **API-layer enforcement**, not a database constraint. Two admins racing to open cycles in the same second could both succeed since there's no transactional lock around the read-then-write. For a hiring tool with a small admin pool that's almost certainly fine; if it ever becomes a problem the path is a partial unique index on a derived `isActive` column.

## Test plan

- [ ] `docker compose down -v && docker compose up` — fresh DB
- [ ] Visit `http://localhost:3001/dev-login-as?netId=rev001&redirect=http://localhost:3001/mentor` — mentor dashboard shows Fall 2026 in interview stage
- [ ] Admin: try to advance Winter 2028 to Open via `/admin/cycle/cycle-winter-2028` — should see error toast / 409
- [ ] Advance Fall 2026 → DecisionsReleased, then advance Winter 2028 → Open — succeeds
- [ ] Reload mentor view — Riley (Fall 2026 reviewer only) sees the empty state because the active cycle changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)