### PR TITLE
Anchor hiring application close deadline to Eastern Time

### DIFF
--- a/dali-api/app/hiring/routes/__tests__/OpenApplicationsConfirmModal.test.tsx
+++ b/dali-api/app/hiring/routes/__tests__/OpenApplicationsConfirmModal.test.tsx
@@ -55,9 +55,12 @@ describe("OpenApplicationsConfirmModal", () => {
       }),
     );
     expect(html).toContain("Applications close:");
-    // toLocaleDateString output varies by env locale, but the year/month
-    // should appear in any common format — assert a stable substring.
+    // toLocaleString output varies by env locale, but the year should appear
+    // in any common format — assert a stable substring.
     expect(html).toMatch(/2026/);
+    // Deadline must be labeled with the Eastern Time zone so leads aren't
+    // misled by a localized rendering that drops the timezone.
+    expect(html).toMatch(/ ET/);
   });
 
   it("renders the dialog with role and aria-labelledby (a11y)", () => {

--- a/dali-api/app/hiring/routes/lead.cycle.$id.tsx
+++ b/dali-api/app/hiring/routes/lead.cycle.$id.tsx
@@ -20,7 +20,10 @@ import { Settings, Users, Calendar, AlertTriangle, Trash2, Plus, CheckCircle, Ar
 import { formatVersionLabel, buildVersionNumberMap } from "~/lib/formatVersion";
 import { getCycleConfidentialityState } from "~/hiring/lib/confidentiality";
 import { ConfidentialityGate } from "~/hiring/components/ConfidentialityGate";
-import { zonedDayStartUtc } from "~/lib/timezone";
+import { zonedDayStartUtc, zonedDayEndUtc, getZonedYMD } from "~/lib/timezone";
+
+const APPLICATION_TZ = "America/New_York";
+const APPLICATION_TZ_LABEL = "ET";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -337,8 +340,10 @@ export async function action({ request, params }: Route.ActionArgs) {
     const closeDate = formData.get("closeDate") as string;
     let parsedClose: Date | null = null;
     if (closeDate) {
-      // Store as end-of-day UTC so the deadline covers the entire selected date
-      parsedClose = new Date(closeDate + "T23:59:59Z");
+      // Deadline is 11:59:59 PM Eastern on the selected date so applicants get
+      // the full day in the lab's local time (not late evening UTC).
+      const [y, m, d] = closeDate.split("-").map(Number);
+      parsedClose = zonedDayEndUtc(y, m, d, APPLICATION_TZ);
     }
     await prisma.applicationCycle.update({
       where: { id: params.id },
@@ -1133,14 +1138,21 @@ export default function HiringLeadCycleDetails() {
         <div className="space-y-6">
           {/* Close Date */}
           <div className="bg-card rounded-xl border border-border shadow-sm p-4 sm:p-6">
-            <h3 className="text-sm font-bold text-foreground/80 mb-3">Application Close Date</h3>
+            <h3 className="text-sm font-bold text-foreground/80 mb-1">Application Close Date</h3>
+            <p className="text-xs text-muted-foreground mb-3">
+              Applications close at 11:59 PM {APPLICATION_TZ_LABEL} (Eastern Time) on the selected date.
+            </p>
             <Form method="post" preventScrollReset className="flex flex-col sm:flex-row sm:items-end gap-3">
               <input type="hidden" name="intent" value="set-close-date" />
               <div className="flex-1">
                 <input
                   type="date"
                   name="closeDate"
-                  defaultValue={cycle?.closeDate ? new Date(cycle.closeDate).toISOString().slice(0, 10) : ''}
+                  defaultValue={(() => {
+                    if (!cycle?.closeDate) return '';
+                    const { year, month, day } = getZonedYMD(new Date(cycle.closeDate), APPLICATION_TZ);
+                    return `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+                  })()}
                   className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm"
                 />
               </div>
@@ -2408,7 +2420,18 @@ export function OpenApplicationsConfirmModal({
           {closeDate && (
             <div className="bg-muted/40 rounded-lg p-3 text-xs">
               <span className="font-medium text-foreground/80">Applications close: </span>
-              <span>{closeDate.toLocaleDateString()}</span>
+              <span>
+                {closeDate.toLocaleString("en-US", {
+                  timeZone: APPLICATION_TZ,
+                  weekday: "short",
+                  month: "short",
+                  day: "numeric",
+                  year: "numeric",
+                  hour: "numeric",
+                  minute: "2-digit",
+                })}{" "}
+                {APPLICATION_TZ_LABEL}
+              </span>
             </div>
           )}
         </div>

--- a/dali-api/app/lib/timezone.ts
+++ b/dali-api/app/lib/timezone.ts
@@ -26,6 +26,27 @@ export function getZonedYMD(
   };
 }
 
+/**
+ * UTC instant corresponding to the last second of `year-month-day` in
+ * `timezone` (i.e. 23:59:59 local). Computed as next-day midnight minus 1s so
+ * DST transition days resolve correctly.
+ */
+export function zonedDayEndUtc(
+  year: number,
+  month: number,
+  day: number,
+  timezone: string,
+): Date {
+  const next = new Date(Date.UTC(year, month - 1, day + 1));
+  const nextStart = zonedDayStartUtc(
+    next.getUTCFullYear(),
+    next.getUTCMonth() + 1,
+    next.getUTCDate(),
+    timezone,
+  );
+  return new Date(nextStart.getTime() - 1000);
+}
+
 /** UTC instant corresponding to local midnight on `year-month-day` in `timezone`. */
 export function zonedDayStartUtc(
   year: number,

--- a/dali-api/app/routes/portal.tsx
+++ b/dali-api/app/routes/portal.tsx
@@ -181,7 +181,7 @@ function formatInterviewLocation(location?: string): string {
 
 function formatDeadline(iso: string): string {
   return new Date(iso).toLocaleDateString("en-US", {
-    timeZone: "UTC",
+    timeZone: "America/New_York",
     weekday: "long",
     month: "long",
     day: "numeric",


### PR DESCRIPTION
## Summary
- Application close dates picked by hiring leads are now stored as 11:59 PM Eastern Time on the selected date instead of 23:59:59 UTC (which fired the deadline at ~7:59 PM ET).
- Lead-facing copy on the cycle setup page and the "Open applications" confirm modal now spell out the deadline in ET (with an "ET" label) so leads aren't relying on an implicit timezone.
- Applicant portal deadline formatter switched from UTC to `America/New_York` so the rendered date stays consistent with the actual close instant near the day boundary.

## Implementation notes
- New `zonedDayEndUtc(year, month, day, tz)` helper in `app/lib/timezone.ts`, computed as next-day-local-midnight minus 1s so DST transition days resolve correctly. Sanity-checked against EDT, EST, and the 2026 spring-forward day.
- `lead.cycle.$id.tsx` action uses `zonedDayEndUtc` to store the close instant; the date input default uses `getZonedYMD` so the picker round-trips through ET (not UTC).
- Existing rows aren't migrated — their stored UTC instant is unchanged, so they still fire at the old time. A hiring lead can re-anchor an active cycle by re-saving the close date in the UI; no DB migration needed for current state.

## Test plan
- [x] `npx vitest run` for cycles / status / OpenApplicationsConfirmModal suites — 19 tests pass
- [x] Added regression assertion in `OpenApplicationsConfirmModal.test.tsx` that the rendered modal contains the `ET` label
- [x] Manual sanity script verifies `zonedDayEndUtc` for EDT (May), EST (Jan), and DST spring-forward (Mar 8 2026)
- [ ] Local smoke: pick a close date as hiring lead, verify the input round-trips and the confirm modal renders "11:59 PM ET" on the selected date
- [ ] Local smoke: applicant portal deadline still shows the picked date when viewed near the close instant

🤖 Generated with [Claude Code](https://claude.com/claude-code)