### PR TITLE
Add Zoom meeting auto-provisioning for online interviews

### DIFF
--- a/dali-api/.env.example
+++ b/dali-api/.env.example
@@ -16,3 +16,8 @@ CAS_BASE_URL="https://login.dartmouth.edu/cas"
 # frontend and api urls
 FRONTEND_URL="http://localhost:5173"
 API_BASE_URL="http://localhost:3001"
+
+# Zoom Server-to-Server OAuth (optional — Zoom provisioning is skipped when missing)
+ZOOM_ACCOUNT_ID=""
+ZOOM_CLIENT_ID=""
+ZOOM_CLIENT_SECRET=""

--- a/dali-api/app/lib/zoom.ts
+++ b/dali-api/app/lib/zoom.ts
@@ -1,0 +1,121 @@
+import { prisma } from "~/lib/db";
+
+const ZOOM_ACCOUNT_ID = process.env.ZOOM_ACCOUNT_ID;
+const ZOOM_CLIENT_ID = process.env.ZOOM_CLIENT_ID;
+const ZOOM_CLIENT_SECRET = process.env.ZOOM_CLIENT_SECRET;
+
+// In-memory token cache — Server-to-Server tokens last 1 hour.
+let cachedToken: string | null = null;
+let tokenExpiresAt = 0;
+
+export function isZoomConfigured(): boolean {
+  return !!(ZOOM_ACCOUNT_ID && ZOOM_CLIENT_ID && ZOOM_CLIENT_SECRET);
+}
+
+async function getAccessToken(): Promise<string> {
+  // Reuse cached token if still valid (1-min buffer)
+  if (cachedToken && Date.now() < tokenExpiresAt - 60_000) {
+    return cachedToken;
+  }
+
+  const credentials = Buffer.from(`${ZOOM_CLIENT_ID}:${ZOOM_CLIENT_SECRET}`).toString("base64");
+  const res = await fetch("https://zoom.us/oauth/token", {
+    method: "POST",
+    headers: {
+      Authorization: `Basic ${credentials}`,
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: new URLSearchParams({
+      grant_type: "account_credentials",
+      account_id: ZOOM_ACCOUNT_ID!,
+    }),
+  });
+
+  if (!res.ok) {
+    throw new Error(`Zoom token refresh failed: ${await res.text()}`);
+  }
+
+  const data = await res.json();
+  cachedToken = data.access_token as string;
+  tokenExpiresAt = Date.now() + (data.expires_in as number) * 1000;
+  return cachedToken;
+}
+
+async function createMeeting(
+  topic: string,
+  startTime: Date,
+  durationMinutes: number,
+): Promise<{ meetingId: string; joinUrl: string }> {
+  const token = await getAccessToken();
+  const res = await fetch("https://api.zoom.us/v2/users/me/meetings", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      topic,
+      type: 2, // scheduled meeting
+      start_time: startTime.toISOString(),
+      duration: durationMinutes,
+      settings: {
+        join_before_host: true,
+        waiting_room: false,
+        auto_recording: "none",
+      },
+    }),
+  });
+
+  if (!res.ok) {
+    throw new Error(`Zoom meeting creation failed: ${await res.text()}`);
+  }
+
+  const data = await res.json();
+  return {
+    meetingId: String(data.id),
+    joinUrl: data.join_url as string,
+  };
+}
+
+async function deleteMeeting(meetingId: string): Promise<void> {
+  const token = await getAccessToken();
+  const res = await fetch(`https://api.zoom.us/v2/meetings/${meetingId}`, {
+    method: "DELETE",
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  // 204 = deleted, 404 = already gone — both are fine
+  if (!res.ok && res.status !== 404) {
+    throw new Error(`Zoom meeting deletion failed: ${await res.text()}`);
+  }
+}
+
+/**
+ * Create a Zoom meeting and store the link on the interview row.
+ * No-ops if Zoom is not configured (dev environments).
+ */
+export async function provisionZoomMeeting(
+  interviewId: string,
+  topic: string,
+  startTime: Date,
+  durationMinutes: number,
+): Promise<void> {
+  if (!isZoomConfigured()) return;
+
+  const { meetingId, joinUrl } = await createMeeting(topic, startTime, durationMinutes);
+  await prisma.interview.update({
+    where: { id: interviewId },
+    data: { zoomMeetingId: meetingId, zoomJoinUrl: joinUrl },
+  });
+}
+
+/**
+ * Delete the Zoom meeting associated with an interview.
+ * No-ops if Zoom is not configured or the interview has no meeting.
+ */
+export async function deprovisionZoomMeeting(
+  interview: { zoomMeetingId: string | null },
+): Promise<void> {
+  if (!isZoomConfigured() || !interview.zoomMeetingId) return;
+  await deleteMeeting(interview.zoomMeetingId);
+}

--- a/dali-api/app/routes/admin.cycle.$id.tsx
+++ b/dali-api/app/routes/admin.cycle.$id.tsx
@@ -33,6 +33,7 @@ interface InterviewRow {
   endTime: string
   status: string
   location: string
+  zoomJoinUrl: string | null
   domainApplication: {
     challengeVersion: { domain: { name: string } }
     application: { user: { firstName: string; lastName: string } }
@@ -1065,6 +1066,10 @@ export default function AdminCycleDetails() {
                             {interview.location === 'PodAppa' ? 'Pod Appa' :
                              interview.location === 'PodMomo' ? 'Pod Momo' : 'Online'}
                           </span>
+                        )}
+                        {interview.location === 'Online' && interview.zoomJoinUrl && (
+                          <a href={interview.zoomJoinUrl} target="_blank" rel="noopener noreferrer"
+                             className="block text-xs text-blue-600 hover:underline mt-0.5">Zoom</a>
                         )}
                       </td>
                       <td className="px-4 py-3 text-muted-foreground text-xs">

--- a/dali-api/app/routes/api.cycles.$cycleId.book-interview.ts
+++ b/dali-api/app/routes/api.cycles.$cycleId.book-interview.ts
@@ -3,6 +3,7 @@ import { prisma } from "~/lib/db";
 import { requireAuth } from "~/lib/auth";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { assignInterviewers } from "~/lib/scheduling";
+import { provisionZoomMeeting } from "~/lib/zoom";
 import { checkRateLimit } from "~/lib/rate-limit";
 import { safeJson } from "~/lib/safe-json";
 
@@ -60,6 +61,16 @@ export async function action({ request, params }: Route.ActionArgs) {
       undefined,
       interviewMode,
     );
+
+    if (interview.location === "Online") {
+      try {
+        const duration = Math.round((new Date(slotEnd).getTime() - new Date(slotStart).getTime()) / 60_000);
+        await provisionZoomMeeting(interview.id, "DALI Lab Interview", new Date(slotStart), duration);
+      } catch (err) {
+        console.error("Failed to provision Zoom meeting:", err);
+      }
+    }
+
     return withCors(request, Response.json(interview, { status: 201 }));
   } catch (err: any) {
     return withCors(request, Response.json({ error: err.message }, { status: 409 }));

--- a/dali-api/app/routes/api.domain-applications.$id.schedule-interview.ts
+++ b/dali-api/app/routes/api.domain-applications.$id.schedule-interview.ts
@@ -2,6 +2,7 @@ import type { Route } from "./+types/api.domain-applications.$id.schedule-interv
 import { prisma } from "~/lib/db";
 import { requireAuth } from "~/lib/auth";
 import { assignInterviewers } from "~/lib/scheduling";
+import { provisionZoomMeeting } from "~/lib/zoom";
 
 export async function action({ request, params }: Route.ActionArgs) {
   const auth = await requireAuth(request);
@@ -77,6 +78,15 @@ export async function action({ request, params }: Route.ActionArgs) {
       undefined,
       interviewMode,
     );
+
+    if (interview.location === "Online") {
+      try {
+        await provisionZoomMeeting(interview.id, "DALI Lab Interview", slotStart, config.slotDurationMinutes);
+      } catch (err) {
+        console.error("Failed to provision Zoom meeting:", err);
+      }
+    }
+
     return Response.json(interview, { status: 201 });
   } catch (err: any) {
     return Response.json({ error: err.message }, { status: 409 });

--- a/dali-api/app/routes/api.interviews.$id.location.ts
+++ b/dali-api/app/routes/api.interviews.$id.location.ts
@@ -2,6 +2,7 @@ import type { Route } from "./+types/api.interviews.$id.location";
 import { prisma } from "~/lib/db";
 import { requireAuth } from "~/lib/auth";
 import { hasCycleAccess } from "~/lib/roles";
+import { provisionZoomMeeting, deprovisionZoomMeeting } from "~/lib/zoom";
 
 const VALID_LOCATIONS = ["PodAppa", "PodMomo", "Online"] as const;
 
@@ -68,6 +69,21 @@ export async function action({ request, params }: Route.ActionArgs) {
         data: { location },
       });
     }, { isolationLevel: "Serializable" });
+
+    // Handle Zoom provisioning/deprovisioning on location transitions
+    const wasOnline = interview.location === "Online";
+    const isNowOnline = location === "Online";
+    if (!wasOnline && isNowOnline) {
+      try {
+        const config = await prisma.interviewConfig.findUnique({ where: { applicationCycleId: interview.applicationCycleId } });
+        await provisionZoomMeeting(interview.id, "DALI Lab Interview", interview.startTime, config?.slotDurationMinutes ?? 30);
+      } catch (err) { console.error("Failed to provision Zoom meeting on location change:", err); }
+    } else if (wasOnline && !isNowOnline) {
+      try {
+        await deprovisionZoomMeeting(interview);
+        await prisma.interview.update({ where: { id: interview.id }, data: { zoomMeetingId: null, zoomJoinUrl: null } });
+      } catch (err) { console.error("Failed to delete Zoom meeting on location change:", err); }
+    }
 
     return Response.json(updated);
   } catch (err: any) {

--- a/dali-api/app/routes/api.my-interview.cancel.ts
+++ b/dali-api/app/routes/api.my-interview.cancel.ts
@@ -2,6 +2,7 @@ import type { Route } from "./+types/api.my-interview.cancel";
 import { prisma } from "~/lib/db";
 import { requireAuth } from "~/lib/auth";
 import { withCors, handlePreflight } from "~/lib/cors";
+import { deprovisionZoomMeeting } from "~/lib/zoom";
 
 export async function action({ request }: Route.ActionArgs) {
   const preflight = handlePreflight(request);
@@ -51,6 +52,9 @@ export async function action({ request }: Route.ActionArgs) {
     where: { id: interview.id },
     data: { status: "CancelledByApplicant" },
   });
+
+  try { await deprovisionZoomMeeting(interview); }
+  catch (err) { console.error("Failed to delete Zoom meeting on cancel:", err); }
 
   return withCors(request, Response.json(updated));
 }

