### PR TITLE
Add /push fast-forward promotion workflows: dev → staging → prod

### DIFF
--- a/.github/workflows/promote-to-prod.yml
+++ b/.github/workflows/promote-to-prod.yml
@@ -6,7 +6,8 @@ name: Promote to prod
 # blocked by branch-protection push restrictions on `prod`).
 #
 # Companion of `promote-to-staging.yml`. See PR description for setup steps
-# (PROMOTE_TOKEN secret + branch protection on `prod`).
+# (PROMOTE_APP_ID + PROMOTE_APP_PRIVATE_KEY secrets, App installed on
+# this repo, App listed as bypass actor on the `prod` ruleset).
 
 on:
   issue_comment:
@@ -109,11 +110,18 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - name: Checkout with PROMOTE_TOKEN
+      - name: Mint installation token from PROMOTE App
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.PROMOTE_APP_ID }}
+          private-key: ${{ secrets.PROMOTE_APP_PRIVATE_KEY }}
+
+      - name: Checkout with App token
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.PROMOTE_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Verify fast-forward feasibility
         env:

--- a/.github/workflows/promote-to-prod.yml
+++ b/.github/workflows/promote-to-prod.yml
@@ -1,0 +1,141 @@
+name: Promote to prod
+
+# Fast-forward push of `staging` onto `prod` when an authorized reviewer leaves
+# a `/push` comment on a staging → prod PR. The PR exists for review/CI; the
+# actual promotion happens here, not via the GitHub merge button (which is
+# blocked by branch-protection push restrictions on `prod`).
+#
+# Companion of `promote-to-staging.yml`. See PR description for setup steps
+# (PROMOTE_TOKEN secret + branch protection on `prod`).
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  check:
+    if: |
+      github.event.issue.pull_request != null &&
+      startsWith(github.event.comment.body, '/push')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    outputs:
+      head_sha: ${{ steps.context.outputs.head_sha }}
+    steps:
+      - name: Read PR context
+        id: context
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          PR: ${{ github.event.issue.number }}
+        run: |
+          set -euo pipefail
+          PR_JSON=$(gh api "repos/$OWNER/$REPO/pulls/$PR")
+          BASE=$(jq -r '.base.ref' <<<"$PR_JSON")
+          HEAD=$(jq -r '.head.ref' <<<"$PR_JSON")
+          HEAD_SHA=$(jq -r '.head.sha' <<<"$PR_JSON")
+          echo "base=$BASE" >>"$GITHUB_OUTPUT"
+          echo "head=$HEAD" >>"$GITHUB_OUTPUT"
+          echo "head_sha=$HEAD_SHA" >>"$GITHUB_OUTPUT"
+
+      - name: Verify base=prod head=staging
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.issue.number }}
+          BASE: ${{ steps.context.outputs.base }}
+          HEAD: ${{ steps.context.outputs.head }}
+        run: |
+          if [ "$BASE" != "prod" ] || [ "$HEAD" != "staging" ]; then
+            gh pr comment "$PR" --body "❌ \`/push\` here would promote \`$HEAD\` → \`$BASE\`. This workflow only handles \`staging\` → \`prod\`."
+            exit 1
+          fi
+
+      - name: Verify commenter has write access
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          PR: ${{ github.event.issue.number }}
+          USER: ${{ github.event.comment.user.login }}
+        run: |
+          set -euo pipefail
+          PERM=$(gh api "repos/$OWNER/$REPO/collaborators/$USER/permission" --jq '.permission' 2>/dev/null || echo "none")
+          case "$PERM" in
+            admin|write|maintain) echo "$USER has $PERM access" ;;
+            *)
+              gh pr comment "$PR" --body "❌ \`/push\` from @$USER ignored — write access required (got: \`$PERM\`)."
+              exit 1
+              ;;
+          esac
+
+      - name: Verify ≥1 approving review from a write-access user
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          PR: ${{ github.event.issue.number }}
+          REQUIRED: 1
+        run: |
+          set -euo pipefail
+          REVIEWS=$(gh api --paginate "repos/$OWNER/$REPO/pulls/$PR/reviews")
+          # Take each reviewer's latest review, keep APPROVED ones.
+          LATEST_APPROVERS=$(jq -r '
+            group_by(.user.login)
+            | map(max_by(.submitted_at // ""))
+            | .[]
+            | select(.state == "APPROVED")
+            | .user.login
+          ' <<<"$REVIEWS" | sort -u)
+
+          COUNT=0
+          for U in $LATEST_APPROVERS; do
+            P=$(gh api "repos/$OWNER/$REPO/collaborators/$U/permission" --jq '.permission' 2>/dev/null || echo "none")
+            case "$P" in admin|write|maintain) COUNT=$((COUNT+1)) ;; esac
+          done
+
+          if [ "$COUNT" -lt "$REQUIRED" ]; then
+            gh pr comment "$PR" --body "❌ \`/push\` ignored — need $REQUIRED approving review(s) from write-access users (got $COUNT)."
+            exit 1
+          fi
+          echo "$COUNT approving review(s) from write-access users"
+
+  promote:
+    needs: check
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout with PROMOTE_TOKEN
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.PROMOTE_TOKEN }}
+
+      - name: Verify fast-forward feasibility
+        env:
+          HEAD_SHA: ${{ needs.check.outputs.head_sha }}
+        run: |
+          set -euo pipefail
+          git fetch origin prod staging
+          if ! git merge-base --is-ancestor origin/prod "$HEAD_SHA"; then
+            echo "::error::prod is not an ancestor of $HEAD_SHA — fast-forward not possible. Did someone push to prod directly, or did staging get rebased?"
+            exit 1
+          fi
+
+      - name: Fast-forward push prod
+        env:
+          HEAD_SHA: ${{ needs.check.outputs.head_sha }}
+        run: git push origin "$HEAD_SHA:refs/heads/prod"
+
+      - name: Comment + close PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.issue.number }}
+          HEAD_SHA: ${{ needs.check.outputs.head_sha }}
+        run: |
+          gh pr comment "$PR" --body "✅ Fast-forwarded \`prod\` to \`$HEAD_SHA\`."
+          gh pr close "$PR"

