### PR TITLE
Fix #204: add admin UI to create and delete domains

### DIFF
--- a/dali-api/app/routes.ts
+++ b/dali-api/app/routes.ts
@@ -50,6 +50,7 @@ export default [
 
   // Domain & member management API
   route("api/domains", "routes/api.domains.ts"),
+  route("api/domains/:domainId", "routes/api.domains.$domainId.ts"),
   route("api/domains/:domainId/leads", "routes/api.domains.$domainId.leads.ts"),
   route("api/members", "routes/api.members.ts"),
   route("api/members/:memberId/roles", "routes/api.members.$memberId.roles.ts"),

--- a/dali-api/app/routes/__tests__/api.domains.delete.test.ts
+++ b/dali-api/app/routes/__tests__/api.domains.delete.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("~/lib/db");
+vi.mock("~/lib/auth");
+vi.mock("~/lib/roles");
+
+import { prisma } from "~/lib/db";
+import { requireAuth } from "~/lib/auth";
+import { isAdmin } from "~/lib/roles";
+import { action, describeDomainUsage } from "~/routes/api.domains.$domainId";
+
+const mockPrisma = prisma as unknown as {
+  $transaction: ReturnType<typeof vi.fn>;
+  domain: {
+    findUnique: ReturnType<typeof vi.fn>;
+    delete: ReturnType<typeof vi.fn>;
+  };
+};
+
+const ADMIN_ID = "admin-user-1";
+const DOMAIN_ID = "domain-1";
+
+const ZERO_COUNTS = {
+  challengeVersions: 0,
+  applicationCycles: 0,
+  domainLeadAssignments: 0,
+  cycleReviewers: 0,
+  cycleInterviewers: 0,
+  rubrics: 0,
+  delibsSessions: 0,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (mockPrisma as any).domain = { findUnique: vi.fn(), delete: vi.fn() };
+  // Run the transaction callback inline against the mocked client.
+  (mockPrisma as any).$transaction = vi.fn((fn: (tx: any) => Promise<any>) => fn(mockPrisma));
+  vi.mocked(requireAuth).mockResolvedValue({
+    ok: true,
+    user: { sub: ADMIN_ID, email: "a@x.com", type: "user" },
+  } as any);
+  vi.mocked(isAdmin).mockResolvedValue(true);
+});
+
+function makeRequest(method = "DELETE") {
+  return new Request(`http://localhost/api/domains/${DOMAIN_ID}`, { method });
+}
+
+describe("describeDomainUsage", () => {
+  it("returns empty list when nothing references the domain", () => {
+    expect(describeDomainUsage(ZERO_COUNTS)).toEqual([]);
+  });
+
+  it("describes only non-zero relations", () => {
+    const out = describeDomainUsage({
+      ...ZERO_COUNTS,
+      applicationCycles: 2,
+      rubrics: 3,
+    });
+    expect(out).toEqual(["2 application cycles", "3 rubrics"]);
+  });
+});
+
+describe("DELETE /api/domains/:domainId", () => {
+  it("returns 403 when caller is not an admin", async () => {
+    vi.mocked(isAdmin).mockResolvedValueOnce(false);
+    const res = await action({ request: makeRequest(), params: { domainId: DOMAIN_ID }, context: {} } as any);
+    expect(res.status).toBe(403);
+    expect(mockPrisma.domain.delete).not.toHaveBeenCalled();
+  });
+
+  it("returns 405 for non-DELETE methods", async () => {
+    const res = await action({ request: makeRequest("POST"), params: { domainId: DOMAIN_ID }, context: {} } as any);
+    expect(res.status).toBe(405);
+  });
+
+  it("returns 404 when the domain does not exist", async () => {
+    mockPrisma.domain.findUnique.mockResolvedValue(null);
+    const res = await action({ request: makeRequest(), params: { domainId: DOMAIN_ID }, context: {} } as any);
+    expect(res.status).toBe(404);
+    expect(mockPrisma.domain.delete).not.toHaveBeenCalled();
+  });
+
+  it("returns 409 with a helpful message when the domain is in use", async () => {
+    mockPrisma.domain.findUnique.mockResolvedValue({
+      id: DOMAIN_ID,
+      name: "Engineering",
+      _count: { ...ZERO_COUNTS, applicationCycles: 1, rubrics: 2 },
+    });
+    const res = await action({ request: makeRequest(), params: { domainId: DOMAIN_ID }, context: {} } as any);
+    expect(res.status).toBe(409);
+    const json = await res.json();
+    expect(json.error).toMatch(/application cycles/);
+    expect(json.error).toMatch(/rubrics/);
+    expect(mockPrisma.domain.delete).not.toHaveBeenCalled();
+  });
+
+  it("deletes the domain when no references exist", async () => {
+    mockPrisma.domain.findUnique.mockResolvedValue({
+      id: DOMAIN_ID,
+      name: "Engineering",
+      _count: ZERO_COUNTS,
+    });
+    mockPrisma.domain.delete.mockResolvedValue({ id: DOMAIN_ID });
+
+    const res = await action({ request: makeRequest(), params: { domainId: DOMAIN_ID }, context: {} } as any);
+    expect(res.status).toBe(200);
+    expect(mockPrisma.domain.delete).toHaveBeenCalledWith({ where: { id: DOMAIN_ID } });
+  });
+});

