### PR TITLE
Claude workflows: 100-turn cap, issue state labels, auto-merge dev, App-token pushes

### DIFF
--- a/.github/actions/set-claude-label/action.yml
+++ b/.github/actions/set-claude-label/action.yml
@@ -1,0 +1,63 @@
+name: Set Claude state label
+description: >
+  Apply exactly one Claude state label to an issue, removing the others.
+  Idempotent: creates the target label if it doesn't exist yet.
+
+inputs:
+  issue:
+    description: Issue number to label
+    required: true
+  label:
+    description: >
+      Target label. One of:
+      claude-plan-needs-review, claude-implementing,
+      claude-pr-needs-review, claude-failed.
+    required: true
+  github-token:
+    description: Token with issues:write
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        ISSUE: ${{ inputs.issue }}
+        TARGET: ${{ inputs.label }}
+      run: |
+        set -euo pipefail
+
+        # Ensure target label exists in the repo. gh label create exits non-zero
+        # if the label already exists; the `|| true` makes this idempotent.
+        case "$TARGET" in
+          claude-plan-needs-review)
+            COLOR="FBCA04"; DESC="Claude has posted a plan; awaiting /implement or @claude refinement" ;;
+          claude-implementing)
+            COLOR="1D76DB"; DESC="Claude is actively implementing" ;;
+          claude-pr-needs-review)
+            COLOR="0E8A16"; DESC="Claude opened a PR; awaiting reviewer" ;;
+          claude-failed)
+            COLOR="B60205"; DESC="Claude implementation or CI auto-fix failed" ;;
+          *)
+            echo "::error::Unknown target label: $TARGET" >&2
+            exit 1 ;;
+        esac
+        gh label create "$TARGET" \
+          --repo "$GITHUB_REPOSITORY" \
+          --color "$COLOR" \
+          --description "$DESC" 2>/dev/null || true
+
+        # Remove every other claude state label from the issue.
+        for L in claude claude-plan-needs-review claude-implementing claude-pr-needs-review claude-failed; do
+          if [ "$L" != "$TARGET" ]; then
+            gh issue edit "$ISSUE" \
+              --repo "$GITHUB_REPOSITORY" \
+              --remove-label "$L" 2>/dev/null || true
+          fi
+        done
+
+        # Add the target.
+        gh issue edit "$ISSUE" \
+          --repo "$GITHUB_REPOSITORY" \
+          --add-label "$TARGET"