--- a/.github/workflows/promote-to-staging.yml
+++ b/.github/workflows/promote-to-staging.yml
@@ -1,0 +1,141 @@
+name: Promote to staging
+
+# Fast-forward push of `dev` onto `staging` when an authorized reviewer leaves
+# a `/push` comment on a dev → staging PR. The PR exists for review/CI; the
+# actual promotion happens here, not via the GitHub merge button (which is
+# blocked by branch-protection push restrictions on `staging`).
+#
+# Companion of `promote-to-prod.yml`. See PR description for setup steps
+# (PROMOTE_TOKEN secret + branch protection on `staging`).
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  check:
+    if: |
+      github.event.issue.pull_request != null &&
+      startsWith(github.event.comment.body, '/push')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    outputs:
+      head_sha: ${{ steps.context.outputs.head_sha }}
+    steps:
+      - name: Read PR context
+        id: context
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          PR: ${{ github.event.issue.number }}
+        run: |
+          set -euo pipefail
+          PR_JSON=$(gh api "repos/$OWNER/$REPO/pulls/$PR")
+          BASE=$(jq -r '.base.ref' <<<"$PR_JSON")
+          HEAD=$(jq -r '.head.ref' <<<"$PR_JSON")
+          HEAD_SHA=$(jq -r '.head.sha' <<<"$PR_JSON")
+          echo "base=$BASE" >>"$GITHUB_OUTPUT"
+          echo "head=$HEAD" >>"$GITHUB_OUTPUT"
+          echo "head_sha=$HEAD_SHA" >>"$GITHUB_OUTPUT"
+
+      - name: Verify base=staging head=dev
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.issue.number }}
+          BASE: ${{ steps.context.outputs.base }}
+          HEAD: ${{ steps.context.outputs.head }}
+        run: |
+          if [ "$BASE" != "staging" ] || [ "$HEAD" != "dev" ]; then
+            gh pr comment "$PR" --body "❌ \`/push\` here would promote \`$HEAD\` → \`$BASE\`. This workflow only handles \`dev\` → \`staging\`."
+            exit 1
+          fi
+
+      - name: Verify commenter has write access
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          PR: ${{ github.event.issue.number }}
+          USER: ${{ github.event.comment.user.login }}
+        run: |
+          set -euo pipefail
+          PERM=$(gh api "repos/$OWNER/$REPO/collaborators/$USER/permission" --jq '.permission' 2>/dev/null || echo "none")
+          case "$PERM" in
+            admin|write|maintain) echo "$USER has $PERM access" ;;
+            *)
+              gh pr comment "$PR" --body "❌ \`/push\` from @$USER ignored — write access required (got: \`$PERM\`)."
+              exit 1
+              ;;
+          esac
+
+      - name: Verify ≥1 approving review from a write-access user
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          PR: ${{ github.event.issue.number }}
+          REQUIRED: 1
+        run: |
+          set -euo pipefail
+          REVIEWS=$(gh api --paginate "repos/$OWNER/$REPO/pulls/$PR/reviews")
+          # Take each reviewer's latest review, keep APPROVED ones.
+          LATEST_APPROVERS=$(jq -r '
+            group_by(.user.login)
+            | map(max_by(.submitted_at // ""))
+            | .[]
+            | select(.state == "APPROVED")
+            | .user.login
+          ' <<<"$REVIEWS" | sort -u)
+
+          COUNT=0
+          for U in $LATEST_APPROVERS; do
+            P=$(gh api "repos/$OWNER/$REPO/collaborators/$U/permission" --jq '.permission' 2>/dev/null || echo "none")
+            case "$P" in admin|write|maintain) COUNT=$((COUNT+1)) ;; esac
+          done
+
+          if [ "$COUNT" -lt "$REQUIRED" ]; then
+            gh pr comment "$PR" --body "❌ \`/push\` ignored — need $REQUIRED approving review(s) from write-access users (got $COUNT)."
+            exit 1
+          fi
+          echo "$COUNT approving review(s) from write-access users"
+
+  promote:
+    needs: check
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout with PROMOTE_TOKEN
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.PROMOTE_TOKEN }}
+
+      - name: Verify fast-forward feasibility
+        env:
+          HEAD_SHA: ${{ needs.check.outputs.head_sha }}
+        run: |
+          set -euo pipefail
+          git fetch origin staging dev
+          if ! git merge-base --is-ancestor origin/staging "$HEAD_SHA"; then
+            echo "::error::staging is not an ancestor of $HEAD_SHA — fast-forward not possible. Did someone push to staging directly, or did dev get rebased?"
+            exit 1
+          fi
+
+      - name: Fast-forward push staging
+        env:
+          HEAD_SHA: ${{ needs.check.outputs.head_sha }}
+        run: git push origin "$HEAD_SHA:refs/heads/staging"
+
+      - name: Comment + close PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.issue.number }}
+          HEAD_SHA: ${{ needs.check.outputs.head_sha }}
+        run: |
+          gh pr comment "$PR" --body "✅ Fast-forwarded \`staging\` to \`$HEAD_SHA\`."
+          gh pr close "$PR"