--- a/dali-api/app/routes/api.my-interview.reschedule.ts
+++ b/dali-api/app/routes/api.my-interview.reschedule.ts
@@ -3,6 +3,7 @@ import { prisma } from "~/lib/db";
 import { requireAuth } from "~/lib/auth";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { assignInterviewers } from "~/lib/scheduling";
+import { provisionZoomMeeting, deprovisionZoomMeeting } from "~/lib/zoom";
 
 export async function action({ request }: Route.ActionArgs) {
   const preflight = handlePreflight(request);
@@ -31,7 +32,7 @@ export async function action({ request }: Route.ActionArgs) {
   // If assignInterviewers throws (no free interviewers at the new slot), the
   // whole transaction rolls back and the old interview stays Scheduled.
   try {
-    const newInterview = await prisma.$transaction(
+    const { newInterview, oldZoomMeetingId, durationMinutes } = await prisma.$transaction(
       async (tx) => {
         const current = await tx.interview.findFirst({
           where: {
@@ -74,7 +75,7 @@ export async function action({ request }: Route.ActionArgs) {
           data: { status: "CancelledByApplicant" },
         });
 
-        return assignInterviewers(
+        const created = await assignInterviewers(
           current.applicationCycleId,
           current.domainApplicationId,
           applicantDomainIds,
@@ -83,9 +84,24 @@ export async function action({ request }: Route.ActionArgs) {
           tx,
           interviewMode,
         );
+
+        return {
+          newInterview: created,
+          oldZoomMeetingId: current.zoomMeetingId,
+          durationMinutes: config?.slotDurationMinutes ?? 30,
+        };
       },
       { isolationLevel: "Serializable" },
     );
+
+    // Zoom cleanup + provisioning after transaction commits (best-effort)
+    try { await deprovisionZoomMeeting({ zoomMeetingId: oldZoomMeetingId }); }
+    catch (err) { console.error("Failed to delete old Zoom meeting:", err); }
+
+    if (newInterview.location === "Online") {
+      try { await provisionZoomMeeting(newInterview.id, "DALI Lab Interview", new Date(newStart), durationMinutes); }
+      catch (err) { console.error("Failed to provision Zoom meeting:", err); }
+    }
 
     return withCors(request, Response.json(newInterview, { status: 201 }));
   } catch (err: any) {

--- a/dali-api/app/routes/domain-lead.tsx
+++ b/dali-api/app/routes/domain-lead.tsx
@@ -770,6 +770,10 @@ export default function DomainLeadDashboard() {
                                         <td className="px-4 py-3 text-muted-foreground text-xs">
                                           {interview.location === 'PodAppa' ? 'Pod Appa' :
                                            interview.location === 'PodMomo' ? 'Pod Momo' : 'Online'}
+                                          {interview.location === 'Online' && interview.zoomJoinUrl && (
+                                            <a href={interview.zoomJoinUrl} target="_blank" rel="noopener noreferrer"
+                                               className="block text-xs text-blue-600 hover:underline mt-0.5">Zoom</a>
+                                          )}
                                         </td>
                                         <td className="px-4 py-3">
                                           <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-bold ${

--- a/dali-api/app/routes/interviewer.interview.$interviewId.tsx
+++ b/dali-api/app/routes/interviewer.interview.$interviewId.tsx
@@ -320,6 +320,13 @@ export default function InterviewDetailPage() {
                       : 'Online'}
                 </span>
               )}
+              {interview.location === 'Online' && interview.zoomJoinUrl && (
+                <a href={interview.zoomJoinUrl} target="_blank" rel="noopener noreferrer"
+                   className="flex items-center text-sm text-blue-600 hover:underline">
+                  <Video className="w-4 h-4 mr-1" />
+                  Join Zoom
+                </a>
+              )}
               <span
                 className={`px-2 py-0.5 rounded text-xs font-medium ${
                   isCompleted

--- a/dali-api/app/routes/portal.tsx
+++ b/dali-api/app/routes/portal.tsx
@@ -98,7 +98,7 @@ export async function loader({ request }: Route.LoaderArgs) {
       domainId: da.challengeVersion?.domainId,
       inferredStatus,
       interview: activeInterview
-        ? { id: activeInterview.id, startTime: activeInterview.startTime, endTime: activeInterview.endTime, status: activeInterview.status, location: activeInterview.location }
+        ? { id: activeInterview.id, startTime: activeInterview.startTime, endTime: activeInterview.endTime, status: activeInterview.status, location: activeInterview.location, zoomJoinUrl: activeInterview.zoomJoinUrl }
         : null,
     };
   });
@@ -121,7 +121,7 @@ interface DomainAppData {
   domainName: string;
   domainId: string;
   inferredStatus: DomainApplicationStatus;
-  interview: { id: string; startTime: string; endTime: string; status: string; location?: string } | null;
+  interview: { id: string; startTime: string; endTime: string; status: string; location?: string; zoomJoinUrl?: string | null } | null;
 }
 
 interface TimeSlot {
@@ -162,23 +162,27 @@ function formatInterviewLocation(location?: string): string {
   return "Online";
 }
 
-function buildGoogleCalendarUrl(slot: TimeSlot, cycleName: string, location?: string): string {
+function buildGoogleCalendarUrl(slot: TimeSlot, cycleName: string, location?: string, zoomJoinUrl?: string | null): string {
   const fmt = (d: string | Date) => new Date(d).toISOString().replace(/[-:]/g, "").replace(/\.\d{3}/, "");
   const locStr = formatInterviewLocation(location);
+  let details = "Your interview with the DALI Lab team. Please arrive 5 minutes early.";
+  if (zoomJoinUrl) details += `\n\nJoin Zoom: ${zoomJoinUrl}`;
   const params = new URLSearchParams({
     action: "TEMPLATE",
     text: `DALI Lab Interview — ${cycleName}`,
     dates: `${fmt(slot.isoStart)}/${fmt(slot.isoEnd)}`,
-    details: "Your interview with the DALI Lab team. Please arrive 5 minutes early.",
-    location: locStr,
+    details,
+    location: zoomJoinUrl ? zoomJoinUrl : locStr,
   });
   return `https://calendar.google.com/calendar/render?${params.toString()}`;
 }
 
-function buildIcsContent(slot: TimeSlot, cycleName: string, location?: string): string {
+function buildIcsContent(slot: TimeSlot, cycleName: string, location?: string, zoomJoinUrl?: string | null): string {
   const fmt = (d: string | Date) => new Date(d).toISOString().replace(/[-:]/g, "").replace(/\.\d{3}/, "");
-  const locStr = formatInterviewLocation(location);
+  const locStr = zoomJoinUrl ? zoomJoinUrl : formatInterviewLocation(location);
   const uid = `dali-interview-${new Date(slot.isoStart).getTime()}@dali.dartmouth.edu`;
+  let description = "Your interview with the DALI Lab team. Please arrive 5 minutes early.";
+  if (zoomJoinUrl) description += `\\nJoin Zoom: ${zoomJoinUrl}`;
   return [
     "BEGIN:VCALENDAR",
     "VERSION:2.0",
@@ -188,15 +192,15 @@ function buildIcsContent(slot: TimeSlot, cycleName: string, location?: string): 
     `DTSTART:${fmt(slot.isoStart)}`,
     `DTEND:${fmt(slot.isoEnd)}`,
     `SUMMARY:DALI Lab Interview — ${cycleName}`,
-    "DESCRIPTION:Your interview with the DALI Lab team. Please arrive 5 minutes early.",
+    `DESCRIPTION:${description}`,
     `LOCATION:${locStr.replace(/\\/g, "\\\\").replace(/,/g, "\\,").replace(/;/g, "\\;")}`,
     "END:VEVENT",
     "END:VCALENDAR",
   ].join("\r\n");
 }
 
-function downloadIcs(slot: TimeSlot, cycleName: string, location?: string): void {
-  const content = buildIcsContent(slot, cycleName, location);
+function downloadIcs(slot: TimeSlot, cycleName: string, location?: string, zoomJoinUrl?: string | null): void {
+  const content = buildIcsContent(slot, cycleName, location, zoomJoinUrl);
   const blob = new Blob([content], { type: "text/calendar" });
   const url = URL.createObjectURL(blob);
   const a = document.createElement("a");
@@ -729,11 +733,23 @@ function InterviewScheduledView({
           <span className="text-xs text-muted-foreground uppercase tracking-wider font-medium">Location</span>
           <p className="text-sm text-dark-blue mt-1">{formatInterviewLocation(interview.location)}</p>
         </div>
+        {interview.location === "Online" && interview.zoomJoinUrl && (
+          <div className="pt-4 border-t border-border/60">
+            <span className="text-xs text-muted-foreground uppercase tracking-wider font-medium">Meeting Link</span>
+            <a href={interview.zoomJoinUrl} target="_blank" rel="noopener noreferrer"
+               className="flex items-center gap-1.5 text-sm text-accent-coral hover:underline mt-1">
+              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z" />
+              </svg>
+              Join Zoom Meeting
+            </a>
+          </div>
+        )}
       </div>
 
       <div className="flex flex-wrap items-center gap-3">
         <a
-          href={buildGoogleCalendarUrl(slot, cycleName, interview.location)}
+          href={buildGoogleCalendarUrl(slot, cycleName, interview.location, interview.zoomJoinUrl)}
           target="_blank"
           rel="noopener noreferrer"
           className="inline-flex items-center gap-2 px-5 py-2.5 rounded-full bg-accent-coral text-white text-sm font-semibold hover:bg-accent-coral/90 transition"
@@ -744,7 +760,7 @@ function InterviewScheduledView({
           Add to Google Calendar
         </a>
         <button
-          onClick={() => downloadIcs(slot, cycleName, interview.location)}
+          onClick={() => downloadIcs(slot, cycleName, interview.location, interview.zoomJoinUrl)}
           className="inline-flex items-center gap-2 px-5 py-2.5 rounded-full border-2 border-border text-sm font-semibold text-muted-foreground hover:border-accent-coral hover:text-accent-coral transition"
         >
           <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/dali-api/prisma/migrations/20260425000002_add_zoom_fields/migration.sql
+++ b/dali-api/prisma/migrations/20260425000002_add_zoom_fields/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Interview" ADD COLUMN "zoomMeetingId" TEXT;
+ALTER TABLE "Interview" ADD COLUMN "zoomJoinUrl" TEXT;

--- a/dali-api/prisma/schema.prisma
+++ b/dali-api/prisma/schema.prisma
@@ -367,6 +367,9 @@ model Interview {
   status    InterviewStatus @default(Scheduled)
   location  InterviewLocation @default(Online)
 
+  zoomMeetingId String?
+  zoomJoinUrl   String?
+
   // Joint outcome — set by either interviewer when marking complete.
   // recommendation values: 'Strong Hire' | 'Hire' | 'Lean Hire' | 'Lean No Hire' | 'No Hire'
   recommendation      String?


### PR DESCRIPTION
## Summary

- Adds automatic Zoom meeting creation/deletion for online interviews via Server-to-Server OAuth
- New `app/lib/zoom.ts` library with in-memory token caching, graceful degradation (no-ops when env vars missing)
- Zoom provisioning wired into all interview lifecycle endpoints: book, schedule, reschedule, cancel, and admin location change
- Zoom join links shown in applicant portal, interviewer view, admin panel, domain lead view, and calendar exports (Google Calendar + ICS)
- Schema migration adds `zoomMeetingId` and `zoomJoinUrl` nullable fields to Interview

## Design decisions

- **Zoom calls run outside serializable transactions** — avoids holding DB locks during HTTP round-trips
- **Best-effort** — Zoom failures are logged but never block interview booking/cancellation
- **Meeting ID stored as String** — avoids BigInt JSON serialization issues
- **3 env vars** (`ZOOM_ACCOUNT_ID`, `ZOOM_CLIENT_ID`, `ZOOM_CLIENT_SECRET`) — all optional, feature is fully disabled when missing

## Dependencies

Stacked on #163 — will auto-retarget to `dev` once that merges.

## Test plan

- [ ] `npm run typecheck` passes
- [ ] `npm test` passes (Zoom is no-op without env vars)
- [ ] Manual: book online interview → Zoom link appears in portal + interviewer view + calendar exports
- [ ] Manual: cancel → Zoom meeting deleted
- [ ] Manual: reschedule → old meeting deleted, new one created
- [ ] Manual: admin changes Online→Pod → meeting deleted; Pod→Online → meeting created
- [ ] Manual: book in-person → no Zoom meeting created

🤖 Generated with [Claude Code](https://claude.com/claude-code)