--- a/.github/workflows/claude-auto-merge.yml
+++ b/.github/workflows/claude-auto-merge.yml
@@ -1,0 +1,216 @@
+name: Claude Auto-Merge Dev
+
+# When dev gets new commits, fast-forward / 3-way merge dev into every open
+# Claude PR (head ref `claude/issue-*`) whose linked issue is in
+# `claude-pr-needs-review` state and whose branch is behind dev.
+#
+# - ff-only merge: silent, no comment, no Claude turn used.
+# - clean 3-way merge: silent, just push the merge commit.
+# - conflict: deferred to a matrix job that invokes Claude with a
+#   "resolve mechanically + light refactor" constraint.
+#
+# In-progress / failed Claude PRs are NOT touched (label gate).
+
+on:
+  push:
+    branches: [dev]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: read
+
+concurrency:
+  group: claude-auto-merge
+  cancel-in-progress: false
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    outputs:
+      conflicts: ${{ steps.scan.outputs.conflicts }}
+    steps:
+      - name: Mint App token (so pushes trigger downstream workflows)
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.PROMOTE_APP_ID }}
+          private-key: ${{ secrets.PROMOTE_APP_PRIVATE_KEY }}
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Configure git
+        run: |
+          git config --global user.email "claude[bot]@users.noreply.github.com"
+          git config --global user.name "claude[bot]"
+
+      - name: Find candidate PRs and merge clean ones
+        id: scan
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          git fetch --all --prune
+
+          # Pull all open Claude PRs targeting dev.
+          PRS=$(gh pr list \
+            --repo "$GITHUB_REPOSITORY" \
+            --base dev --state open \
+            --json number,headRefName \
+            --jq '[.[] | select(.headRefName | startswith("claude/issue-")) | "\(.number) \(.headRefName)"]')
+
+          # Persist conflict list across loop body (subshell-safe via tempfile).
+          echo '[]' > /tmp/conflicts.json
+
+          echo "$PRS" | jq -r '.[]' | while IFS= read -r line; do
+            [ -n "$line" ] || continue
+            NUMBER=$(printf '%s' "$line" | awk '{print $1}')
+            HEAD_REF=$(printf '%s' "$line" | awk '{print $2}')
+            ISSUE="${HEAD_REF#claude/issue-}"
+
+            # Issue must be in claude-pr-needs-review.
+            LABELS=$(gh issue view "$ISSUE" \
+              --repo "$GITHUB_REPOSITORY" \
+              --json labels --jq '[.labels[].name]' 2>/dev/null || echo '[]')
+            if [ "$(printf '%s' "$LABELS" | jq 'any(. == "claude-pr-needs-review")')" != "true" ]; then
+              echo "PR #$NUMBER (issue #$ISSUE): not in claude-pr-needs-review, skipping."
+              continue
+            fi
+
+            REMOTE_REF="refs/remotes/origin/$HEAD_REF"
+            if ! git rev-parse --verify "$REMOTE_REF" >/dev/null 2>&1; then
+              echo "PR #$NUMBER: $REMOTE_REF not present after fetch, skipping."
+              continue
+            fi
+
+            # Already up-to-date with dev?
+            if git merge-base --is-ancestor origin/dev "$REMOTE_REF" 2>/dev/null; then
+              echo "PR #$NUMBER: already up-to-date with dev."
+              continue
+            fi
+
+            # Reset workspace cleanly to the PR branch tip.
+            git checkout -B "$HEAD_REF" "$REMOTE_REF" >/dev/null 2>&1
+
+            # 1) Fast-forward (silent, no Claude, no merge commit, no comment).
+            if git merge --ff-only origin/dev >/dev/null 2>&1; then
+              git push origin "$HEAD_REF"
+              echo "PR #$NUMBER: fast-forwarded to dev."
+              continue
+            fi
+
+            # Reset before trying the next strategy.
+            git reset --hard "$REMOTE_REF" >/dev/null
+
+            # 2) Clean 3-way merge with merge commit (silent, no Claude).
+            if git merge --no-edit origin/dev >/dev/null 2>&1; then
+              git push origin "$HEAD_REF"
+              echo "PR #$NUMBER: clean 3-way merge pushed."
+              continue
+            fi
+
+            # Conflict — abort and defer to Claude.
+            git merge --abort >/dev/null 2>&1 || true
+            git reset --hard "$REMOTE_REF" >/dev/null
+            echo "PR #$NUMBER: conflicts; deferring to Claude."
+            jq --arg n "$NUMBER" --arg h "$HEAD_REF" \
+              '. + [{number: ($n | tonumber), headRefName: $h}]' \
+              /tmp/conflicts.json > /tmp/conflicts.json.new
+            mv /tmp/conflicts.json.new /tmp/conflicts.json
+          done
+
+          CONFLICTS=$(jq -c '.' /tmp/conflicts.json)
+          echo "conflicts=$CONFLICTS" >> "$GITHUB_OUTPUT"
+          echo "Conflict PRs: $CONFLICTS"
+
+  resolve:
+    needs: scan
+    if: needs.scan.outputs.conflicts != '[]' && needs.scan.outputs.conflicts != ''
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        pr: ${{ fromJSON(needs.scan.outputs.conflicts) }}
+    concurrency:
+      group: claude-auto-merge-${{ matrix.pr.number }}
+      cancel-in-progress: false
+    steps:
+      - name: Mint App token (so pushes trigger downstream workflows)
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.PROMOTE_APP_ID }}
+          private-key: ${{ secrets.PROMOTE_APP_PRIVATE_KEY }}
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ matrix.pr.headRefName }}
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Configure git
+        run: |
+          git config --global user.email "claude[bot]@users.noreply.github.com"
+          git config --global user.name "claude[bot]"
+
+      - name: Start the merge so Claude sees the conflicts in the worktree
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          git fetch origin dev
+          # Intentionally proceed past non-zero exit — we expect conflicts.
+          git merge --no-commit --no-ff origin/dev || true
+          # Confirm there are conflicts; if not, the scan job's signal is stale —
+          # commit and push the clean merge then exit cleanly.
+          if [ -z "$(git diff --name-only --diff-filter=U)" ]; then
+            git commit --no-edit
+            git push origin "${{ matrix.pr.headRefName }}"
+            echo "RESOLVED_BY=fallback-clean-merge" >> "$GITHUB_ENV"
+          fi
+
+      - uses: anthropics/claude-code-action@v1
+        if: env.RESOLVED_BY != 'fallback-clean-merge'
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            You are resolving merge conflicts on Claude PR #${{ matrix.pr.number }}
+            in ${{ github.repository }} (branch `${{ matrix.pr.headRefName }}`).
+
+            The current worktree is mid-merge: `git merge --no-commit --no-ff origin/dev`
+            has run and conflict markers are present. List the unmerged paths with
+            `git diff --name-only --diff-filter=U`.
+
+            Step 1 — read context:
+              - Read CLAUDE.md.
+              - For each conflicting file, look at the conflict markers, the surrounding code,
+                and (if helpful) `git log --oneline origin/dev..HEAD -- <file>` plus
+                `git log --oneline HEAD..origin/dev -- <file>` to understand the two intents.
+
+            Step 2 — resolve. The constraint is RESOLVE MECHANICALLY + LIGHT REFACTOR ONLY:
+              - Allowed: pick a side, splice both sides, rename a symbol the other side renamed,
+                update an import or a call site so the merged code compiles/typechecks.
+              - Forbidden: deciding between two semantically different behaviors, dropping a
+                feature, changing an API contract, "guessing" what the human meant. If a conflict
+                requires a judgement call, do NOT push. Run `git merge --abort` and instead
+                comment on PR #${{ matrix.pr.number }} explaining:
+                  * which file/lines are ambiguous,
+                  * what each side appears to intend,
+                  * what a human needs to decide.
+
+            Step 3 — if you resolved everything safely:
+              - `cd dali-api && npm install --silent && npm run typecheck` if any TS/TSX file
+                was touched. Fix any new type errors caused by the merge (still under the
+                "light refactor" constraint).
+              - `git add -A`
+              - `git commit --no-edit` (default merge commit message).
+              - `git push origin ${{ matrix.pr.headRefName }}`
+              - Leave a short PR comment summarising which files conflicted and how you resolved
+                each (one line per file).
+
+            Rules:
+              - Do NOT modify `.github/workflows/*`.
+              - Do NOT use `--no-verify`.
+              - Do NOT force-push.
+          claude_args: --model opus --max-turns 100 --allowedTools "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git:*),Bash(gh:*),Bash(npm:*),Bash(npx:*)"

