### PR TITLE
Gate /dev-login on ENABLE_DEV_LOGIN flag, not just NODE_ENV

### DIFF
--- a/dali-api/app/lib/dev-login.ts
+++ b/dali-api/app/lib/dev-login.ts
@@ -1,0 +1,5 @@
+export function isDevLoginEnabled(): boolean {
+  const env = process.env.NODE_ENV;
+  if (env === "development" || env === "test") return true;
+  return process.env.ENABLE_DEV_LOGIN === "true";
+}

--- a/dali-api/app/routes/dev-login-as.ts
+++ b/dali-api/app/routes/dev-login-as.ts
@@ -6,11 +6,11 @@
 
 import type { Route } from "./+types/dev-login-as";
 import { signAccessToken } from "~/lib/auth";
+import { isDevLoginEnabled } from "~/lib/dev-login";
 import { prisma } from "~/lib/db";
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const env = process.env.NODE_ENV;
-  if (env !== "development" && env !== "test") {
+  if (!isDevLoginEnabled()) {
     return new Response("Not found", { status: 404 });
   }
 

--- a/dali-api/app/routes/dev-login.ts
+++ b/dali-api/app/routes/dev-login.ts
@@ -4,11 +4,11 @@
 
 import type { Route } from "./+types/dev-login";
 import { signAccessToken } from "~/lib/auth";
+import { isDevLoginEnabled } from "~/lib/dev-login";
 import { prisma } from "~/lib/db";
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const env = process.env.NODE_ENV;
-  if (env !== "development" && env !== "test") {
+  if (!isDevLoginEnabled()) {
     return new Response("Not found", { status: 404 });
   }
 


### PR DESCRIPTION
## Problem
`/dev-login` (and `/dev-login-as`) return 404 "Not found" on the Fly dev deployment. `react-router-serve` runs with `NODE_ENV=production`, and the existing guard rejects anything that isn't `development` or `test`.

## Why not just set `NODE_ENV=development` on `dali-api-dev`?
Because `app/lib/cookies.ts:6` and `app/routes/login.tsx:24` also branch on `NODE_ENV === "production"` to decide whether to add the `Secure` flag on auth cookies. The dev app is served over HTTPS, so dropping `Secure` there would be a real regression.

## Change
- New helper `app/lib/dev-login.ts#isDevLoginEnabled()` — returns true when `NODE_ENV` is `development`/`test`, OR when `ENABLE_DEV_LOGIN=true`.
- `dev-login.ts` and `dev-login-as.ts` now call the helper instead of checking `NODE_ENV` inline.
- `ENABLE_DEV_LOGIN=true` has already been staged on `dali-api-dev` via `flyctl secrets set ... --stage`; it takes effect on the next deploy. Staging/prod are unaffected — dev-login stays off there by default.

## Test plan
- [ ] Local dev (`NODE_ENV=development`): `/dev-login` still loads the picker
- [ ] After merge + deploy to `dev`: `/dev-login` loads (no longer 404)
- [ ] `dali-api-staging` and `dali-api` (prod): `/dev-login` returns 404 (no `ENABLE_DEV_LOGIN` secret set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)