### PR TITLE
Bump plan and implement max-turns

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -171,7 +171,7 @@ jobs:
                 a real tradeoff, STOP. Do NOT open a PR. Instead comment on
                 issue #${{ github.event.issue.number }} explaining what's
                 blocking you and what options you considered.
-          claude_args: --model opus --max-turns 50 --allowedTools "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git:*),Bash(gh:*),Bash(npm:*),Bash(npx:*)"
+          claude_args: --model opus --max-turns 100 --allowedTools "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git:*),Bash(gh:*),Bash(npm:*),Bash(npx:*)"
 
   respond_review:
     if: >

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -75,7 +75,7 @@ jobs:
             Rules:
               - Do NOT open a PR, push a branch, or modify any files. Comment only.
               - Do NOT modify `.github/workflows/*`.
-          claude_args: --model opus --max-turns 15 --allowedTools "Read,Glob,Grep,LS,Bash(gh:*)"
+          claude_args: --model opus --max-turns 30 --allowedTools "Read,Glob,Grep,LS,Bash(gh:*)"
 
   refine:
     if: >


### PR DESCRIPTION
## Summary

Increases `--max-turns` on two jobs in `.github/workflows/claude.yml`:

| Job | Before | After |
|---|---|---|
| `plan` | 15 | **30** |
| `implement` | 50 | **100** |

Reasons:
- **`plan`**: more headroom to read additional files and iterate on the plan when an issue spans multiple modules.
- **`implement`**: large issues that touch many files or need several typecheck-fix iterations were bumping into the 50-turn cap.

Other jobs unchanged (`refine: 10`, `respond_review: 30`, `claude-ci-fix: 40`).

## Test plan

- [ ] Merge.
- [ ] Add the `claude` label to a non-trivial issue → confirm the plan comment posts; check action log shows `--max-turns 30`.
- [ ] Run a full `/implement` end-to-end on a multi-file issue → check action log shows `--max-turns 100`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)