--- a/.github/workflows/claude-ci-fix.yml
+++ b/.github/workflows/claude-ci-fix.yml
@@ -47,6 +47,17 @@ jobs:
       HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
       PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
     steps:
+      - name: Derive issue number from branch
+        id: issue
+        run: |
+          # HEAD_BRANCH is `claude/issue-N`. Extract N for label management.
+          NUM="${HEAD_BRANCH#claude/issue-}"
+          if ! [[ "$NUM" =~ ^[0-9]+$ ]]; then
+            echo "::error::Could not parse issue number from branch '$HEAD_BRANCH'"
+            exit 1
+          fi
+          echo "number=$NUM" >> "$GITHUB_OUTPUT"
+
       - name: Stale-SHA guard
         id: stale
         run: |
@@ -131,7 +142,7 @@ jobs:
           echo "skip=false" >> "$GITHUB_OUTPUT"
 
       - name: Retry-cap check
-        if: steps.stale.outputs.skip != 'true' && steps.lock.outputs.skip != 'true'
+        if: steps.stale.outputs.skip != 'true' && steps.summary.outputs.failed_count != '0' && steps.lock.outputs.skip != 'true'
         id: retry
         run: |
           # Count existing claude-ci-attempts sentinels on the PR.
@@ -145,6 +156,7 @@ jobs:
             BODY=$(printf '<!-- claude-ci-cap-hit -->\nHit the auto-fix retry cap (3 attempts). Handing back for human review.')
             gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" -f body="$BODY" > /dev/null
             echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "cap_hit=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           BODY=$(printf '<!-- claude-ci-attempts -->\nAttempt %d of 3.' "$NEXT")
