### PR TITLE
Scope reviewer application page to assigned domains

### DIFF
--- a/dali-api/app/hiring/routes/reviewer.application.$id.tsx
+++ b/dali-api/app/hiring/routes/reviewer.application.$id.tsx
@@ -24,37 +24,61 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   const auth = await requireAuth(request)
   if (!auth.ok) return withAuth(auth, redirect('/login'))
 
-  const [application, reviewer, existingReview] = await Promise.all([
-    prisma.application.findUniqueOrThrow({
-      where: { id: params.id },
-      include: {
-        user: true,
-        generalChallengeVersion: true,
-        applicationCycle: {
-          include: {
-            statusUpdates: { orderBy: { createdAt: 'desc' }, take: 1 },
-            generalRubricVersion: { include: { rubric: true } },
-            domains: {
-              include: {
-                rubricVersion: { include: { rubric: true } },
-                domain: true,
-              },
-            },
-          },
-        },
-        domainApplications: {
-          include: {
-            challengeVersion: {
-              include: {
-                domain: true,
-                challenge: true,
-              },
+  const applicationBase = await prisma.application.findUniqueOrThrow({
+    where: { id: params.id },
+    include: {
+      user: true,
+      generalChallengeVersion: true,
+      applicationCycle: {
+        include: {
+          statusUpdates: { orderBy: { createdAt: 'desc' }, take: 1 },
+          generalRubricVersion: { include: { rubric: true } },
+          domains: {
+            include: {
+              rubricVersion: { include: { rubric: true } },
+              domain: true,
             },
           },
         },
       },
-    }),
+    },
+  })
+
+  if (!(await hasCycleAccess(auth.user.sub, applicationBase.applicationCycleId)))
+    throw redirect('/login')
+
+  const confRedirect = await requirePageSignedOrRedirect(
+    auth.user.sub,
+    applicationBase.applicationCycleId,
+    request,
+  )
+  if (confRedirect) return confRedirect
+
+  // Scope domainApplications to only the domains this reviewer is assigned to
+  // for this cycle. Reviewers assigned to one domain should not see that the
+  // applicant also applied to other domains.
+  const cycleReviewers = await prisma.cycleReviewer.findMany({
+    where: {
+      applicationCycleId: applicationBase.applicationCycleId,
+      daliMember: { userId: auth.user.sub },
+    },
+    select: { id: true, domainId: true },
+  })
+  const reviewerDomainIds = cycleReviewers.map((cr) => cr.domainId)
+
+  const [reviewer, domainApplications, existingReview] = await Promise.all([
     prisma.user.findUniqueOrThrow({ where: { id: auth.user.sub } }),
+    prisma.domainApplication.findMany({
+      where: {
+        applicationId: params.id,
+        challengeVersion: { domainId: { in: reviewerDomainIds } },
+      },
+      include: {
+        challengeVersion: {
+          include: { domain: true, challenge: true },
+        },
+      },
+    }),
     prisma.applicationReview.findFirst({
       where: {
         domainApplication: { applicationId: params.id },
@@ -63,15 +87,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     }),
   ])
 
-  if (!(await hasCycleAccess(auth.user.sub, application.applicationCycleId)))
-    throw redirect('/login')
-
-  const confRedirect = await requirePageSignedOrRedirect(
-    auth.user.sub,
-    application.applicationCycleId,
-    request,
-  )
-  if (confRedirect) return confRedirect
+  const application = { ...applicationBase, domainApplications }
 
   // If this reviewer is assigned to a domain on this application but no
   // ApplicationReview row exists yet, create one so the collaborative editors
@@ -80,41 +96,28 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   // there is no save button for these fields (they save via collab sync).
   let review = existingReview
   if (!review) {
-    const member = await prisma.dALIMember.findFirst({
-      where: { userId: auth.user.sub },
-      select: { id: true },
-    })
-    if (member) {
-      const appDomainIds = application.domainApplications.map(
-        (da: any) => da.challengeVersion.domainId,
-      )
-      const cycleReviewer = await prisma.cycleReviewer.findFirst({
+    const cycleReviewer = cycleReviewers.find((cr) =>
+      domainApplications.some((da) => da.challengeVersion.domainId === cr.domainId),
+    )
+    const matchingDa = cycleReviewer
+      ? domainApplications.find(
+          (da) => da.challengeVersion.domainId === cycleReviewer.domainId,
+        )
+      : null
+    if (cycleReviewer && matchingDa) {
+      review = await prisma.applicationReview.upsert({
         where: {
-          daliMemberId: member.id,
-          applicationCycleId: application.applicationCycleId,
-          domainId: { in: appDomainIds },
-        },
-      })
-      const matchingDa = cycleReviewer
-        ? application.domainApplications.find(
-            (da: any) => da.challengeVersion.domainId === cycleReviewer.domainId,
-          )
-        : null
-      if (cycleReviewer && matchingDa) {
-        review = await prisma.applicationReview.upsert({
-          where: {
-            cycleReviewerId_domainApplicationId: {
-              cycleReviewerId: cycleReviewer.id,
-              domainApplicationId: matchingDa.id,
-            },
-          },
-          create: {
+          cycleReviewerId_domainApplicationId: {
             cycleReviewerId: cycleReviewer.id,
             domainApplicationId: matchingDa.id,
           },
-          update: {},
-        })
-      }
+        },
+        create: {
+          cycleReviewerId: cycleReviewer.id,
+          domainApplicationId: matchingDa.id,
+        },
+        update: {},
+      })
     }
   }
 


### PR DESCRIPTION
## Summary
- Reviewers in `reviewer.application.$id.tsx` could previously see in the loader payload that a multi-domain applicant had also applied to domains outside their assignment (the loader fetched every `DomainApplication` on the parent `Application`).
- Loader now looks up the reviewer's `CycleReviewer` rows for this cycle and filters `DomainApplication` to only those domains. The auto-create-review logic was simplified to reuse the already-fetched `cycleReviewers` list (drops a redundant `dALIMember.findFirst`).
- No functional change for the reviewer's own domain — they still see the same application content, scoring, and review they always did. They just no longer learn that the same applicant is in the queue elsewhere.

## Tradeoffs
- One extra round-trip: was 3 parallel queries, now 1 query → 3 parallel queries. Acceptable for the scoping benefit, and the extra query (`cycleReviewer.findMany` by user+cycle) is hot-path cheap.

## Test plan
- [ ] Reviewer assigned only to Design opens an application from an applicant who applied to Design + Dev → only the Design `DomainApplication` appears in the page payload and rubric sections.
- [ ] Reviewer assigned to Design + Dev for the same cycle opens that same application → both `DomainApplication`s appear and both rubric sections render.
- [ ] First-time review auto-create still works (no existing `ApplicationReview` row → page loads with editable collab editors).
- [ ] Existing review still loads its scores / recommendation / annotations correctly.
- [ ] Reviewer with no `CycleReviewer` assignment matching any of the applicant's domains gets an empty domainApplications list (existing behavior — they shouldn't be on this page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)