### PR TITLE
Fix e2e test for domain lead collapsible sections

### DIFF
--- a/dali-api/e2e/domain-lead.spec.ts
+++ b/dali-api/e2e/domain-lead.spec.ts
@@ -21,7 +21,8 @@ test.describe('domain lead workflow', () => {
 
   test('shows collapsible sections', async ({ page }) => {
     await page.goto('/domain-lead');
-    await expect(page.getByText('Team').first()).toBeVisible();
+    await expect(page.getByText('Setup').first()).toBeVisible();
+    await expect(page.getByText('Reviews').first()).toBeVisible();
     await expect(page.getByText('Applications').first()).toBeVisible();
     await expect(page.getByText('Deliberations').first()).toBeVisible();
   });


### PR DESCRIPTION
## Summary
- Updates the `domain-lead.spec.ts` e2e test to match the section restructuring from #102
- "Team" was moved from a top-level collapsible section into a sub-heading inside "Reviews", and a new "Setup" section was added — the test now asserts on Setup, Reviews, Applications, and Deliberations

## Test plan
- [ ] CI passes (the failing `Test dali-api` check should now be green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)