### PR TITLE
Fix flyctl release_command never running (migrations skipped on deploy)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: superfly/flyctl-actions/setup-flyctl@master
-      - run: flyctl deploy --config ./dali-api/fly.${{ github.ref_name }}.toml ./dali-api -a dali-api-${{ github.ref_name }}
+      - run: cd ./dali-api && flyctl deploy --config fly.${{ github.ref_name }}.toml -a dali-api-${{ github.ref_name }}
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 


### PR DESCRIPTION
## Summary
- `flyctl deploy --config ./dali-api/fly.env.toml ./dali-api` has a known bug where the positional context-dir arg breaks `--config` path resolution, silently skipping the `release_command`
- This means `prisma migrate deploy` has **never run** on any dev or prod deployment
- Dev hasn't noticed because the Neon dev branch is reset from prod before each deploy (inheriting prod's schema), but prod has been missing migrations since the first deploy with new tables

## Fix
```bash
# Before (broken)
flyctl deploy --config ./dali-api/fly.prod.toml ./dali-api -a dali-api-prod

# After (fixed)  
cd ./dali-api && flyctl deploy --config fly.prod.toml -a dali-api-prod
```

This was documented and supposedly fixed in PR #28 but the workflow was never actually updated.

## Test plan
- [ ] Merge and verify the next dev deploy shows `prisma migrate deploy` output in CI logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)