--- a/dali-api/app/routes/admin-console.tsx
+++ b/dali-api/app/routes/admin-console.tsx
@@ -1,17 +1,22 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { redirect, useLoaderData, useFetcher } from "react-router";
 import type { Route } from "./+types/admin-console";
 import { prisma } from "~/lib/db";
 import { requireAuth } from "~/lib/auth";
 import { isAdmin, isHiringLead } from "~/lib/roles";
-import { Shield, Users, ChevronDown, X, Check } from "lucide-react";
+import { describeDomainUsage } from "./api.domains.$domainId";
+import { Shield, Users, ChevronDown, X, Check, Trash2, Plus } from "lucide-react";
 
 // ─── Loader ──────────────────────────────────────────────────────────────────
 
 export async function loader({ request }: Route.LoaderArgs) {
   const auth = await requireAuth(request);
   if (!auth.ok) return redirect("/login");
-  if (!(await isAdmin(auth.user.sub)) && !(await isHiringLead(auth.user.sub))) return redirect("/");
+  const [admin, hiringLead] = await Promise.all([
+    isAdmin(auth.user.sub),
+    isHiringLead(auth.user.sub),
+  ]);
+  if (!admin && !hiringLead) return redirect("/");
 
   const [members, domains] = await Promise.all([
     prisma.dALIMember.findMany({
@@ -21,10 +26,25 @@ export async function loader({ request }: Route.LoaderArgs) {
       },
       orderBy: [{ lastName: "asc" }, { firstName: "asc" }],
     }),
-    prisma.domain.findMany({ orderBy: { name: "asc" } }),
+    prisma.domain.findMany({
+      orderBy: { name: "asc" },
+      include: {
+        _count: {
+          select: {
+            challengeVersions: true,
+            applicationCycles: true,
+            domainLeadAssignments: true,
+            cycleReviewers: true,
+            cycleInterviewers: true,
+            rubrics: true,
+            delibsSessions: true,
+          },
+        },
+      },
+    }),
   ]);
 
-  return { members, domains };
+  return { members, domains, isAdmin: admin };
 }
 
 // ─── Action ──────────────────────────────────────────────────────────────────