--- a/.github/workflows/promote-to-staging.yml
+++ b/.github/workflows/promote-to-staging.yml
@@ -6,7 +6,8 @@ name: Promote to staging
 # blocked by branch-protection push restrictions on `staging`).
 #
 # Companion of `promote-to-prod.yml`. See PR description for setup steps
-# (PROMOTE_TOKEN secret + branch protection on `staging`).
+# (PROMOTE_APP_ID + PROMOTE_APP_PRIVATE_KEY secrets, App installed on
+# this repo, App listed as bypass actor on the `staging` ruleset).
 
 on:
   issue_comment:
@@ -109,11 +110,18 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - name: Checkout with PROMOTE_TOKEN
+      - name: Mint installation token from PROMOTE App
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.PROMOTE_APP_ID }}
+          private-key: ${{ secrets.PROMOTE_APP_PRIVATE_KEY }}
+
+      - name: Checkout with App token
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.PROMOTE_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Verify fast-forward feasibility
         env:


### PR DESCRIPTION
## Summary

Two GitHub Actions workflows that promote between branches via true git fast-forward, so `prod` stays a strict ancestor of `staging` stays a strict ancestor of `dev` — `git merge-base --is-ancestor prod staging` and `git merge-base --is-ancestor staging dev` always hold.

- `.github/workflows/promote-to-staging.yml` — `dev` → `staging`, requires ≥1 approving review from a write-access user.
- `.github/workflows/promote-to-prod.yml` — `staging` → `prod`, requires ≥1 approving review from a write-access user.

Both trigger on PR comments starting with `/push`. The `check` job validates: the comment is on a PR, base/head match the expected pair, commenter has write access, and ≥1 approving review (latest per reviewer) from a write-access user. The `promote` job mints a short-lived installation token from the GitHub App, checks out, verifies fast-forward feasibility (`merge-base --is-ancestor`), pushes, then comments and closes the PR.

## Why this and not the merge button

GitHub's three native merge methods (merge / squash / rebase) all rewrite SHAs even when a fast-forward would be possible — rebase rewrites the committer field, squash collapses, merge adds a merge commit. The only way to get true SHA-equality between branches is to bypass the merge button and `git push origin <head>:refs/heads/<base>`. Branch protection's update restriction on `staging`/`prod` blocks the merge button (and direct CLI pushes) for everyone except the App, so the only way to advance these branches is through the workflow.

## Why a GitHub App instead of a PAT

