### PR TITLE
Fix flaky portal-withdraw E2E test

### DIFF
--- a/dali-api/e2e/portal-withdraw.spec.ts
+++ b/dali-api/e2e/portal-withdraw.spec.ts
@@ -21,7 +21,9 @@ test.describe('portal: withdraw application', () => {
     await expect(page.getByRole('button', { name: /withdraw application/i })).toHaveCount(0);
 
     // Dashboard should show the withdrawn state too.
-    await page.goto('/portal');
+    // Use the client-side link instead of page.goto() to avoid racing with
+    // React Router's post-fetcher revalidation (which can abort full navigations).
+    await page.getByRole('link', { name: /back to portal/i }).click();
     await expect(page.getByText(/application withdrawn/i)).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary
- Replace `page.goto('/portal')` with a click on the "Back to portal" client-side link in the withdraw E2E test
- The full-page navigation was racing with React Router's post-fetcher revalidation, causing `net::ERR_ABORTED` in CI

## Test plan
- [ ] `portal-withdraw` E2E test passes consistently in CI
- [ ] Other E2E tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)