### PR TITLE
Fix dev login on PR preview deploys after #356

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -202,7 +202,7 @@ jobs:
           n=0
           until flyctl secrets set -a "$APP" --stage \
             DATABASE_URL="$DATABASE_URL" \
-            ENABLE_DEV_LOGIN=true \
+            NODE_ENV=development \
             JWT_SECRET="$JWT_SECRET" \
             API_BASE_URL="$URL" \
             GOOGLE_CLIENT_ID="preview-placeholder.apps.googleusercontent.com" \


### PR DESCRIPTION
## Summary
- PR #356 removed the `ENABLE_DEV_LOGIN` escape hatch from `isDevLoginEnabled()`, gating dev login strictly on `NODE_ENV`. This broke `/dev-login` on preview Fly apps which run with `NODE_ENV=production`.
- Replace the now-inert `ENABLE_DEV_LOGIN=true` secret with `NODE_ENV=development` in `preview-deploy.yml` so preview deploys can use dev login again.

## Test plan
- [ ] Verify `/dev-login` works on the next PR preview deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)