@@ -152,22 +164,48 @@ jobs:
           echo "skip=false" >> "$GITHUB_OUTPUT"
           echo "attempt_num=$NEXT" >> "$GITHUB_OUTPUT"
 
+      - name: Mark issue claude-failed (retry cap hit)
+        if: steps.retry.outputs.cap_hit == 'true'
+        env:
+          ISSUE: ${{ steps.issue.outputs.number }}
+        run: |
+          set -euo pipefail
+          # Inline (not via composite action) because this step can fire
+          # before the Checkout PR branch step, so the workspace may not
+          # contain the action.yml. Mirrors composite action's behavior.
+          gh label create claude-failed \
+            --repo "$GITHUB_REPOSITORY" \
+            --color "B60205" \
+            --description "Claude implementation or CI auto-fix failed" 2>/dev/null || true
+          for L in claude claude-plan-needs-review claude-implementing claude-pr-needs-review; do
+            gh issue edit "$ISSUE" --repo "$GITHUB_REPOSITORY" --remove-label "$L" 2>/dev/null || true
+          done
+          gh issue edit "$ISSUE" --repo "$GITHUB_REPOSITORY" --add-label claude-failed
+
+      - name: Mint App token (so pushes trigger downstream workflows)
+        if: steps.stale.outputs.skip != 'true' && steps.summary.outputs.failed_count != '0' && steps.lock.outputs.skip != 'true' && steps.retry.outputs.skip != 'true'
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.PROMOTE_APP_ID }}
+          private-key: ${{ secrets.PROMOTE_APP_PRIVATE_KEY }}
+
       - name: Checkout PR branch
-        if: steps.stale.outputs.skip != 'true' && steps.lock.outputs.skip != 'true' && steps.retry.outputs.skip != 'true'
+        if: steps.stale.outputs.skip != 'true' && steps.summary.outputs.failed_count != '0' && steps.lock.outputs.skip != 'true' && steps.retry.outputs.skip != 'true'
         uses: actions/checkout@v6
         with:
           ref: ${{ env.HEAD_BRANCH }}
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Configure git
-        if: steps.stale.outputs.skip != 'true' && steps.lock.outputs.skip != 'true' && steps.retry.outputs.skip != 'true'
+        if: steps.stale.outputs.skip != 'true' && steps.summary.outputs.failed_count != '0' && steps.lock.outputs.skip != 'true' && steps.retry.outputs.skip != 'true'
         run: |
           git config --global user.email "claude[bot]@users.noreply.github.com"
           git config --global user.name "claude[bot]"
 
       - name: Gather failing logs