Rulesets' "Restrict updates" bypass list supports specific GitHub Apps but not individual users. With a PAT, the strictest bypass we could configure was "Repository admin" — meaning all repo admins could still push directly to staging/prod. With a GitHub App, the only identity that can push is the App itself, regardless of who's a repo admin. Plus: no expiry to rotate, no dependency on any individual user's account.

## Required setup before this lands (manual, repo admin)

These can't be done from a PR — they need repo Settings access:

1. **Create a GitHub App.** Settings → Developer settings → GitHub Apps → New GitHub App.
   - Name: something like `dali-os-promote-bot`.
   - Homepage URL: anything (e.g. `https://github.com/dali-lab/dali-os`).
   - Uncheck "Active" under Webhook (no webhook needed).
   - Repository permissions:
     - Contents: **Read and write**
     - Pull requests: **Read and write**
   - Where can this App be installed: "Only on this account".
   - Create the App, then on the App page: generate a private key (downloads a `.pem` file — keep it safe, it doesn't show again).
2. **Install the App** on the `dali-lab/dali-os` repo only (Install App → select dali-os).
3. **Add two repo secrets** at Settings → Secrets and variables → Actions:
   - `PROMOTE_APP_ID` — the App's numeric ID (visible on the App's settings page).
   - `PROMOTE_APP_PRIVATE_KEY` — paste the entire contents of the `.pem` file (including the `-----BEGIN…END-----` lines).
4. **Bootstrap the `staging` branch** at current `prod` HEAD (do this *before* configuring `staging`'s ruleset, or while the ruleset is in "Evaluate" mode, since pushes are about to be locked down):
   ```bash
   git fetch origin prod
   git push origin origin/prod:refs/heads/staging
   ```
5. **Configure rulesets** for `staging` and `prod` (Settings → Rules → Rulesets → New branch ruleset, one ruleset per branch or a shared one targeting both):
   - Target: `staging` and/or `prod` (include patterns).
   - Bypass list: add the App as a bypass actor.
   - Rules:
     - **Restrict updates**: ON (this is the lever — disables the merge button + direct CLI pushes for everyone not in the bypass list).
     - **Restrict deletions**: ON.
     - **Require linear history**: ON (belt-and-suspenders; the workflow only fast-forwards, this catches accidents).
     - *Don't* enable "Require pull request before merging" or "Require approving reviews" — those gate the merge button (which we're disabling), not direct pushes. The workflow does its own gating.

Until the App + secrets + ruleset bypass are in place, `/push` will gate correctly but the actual push will fail with a permissions error.

## How a promotion works once it's live

1. Open a PR `dev` → `staging` (or `staging` → `prod`). CI runs against the diff like normal.
2. A reviewer with write access approves.
3. Same or another reviewer leaves `/push` as the comment body. (`/push` must be at the start of the comment.)
4. Workflow validates everything, fast-forwards, comments `✅ Fast-forwarded \`<branch>\` to \`<sha>\`.`, closes the PR.
5. The existing `deploy.yml` triggers on push to staging/prod and deploys via flyctl.

## Test plan

- [ ] After merge, set up the GitHub App + secrets + rulesets per the steps above.
- [ ] Bootstrap `staging` at current `prod` HEAD; verify `gh api repos/dali-lab/dali-os/branches/staging --jq '.commit.sha'` matches `gh api repos/dali-lab/dali-os/branches/prod --jq '.commit.sha'`.
- [ ] Open a no-op PR `dev` → `staging`. Approve. Comment `/push`. Verify the workflow runs, posts ✅, closes the PR, and that `staging` SHA after the push exactly equals `dev` SHA before the push (no rewrite).
- [ ] Open a PR `staging` → `prod`. Approve. Comment `/push`. Verify same outcome on `prod`.
- [ ] Negative: `/push` from a user without write access → ❌ comment, workflow fails.
- [ ] Negative: `/push` on a PR with no approving review → ❌ comment, workflow fails.
- [ ] Negative: `/push` on a PR whose base/head pair is wrong (e.g. base=main) → ❌ comment, workflow fails.
- [ ] Negative: human clicks the GitHub merge button on a dev → staging PR → ruleset rejects it.
- [ ] Negative: a repo admin runs `git push origin <sha>:staging` from a laptop → ruleset rejects it.

## Out of scope

- Provisioning `dali-api-staging` Fly app + the `staging` Neon branch. Separate task; the git plumbing works without them, though pushes to `staging` won't deploy until those exist.
- "Dismiss stale approvals on new commits" — currently the workflow counts approving reviews regardless of which SHA they were against. Tighten later if it bites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