@@ -32,11 +52,61 @@ export async function loader({ request }: Route.LoaderArgs) {
 export async function action({ request }: Route.ActionArgs) {
   const auth = await requireAuth(request);
   if (!auth.ok) return auth.response;
-  if (!(await isAdmin(auth.user.sub)) && !(await isHiringLead(auth.user.sub)))
+  const admin = await isAdmin(auth.user.sub);
+  if (!admin && !(await isHiringLead(auth.user.sub)))
     return new Response(JSON.stringify({ error: "Forbidden" }), { status: 403 });
 
   const formData = await request.formData();
   const intent = formData.get("intent") as string;
+
+  if (intent === "create-domain") {
+    if (!admin) return Response.json({ error: "Forbidden" }, { status: 403 });
+    const name = String(formData.get("name") ?? "").trim();
+    if (!name) return Response.json({ error: "Name is required" }, { status: 400 });
+    await prisma.domain.create({ data: { name } });
+    return null;
+  }
+
+  if (intent === "delete-domain") {
+    if (!admin) return Response.json({ error: "Forbidden" }, { status: 403 });
+    const domainId = String(formData.get("domainId") ?? "");
+    if (!domainId) return Response.json({ error: "domainId is required" }, { status: 400 });
+
+    const result = await prisma.$transaction(async (tx) => {
+      const domain = await tx.domain.findUnique({
+        where: { id: domainId },
+        include: {
+          _count: {
+            select: {
+              challengeVersions: true,
+              applicationCycles: true,
+              domainLeadAssignments: true,
+              cycleReviewers: true,
+              cycleInterviewers: true,
+              rubrics: true,
+              delibsSessions: true,
+            },
+          },
+        },
+      });
+      if (!domain) return { kind: "not-found" as const };
+      const blocking = describeDomainUsage(domain._count);
+      if (blocking.length > 0) return { kind: "in-use" as const, blocking };
+      await tx.domain.delete({ where: { id: domainId } });
+      return { kind: "ok" as const };
+    });
+
+    if (result.kind === "not-found") {
+      return Response.json({ error: "Domain not found" }, { status: 404 });
+    }
+    if (result.kind === "in-use") {
+      return Response.json(
+        { error: `Cannot delete: domain is in use by ${result.blocking.join(", ")}.` },
+        { status: 409 },
+      );
+    }
+    return null;
+  }
 
   if (intent === "set-admin") {
     const memberId = formData.get("memberId") as string;
@@ -105,6 +175,112 @@ interface Member {
 }
 
 type Domain = DomainRow;
+
+interface DomainWithCounts extends DomainRow {
+  _count: {
+    challengeVersions: number;
+    applicationCycles: number;
+    domainLeadAssignments: number;
+    cycleReviewers: number;
+    cycleInterviewers: number;
+    rubrics: number;
+    delibsSessions: number;
+  };
+}
+
+function DomainsSection({ domains }: { domains: DomainWithCounts[] }) {
+  const createFetcher = useFetcher<{ error?: string } | null>();
+  const [name, setName] = useState("");
+  const isCreating = createFetcher.state !== "idle";
+  const wasCreating = useRef(false);
+
+  useEffect(() => {
+    if (isCreating) wasCreating.current = true;
+    else if (wasCreating.current) {
+      wasCreating.current = false;
+      if (!createFetcher.data?.error) setName("");
+    }
+  }, [isCreating, createFetcher.data]);
+
+  return (
+    <div className="bg-card border border-border rounded-lg overflow-hidden">
+      <div className="flex items-center justify-between px-4 py-3 border-b border-border bg-muted/50">
+        <h2 className="text-sm font-medium text-muted-foreground">Domains ({domains.length})</h2>
+        <createFetcher.Form method="post" className="flex items-center gap-2">
+          <input type="hidden" name="intent" value="create-domain" />
+          <label htmlFor="new-domain-name" className="sr-only">New domain name</label>
+          <input
+            id="new-domain-name"
+            type="text"
+            name="name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="New domain name"
+            className="px-2 py-1 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+            disabled={isCreating}
+          />
+          <button
+            type="submit"
+            disabled={isCreating || !name.trim()}
+            className="inline-flex items-center gap-1 px-2.5 py-1 rounded-md text-xs font-medium bg-gray-900 text-white hover:bg-gray-800 disabled:opacity-50"
+          >
+            <Plus className="w-3 h-3" />
+            Create
+          </button>
+        </createFetcher.Form>
+      </div>
+      {createFetcher.data?.error && (
+        <div className="px-4 py-2 text-sm text-red-700 bg-red-50 border-b border-red-200">
+          {createFetcher.data.error}
+        </div>
+      )}
+      <ul className="divide-y divide-gray-100">
+        {domains.length === 0 && (
+          <li className="px-4 py-6 text-center text-sm text-muted-foreground/70">No domains yet.</li>
+        )}
+        {domains.map((d) => (
+          <DomainRowItem key={d.id} domain={d} />
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function DomainRowItem({ domain }: { domain: DomainWithCounts }) {
+  const fetcher = useFetcher<{ error?: string }>();
+  const inUseBy = describeDomainUsage(domain._count);
+  const inUse = inUseBy.length > 0;
+  const isDeleting = fetcher.state !== "idle";
+
+  return (
+    <li className="px-4 py-3 flex items-center justify-between gap-3">
+      <div className="flex flex-col gap-0.5 min-w-0">
+        <span className="text-sm font-medium text-foreground">{domain.name}</span>
+        {inUse ? (
+          <span className="text-xs text-muted-foreground">In use by {inUseBy.join(", ")}</span>
+        ) : (
+          <span className="text-xs text-muted-foreground/70">Not in use</span>
+        )}
+        {fetcher.data?.error && (
+          <span className="text-xs text-red-700">{fetcher.data.error}</span>
+        )}
+      </div>
+      <fetcher.Form method="post">
+        <input type="hidden" name="intent" value="delete-domain" />
+        <input type="hidden" name="domainId" value={domain.id} />
+        <button
+          type="submit"
+          disabled={inUse || isDeleting}
+          title={inUse ? `Cannot delete — in use by ${inUseBy.join(", ")}` : "Delete domain"}
+          className="inline-flex items-center gap-1 px-2.5 py-1 rounded-md text-xs font-medium bg-red-50 text-red-700 hover:bg-red-100 disabled:bg-muted disabled:text-muted-foreground/60 disabled:cursor-not-allowed"
+        >
+          <Trash2 className="w-3 h-3" />
+          Delete
+        </button>
+      </fetcher.Form>
+    </li>
+  );
+}
 
 function RemoveDomainLeadButton({ assignmentId }: { assignmentId: string }) {
   const fetcher = useFetcher();
@@ -248,7 +424,7 @@ function HiringLeadToggle({ member }: { member: Member }) {
 type RoleFilter = "all" | "admin" | "hiringLead";
 
 export default function AdminConsole() {
-  const { members, domains } = useLoaderData<typeof loader>();
+  const { members, domains, isAdmin: isAdminMember } = useLoaderData<typeof loader>();
   const [search, setSearch] = useState("");
   const [roleFilter, setRoleFilter] = useState<RoleFilter>("all");
 
@@ -300,6 +476,8 @@ export default function AdminConsole() {
           />
         </div>
       </div>
+
+      {isAdminMember && <DomainsSection domains={domains} />}
 
       <div className="bg-card border border-border rounded-lg overflow-hidden">
         <table className="w-full text-sm">

--- a/dali-api/app/routes/admin-console.tsx
+++ b/dali-api/app/routes/admin-console.tsx
@@ -29,6 +29,14 @@ export async function loader({ request }: Route.LoaderArgs) {
     prisma.domain.findMany({
       orderBy: { name: "asc" },
       include: {
+        domainLeadAssignments: {
+          include: {
+            member: {
+              select: { id: true, firstName: true, lastName: true, daliEmail: true },
+            },
+          },
+          orderBy: [{ member: { lastName: "asc" } }, { member: { firstName: "asc" } }],
+        },
         _count: {
           select: {
             challengeVersions: true,
@@ -176,7 +184,18 @@ interface Member {
 
 type Domain = DomainRow;
 
+interface DomainLeadAssignmentWithMember {
+  id: string;
+  member: {
+    id: string;
+    firstName: string | null;
+    lastName: string | null;
+    daliEmail: string | null;
+  };
+}
+
 interface DomainWithCounts extends DomainRow {
+  domainLeadAssignments: DomainLeadAssignmentWithMember[];
   _count: {
     challengeVersions: number;
     applicationCycles: number;
@@ -188,7 +207,7 @@ interface DomainWithCounts extends DomainRow {
   };
 }
 
-function DomainsSection({ domains }: { domains: DomainWithCounts[] }) {
+function DomainsSection({ domains, members }: { domains: DomainWithCounts[]; members: Member[] }) {
   const createFetcher = useFetcher<{ error?: string } | null>();
   const [name, setName] = useState("");
   const isCreating = createFetcher.state !== "idle";
@@ -239,14 +258,14 @@ function DomainsSection({ domains }: { domains: DomainWithCounts[] }) {
           <li className="px-4 py-6 text-center text-sm text-muted-foreground/70">No domains yet.</li>
         )}
         {domains.map((d) => (
-          <DomainRowItem key={d.id} domain={d} />
+          <DomainRowItem key={d.id} domain={d} members={members} />
         ))}
       </ul>
     </div>
   );
 }
 
-function DomainRowItem({ domain }: { domain: DomainWithCounts }) {
+function DomainRowItem({ domain, members }: { domain: DomainWithCounts; members: Member[] }) {
   const fetcher = useFetcher<{ error?: string }>();
   const inUseBy = describeDomainUsage(domain._count);
   const inUse = inUseBy.length > 0;
@@ -254,13 +273,14 @@ function DomainRowItem({ domain }: { domain: DomainWithCounts }) {
 
   return (
     <li className="px-4 py-3 flex items-center justify-between gap-3">
-      <div className="flex flex-col gap-0.5 min-w-0">
+      <div className="flex flex-col gap-1 min-w-0 flex-1">
         <span className="text-sm font-medium text-foreground">{domain.name}</span>
         {inUse ? (
           <span className="text-xs text-muted-foreground">In use by {inUseBy.join(", ")}</span>
         ) : (
           <span className="text-xs text-muted-foreground/70">Not in use</span>
         )}
+        <DomainLeadsForDomain domain={domain} members={members} />
         {fetcher.data?.error && (
           <span className="text-xs text-red-700">{fetcher.data.error}</span>
         )}
@@ -279,6 +299,98 @@ function DomainRowItem({ domain }: { domain: DomainWithCounts }) {
         </button>
       </fetcher.Form>
     </li>
+  );
+}
+
+function memberLabel(member: { firstName: string | null; lastName: string | null; daliEmail: string | null }) {
+  const name = `${member.firstName ?? ""} ${member.lastName ?? ""}`.trim();
+  return name || member.daliEmail || "Unnamed member";
+}
+
+function AddDomainLeadForMemberButton({ domainId, member, onAdded }: { domainId: string; member: Member; onAdded: () => void }) {
+  const fetcher = useFetcher();
+  return (
+    <fetcher.Form method="post" onSubmit={onAdded}>
+      <input type="hidden" name="intent" value="add-domain-lead" />
+      <input type="hidden" name="memberId" value={member.id} />
+      <input type="hidden" name="domainId" value={domainId} />
+      <button type="submit" className="w-full text-left px-4 py-2 text-sm text-foreground/80 hover:bg-muted/50">
+        {memberLabel(member)}
+      </button>
+    </fetcher.Form>
+  );
+}
+
+function DomainLeadsForDomain({ domain, members }: { domain: DomainWithCounts; members: Member[] }) {
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
+  const assignedMemberIds = new Set(domain.domainLeadAssignments.map((a) => a.member.id));
+  const available = members.filter((m) => !assignedMemberIds.has(m.id));
+  const q = search.trim().toLowerCase();
+  const filtered = q
+    ? available.filter((m) => memberLabel(m).toLowerCase().includes(q) || (m.daliEmail ?? "").toLowerCase().includes(q))
+    : available;
+
+  return (
+    <div className="flex flex-wrap gap-1.5 items-center">
+      <span className="text-xs text-muted-foreground/70 mr-1">Leads:</span>
+      {domain.domainLeadAssignments.length === 0 && (
+        <span className="text-xs text-muted-foreground/70 italic">none</span>
+      )}
+      {domain.domainLeadAssignments.map((assignment) => (
+        <span
+          key={assignment.id}
+          className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-800"
+        >
+          {memberLabel(assignment.member)}
+          <RemoveDomainLeadButton assignmentId={assignment.id} />
+        </span>
+      ))}
+
+      {available.length > 0 && (
+        <div className="relative">
+          <button
+            type="button"
+            onClick={() => setOpen(!open)}
+            className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-muted text-muted-foreground hover:bg-muted"
+          >
+            + Lead
+            <ChevronDown className="w-3 h-3" />
+          </button>
+          {open && (
+            <>
+              <div className="fixed inset-0 z-10" onClick={() => { setOpen(false); setSearch(""); }} />
+              <div className="absolute left-0 z-20 mt-1 w-64 rounded-md shadow-lg bg-card ring-1 ring-black ring-opacity-5">
+                <div className="p-2 border-b border-border">
+                  <input
+                    type="text"
+                    autoFocus
+                    value={search}
+                    onChange={(e) => setSearch(e.target.value)}
+                    placeholder="Search members…"
+                    className="w-full px-2 py-1 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  />
+                </div>
+                <div className="py-1 max-h-64 overflow-y-auto">
+                  {filtered.length === 0 ? (
+                    <div className="px-4 py-2 text-sm text-muted-foreground/70">No matching members.</div>
+                  ) : (
+                    filtered.map((member) => (
+                      <AddDomainLeadForMemberButton
+                        key={member.id}
+                        domainId={domain.id}
+                        member={member}
+                        onAdded={() => { setOpen(false); setSearch(""); }}
+                      />
+                    ))
+                  )}
+                </div>
+              </div>
+            </>
+          )}
+        </div>
+      )}
+    </div>
   );
 }
 
@@ -477,7 +589,7 @@ export default function AdminConsole() {
         </div>
       </div>
 
-      {isAdminMember && <DomainsSection domains={domains} />}
+      {isAdminMember && <DomainsSection domains={domains} members={members} />}
 
       <div className="bg-card border border-border rounded-lg overflow-hidden">
         <table className="w-full text-sm">

--- a/dali-api/app/routes/api.domains.$domainId.ts
+++ b/dali-api/app/routes/api.domains.$domainId.ts
@@ -1,0 +1,88 @@
+import type { Route } from "./+types/api.domains.$domainId";
+import { prisma } from "~/lib/db";
+import { requireAuth } from "~/lib/auth";
+import { isAdmin } from "~/lib/roles";
+import { withCors, handlePreflight } from "~/lib/cors";
+
+const RELATION_LABELS: Record<string, string> = {
+  challengeVersions: "challenge versions",
+  applicationCycles: "application cycles",
+  domainLeadAssignments: "domain lead assignments",
+  cycleReviewers: "cycle reviewers",
+  cycleInterviewers: "cycle interviewers",
+  rubrics: "rubrics",
+  delibsSessions: "delibs sessions",
+};
+
+export type DomainUsageCounts = {
+  challengeVersions: number;
+  applicationCycles: number;
+  domainLeadAssignments: number;
+  cycleReviewers: number;
+  cycleInterviewers: number;
+  rubrics: number;
+  delibsSessions: number;
+};
+
+export function describeDomainUsage(counts: DomainUsageCounts): string[] {
+  return Object.entries(counts)
+    .filter(([, n]) => n > 0)
+    .map(([key, n]) => `${n} ${RELATION_LABELS[key] ?? key}`);
+}
+
+export async function action({ request, params }: Route.ActionArgs) {
+  const preflight = handlePreflight(request);
+  if (preflight) return preflight;
+
+  const auth = await requireAuth(request);
+  if (!auth.ok) return withCors(request, auth.response);
+  if (!(await isAdmin(auth.user.sub)))
+    return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
+
+  if (request.method !== "DELETE") {
+    return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));
+  }
+
+  const domainId = params.domainId!;
+
+  const result = await prisma.$transaction(async (tx) => {
+    const domain = await tx.domain.findUnique({
+      where: { id: domainId },
+      include: {
+        _count: {
+          select: {
+            challengeVersions: true,
+            applicationCycles: true,
+            domainLeadAssignments: true,
+            cycleReviewers: true,
+            cycleInterviewers: true,
+            rubrics: true,
+            delibsSessions: true,
+          },
+        },
+      },
+    });
+
+    if (!domain) return { kind: "not-found" as const };
+
+    const blocking = describeDomainUsage(domain._count);
+    if (blocking.length > 0) return { kind: "in-use" as const, blocking };
+
+    await tx.domain.delete({ where: { id: domainId } });
+    return { kind: "ok" as const };
+  });
+
+  if (result.kind === "not-found") {
+    return withCors(request, Response.json({ error: "Domain not found" }, { status: 404 }));
+  }
+  if (result.kind === "in-use") {
+    return withCors(
+      request,
+      Response.json(
+        { error: `Cannot delete: domain is in use by ${result.blocking.join(", ")}.` },
+        { status: 409 },
+      ),
+    );
+  }
+  return withCors(request, Response.json({ ok: true }));
+}

--- a/dali-api/app/routes/api.domains.ts
+++ b/dali-api/app/routes/api.domains.ts
@@ -25,6 +25,17 @@ export async function loader({ request }: Route.LoaderArgs) {
       domainLeadAssignments: {
         include: { member: { include: { user: true } } },
       },
+      _count: {
+        select: {
+          challengeVersions: true,
+          applicationCycles: true,
+          domainLeadAssignments: true,
+          cycleReviewers: true,
+          cycleInterviewers: true,
+          rubrics: true,
+          delibsSessions: true,
+        },
+      },
     },
   });
 
@@ -37,7 +48,7 @@ export async function action({ request }: Route.ActionArgs) {
 
   const auth = await requireAuth(request);
   if (!auth.ok) return withCors(request, auth.response);
-  if (!(await isHiringLead(auth.user.sub))) return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
+  if (!(await isAdmin(auth.user.sub))) return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
 
   if (request.method !== "POST") {
     return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));

--- a/dali-api/e2e/domain-management.spec.ts
+++ b/dali-api/e2e/domain-management.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from './fixtures';
+
+const ADMIN_EMAIL = 'admin@dali.dartmouth.edu';
+
+test.describe('admin domain management', () => {
+  test.beforeEach(async ({ loginAs }) => {
+    await loginAs({ daliEmail: ADMIN_EMAIL });
+  });
+
+  test('admin can create a new domain and then delete it', async ({ page }) => {
+    const name = `E2E Domain ${Date.now()}`;
+
+    await page.goto('/admin-console');
+    await expect(page.getByRole('heading', { name: 'DALI Members' })).toBeVisible();
+
+    await page.getByLabel('New domain name').fill(name);
+    await page.getByRole('button', { name: 'Create' }).click();
+
+    const row = page.getByRole('listitem').filter({ hasText: name });
+    await expect(row).toBeVisible();
+    await expect(row.getByText(/Not in use/)).toBeVisible();
+
+    await row.getByRole('button', { name: 'Delete' }).click();
+    await expect(row).toHaveCount(0);
+  });
+
+  test('delete is disabled for a seeded domain that is in use', async ({ page }) => {
+    await page.goto('/admin-console');
+
+    const engRow = page.getByRole('listitem').filter({ hasText: /^Engineering/ });
+    await expect(engRow).toBeVisible();
+    await expect(engRow.getByText(/In use by/)).toBeVisible();
+    await expect(engRow.getByRole('button', { name: 'Delete' })).toBeDisabled();
+  });
+});
+
+test.describe('non-admin domain management', () => {
+  test('hiring lead does not see the Domains section', async ({ loginAs, page }) => {
+    await loginAs({ daliEmail: 'jordan.taylor@dali.dartmouth.edu' });
+    await page.goto('/admin-console');
+    await expect(page.getByRole('heading', { name: 'DALI Members' })).toBeVisible();
+    await expect(page.getByText(/^Domains \(/)).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
Closes #204.

## Summary
- Add a **Domains** section to `/admin-console` (admin-only) with a create form and per-row Delete. Delete is disabled when the domain is referenced by any of its seven Prisma relations and the row shows what is keeping it alive (e.g. *In use by 2 application cycles, 3 rubrics*).
- Tighten `POST /api/domains` from `isHiringLead` to `isAdmin`. The loader stays open to hiring leads / domain leads / admins (other UIs depend on it) and now returns `_count` for each domain so callers can decide whether deletion is allowed.
- Add `DELETE /api/domains/:domainId` (admin-only). Inside a transaction it counts references across all seven `Domain` relations; non-zero → `409` with a message naming the blocking relation(s); otherwise the row is deleted.
- Mirror the create / delete logic in the page action (`create-domain`, `delete-domain` intents) so the Domains section uses the existing fetcher pattern.

## Implementation notes
- "In use" = referenced by any of: `challengeVersions`, `applicationCycles`, `domainLeadAssignments`, `cycleReviewers`, `cycleInterviewers`, `rubrics`, `delibsSessions`. Any reference is blocking — including `domainLeadAssignments`. Per the plan, if you'd like lead assignments to cascade-clean instead of block, that's a follow-up.
- No Prisma schema migration. No CRDT-touching changes.
- The existing `/admin-console` route guard still admits admins or hiring leads, so the Members table stays visible to HLs. The Domains section is hidden when `!isAdmin`.

## Tests
- New Vitest unit test (`api.domains.delete.test.ts`) covers: non-admin → 403, non-DELETE → 405, missing domain → 404, in-use → 409 with relation names, no references → delete.
- New Playwright spec (`e2e/domain-management.spec.ts`) covers: admin creates a fresh domain and deletes it; Delete is disabled and labeled "In use by …" for the seeded `Engineering` domain; hiring leads do not see the Domains section.

## Test plan
- [ ] CI: `test.yml` (Vitest + Playwright) green
- [ ] CI: `build-check.yml`, `migration-check.yml`, `codeql.yml` green
- [ ] Manual: as admin, create + delete a domain; confirm Delete is disabled for any seeded in-use domain with a tooltip listing the blocking relations
- [ ] Manual: as a hiring lead (non-admin), confirm the Domains section is not rendered

🤖 Generated with [Claude Code](https://claude.com/claude-code)