### PR TITLE
Seed: add admin role and rename Henry Scheible to Jordan Taylor

### DIFF
--- a/dali-api/e2e/hiring-lead.spec.ts
+++ b/dali-api/e2e/hiring-lead.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from './fixtures';
 
 test.describe('hiring lead workflow', () => {
   test.beforeEach(async ({ loginAs }) => {
-    await loginAs({ daliEmail: 'henry.scheible@dali.dartmouth.edu' });
+    await loginAs({ daliEmail: 'jordan.taylor@dali.dartmouth.edu' });
   });
 
   test('cycles list shows all cycles with status badges', async ({ page }) => {

--- a/dali-api/e2e/nav.spec.ts
+++ b/dali-api/e2e/nav.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from './fixtures';
 
 test.describe('navigation for hiring lead', () => {
   test.beforeEach(async ({ loginAs }) => {
-    await loginAs({ daliEmail: 'henry.scheible@dali.dartmouth.edu' });
+    await loginAs({ daliEmail: 'jordan.taylor@dali.dartmouth.edu' });
   });
 
   test('shows hiring lead and domain lead nav tabs', async ({ page }) => {

--- a/dali-api/prisma/seed.ts
+++ b/dali-api/prisma/seed.ts
@@ -13,12 +13,19 @@ async function main() {
       daliEmail: "admin@dali.dartmouth.edu",
       firstName: "Admin",
       lastName: "User",
-      daliMember: { create: { daliEmail: "admin@dali.dartmouth.edu", firstName: "Admin", lastName: "User" } },
+      daliMember: {
+        create: {
+          daliEmail: "admin@dali.dartmouth.edu",
+          firstName: "Admin",
+          lastName: "User",
+          roles: ["Admin"],
+        },
+      },
     },
   });
   await prisma.dALIMember.update({
     where: { daliEmail: "admin@dali.dartmouth.edu" },
-    data: { firstName: "Admin", lastName: "User" },
+    data: { firstName: "Admin", lastName: "User", roles: ["Admin"] },
   });
 
   // ── Domains ────────────────────────────────────────────────────────────────

--- a/dali-api/prisma/seed.ts
+++ b/dali-api/prisma/seed.ts
@@ -1469,19 +1469,19 @@ async function main() {
     },
   });
 
-  // ── Henry Scheible (Hiring Lead + Engineering Domain Lead) ─────────────────
-  const henry = await prisma.user.upsert({
-    where: { daliEmail: "henry.scheible@dali.dartmouth.edu" },
-    update: { firstName: "Henry", lastName: "Scheible" },
+  // ── Jordan Taylor (Hiring Lead + Engineering Domain Lead) ──────────────────
+  const jordan = await prisma.user.upsert({
+    where: { daliEmail: "jordan.taylor@dali.dartmouth.edu" },
+    update: { firstName: "Jordan", lastName: "Taylor" },
     create: {
-      daliEmail: "henry.scheible@dali.dartmouth.edu",
-      firstName: "Henry",
-      lastName: "Scheible",
+      daliEmail: "jordan.taylor@dali.dartmouth.edu",
+      firstName: "Jordan",
+      lastName: "Taylor",
       daliMember: {
         create: {
-          daliEmail: "henry.scheible@dali.dartmouth.edu",
-          firstName: "Henry",
-          lastName: "Scheible",
+          daliEmail: "jordan.taylor@dali.dartmouth.edu",
+          firstName: "Jordan",
+          lastName: "Taylor",
           roles: ["HiringLead"],
         },
       },
@@ -1489,17 +1489,17 @@ async function main() {
     include: { daliMember: true },
   });
 
-  const henryMember = await prisma.dALIMember.update({
-    where: { daliEmail: "henry.scheible@dali.dartmouth.edu" },
-    data: { firstName: "Henry", lastName: "Scheible" },
+  const jordanMember = await prisma.dALIMember.update({
+    where: { daliEmail: "jordan.taylor@dali.dartmouth.edu" },
+    data: { firstName: "Jordan", lastName: "Taylor" },
   });
 
   await prisma.domainLeadAssignment.upsert({
-    where: { id: "dla-henry-eng" },
+    where: { id: "dla-jordan-eng" },
     update: {},
     create: {
-      id: "dla-henry-eng",
-      memberId: henryMember.id,
+      id: "dla-jordan-eng",
+      memberId: jordanMember.id,
       domainId: engDomain.id,
     },
   });
@@ -1656,7 +1656,7 @@ async function main() {
         domainApplicationId: spec.domainAppId,
         type: spec.type,
         stage: "Released",
-        madeById: henryMember.id,
+        madeById: jordanMember.id,
         // Waitlist rank is taken from the position inside the Waitlisted
         // subset (stable, deterministic).
         waitlistRank: spec.type === "Waitlisted"
@@ -2070,7 +2070,7 @@ async function main() {
         domainApplicationId: spec.domainAppId,
         type: spec.type,
         stage: "Released",
-        madeById: henryMember.id,
+        madeById: jordanMember.id,
         createdAt: ts(-250),
         notes: spec.notes ?? null,
       },


### PR DESCRIPTION
## Summary
- The existing `admin@dali.dartmouth.edu` seed user had no `MemberRole` set, so seeded databases had zero admins. Set `roles: ["Admin"]` on its `DALIMember` in both the create and update branches of the upsert.
- Renamed the `Henry Scheible` seed user (Hiring Lead + Engineering Domain Lead) to `Jordan Taylor` — name, email (`jordan.taylor@dali.dartmouth.edu`), variable names, and the `dla-*-eng` id. Updated the two e2e specs (`nav.spec.ts`, `hiring-lead.spec.ts`) that log in as this user.

## Test plan
- [ ] Run `prisma db seed` against a fresh dev DB and confirm the admin member has `roles = [Admin]` and Jordan Taylor seeds correctly as Hiring Lead + Engineering Domain Lead.
- [ ] Run the e2e suite and confirm `nav.spec.ts` and `hiring-lead.spec.ts` still pass with the renamed login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)