### PR TITLE
Fix interview cycle config date submission (#431)

### DIFF
--- a/dali-api/app/components/Layout.tsx
+++ b/dali-api/app/components/Layout.tsx
@@ -14,6 +14,7 @@ import {
   MessageSquare,
   Menu,
   X,
+  BarChart3,
 } from 'lucide-react'
 import { userInitials } from '~/lib/display'
 import { bumpLogoClick, hydrateRetroClass, logConsoleBootBanner } from '~/lib/party'
@@ -103,6 +104,14 @@ export function Layout({ children, user, isHiringLead = false, isAdmin = false, 
       icon: Calendar,
       show: isHiringLead,
       active: path.startsWith('/hiring/lead'),
+      sub: null,
+    },
+    {
+      label: 'Analytics',
+      to: '/hiring/analytics',
+      icon: BarChart3,
+      show: isHiringLead || isDomainLead,
+      active: path.startsWith('/hiring/analytics'),
       sub: null,
     },
     {

--- a/dali-api/app/components/analytics/ApplicationList.tsx
+++ b/dali-api/app/components/analytics/ApplicationList.tsx
@@ -1,0 +1,69 @@
+export interface ApplicationRow {
+  id: string;
+  applicantName: string;
+  status: string;
+  statusLabel: string;
+  domain: string;
+  reviewers: string[];
+  interviewers: string[];
+}
+
+interface Props {
+  rows: ApplicationRow[];
+  selectedStatusLabel: string | null;
+  selectedDomainName: string | null;
+}
+
+export function ApplicationList({ rows, selectedStatusLabel, selectedDomainName }: Props) {
+  const heading = selectedStatusLabel
+    ? `${selectedStatusLabel} · ${selectedDomainName ?? "All Domains"}`
+    : `All Applications · ${selectedDomainName ?? "All Domains"}`;
+
+  return (
+    <div className="bg-card border border-border rounded-lg">
+      <div className="flex items-center justify-between px-4 py-3 border-b border-border">
+        <h3 className="text-sm font-medium text-foreground">{heading}</h3>
+        <span className="text-xs text-muted-foreground">
+          {rows.length} {rows.length === 1 ? "application" : "applications"}
+        </span>
+      </div>
+
+      {rows.length === 0 ? (
+        <div className="px-4 py-8 text-center text-sm text-muted-foreground">
+          {selectedStatusLabel
+            ? "No applications in this category."
+            : "Select a slice of the pie chart to filter, or no applications match the current filter."}
+        </div>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead className="bg-muted/30 text-muted-foreground text-xs uppercase tracking-wide">
+              <tr>
+                <th className="text-left font-medium px-4 py-2">Name</th>
+                <th className="text-left font-medium px-4 py-2">Status</th>
+                <th className="text-left font-medium px-4 py-2">Domain</th>
+                <th className="text-left font-medium px-4 py-2">Reviewers</th>
+                <th className="text-left font-medium px-4 py-2">Interviewers</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((r) => (
+                <tr key={r.id} className="border-t border-border hover:bg-muted/20">
+                  <td className="px-4 py-2 text-foreground">{r.applicantName}</td>
+                  <td className="px-4 py-2 text-foreground">{r.statusLabel}</td>
+                  <td className="px-4 py-2 text-foreground">{r.domain}</td>
+                  <td className="px-4 py-2 text-muted-foreground">
+                    {r.reviewers.length > 0 ? r.reviewers.join(", ") : "—"}
+                  </td>
+                  <td className="px-4 py-2 text-muted-foreground">
+                    {r.interviewers.length > 0 ? r.interviewers.join(", ") : "—"}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dali-api/app/components/analytics/CycleSelector.tsx
+++ b/dali-api/app/components/analytics/CycleSelector.tsx
@@ -1,0 +1,55 @@
+import { useNavigate, useSearchParams } from "react-router";
+
+interface CycleSelectorProps {
+  cycles: Array<{ id: string; name: string; status: string }>;
+  selectedCycleId: string;
+}
+
+const STATUS_COLORS: Record<string, string> = {
+  Draft: "bg-muted text-foreground/80",
+  Open: "bg-green-100 text-green-700",
+  UnderReview: "bg-yellow-100 text-yellow-700",
+  Completed: "bg-blue-100 text-blue-700",
+};
+
+const STATUS_LABELS: Record<string, string> = {
+  Draft: "Draft",
+  Open: "Open",
+  UnderReview: "Under Review",
+  Completed: "Completed",
+};
+
+export function CycleSelector({ cycles, selectedCycleId }: CycleSelectorProps) {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const selectedCycle = cycles.find((c) => c.id === selectedCycleId);
+
+  function handleChange(e: React.ChangeEvent<HTMLSelectElement>) {
+    const params = new URLSearchParams(searchParams);
+    params.set("cycleId", e.target.value);
+    navigate(`/hiring/analytics?${params.toString()}`);
+  }
+
+  return (
+    <div className="flex items-center gap-3">
+      <select
+        value={selectedCycleId}
+        onChange={handleChange}
+        className="px-3 py-1.5 text-sm border border-border rounded-md bg-card text-foreground focus:outline-none focus:ring-2 focus:ring-blue-500"
+      >
+        {cycles.map((c) => (
+          <option key={c.id} value={c.id}>
+            {c.name}
+          </option>
+        ))}
+      </select>
+      {selectedCycle && (
+        <span
+          className={`inline-flex items-center px-2 py-0.5 text-xs font-medium rounded-full ${STATUS_COLORS[selectedCycle.status] ?? "bg-muted text-foreground/80"}`}
+        >
+          {STATUS_LABELS[selectedCycle.status] ?? selectedCycle.status}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/dali-api/app/components/analytics/DomainToggle.tsx
+++ b/dali-api/app/components/analytics/DomainToggle.tsx
@@ -1,0 +1,45 @@
+import { useNavigate, useSearchParams } from "react-router";
+
+interface Props {
+  domains: Array<{ id: string; name: string }>;
+  selectedDomainId: string | null;
+}
+
+export function DomainToggle({ domains, selectedDomainId }: Props) {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+
+  function select(domainId: string | null) {
+    const params = new URLSearchParams(searchParams);
+    if (domainId === null) params.delete("domain");
+    else params.set("domain", domainId);
+    params.delete("status");
+    navigate(`/hiring/analytics?${params.toString()}`);
+  }
+
+  const options: Array<{ id: string | null; name: string }> = [
+    { id: null, name: "All Domains" },
+    ...domains.map((d) => ({ id: d.id, name: d.name })),
+  ];
+
+  return (
+    <div className="inline-flex rounded-md border border-border bg-card p-0.5">
+      {options.map((opt) => {
+        const active = (opt.id ?? null) === (selectedDomainId ?? null);
+        return (
+          <button
+            key={opt.id ?? "__all__"}
+            onClick={() => select(opt.id)}
+            className={`px-3 py-1.5 text-sm rounded transition-colors ${
+              active
+                ? "bg-accent-teal text-white"
+                : "text-foreground hover:bg-muted/50"
+            }`}
+          >
+            {opt.name}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/dali-api/app/components/analytics/StatusPie.tsx
+++ b/dali-api/app/components/analytics/StatusPie.tsx
@@ -1,0 +1,137 @@
+import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, Legend } from "recharts";
+import { useNavigate, useSearchParams } from "react-router";
+import { useChartColors } from "./useChartColors";
+
+export interface StatusSlice {
+  status: string;
+  label: string;
+  count: number;
+}
+
+interface Props {
+  data: StatusSlice[];
+  selectedStatus: string | null;
+}
+
+function renderSliceLabel(props: any) {
+  const { x, y, label, count, textAnchor } = props;
+  return (
+    <text
+      x={x}
+      y={y}
+      textAnchor={textAnchor}
+      dominantBaseline="central"
+      fontSize={12}
+      fill="var(--color-foreground)"
+    >
+      {`${label}: ${count}`}
+    </text>
+  );
+}
+
+export function StatusPie({ data, selectedStatus }: Props) {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const colors = useChartColors();
+
+  const palette = [
+    colors.teal,
+    colors.coral,
+    colors.green,
+    colors.pink,
+    colors.yellow,
+    colors.coralLight,
+    colors.muted,
+    colors.border,
+  ];
+
+  const colorFor = (status: string, i: number) => {
+    const map: Record<string, string> = {
+      Accepted: colors.green,
+      Rejected: colors.coral,
+      Waitlisted: colors.pink,
+      InvitedToInterview: colors.teal,
+      InterviewScheduled: colors.teal,
+      PostInterviewPending: colors.yellow,
+      Pending: colors.yellow,
+      InProgress: colors.coralLight,
+      ApplicationOpen: colors.muted,
+      Withdrawn: colors.border,
+    };
+    return map[status] ?? palette[i % palette.length];
+  };
+
+  const filtered = data.filter((d) => d.count > 0);
+  const total = filtered.reduce((sum, d) => sum + d.count, 0);
+
+  if (total === 0) {
+    return (
+      <div className="flex items-center justify-center h-96 text-muted-foreground">
+        No applications match the current filter.
+      </div>
+    );
+  }
+
+  function handleClick(slice: StatusSlice) {
+    const params = new URLSearchParams(searchParams);
+    if (selectedStatus === slice.status) params.delete("status");
+    else params.set("status", slice.status);
+    navigate(`/hiring/analytics?${params.toString()}`);
+  }
+
+  return (
+    <ResponsiveContainer width="100%" height={480}>
+      <PieChart>
+        <Pie
+          data={filtered}
+          dataKey="count"
+          nameKey="label"
+          cx="50%"
+          cy="50%"
+          outerRadius={180}
+          label={renderSliceLabel}
+          labelLine={{ stroke: "var(--color-muted-foreground)" }}
+          onClick={(_, idx) => handleClick(filtered[idx])}
+          isAnimationActive={false}
+        >
+          {filtered.map((slice, i) => {
+            const isSelected = selectedStatus === slice.status;
+            const isDimmed = selectedStatus !== null && !isSelected;
+            return (
+              <Cell
+                key={slice.status}
+                fill={colorFor(slice.status, i)}
+                stroke={isSelected ? "#000" : "#fff"}
+                strokeWidth={isSelected ? 3 : 1}
+                opacity={isDimmed ? 0.35 : 1}
+                style={{ cursor: "pointer" }}
+              />
+            );
+          })}
+        </Pie>
+        <Tooltip
+          contentStyle={{
+            backgroundColor: "var(--color-card)",
+            border: "1px solid var(--color-border)",
+            borderRadius: 6,
+            color: "var(--color-foreground)",
+          }}
+          labelStyle={{ color: "var(--color-foreground)" }}
+          itemStyle={{ color: "var(--color-foreground)" }}
+          formatter={((value: any, _name: any, props: any) => [
+            `${value} (${(((value as number) / total) * 100).toFixed(0)}%)`,
+            props.payload.label,
+          ]) as any}
+        />
+        <Legend
+          iconSize={10}
+          wrapperStyle={{ fontSize: 12, cursor: "pointer" }}
+          onClick={(entry: any) => {
+            const slice = filtered.find((s) => s.label === entry.value);
+            if (slice) handleClick(slice);
+          }}
+        />
+      </PieChart>
+    </ResponsiveContainer>
+  );
+}

--- a/dali-api/app/components/analytics/useChartColors.ts
+++ b/dali-api/app/components/analytics/useChartColors.ts
@@ -1,0 +1,18 @@
+import { useMemo } from "react";
+
+export function useChartColors() {
+  return useMemo(() => {
+    const s = getComputedStyle(document.documentElement);
+    const get = (name: string) => s.getPropertyValue(`--color-${name}`).trim();
+    return {
+      teal: get("accent-teal"),
+      coral: get("accent-coral"),
+      coralLight: get("accent-coral-light"),
+      green: get("accent-green"),
+      pink: get("accent-pink"),
+      yellow: get("accent-yellow"),
+      border: get("border"),
+      muted: get("muted-foreground"),
+    };
+  }, []);
+}

--- a/dali-api/app/hiring/routes/analytics.tsx
+++ b/dali-api/app/hiring/routes/analytics.tsx
@@ -1,0 +1,299 @@
+import { redirect, useLoaderData } from "react-router";
+import type { Route } from "./+types/analytics";
+import { prisma } from "~/lib/db";
+import { requireAuth, withAuth } from "~/lib/auth";
+import { getUserRoles } from "~/lib/roles";
+import {
+  inferDomainApplicationStatus,
+  domainApplicationStatusInclude,
+} from "~/hiring/lib/domain-application-status";
+import type { DomainApplicationStatus } from "~/types";
+import { CycleSelector } from "~/components/analytics/CycleSelector";
+import { DomainToggle } from "~/components/analytics/DomainToggle";
+import { StatusPie } from "~/components/analytics/StatusPie";
+import type { StatusSlice } from "~/components/analytics/StatusPie";
+import { ApplicationList } from "~/components/analytics/ApplicationList";
+import type { ApplicationRow } from "~/components/analytics/ApplicationList";
+
+export const meta: Route.MetaFunction = () => [{ title: "Analytics · DALI OS" }];
+
+// Status used in the analytics view. Adds an "InProgress" bucket on top of
+// `DomainApplicationStatus` for domain applications whose owner has never
+// submitted (post-process override; schema unchanged).
+type AnalyticsStatus = DomainApplicationStatus | "InProgress";
+
+const STATUS_LABELS: Record<AnalyticsStatus, string> = {
+  ApplicationOpen: "Application Open",
+  InProgress: "In Progress",
+  Pending: "Pending",
+  InvitedToInterview: "Invited to Interview",
+  InterviewScheduled: "Interview Scheduled",
+  PostInterviewPending: "Post-Interview",
+  Withdrawn: "Withdrawn",
+  Accepted: "Accepted",
+  Rejected: "Rejected",
+  Waitlisted: "Waitlisted",
+};
+
+// Display order for the pie/legend.
+const STATUS_ORDER: AnalyticsStatus[] = [
+  "InProgress",
+  "Pending",
+  "InvitedToInterview",
+  "InterviewScheduled",
+  "PostInterviewPending",
+  "Accepted",
+  "Waitlisted",
+  "Rejected",
+  "Withdrawn",
+  "ApplicationOpen",
+];
+
+export async function loader({ request }: Route.LoaderArgs) {
+  const auth = await requireAuth(request);
+  if (!auth.ok) return withAuth(auth, redirect("/login"));
+
+  const roles = await getUserRoles(auth.user.sub);
+  if (!roles.isHiringLead && !roles.isDomainLead) return withAuth(auth, redirect("/"));
+
+  // Cycles for the selector
+  const allCycles = await prisma.applicationCycle.findMany({
+    include: {
+      statusUpdates: { orderBy: { createdAt: "desc" }, take: 1 },
+    },
+    orderBy: { createdAt: "desc" },
+  });
+
+  const cycles = allCycles.map((c) => ({
+    id: c.id,
+    name: c.name,
+    status: c.statusUpdates[0]?.newStatus ?? "Draft",
+  }));
+
+  if (cycles.length === 0) {
+    return withAuth(auth, {
+      cycles: [],
+      selectedCycleId: "",
+      cycleStatus: "",
+      accessibleDomains: [],
+      selectedDomainId: null,
+      selectedStatus: null,
+      slices: [],
+      rows: [],
+    });
+  }
+
+  const url = new URL(request.url);
+  const requestedCycleId = url.searchParams.get("cycleId");
+  const selectedCycle =
+    (requestedCycleId ? cycles.find((c) => c.id === requestedCycleId) : null) ??
+    cycles.find((c) => ["Open", "UnderReview"].includes(c.status)) ??
+    cycles[0];
+  const cycleId = selectedCycle.id;
+  const cycleStatus = selectedCycle.status as
+    | "Draft"
+    | "Open"
+    | "UnderReview"
+    | "Completed";
+
+  // Domains in this cycle
+  const cycleDomains = await prisma.domainApplicationCycle.findMany({
+    where: { applicationCycleId: cycleId },
+    include: { domain: { select: { id: true, name: true } } },
+  });
+  const allCycleDomains = cycleDomains.map((d) => ({
+    id: d.domain.id,
+    name: d.domain.name,
+  }));
+
+  // Both hiring leads and domain leads see all cycle domains in analytics.
+  const accessibleDomains = allCycleDomains;
+
+  // Domain toggle: ?domain=<id> selects one; absent = all accessible
+  const domainParam = url.searchParams.get("domain");
+  const selectedDomainId =
+    domainParam && accessibleDomains.some((d) => d.id === domainParam)
+      ? domainParam
+      : null;
+
+  const queryDomainIds = selectedDomainId
+    ? [selectedDomainId]
+    : accessibleDomains.map((d) => d.id);
+
+  // Selected pie slice: ?status=<status>
+  const statusParam = url.searchParams.get("status") as AnalyticsStatus | null;
+  const selectedStatus =
+    statusParam && STATUS_ORDER.includes(statusParam) ? statusParam : null;
+
+  // ─── Fetch all selected domain applications with the relations needed
+  //     for both status inference and the list rendering ────────────────
+  const domainApplications = await prisma.domainApplication.findMany({
+    where: {
+      selected: true,
+      challengeVersion: { domainId: { in: queryDomainIds } },
+      application: { applicationCycleId: cycleId },
+    },
+    include: {
+      ...domainApplicationStatusInclude,
+      challengeVersion: {
+        select: { domain: { select: { id: true, name: true } } },
+      },
+      application: {
+        include: {
+          statusUpdates: true,
+          user: { select: { firstName: true, lastName: true } },
+        },
+      },
+      reviews: {
+        select: {
+          id: true,
+          cycleReviewer: {
+            select: {
+              daliMember: { select: { firstName: true, lastName: true } },
+            },
+          },
+        },
+      },
+      interviews: {
+        where: { status: { in: ["Scheduled", "Completed"] } },
+        select: {
+          id: true,
+          assignments: {
+            where: { status: "Active" },
+            select: {
+              cycleInterviewer: {
+                select: {
+                  daliMember: { select: { firstName: true, lastName: true } },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  });
+
+  function fullName(p: { firstName: string | null; lastName: string | null }) {
+    return `${p.firstName ?? ""} ${p.lastName ?? ""}`.trim() || "Unknown";
+  }
+
+  // Build rows + slice counts in one pass.
+  const sliceCounts = new Map<AnalyticsStatus, number>();
+  const allRows: Array<ApplicationRow & { rawStatus: AnalyticsStatus }> = [];
+
+  for (const da of domainApplications) {
+    const baseStatus = inferDomainApplicationStatus(da as any, cycleStatus);
+    const hasSubmitted = da.application.statusUpdates.some(
+      (u) => u.newStatus === "Submitted",
+    );
+
+    // Override: any DA whose application was never submitted is "InProgress"
+    // for analytics purposes, regardless of cycle status.
+    const status: AnalyticsStatus = !hasSubmitted ? "InProgress" : baseStatus;
+
+    sliceCounts.set(status, (sliceCounts.get(status) ?? 0) + 1);
+
+    const reviewerNames = Array.from(
+      new Set(
+        (da as any).reviews.map((r: any) => fullName(r.cycleReviewer.daliMember)),
+      ),
+    ) as string[];
+
+    const interviewerNames = Array.from(
+      new Set(
+        ((da as any).interviews as any[]).flatMap((iv) =>
+          iv.assignments.map((a: any) => fullName(a.cycleInterviewer.daliMember)),
+        ),
+      ),
+    ) as string[];
+
+    allRows.push({
+      id: da.id,
+      applicantName: fullName(da.application.user),
+      status,
+      statusLabel: STATUS_LABELS[status],
+      domain: (da as any).challengeVersion.domain.name,
+      reviewers: reviewerNames,
+      interviewers: interviewerNames,
+      rawStatus: status,
+    });
+  }
+
+  const slices: StatusSlice[] = STATUS_ORDER.map((s) => ({
+    status: s,
+    label: STATUS_LABELS[s],
+    count: sliceCounts.get(s) ?? 0,
+  })).filter((s) => s.count > 0);
+
+  const rows: ApplicationRow[] = (selectedStatus
+    ? allRows.filter((r) => r.rawStatus === selectedStatus)
+    : allRows
+  )
+    .map(({ rawStatus: _r, ...rest }) => rest)
+    .sort((a, b) => a.applicantName.localeCompare(b.applicantName));
+
+  return withAuth(auth, {
+    cycles,
+    selectedCycleId: cycleId,
+    cycleStatus,
+    accessibleDomains,
+    selectedDomainId,
+    selectedStatus,
+    slices,
+    rows,
+  });
+}
+
+export default function AnalyticsDashboard() {
+  const data = useLoaderData<typeof loader>() as any;
+
+  if (!data.cycles || data.cycles.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-64 text-muted-foreground">
+        No hiring cycles found.
+      </div>
+    );
+  }
+
+  const selectedDomainName =
+    data.accessibleDomains.find((d: any) => d.id === data.selectedDomainId)?.name ??
+    null;
+  const selectedSlice = data.slices.find(
+    (s: StatusSlice) => s.status === data.selectedStatus,
+  );
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between flex-wrap gap-3">
+        <h1 className="text-2xl font-bold text-foreground">Analytics</h1>
+        <div className="flex items-center gap-2">
+          {data.accessibleDomains.length > 1 && (
+            <DomainToggle
+              domains={data.accessibleDomains}
+              selectedDomainId={data.selectedDomainId}
+            />
+          )}
+          <CycleSelector cycles={data.cycles} selectedCycleId={data.selectedCycleId} />
+        </div>
+      </div>
+
+      <div className="bg-card border border-border rounded-lg p-4">
+        <div className="flex items-center justify-between mb-2">
+          <h3 className="text-sm font-medium text-muted-foreground">
+            Applications by Status
+          </h3>
+          <span className="text-xs text-muted-foreground">
+            Click a slice to filter the list below
+          </span>
+        </div>
+        <StatusPie data={data.slices} selectedStatus={data.selectedStatus} />
+      </div>
+
+      <ApplicationList
+        rows={data.rows}
+        selectedStatusLabel={selectedSlice?.label ?? null}
+        selectedDomainName={selectedDomainName}
+      />
+    </div>
+  );
+}

--- a/dali-api/app/hiring/routes/lead.cycle.$id.tsx
+++ b/dali-api/app/hiring/routes/lead.cycle.$id.tsx
@@ -11,6 +11,7 @@ import { Settings, Users, Calendar, AlertTriangle, Trash2, Plus, CheckCircle, Ar
 import { formatVersionLabel, buildVersionNumberMap } from "~/lib/formatVersion";
 import { getCycleConfidentialityState } from "~/hiring/lib/confidentiality";
 import { ConfidentialityGate } from "~/hiring/components/ConfidentialityGate";
+import { zonedDayStartUtc } from "~/lib/timezone";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -860,11 +861,25 @@ export default function HiringLeadCycleDetails() {
     if (!cycleId) return
     setConfigSaving(true)
     try {
+      // Anchor the date inputs at midnight in the cycle's timezone — my-availability and slot generation expect this.
+      const toZonedMidnightIso = (ymd: string): string => {
+        const [y, m, d] = ymd.split('-').map(Number)
+        return zonedDayStartUtc(y, m, d, config.timezone).toISOString()
+      }
+      const payload = {
+        ...config,
+        interviewStartDate: config.interviewStartDate
+          ? toZonedMidnightIso(config.interviewStartDate)
+          : config.interviewStartDate,
+        interviewEndDate: config.interviewEndDate
+          ? toZonedMidnightIso(config.interviewEndDate)
+          : config.interviewEndDate,
+      }
       const res = await fetch(`/api/hiring/cycles/${cycleId}/interview-config`, {
         method: 'POST',
         credentials: 'include',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(config),
+        body: JSON.stringify(payload),
       })
       if (res.ok) {
         setConfigSaved(true)

--- a/dali-api/app/routes.ts
+++ b/dali-api/app/routes.ts
@@ -24,6 +24,7 @@ export default [
     route("hiring/cycles/:cycleId/confidentiality", "hiring/routes/cycles.$cycleId.confidentiality.tsx"),
     route("hiring/interviewer", "hiring/routes/interviewer.tsx"),
     route("hiring/interviewer/interview/:interviewId", "hiring/routes/interviewer.interview.$interviewId.tsx"),
+    route("hiring/analytics", "hiring/routes/analytics.tsx"),
 
     // Admin console (top-level, not hiring)
     route("admin-console", "routes/admin-console.tsx"),

--- a/dali-api/package-lock.json
+++ b/dali-api/package-lock.json
@@ -36,6 +36,7 @@
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-router": "7.14.0",
+        "recharts": "^3.8.1",
         "y-indexeddb": "^9.0.12",
         "y-prosemirror": "^1.3.7",
         "yjs": "^13.6.30",
@@ -2921,6 +2922,42 @@
         "react-router": "7.14.0"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@remirror/core-constants": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-3.0.0.tgz",
@@ -4283,7 +4320,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@tailwindcss/node": {
@@ -5143,6 +5185,69 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -5822,6 +5927,15 @@
         "consola": "^3.2.3"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/cluster-key-slot": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
@@ -5976,6 +6090,127 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
@@ -6019,6 +6254,12 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
     "node_modules/dedent": {
@@ -6262,6 +6503,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-toolkit": {
+      "version": "1.46.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.1.tgz",
+      "integrity": "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
+    },
     "node_modules/esbuild": {
       "version": "0.27.7",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
@@ -6350,6 +6601,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/exit-hook": {
       "version": "2.2.1",
@@ -6998,11 +7255,30 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/ioredis": {
       "version": "5.10.1",
@@ -8721,6 +8997,36 @@
         "react": "^19.2.5"
       }
     },
+    "node_modules/react-is": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.5.tgz",
+      "integrity": "sha512-Dn0t8IQhCmeIT3wu+Apm1/YVsJXsGWi6k4sPdnBIdqMVtHtv0IGi6dcpNpNkNac0zB2uUAqNX3MHzN8c+z2rwQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.14.2",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
@@ -8780,6 +9086,36 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/redis-errors": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
@@ -8801,6 +9137,21 @@
         "node": ">=4"
       }
     },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
     "node_modules/remeda": {
       "version": "2.33.4",
       "resolved": "https://registry.npmjs.org/remeda/-/remeda-2.33.4.tgz",
@@ -8819,6 +9170,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
@@ -9299,6 +9656,12 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -9573,6 +9936,28 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/dali-api/package.json
+++ b/dali-api/package.json
@@ -48,6 +48,7 @@
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-router": "7.14.0",
+    "recharts": "^3.8.1",
     "y-indexeddb": "^9.0.12",
     "y-prosemirror": "^1.3.7",
     "yjs": "^13.6.30",


### PR DESCRIPTION
The cycle config form's <input type="date"> emits YYYY-MM-DD, but the interview-config API requires full ISO 8601 with offset. Convert dates in saveConfig() using zonedDayStartUtc so they're anchored at midnight in the cycle's timezone, matching what my-availability and slot generation already expect.