-        if: steps.stale.outputs.skip != 'true' && steps.lock.outputs.skip != 'true' && steps.retry.outputs.skip != 'true'
+        if: steps.stale.outputs.skip != 'true' && steps.summary.outputs.failed_count != '0' && steps.lock.outputs.skip != 'true' && steps.retry.outputs.skip != 'true'
         id: logs
         run: |
           mkdir -p /tmp/claude-logs
@@ -186,7 +224,7 @@ jobs:
           ls -la /tmp/claude-logs/
 
       - name: Build prompt
-        if: steps.stale.outputs.skip != 'true' && steps.lock.outputs.skip != 'true' && steps.retry.outputs.skip != 'true'
+        if: steps.stale.outputs.skip != 'true' && steps.summary.outputs.failed_count != '0' && steps.lock.outputs.skip != 'true' && steps.retry.outputs.skip != 'true'
         id: prompt
         run: |
           {
@@ -237,8 +275,23 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - uses: anthropics/claude-code-action@v1
-        if: steps.stale.outputs.skip != 'true' && steps.lock.outputs.skip != 'true' && steps.retry.outputs.skip != 'true'
+        if: steps.stale.outputs.skip != 'true' && steps.summary.outputs.failed_count != '0' && steps.lock.outputs.skip != 'true' && steps.retry.outputs.skip != 'true'
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: ${{ steps.prompt.outputs.text }}
-          claude_args: --model sonnet --max-turns 40 --allowedTools "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git:*),Bash(gh:*),Bash(npm:*),Bash(npx:*)"
+          claude_args: --model sonnet --max-turns 100 --allowedTools "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git:*),Bash(gh:*),Bash(npm:*),Bash(npx:*)"
+
+      - name: Mark issue claude-failed (job step failure)
+        if: failure()
+        env:
+          ISSUE: ${{ steps.issue.outputs.number }}
+        run: |
+          set -euo pipefail
+          gh label create claude-failed \
+            --repo "$GITHUB_REPOSITORY" \
+            --color "B60205" \
+            --description "Claude implementation or CI auto-fix failed" 2>/dev/null || true
+          for L in claude claude-plan-needs-review claude-implementing claude-pr-needs-review; do
+            gh issue edit "$ISSUE" --repo "$GITHUB_REPOSITORY" --remove-label "$L" 2>/dev/null || true
+          done
+          gh issue edit "$ISSUE" --repo "$GITHUB_REPOSITORY" --add-label claude-failed

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -75,7 +75,14 @@ jobs:
             Rules:
               - Do NOT open a PR, push a branch, or modify any files. Comment only.
               - Do NOT modify `.github/workflows/*`.
-          claude_args: --model opus --max-turns 30 --allowedTools "Read,Glob,Grep,LS,Bash(gh:*)"
+          claude_args: --model opus --max-turns 100 --allowedTools "Read,Glob,Grep,LS,Bash(gh:*)"
+      - name: Mark issue claude-plan-needs-review
+        if: success()
+        uses: ./.github/actions/set-claude-label
+        with:
+          issue: ${{ github.event.issue.number }}
+          label: claude-plan-needs-review
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
   refine:
     if: >
@@ -114,7 +121,14 @@ jobs:
             Rules:
               - Do NOT open a PR, push a branch, or modify any files. Comment only.
               - Do NOT modify `.github/workflows/*`.
-          claude_args: --model opus --max-turns 10 --allowedTools "Read,Glob,Grep,LS,Bash(gh:*)"
+          claude_args: --model opus --max-turns 100 --allowedTools "Read,Glob,Grep,LS,Bash(gh:*)"
+      - name: Mark issue claude-plan-needs-review
+        if: success()
+        uses: ./.github/actions/set-claude-label
+        with:
+          issue: ${{ github.event.issue.number }}
+          label: claude-plan-needs-review
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
   implement:
     if: >
@@ -135,6 +149,12 @@ jobs:
           git config --global user.name "claude[bot]"
       - name: Create branch
         run: git checkout -b "claude/issue-${{ github.event.issue.number }}"
+      - name: Mark issue claude-implementing
+        uses: ./.github/actions/set-claude-label
+        with:
+          issue: ${{ github.event.issue.number }}
+          label: claude-implementing
+          github-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -161,7 +181,7 @@ jobs:
               - Target base branch: `dev`.
               - Title: `Fix #${{ github.event.issue.number }}: <short description>`.
               - Body must include `Closes #${{ github.event.issue.number }}` and a link back to your plan comment.
-              - Apply the `claude` label to the PR: `gh pr edit <N> --add-label claude`.
+              - Do NOT add labels to the PR. Issue-level state labels are managed by the workflow.
 
             Rules:
               - Do NOT modify `.github/workflows/*`.
@@ -172,6 +192,39 @@ jobs:
                 issue #${{ github.event.issue.number }} explaining what's
                 blocking you and what options you considered.
           claude_args: --model opus --max-turns 100 --allowedTools "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git:*),Bash(gh:*),Bash(npm:*),Bash(npx:*)"
+      - name: Determine implement outcome
+        id: outcome
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE: ${{ github.event.issue.number }}
+        run: |
+          PR_COUNT=$(gh pr list \
+            --repo "$GITHUB_REPOSITORY" \
+            --head "claude/issue-$ISSUE" \
+            --state open \
+            --json number --jq 'length')
+          if [ "$PR_COUNT" -gt 0 ]; then
+            echo "label=claude-pr-needs-review" >> "$GITHUB_OUTPUT"
+          else
+            # Claude exited cleanly without opening a PR (escape-hatch handoff).
+            # Treat as failure so a human knows to look.
+            echo "label=claude-failed" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Mark issue per implement outcome
+        if: success()
+        uses: ./.github/actions/set-claude-label
+        with:
+          issue: ${{ github.event.issue.number }}
+          label: ${{ steps.outcome.outputs.label }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Mark issue claude-failed (any prior step failed)
+        if: failure()
+        uses: ./.github/actions/set-claude-label
+        with:
+          issue: ${{ github.event.issue.number }}
+          label: claude-failed
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
   respond_review:
     if: >
@@ -180,14 +233,20 @@ jobs:
         (github.event_name == 'pull_request_review_comment' && github.event.action == 'created')
       ) &&
       startsWith(github.event.pull_request.head.ref, 'claude/issue-') &&
-      contains(github.event.pull_request.labels.*.name, 'claude') &&
       github.event.sender.type != 'Bot'
     runs-on: ubuntu-latest
     steps:
+      - name: Mint App token (so pushes trigger downstream workflows)
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.PROMOTE_APP_ID }}
+          private-key: ${{ secrets.PROMOTE_APP_PRIVATE_KEY }}
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ steps.app-token.outputs.token }}
       - name: Configure git
         run: |
           git config --global user.email "claude[bot]@users.noreply.github.com"
