### PR TITLE
Wrap dev release_command in sh -c so seed actually runs

### DIFF
--- a/dali-api/fly.dev.toml
+++ b/dali-api/fly.dev.toml
@@ -2,7 +2,7 @@ app = "dali-api-dev"
 primary_region = "iad"
 
 [deploy]
-  release_command = "npx prisma migrate deploy && npx prisma db seed"
+  release_command = "sh -c 'npx prisma migrate deploy && npx prisma db seed'"
 
 [build.args]
   OMIT_DEV = "false"


### PR DESCRIPTION
## Problem
`/dev-login` on the Fly dev deployment shows no users. Both the wipe step (PR #65) and the dev-login flag (PR #66) are working — the DB is getting wiped to an empty schema, migrations apply cleanly, but `prisma db seed` never runs, so the app comes back up against an empty database.

## Root cause
Fly passes `release_command` to the container as **argv**, not through a shell. With
```
release_command = "npx prisma migrate deploy && npx prisma db seed"
```
the container sees argv `["npx", "prisma", "migrate", "deploy", "&&", "npx", "prisma", "db", "seed"]`. Prisma silently ignores the extra positional args after `deploy`, runs migrate deploy, and exits 0. Seed is never invoked. Deploy succeeds; DB stays empty.

Verified against the live dev app: release machine only existed 11s, log shows `Applying migration 1 / 2` then shutdown (rest got applied silently by migrate deploy — the `_prisma_migrations` table confirms all 9), and no seed output anywhere. Running `npx prisma db seed` manually on the machine populates the DB correctly.

## Fix
Wrap in `sh -c` so `&&` is actually shell-parsed:
```
release_command = "sh -c 'npx prisma migrate deploy && npx prisma db seed'"
```
Staging/prod use a single command (`npx prisma migrate deploy`) and don't need this.

## Test plan
- [ ] Merge, watch Fly Deploy on dev
- [ ] `flyctl logs -a dali-api-dev` should show seed output (`Seed complete:` block)
- [ ] `/dev-login` on dev loads with ~29 users

🤖 Generated with [Claude Code](https://claude.com/claude-code)