### PR TITLE
Fix #210: scope preview deploys to PRs targeting dev

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -3,6 +3,7 @@ name: PR Preview Deploy
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+    branches: [dev]
 
 concurrency:
   group: preview-pr-${{ github.event.pull_request.number }}

--- a/.github/workflows/preview-teardown.yml
+++ b/.github/workflows/preview-teardown.yml
@@ -3,6 +3,7 @@ name: PR Preview Teardown
 on:
   pull_request:
     types: [closed]
+    branches: [dev]
 
 concurrency:
   group: preview-pr-${{ github.event.pull_request.number }}


### PR DESCRIPTION
Closes #210.

## Summary

- Adds `branches: [dev]` to the `pull_request` trigger in `preview-deploy.yml` and `preview-teardown.yml` so the preview Neon branch + Fly app workflow only fires for PRs whose base is `dev`.
- Promotion PRs (`dev → staging`, `staging → prod`) no longer spawn previews — saves Neon branches, Fly apps, and CI minutes per promotion.
- Identical two-line diff to what was proposed in [this comment on #210](https://github.com/dali-lab/dali-os/issues/210#issuecomment-4323658212); pushed by a human because the Claude GitHub App lacks the `workflows` permission.

## Test plan

- [ ] Open a throwaway PR targeting a non-`dev` base (e.g. a `dev → staging` promotion PR) and confirm `PR Preview Deploy` does **not** run
- [ ] Open or push to a PR targeting `dev` and confirm `PR Preview Deploy` still runs and posts the preview comment
- [ ] Close a PR targeting `dev` and confirm `PR Preview Teardown` still tears the preview down
- [ ] Close a PR targeting a non-`dev` base and confirm `PR Preview Teardown` does **not** run (nothing to tear down anyway since deploy didn't fire)

🤖 Generated with [Claude Code](https://claude.com/claude-code)