### PR TITLE
Fix interview cycle config date submission

### DIFF
--- a/dali-api/app/hiring/routes/lead.cycle.$id.tsx
+++ b/dali-api/app/hiring/routes/lead.cycle.$id.tsx
@@ -11,6 +11,7 @@ import { Settings, Users, Calendar, AlertTriangle, Trash2, Plus, CheckCircle, Ar
 import { formatVersionLabel, buildVersionNumberMap } from "~/lib/formatVersion";
 import { getCycleConfidentialityState } from "~/hiring/lib/confidentiality";
 import { ConfidentialityGate } from "~/hiring/components/ConfidentialityGate";
+import { zonedDayStartUtc } from "~/lib/timezone";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -860,11 +861,25 @@ export default function HiringLeadCycleDetails() {
     if (!cycleId) return
     setConfigSaving(true)
     try {
+      // Anchor the date inputs at midnight in the cycle's timezone — my-availability and slot generation expect this.
+      const toZonedMidnightIso = (ymd: string): string => {
+        const [y, m, d] = ymd.split('-').map(Number)
+        return zonedDayStartUtc(y, m, d, config.timezone).toISOString()
+      }
+      const payload = {
+        ...config,
+        interviewStartDate: config.interviewStartDate
+          ? toZonedMidnightIso(config.interviewStartDate)
+          : config.interviewStartDate,
+        interviewEndDate: config.interviewEndDate
+          ? toZonedMidnightIso(config.interviewEndDate)
+          : config.interviewEndDate,
+      }
       const res = await fetch(`/api/hiring/cycles/${cycleId}/interview-config`, {
         method: 'POST',
         credentials: 'include',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(config),
+        body: JSON.stringify(payload),
       })
       if (res.ok) {
         setConfigSaved(true)


### PR DESCRIPTION
## Summary
- The hiring cycle config form's `<input type="date">` produces `YYYY-MM-DD`, but `/api/hiring/cycles/:id/interview-config` validates with `z.string().datetime({ offset: true })` and rejects it (`Invalid ISO datetime`). Saving has been broken end-to-end.
- `saveConfig()` in `lead.cycle.$id.tsx` now converts both dates with `zonedDayStartUtc(...).toISOString()`, anchoring them to midnight in the cycle's timezone — matching the convention `api.cycles.$cycleId.my-availability.ts` and `scheduling.ts` already rely on.
- No API/schema change; UI-only fix.

## Test plan
- [ ] Open a cycle as hiring lead → set interview start/end dates → click Save and confirm 200 response (no longer 400 `Invalid ISO datetime`).
- [ ] Reload the cycle and confirm the saved dates render correctly in the date inputs.
- [ ] Confirm reviewer availability calendar at `/hiring/reviewer` still clips to the saved window.
- [ ] Sanity-check with a non-ET cycle timezone (e.g., `America/Los_Angeles`) that the stored UTC value resolves to local midnight in that zone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)