### PR TITLE
Fix #96: lock domain challenge edit link after reviewers assigned

### DIFF
--- a/dali-api/app/routes/domain-lead.tsx
+++ b/dali-api/app/routes/domain-lead.tsx
@@ -543,8 +543,11 @@ export default function DomainLeadDashboard() {
                               <div className="flex items-center gap-2 text-sm text-gray-600">
                                 <CheckCircle className="w-4 h-4 text-green-600" />
                                 <span>{challengeVersionOptions.find((c: any) => c.id === selectedChallengeVersionId)?.challenge?.name ?? "Linked"}</span>
+                                {hasApplicationReviews && (
+                                  <span className="text-xs text-gray-400 ml-1">(locked — reviewers have been assigned)</span>
+                                )}
                               </div>
-                              {(() => {
+                              {!hasApplicationReviews && (() => {
                                 const cv = challengeVersionOptions.find((c: any) => c.id === selectedChallengeVersionId);
                                 return cv?.challenge?.id ? (
                                   <Link to={`/challenges/${cv.challenge.id}`} className="text-xs text-blue-600 hover:text-blue-800 font-medium">


### PR DESCRIPTION
## Summary

Fixes #96 — when the cycle is "Configured" and reviewers have been assigned, the Domain Rubric row correctly shows "(locked — reviewers have been assigned)", but the Domain Challenge row was still offering a blue "Edit →" link.

The link routed to \`/challenges/{id}\`, which only supports appending a new \`ChallengeVersion\` — it doesn't (and can't) edit the version applicants already answered. Users clicking "Edit" expecting to fix a typo either created an unused new version or got confused.

Mirrors the rubric row behavior: once \`hasApplicationReviews\` is true, show the locked label and hide the Edit link.

## Test plan
- [ ] Domain lead dashboard — before reviewers are assigned: challenge shows with "Edit →" link
- [ ] After reviewers are assigned: challenge shows "(locked — reviewers have been assigned)" and no Edit link

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)