### PR TITLE
respond_review: only fire on Request Changes reviews

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -4,8 +4,10 @@ name: Claude
 #   1. Add the `claude` label to an issue -> Claude posts an implementation plan.
 #   2. Reply with @claude to refine the plan in-thread.
 #   3. Comment `/implement` on the issue to approve -> Claude opens a PR.
-#   4. When a review or review comment is left on a Claude-owned PR, Claude
-#      addresses it or leaves a comment explaining why it can't.
+#   4. When a "Request Changes" review is submitted on a Claude-owned PR,
+#      Claude flips the PR to draft, addresses the feedback, then flips it
+#      back to ready-for-review. Approvals and bare comments do not fire
+#      respond_review.
 #
 # CI auto-fix lives in claude-ci-fix.yml (separate because it debounces on
 # check-run completion across the whole PR head SHA).
@@ -26,8 +28,6 @@ on:
     types: [created]
   pull_request_review:
     types: [submitted]
-  pull_request_review_comment:
-    types: [created]
 
 permissions:
   contents: write
@@ -228,10 +228,9 @@ jobs:
 
   respond_review:
     if: >
-      (
-        (github.event_name == 'pull_request_review' && github.event.action == 'submitted') ||
-        (github.event_name == 'pull_request_review_comment' && github.event.action == 'created')
-      ) &&
+      github.event_name == 'pull_request_review' &&
+      github.event.action == 'submitted' &&
+      github.event.review.state == 'changes_requested' &&
       startsWith(github.event.pull_request.head.ref, 'claude/issue-') &&
       github.event.sender.type != 'Bot'
     runs-on: ubuntu-latest
@@ -300,11 +299,9 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
-            A reviewer (@${{ github.event.sender.login }}) left feedback on
-            PR #${{ github.event.pull_request.number }} in ${{ github.repository }}
-            (branch `${{ github.event.pull_request.head.ref }}`).
-
-            Event: ${{ github.event_name }}
+            A reviewer (@${{ github.event.sender.login }}) submitted a
+            **Request Changes** review on PR #${{ github.event.pull_request.number }}
+            in ${{ github.repository }} (branch `${{ github.event.pull_request.head.ref }}`).
 
             The workflow has already:
               - Converted the PR to draft.
@@ -317,11 +314,9 @@ jobs:
               - Read `CLAUDE.md`.
               - `gh pr view ${{ github.event.pull_request.number }} --json title,body,headRefName,baseRefName`.
               - `gh pr diff ${{ github.event.pull_request.number }}`.
-              - Fetch the review / review comment itself:
-                - If pull_request_review: `gh api /repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews/${{ github.event.review.id }}`.
-                - If pull_request_review_comment: `gh api /repos/${{ github.repository }}/pulls/comments/${{ github.event.comment.id }}`.
-              - Also fetch all review comments on the PR so you see any inline threads:
-                `gh api /repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments --paginate`.
+              - Read the review body and any inline review comments attached to it:
+                - `gh api /repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews/${{ github.event.review.id }}` (review-level body).
+                - `gh api /repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews/${{ github.event.review.id }}/comments --paginate` (inline comments belonging to this review).
 
             Step 2 — respond. For each distinct review point, choose ONE:
               (a) Make the requested change. Run `cd dali-api && npm run typecheck` if you touched TS files. Commit. Push.


### PR DESCRIPTION
## Summary
Today `respond_review` fires on **any** review submission and on **any** standalone inline comment. That's noisy: an approval, a "looks good!" comment review, or a single nit-pick inline comment all currently boot Claude, flip the PR to draft, and bill turns.

This PR narrows the trigger to: **only when a reviewer submits a "Request Changes" review.**

## Changes
- `on:` — drop `pull_request_review_comment` (`respond_review` was the only consumer).
- `respond_review` `if:` — add `github.event.review.state == 'changes_requested'` and remove the inline-comment branch.
- Prompt — drop the `pull_request_review_comment` branch; read the review's attached inline comments via `/pulls/{n}/reviews/{id}/comments` instead of the PR-wide comments endpoint.
- File-header comment updated to reflect the narrower trigger.

## Behaviour after this lands

| Reviewer action | Before | After |
|---|---|---|
| Submit "Request Changes" review (with or without inline comments) | Claude runs | Claude runs ✓ |
| Submit "Approve" review | Claude runs (wasted) | No-op |
| Submit bare "Comment" review | Claude runs (wasted) | No-op |
| Drop a single inline comment outside of any review | Claude runs (wasted) | No-op |

## Test plan
- [ ] On a Claude PR, submit an "Approve" review → `respond_review` does not fire (no draft, no comment, no Claude turn).
- [ ] Submit a "Comment" review → no fire.
- [ ] Drop a single inline comment without submitting a review → no fire.
- [ ] Submit a "Request Changes" review → flips to draft, posts working comment, Claude responds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)