### PR TITLE
Fix #113: block applicants from accessing member routes

### DIFF
--- a/dali-api/app/routes/home.tsx
+++ b/dali-api/app/routes/home.tsx
@@ -1,6 +1,10 @@
 import { redirect } from "react-router";
+import { requireAuth } from "~/lib/auth";
 import type { Route } from "./+types/home";
 
-export function loader({}: Route.LoaderArgs) {
+export async function loader({ request }: Route.LoaderArgs) {
+  const auth = await requireAuth(request);
+  if (!auth.ok) return redirect("/login");
+  if (auth.user.type === "applicant") return redirect("/portal");
   return redirect("/reviewer");
 }

--- a/dali-api/app/routes/layout.tsx
+++ b/dali-api/app/routes/layout.tsx
@@ -9,6 +9,7 @@ import type { Route } from './+types/layout'
 export async function loader({ request }: Route.LoaderArgs) {
   const auth = await requireAuth(request)
   if (!auth.ok) return redirect('/login')
+  if (auth.user.type === 'applicant') return redirect('/portal')
   const { memberId, isHiringLead: hiringLead, isAdmin: admin, isDomainLead: domainLead } = await getUserRoles(auth.user.sub)
 
   let isInterviewer = false


### PR DESCRIPTION
## Summary
- Adds a user type check in `layout.tsx` to redirect applicants to `/portal` before any member UI renders — protects all internal routes at once
- Makes `home.tsx` type-aware so applicants go to `/portal` instead of `/reviewer`

Fixes #113

## Test plan
- [ ] Log in as applicant → navigate to `/reviewer` → redirects to `/portal`
- [ ] Log in as applicant → navigate to `/admin-console` → redirects to `/portal`
- [ ] Log in as member → navigate to `/reviewer` → shows dashboard (unchanged)
- [ ] Unauthenticated → navigate to `/` → redirects to `/login` (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)