### PR TITLE
Fix #101 (dev/staging/prod): retry prisma migrate on Neon cold-start flake

### DIFF
--- a/dali-api/fly.dev.toml
+++ b/dali-api/fly.dev.toml
@@ -2,7 +2,10 @@ app = "dali-api-dev"
 primary_region = "iad"
 
 [deploy]
-  release_command = "sh -c 'npx prisma migrate deploy && npx prisma db seed'"
+  # Retry migrate deploy up to 4× with linear backoff to absorb Neon
+  # cold-start latency that intermittently blows Prisma's hardcoded
+  # 10s pg_advisory_lock timeout (P1002). Issue #101.
+  release_command = "sh -c 'n=0; until npx prisma migrate deploy; do n=$((n+1)); [ $n -ge 4 ] && exit 1; sleep $n; done; npx prisma db seed'"
 
 [build.args]
   OMIT_DEV = "false"

--- a/dali-api/fly.prod.toml
+++ b/dali-api/fly.prod.toml
@@ -2,7 +2,10 @@ app = "dali-api-prod"
 primary_region = "iad"
 
 [deploy]
-  release_command = "npx prisma migrate deploy"
+  # Retry migrate deploy up to 4× with linear backoff to absorb Neon
+  # cold-start latency that intermittently blows Prisma's hardcoded
+  # 10s pg_advisory_lock timeout (P1002). Issue #101.
+  release_command = "sh -c 'n=0; until npx prisma migrate deploy; do n=$((n+1)); [ $n -ge 4 ] && exit 1; sleep $n; done'"
 
 [build]
 

--- a/dali-api/fly.staging.toml
+++ b/dali-api/fly.staging.toml
@@ -2,7 +2,10 @@ app = "dali-api-staging"
 primary_region = "iad"
 
 [deploy]
-  release_command = "npx prisma migrate deploy"
+  # Retry migrate deploy up to 4× with linear backoff to absorb Neon
+  # cold-start latency that intermittently blows Prisma's hardcoded
+  # 10s pg_advisory_lock timeout (P1002). Issue #101.
+  release_command = "sh -c 'n=0; until npx prisma migrate deploy; do n=$((n+1)); [ $n -ge 4 ] && exit 1; sleep $n; done'"
 
 [build]
 


### PR DESCRIPTION
Closes the dev/staging/prod legs of #101. Preview was already fixed in PR #79.

## Summary
Mirror the `release_command` retry-with-backoff pattern from `fly.preview.toml` into `fly.dev.toml`, `fly.staging.toml`, and `fly.prod.toml`.

## Why
Prisma's `pg_advisory_lock` acquire has a hardcoded 10-second timeout. Neon's compute can cold-start when no machine has connected recently; the first lock query then pays the warm-up latency, blows the 10s budget, and `prisma migrate deploy` fails with P1002.

This just hit dev on workflow run [25037099514](https://github.com/dali-lab/dali-os/actions/runs/25037099514/job/73331220081):

```
2026-04-28T06:15:14Z Machine started
2026-04-28T06:15:19Z Prisma schema loaded
2026-04-28T06:15:30Z Error: P1002 — pg_advisory_lock timed out (10000ms)
```

Recent dev deploy history: 5 failures → 1 success → 1 failure (the run above). Classic flake — succeeds when the compute happens to be warm from a prior attempt.

The retry loop warms the compute on attempt 1 and lets attempt 2 (or 3 / 4) succeed. Same shape as `fly.preview.toml:9`.

## Pattern

```toml
# dev (keeps the seed)
release_command = "sh -c 'n=0; until npx prisma migrate deploy; do n=$((n+1)); [ $n -ge 4 ] && exit 1; sleep $n; done; npx prisma db seed'"

# staging / prod (migrate-only)
release_command = "sh -c 'n=0; until npx prisma migrate deploy; do n=$((n+1)); [ $n -ge 4 ] && exit 1; sleep $n; done'"
```

4× attempts max, linear backoff (sleep 1s, 2s, 3s between attempts). Total worst-case time before bail: ~6s of sleeps + 4 × 10s of timeouts = ~46s.

## Test plan
- [ ] Merge → next dev push triggers Fly Deploy → migrate either succeeds first-try (warm compute) or retries cleanly. Watch the workflow log for any "until" retry messages.
- [ ] Eventually verify on the next staging promotion (no drift expected; same pattern as preview which has been running this for weeks).
- [ ] Eventually verify on prod promotion same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)