### PR TITLE
Fix #103: allow removing reviewers after they've submitted

### DIFF
--- a/dali-api/app/routes/api.reviews.$id.ts
+++ b/dali-api/app/routes/api.reviews.$id.ts
@@ -45,16 +45,15 @@ export async function action({ request, params }: Route.ActionArgs) {
   }
 
   if (request.method === "DELETE") {
-    if (review.submittedAt) {
-      return Response.json({ error: "Cannot delete a submitted review" }, { status: 409 });
-    }
-
     const isLead = await isDomainLead(auth.user.sub);
     const isHL = await isHiringLead(auth.user.sub);
     if (!isLead && !isHL) {
       return Response.json({ error: "Forbidden" }, { status: 403 });
     }
 
+    // Submitted reviews are allowed to be deleted by domain/hiring leads —
+    // the client is expected to confirm with the user first since this
+    // destroys the submitted scores/feedback.
     await prisma.applicationReview.delete({ where: { id: params.id } });
     return Response.json({ deleted: true });
   }

--- a/dali-api/app/routes/domain-lead.tsx
+++ b/dali-api/app/routes/domain-lead.tsx
@@ -1590,7 +1590,11 @@ function ReviewerAssignmentCell({ domainApplicationId, reviews, cycleReviewers, 
     }
   }
 
-  async function removeReview(reviewId: string) {
+  async function removeReview(reviewId: string, wasSubmitted: boolean) {
+    if (wasSubmitted) {
+      const ok = confirm("This reviewer has already submitted their review. Removing them will delete their scores and feedback. Continue?");
+      if (!ok) return;
+    }
     setRemoving(reviewId);
     try {
       const res = await fetch(`/api/reviews/${reviewId}`, {
@@ -1650,15 +1654,15 @@ function ReviewerAssignmentCell({ domainApplicationId, reviews, cycleReviewers, 
           >
             {icon}
             {name}
-            {editable && status !== "submitted" && (
+            {editable && (
               <button
                 onClick={(e) => {
                   e.stopPropagation();
-                  removeReview(r.id);
+                  removeReview(r.id, status === "submitted");
                 }}
                 disabled={removing === r.id}
                 className="ml-0.5 text-gray-400 hover:text-red-500 transition"
-                title="Remove reviewer"
+                title={status === "submitted" ? "Remove reviewer (deletes submitted review)" : "Remove reviewer"}
               >
                 <Trash2 className="w-3 h-3" />
               </button>


### PR DESCRIPTION
## Summary

Fixes #103 — domain/hiring leads couldn't unassign a reviewer after the reviewer had submitted their review. Now they can, with a confirmation prompt warning that the submitted scores and feedback will be destroyed.

### Changes
- **UI**: trash icon now shows on all reviewer pills when \`editable\`. For submitted reviews, a \`confirm()\` prompt appears before the delete request.
- **API**: removed the \`submittedAt\` block from \`DELETE /api/reviews/:id\`. Role check (domain lead or hiring lead) remains.

## Test plan
- [ ] Domain lead can remove a not-yet-started reviewer (no confirmation)
- [ ] Domain lead can remove an in-progress reviewer (no confirmation)
- [ ] Domain lead removing a submitted reviewer sees a confirmation dialog
- [ ] Declining the confirmation keeps the review
- [ ] Accepting deletes the review
- [ ] Non-leads still get 403

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)