@@ -224,4 +283,4 @@ jobs:
               - Do NOT force-push unless rebasing on `dev` is genuinely necessary; if so, explain in the comment.
               - Do NOT modify `.github/workflows/*`.
               - Do NOT use `--no-verify`.
-          claude_args: --model sonnet --max-turns 30 --allowedTools "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git:*),Bash(gh:*),Bash(npm:*),Bash(npx:*)"
+          claude_args: --model sonnet --max-turns 100 --allowedTools "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git:*),Bash(gh:*),Bash(npm:*),Bash(npx:*)"


### PR DESCRIPTION
## Summary
Five changes to the Claude-in-the-loop GitHub workflows.

### 1. Turn caps → 100 everywhere
All Claude-action `--max-turns` raised to 100: `plan`, `refine`, `respond_review`, and `ci-fix`. (`implement` was already at 100.)

### 2. Mutually exclusive issue state labels
Replaces the single \`claude\` label with a 5-state machine on the **issue** (never the PR):

| State | Label | Set by |
|---|---|---|
| Queued | `claude` | Human (existing — triggers plan) |
| Plan posted (or refined) | `claude-plan-needs-review` | plan / refine |
| Implementation running | `claude-implementing` | implement (start) |
| PR open, awaiting reviewer | `claude-pr-needs-review` | implement (success + PR exists) |
| Implementation broken | `claude-failed` | implement (any failure) or ci-fix (failure / cap-hit) |

Managed by a new composite action `.github/actions/set-claude-label/` that's idempotent and self-bootstrapping (creates the target label on first use). Implement also drops the prompt instruction to label the PR — labels live only on the issue now. `respond_review`'s `if:` no longer requires `claude` on the PR; the existing `head.ref` claude/issue-* check is the gate.

### 3. New `.github/workflows/claude-auto-merge.yml`
On push to \`dev\`, scan open Claude PRs whose linked issue is \`claude-pr-needs-review\` and whose branch is behind \`dev\`. Cheapest-first:
- **ff-only**: silent push, no Claude turn used.
- **clean 3-way**: silent push, no Claude turn used.
- **conflict**: deferred to a matrix job that invokes Claude with a *resolve mechanically + light refactor* constraint. Anything requiring a judgement call → \`git merge --abort\` and a handoff comment.

Issues in any other label state (`claude-implementing`, `claude-failed`, etc.) are skipped.

### 4. Bug fix in \`claude-ci-fix.yml\` (the spurious "Attempt N of 3" comments)
The retry-cap step and five downstream steps gated on `steps.lock.outputs.skip != 'true'` but **not** on `steps.summary.outputs.failed_count != '0'`. The `First-mover lock` step is itself gated on `failed_count != '0'`, so when there were no failures it was skipped — and skipped steps emit empty outputs, so `'' != 'true'` evaluated true and the entire chain fired anyway.

Effect on PR #277: every successful watched-workflow completion posted an `Attempt N of 3` sentinel, and the third actually invoked Claude against a green PR (which then posted a confused "all checks passing" comment). Fix: every downstream `if:` now also requires `failed_count != '0'`.

### 5. App-token pushes (so preview-deploy actually fires)
Pushes from `claude.yml` `respond_review`, `claude-ci-fix.yml`, and `claude-auto-merge.yml` now use the existing `PROMOTE_APP_ID` / `PROMOTE_APP_PRIVATE_KEY` GitHub App (already wired for `promote-to-staging.yml`) instead of `GITHUB_TOKEN`. Pushes from `GITHUB_TOKEN` are silently suppressed by GitHub's anti-loop guard, so previously a Claude-pushed commit would not trigger preview-deploy. See PR #277 commit \`cec44a3\` for the symptom.

## Test plan
- [ ] On a throwaway issue, add the \`claude\` label → expect plan to post and label flip to \`claude-plan-needs-review\`.
- [ ] \`@claude please reconsider X\` → expect refined plan, label still \`claude-plan-needs-review\`.
- [ ] \`/implement\` → expect \`claude-implementing\` mid-flight, \`claude-pr-needs-review\` once the PR opens.
- [ ] \`gh issue view N --json labels --jq '.labels[].name | select(startswith(\"claude\"))'\` returns exactly one label at every step.
- [ ] Push something to \`dev\` while the throwaway PR is in \`claude-pr-needs-review\` → expect a clean fast-forward (no comment, no Claude run) or a clean 3-way merge.
- [ ] Force a conflict by editing the same file on \`dev\` and on the PR → expect Claude to resolve and push, OR a handoff comment.
- [ ] Verify Claude's pushes (e.g. from \`respond_review\`) trigger preview-deploy on the PR.
- [ ] Force a CI failure on a Claude PR → expect ci-fix to attempt repair; on cap-hit / error, label flips to \`claude-failed\`. No more spurious \`Attempt N of 3\` posts on green PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)