### PR TITLE
Fix promote workflows: add --repo to gh pr comment in check job

### DIFF
--- a/.github/workflows/promote-to-prod.yml
+++ b/.github/workflows/promote-to-prod.yml
@@ -45,12 +45,14 @@ jobs:
       - name: Verify base=prod head=staging
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
           PR: ${{ github.event.issue.number }}
           BASE: ${{ steps.context.outputs.base }}
           HEAD: ${{ steps.context.outputs.head }}
         run: |
           if [ "$BASE" != "prod" ] || [ "$HEAD" != "staging" ]; then
-            gh pr comment "$PR" --body "❌ \`/push\` here would promote \`$HEAD\` → \`$BASE\`. This workflow only handles \`staging\` → \`prod\`."
+            gh pr comment "$PR" --repo "$OWNER/$REPO" --body "❌ \`/push\` here would promote \`$HEAD\` → \`$BASE\`. This workflow only handles \`staging\` → \`prod\`."
             exit 1
           fi
 
@@ -67,7 +69,7 @@ jobs:
           case "$PERM" in
             admin|write|maintain) echo "$USER has $PERM access" ;;
             *)
-              gh pr comment "$PR" --body "❌ \`/push\` from @$USER ignored — write access required (got: \`$PERM\`)."
+              gh pr comment "$PR" --repo "$OWNER/$REPO" --body "❌ \`/push\` from @$USER ignored — write access required (got: \`$PERM\`)."
               exit 1
               ;;
           esac
@@ -98,7 +100,7 @@ jobs:
           done
 
           if [ "$COUNT" -lt "$REQUIRED" ]; then
-            gh pr comment "$PR" --body "❌ \`/push\` ignored — need $REQUIRED approving review(s) from write-access users (got $COUNT)."
+            gh pr comment "$PR" --repo "$OWNER/$REPO" --body "❌ \`/push\` ignored — need $REQUIRED approving review(s) from write-access users (got $COUNT)."
             exit 1
           fi
           echo "$COUNT approving review(s) from write-access users"

--- a/.github/workflows/promote-to-staging.yml
+++ b/.github/workflows/promote-to-staging.yml
@@ -45,12 +45,14 @@ jobs:
       - name: Verify base=staging head=dev
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
           PR: ${{ github.event.issue.number }}
           BASE: ${{ steps.context.outputs.base }}
           HEAD: ${{ steps.context.outputs.head }}
         run: |
           if [ "$BASE" != "staging" ] || [ "$HEAD" != "dev" ]; then
-            gh pr comment "$PR" --body "❌ \`/push\` here would promote \`$HEAD\` → \`$BASE\`. This workflow only handles \`dev\` → \`staging\`."
+            gh pr comment "$PR" --repo "$OWNER/$REPO" --body "❌ \`/push\` here would promote \`$HEAD\` → \`$BASE\`. This workflow only handles \`dev\` → \`staging\`."
             exit 1
           fi
 
@@ -67,7 +69,7 @@ jobs:
           case "$PERM" in
             admin|write|maintain) echo "$USER has $PERM access" ;;
             *)
-              gh pr comment "$PR" --body "❌ \`/push\` from @$USER ignored — write access required (got: \`$PERM\`)."
+              gh pr comment "$PR" --repo "$OWNER/$REPO" --body "❌ \`/push\` from @$USER ignored — write access required (got: \`$PERM\`)."
               exit 1
               ;;
           esac
@@ -98,7 +100,7 @@ jobs:
           done
 
           if [ "$COUNT" -lt "$REQUIRED" ]; then
-            gh pr comment "$PR" --body "❌ \`/push\` ignored — need $REQUIRED approving review(s) from write-access users (got $COUNT)."
+            gh pr comment "$PR" --repo "$OWNER/$REPO" --body "❌ \`/push\` ignored — need $REQUIRED approving review(s) from write-access users (got $COUNT)."
             exit 1
           fi
           echo "$COUNT approving review(s) from write-access users"


### PR DESCRIPTION
## Summary

- The `check` job in `promote-to-staging.yml` and `promote-to-prod.yml` has no `actions/checkout` step, so failure-path `gh pr comment` calls fail with `fatal: not a git repository` and the intended user-facing "❌ /push ignored — …" comment never lands on the PR.
- Pass `--repo "$OWNER/$REPO"` to all three `gh pr comment` calls in each `check` job so they don't need a git working directory. Also adds `OWNER`/`REPO` to the `Verify base=… head=…` step's `env:` block (the other two steps already had them).
- The `promote` job's `gh pr comment` is unchanged — it already works because that job checks out the repo.

Surfaced by run [24972410440](https://github.com/dali-lab/dali-os/actions/runs/24972410440/job/73117808089), where the gate correctly refused to promote PR #208 (zero approving reviews) but the comment explaining why never posted.

## Test plan

- [ ] Comment `/push` on a non-conforming PR (wrong base/head) and confirm the ❌ explanation comment now lands on the PR
- [ ] Comment `/push` on a `dev` → `staging` PR with no approving reviews and confirm the "need 1 approving review" comment lands
- [ ] Confirm happy path still works: get an approving review on a `dev` → `staging` PR, comment `/push`, and verify the ✅ fast-forward comment posts as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)