### PR TITLE
Fix dev deploy: wipe Neon dev DB via psql, not bogus /sql endpoint

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,17 +16,10 @@ jobs:
       - name: Wipe dev database
         if: github.ref_name == 'dev'
         env:
-          NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
-          PROJECT_ID: falling-morning-15858013
+          DEV_DATABASE_URL: ${{ secrets.DEV_DATABASE_URL }}
         run: |
-          BRANCHES=$(curl -sf "https://console.neon.tech/api/v2/projects/$PROJECT_ID/branches" \
-            -H "Authorization: Bearer $NEON_API_KEY")
-          DEV_ID=$(echo "$BRANCHES" | jq -r '.branches[] | select(.name=="development") | .id')
-          curl -sf -X POST \
-            "https://console.neon.tech/api/v2/projects/$PROJECT_ID/branches/$DEV_ID/sql" \
-            -H "Authorization: Bearer $NEON_API_KEY" \
-            -H "Content-Type: application/json" \
-            -d '{"query": "DROP SCHEMA public CASCADE; CREATE SCHEMA public;", "database": "neondb"}'
+          psql "$DEV_DATABASE_URL" -v ON_ERROR_STOP=1 \
+            -c "DROP SCHEMA public CASCADE; CREATE SCHEMA public;"
 
       - name: Restore staging database from prod
         if: github.ref_name == 'staging'


### PR DESCRIPTION
## Summary
- The "Wipe dev database" step added in #62 calls `POST https://console.neon.tech/api/v2/projects/{id}/branches/{id}/sql` — an endpoint that does not exist (verified against Neon's OpenAPI spec at https://neon.com/api_spec/release/v2.json). `curl -sf` turns the 4xx into exit code 22, killing every dev deploy before `flyctl deploy` runs.
- Replace the call with a `psql` invocation that runs `DROP SCHEMA public CASCADE; CREATE SCHEMA public;` directly against the Neon dev Postgres via a new `DEV_DATABASE_URL` repo secret.
- Staging's `/restore` step is a real, documented endpoint and is left untouched.

## Required before merging
- [ ] Add repo secret `DEV_DATABASE_URL` — set to the Postgres connection string for the Neon `development` branch (same value Fly already has as `DATABASE_URL` on `dali-api-dev`). Without this secret set, the workflow will still fail.

## Test plan
- [ ] After the secret is in place, merge and watch the `Fly Deploy` run on `dev`
- [ ] Confirm the "Wipe dev database" step succeeds
- [ ] Confirm `deploy-api` runs and the Fly release_command (`prisma migrate deploy && prisma db seed`) completes — `fly logs -a dali-api-dev`
- [ ] Spot-check that dev has a freshly seeded schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)