### PR TITLE
Add extension-notice email for unsubmitted applicants (#467)

### DIFF
--- a/dali-api/app/hiring/lib/__tests__/email-variables.test.ts
+++ b/dali-api/app/hiring/lib/__tests__/email-variables.test.ts
@@ -87,6 +87,7 @@ describe("TEMPLATE_VARIABLES registry shape", () => {
         "decision:InvitedToInterview",
         "decision:Rejected",
         "decision:Waitlisted",
+        "notification:ApplicationExtensionNotice",
         "notification:ApplicationReceived",
         "notification:InterviewCancelledApplicant",
         "notification:InterviewCancelledInterviewer",
@@ -131,6 +132,8 @@ describe("registry/call-site drift guard", () => {
     "decision:Waitlisted": ["firstName", "domain"],
     // api.my-application.ts
     "notification:ApplicationReceived": ["firstName"],
+    // extension-notice.ts
+    "notification:ApplicationExtensionNotice": ["firstName", "originalCloseDate", "newCloseDate"],
     // interview-emails.ts — intersection across cancel, invite, reassignment, location-change
     "notification:InterviewInviteMentor": ["firstName", "domain", "time", "location", "meetingUrl"],
     "notification:InterviewConfirmedApplicant": ["firstName", "domain", "time", "location", "meetingUrl"],

--- a/dali-api/app/hiring/lib/email-variables.ts
+++ b/dali-api/app/hiring/lib/email-variables.ts
@@ -14,6 +14,8 @@ export const TEMPLATE_VARIABLE_DESCRIPTIONS: Record<keyof InterpolationVars, str
   time: "Interview start time, formatted in Eastern Time.",
   location: "Interview location (Pod or online).",
   meetingUrl: "Zoom join URL for online interviews.",
+  originalCloseDate: "The cycle's original close date (pre-extension), formatted in Eastern Time.",
+  newCloseDate: "The cycle's new close date (post-extension), formatted in Eastern Time.",
 };
 
 export type TemplateVariableName = keyof InterpolationVars;
@@ -24,6 +26,8 @@ export const ALL_TEMPLATE_VARIABLES: readonly TemplateVariableName[] = [
   "time",
   "location",
   "meetingUrl",
+  "originalCloseDate",
+  "newCloseDate",
 ];
 
 export type DecisionSlotType = "Rejected" | "InvitedToInterview" | "Accepted" | "Waitlisted";
@@ -52,6 +56,12 @@ export const TEMPLATE_VARIABLES: Record<TemplateSlot, readonly TemplateVariableN
   // {{domain}} is intentionally omitted: an applicant may apply to multiple
   // domains in one go, so a single per-application domain is meaningless.
   "notification:ApplicationReceived": ["firstName"],
+
+  // Deadline-extension nudge — sent to applicants with a draft application
+  // when the original close passes and an extension is in effect. {{domain}}
+  // is omitted for the same reason as ApplicationReceived (a draft can span
+  // multiple domains).
+  "notification:ApplicationExtensionNotice": ["firstName", "originalCloseDate", "newCloseDate"],
 
   // Interview invites — interview-emails sends with full vars.
   "notification:InterviewInviteMentor": ["firstName", "domain", "time", "location", "meetingUrl"],

--- a/dali-api/app/hiring/lib/extension-notice.ts
+++ b/dali-api/app/hiring/lib/extension-notice.ts
@@ -1,0 +1,326 @@
+// Sends the deadline-extension nudge to applicants who started but did not
+// submit before a cycle's original close. Modeled on autoCloseIfExpired in
+// cycles.ts: lazy, idempotent, request-time. There is no scheduler — the
+// trigger fires the first time something hits a request path after the
+// original close has passed.
+//
+// Idempotency has two layers:
+//   1) ApplicationCycle.extensionNoticeSentAt — cycle-level marker. Set the
+//      first time a blast is initiated. Prevents thundering-herd: 50
+//      concurrent loaders all hitting the trigger at once result in exactly
+//      one running the loop (the rest see the marker and bail).
+//   2) CycleNotificationSend rows — per-recipient ledger. Created after a
+//      successful send. The blast loop skips any recipient with an existing
+//      row, so a partial-failure-then-resend cannot duplicate to recipients
+//      who already received the email.
+
+import { prisma } from "~/lib/db";
+import { sendEmail } from "~/lib/gmail";
+import { renderForSlot, notificationSlot } from "./email-variables";
+import { logAuditEvent } from "~/lib/audit";
+
+const GMAIL_USER = "applications@dali.dartmouth.edu";
+
+function formatCloseInstant(d: Date): string {
+  return `${d.toLocaleString("en-US", {
+    timeZone: "America/New_York",
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  })} ET`;
+}
+
+async function getGmailRefreshToken(): Promise<string | null> {
+  const gmailUser = await prisma.user.findUnique({
+    where: { daliEmail: GMAIL_USER },
+    select: { googleRefreshToken: true },
+  });
+  return gmailUser?.googleRefreshToken ?? null;
+}
+
+interface DraftRecipient {
+  applicationId: string;
+  email: string;
+  firstName: string;
+}
+
+// Recipients are applicants in this cycle who:
+//   - have an Application row (one per applicant per cycle, by unique constraint)
+//   - have at least one DomainApplication selected (i.e. they meaningfully
+//     engaged beyond just clicking "Start Application")
+//   - have no Submitted or Withdrawn status update (i.e. still a draft)
+//
+// One Application per applicant means one email per applicant regardless
+// of how many DomainApplications they have.
+async function getDraftRecipients(cycleId: string): Promise<DraftRecipient[]> {
+  const applications = await prisma.application.findMany({
+    where: {
+      applicationCycleId: cycleId,
+      // Skip applicants who never picked a domain — clicked Start, didn't
+      // engage. They aren't really "drafts" in any meaningful sense.
+      domainApplications: { some: { selected: true } },
+      // Exclude any application that has *ever* been Submitted or Withdrawn
+      // (not just whose latest status is Submitted/Withdrawn). Defensive
+      // against future state machines that might re-enter Draft.
+      statusUpdates: {
+        none: { newStatus: { in: ["Submitted", "Withdrawn"] } },
+      },
+    },
+    include: {
+      user: { select: { firstName: true, dartmouthEmail: true, netId: true } },
+    },
+  });
+  const out: DraftRecipient[] = [];
+  for (const app of applications) {
+    const email = app.user.dartmouthEmail ?? (app.user.netId ? `${app.user.netId}@dartmouth.edu` : null);
+    if (!email) continue;
+    out.push({ applicationId: app.id, email, firstName: app.user.firstName });
+  }
+  return out;
+}
+
+interface SendResult {
+  attempted: number;
+  succeeded: number;
+  failed: number;
+  alreadySent: number;
+}
+
+interface BlastContext {
+  cycleId: string;
+  refreshToken: string;
+  binding: { emailTemplateVersion: { subject: string; body: string } };
+  originalCloseDate: Date;
+  closeDate: Date;
+}
+
+// Core sender. Caller is responsible for having validated preflight
+// (gmail token + binding) — those are passed in so we don't double-fetch
+// and to keep the preflight-then-blast contract clear.
+async function blastExtensionNotice(ctx: BlastContext): Promise<SendResult> {
+  const recipients = await getDraftRecipients(ctx.cycleId);
+
+  // Prefetch existing send rows so we skip in-loop without a roundtrip per
+  // recipient. The cycle-level marker prevents concurrent blasts in the
+  // common case, so this snapshot is normally accurate for the duration of
+  // the loop. The post-send create() also acts as a final guard via the
+  // unique constraint — race-loser writes throw and we count as alreadySent.
+  const existing = await prisma.cycleNotificationSend.findMany({
+    where: {
+      applicationCycleId: ctx.cycleId,
+      notificationType: "ApplicationExtensionNotice",
+    },
+    select: { applicationId: true },
+  });
+  const alreadySentIds = new Set(existing.map((r) => r.applicationId));
+
+  const originalCloseDate = formatCloseInstant(ctx.originalCloseDate);
+  const newCloseDate = formatCloseInstant(ctx.closeDate);
+
+  let succeeded = 0;
+  let failed = 0;
+  let alreadySent = 0;
+  for (const r of recipients) {
+    if (alreadySentIds.has(r.applicationId)) {
+      alreadySent++;
+      continue;
+    }
+    try {
+      const { subject, html } = renderForSlot(
+        notificationSlot("ApplicationExtensionNotice"),
+        ctx.binding.emailTemplateVersion,
+        { firstName: r.firstName, originalCloseDate, newCloseDate },
+      );
+      await sendEmail({ refreshToken: ctx.refreshToken, to: r.email, subject, html });
+      try {
+        await prisma.cycleNotificationSend.create({
+          data: {
+            applicationCycleId: ctx.cycleId,
+            notificationType: "ApplicationExtensionNotice",
+            applicationId: r.applicationId,
+          },
+        });
+      } catch (err) {
+        // Unique-constraint race with a concurrent blast — the email did
+        // go out, but treat as already-sent for the counters so the audit
+        // log doesn't claim a "fresh" send.
+        alreadySent++;
+        continue;
+      }
+      succeeded++;
+    } catch (err) {
+      failed++;
+      console.error(`Failed to send extension notice to ${r.email}:`, err);
+    }
+  }
+  return { attempted: recipients.length, succeeded, failed, alreadySent };
+}
+
+// Returns the cycle's send-relevant fields if an extension is currently
+// configured (originalCloseDate set, closeDate after it). Returns null
+// otherwise. Used by both lazy and manual paths to check before claiming.
+async function loadExtensionContext(cycleId: string): Promise<{
+  originalCloseDate: Date;
+  closeDate: Date;
+  extensionNoticeSentAt: Date | null;
+} | null> {
+  const cycle = await prisma.applicationCycle.findUnique({
+    where: { id: cycleId },
+    select: {
+      originalCloseDate: true,
+      closeDate: true,
+      extensionNoticeSentAt: true,
+    },
+  });
+  if (!cycle) return null;
+  if (!cycle.originalCloseDate || !cycle.closeDate) return null;
+  if (cycle.closeDate.getTime() <= cycle.originalCloseDate.getTime()) return null;
+  return {
+    originalCloseDate: cycle.originalCloseDate,
+    closeDate: cycle.closeDate,
+    extensionNoticeSentAt: cycle.extensionNoticeSentAt,
+  };
+}
+
+// Validates gmail token + cycle template binding without writing anything.
+// Returns the validated values for the caller to pass into blast, or null
+// if either is missing — in which case the caller MUST NOT claim the
+// cycle marker (otherwise the auto-fire is permanently disabled until
+// someone manually clears it).
+async function preflight(cycleId: string): Promise<{
+  refreshToken: string;
+  binding: { emailTemplateVersion: { subject: string; body: string } };
+} | null> {
+  const refreshToken = await getGmailRefreshToken();
+  if (!refreshToken) return null;
+  const binding = await prisma.cycleNotificationEmail.findUnique({
+    where: {
+      applicationCycleId_notificationType: {
+        applicationCycleId: cycleId,
+        notificationType: "ApplicationExtensionNotice",
+      },
+    },
+    include: { emailTemplateVersion: true },
+  });
+  if (!binding) return null;
+  return { refreshToken, binding };
+}
+
+/**
+ * Lazy trigger: send the extension-notice blast if the original close has
+ * passed and we haven't already sent. Idempotent — preflight runs first
+ * (so a missing template/token doesn't poison the marker), then a single
+ * atomic `updateMany` claims the right to run the blast.
+ *
+ * Conditions for firing:
+ *   - originalCloseDate is set (i.e. an extension was applied)
+ *   - now > originalCloseDate
+ *   - now < closeDate (extension is still in effect — past it, the regular
+ *     "applications closed" view takes over)
+ *   - extensionNoticeSentAt is null (no prior blast attempt)
+ *   - gmail refresh token is configured AND a template is bound to the slot
+ *
+ * Best-effort: errors are swallowed so loaders never fail because of email.
+ */
+export async function sendExtensionNoticeIfDue(cycleId: string): Promise<void> {
+  try {
+    const ctx = await loadExtensionContext(cycleId);
+    if (!ctx) return;
+    if (ctx.extensionNoticeSentAt) return;
+    const now = Date.now();
+    if (now <= ctx.originalCloseDate.getTime()) return;
+    if (now >= ctx.closeDate.getTime()) return;
+
+    // Preflight BEFORE claim. If gmail token / binding is missing, skip
+    // without setting the marker — the next request can retry once the
+    // lead bound a template (or the gmail user's refresh token was set).
+    // No audit log here: the auto path runs on every loader request, and
+    // a misconfigured cycle would otherwise spam the audit table once per
+    // page load. The manual resend path does log preflight failures.
+    const pf = await preflight(cycleId);
+    if (!pf) return;
+
+    // Atomic claim — only the request that flips the marker from null to
+    // now() proceeds. Concurrent loaders see count === 0 and bail.
+    const claimed = await prisma.applicationCycle.updateMany({
+      where: { id: cycleId, extensionNoticeSentAt: null },
+      data: { extensionNoticeSentAt: new Date() },
+    });
+    if (claimed.count === 0) return;
+
+    const result = await blastExtensionNotice({
+      cycleId,
+      refreshToken: pf.refreshToken,
+      binding: pf.binding,
+      originalCloseDate: ctx.originalCloseDate,
+      closeDate: ctx.closeDate,
+    });
+    await logAuditEvent({
+      action: "email.extension_notice",
+      targetId: cycleId,
+      metadata: { mode: "auto", ...result },
+    });
+  } catch (err) {
+    console.error("sendExtensionNoticeIfDue failed:", err);
+    await logAuditEvent({
+      action: "email.extension_notice",
+      targetId: cycleId,
+      metadata: {
+        mode: "auto",
+        outcome: "error",
+        error: err instanceof Error ? err.message : String(err),
+      },
+    });
+  }
+}
+
+/**
+ * Manual resend triggered from the lead cycle page. Bypasses the marker
+ * idempotency check (so leads can re-send after a partial failure) but
+ * relies on per-recipient `CycleNotificationSend` rows to skip recipients
+ * who already received the email. Still requires preflight — caller gets
+ * an `outcome: "preflight_skipped"` result if gmail/template isn't ready.
+ */
+export async function resendExtensionNotice(cycleId: string): Promise<SendResult & { outcome: "ok" | "no_extension" | "preflight_skipped" }> {
+  const ctx = await loadExtensionContext(cycleId);
+  if (!ctx) {
+    await logAuditEvent({
+      action: "email.extension_notice",
+      targetId: cycleId,
+      metadata: { mode: "manual", outcome: "no_extension" },
+    });
+    return { attempted: 0, succeeded: 0, failed: 0, alreadySent: 0, outcome: "no_extension" };
+  }
+  const pf = await preflight(cycleId);
+  if (!pf) {
+    await logAuditEvent({
+      action: "email.extension_notice",
+      targetId: cycleId,
+      metadata: { mode: "manual", outcome: "preflight_skipped" },
+    });
+    return { attempted: 0, succeeded: 0, failed: 0, alreadySent: 0, outcome: "preflight_skipped" };
+  }
+  // Set the marker so any in-flight or future auto-fire loaders see "already
+  // started" and bail. Doesn't gate the manual path itself — leads can
+  // resend repeatedly to retry failures.
+  await prisma.applicationCycle.update({
+    where: { id: cycleId },
+    data: { extensionNoticeSentAt: new Date() },
+  });
+  const result = await blastExtensionNotice({
+    cycleId,
+    refreshToken: pf.refreshToken,
+    binding: pf.binding,
+    originalCloseDate: ctx.originalCloseDate,
+    closeDate: ctx.closeDate,
+  });
+  await logAuditEvent({
+    action: "email.extension_notice",
+    targetId: cycleId,
+    metadata: { mode: "manual", ...result },
+  });
+  return { ...result, outcome: "ok" };
+}

--- a/dali-api/app/hiring/routes/__tests__/lead.cycle.$id.test.ts
+++ b/dali-api/app/hiring/routes/__tests__/lead.cycle.$id.test.ts
@@ -487,7 +487,7 @@ describe("admin.cycle.$id action — hiring lead overrides", () => {
 
       expect(mockPrisma.applicationCycle.update).toHaveBeenCalledWith({
         where: { id: CYCLE_ID },
-        data: { closeDate: original, originalCloseDate: null },
+        data: { closeDate: original, originalCloseDate: null, extensionNoticeSentAt: null },
       });
     });
 

--- a/dali-api/app/hiring/routes/lead.cycle.$id.tsx
+++ b/dali-api/app/hiring/routes/lead.cycle.$id.tsx
@@ -19,6 +19,7 @@ import { ChallengePreviewModal } from "~/hiring/components/ChallengePreviewModal
 import { Settings, Users, Calendar, AlertTriangle, Trash2, Plus, CheckCircle, ArrowRight, Circle, ChevronRight, X, LayoutDashboard, Eye } from 'lucide-react'
 import { formatVersionLabel, buildVersionNumberMap } from "~/lib/formatVersion";
 import { getCycleConfidentialityState } from "~/hiring/lib/confidentiality";
+import { sendExtensionNoticeIfDue, resendExtensionNotice } from "~/hiring/lib/extension-notice";
 import { ConfidentialityGate } from "~/hiring/components/ConfidentialityGate";
 import { zonedDayStartUtc, zonedDayEndUtc, getZonedYMD } from "~/lib/timezone";
 
@@ -104,6 +105,12 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   const confState = await getCycleConfidentialityState(auth.user.sub, params.id);
   const confidentialityRequired =
     confState.status === "signed" ? null : confState.status;
+
+  // Lazy trigger for the deadline-extension notice blast (idempotent,
+  // best-effort). Mirrors how autoCloseIfExpired runs from the cycle status
+  // loader: leads loading their cycle page will wake up the blast if the
+  // original close has just passed.
+  await sendExtensionNoticeIfDue(params.id!);
 
   const cycleBase = await prisma.applicationCycle.findUniqueOrThrow({
     where: { id: params.id },
@@ -443,9 +450,37 @@ export async function action({ request, params }: Route.ActionArgs) {
     await prisma.applicationCycle.update({
       where: { id: params.id },
       // Snap back to the original deadline; clear the extension marker.
-      data: { closeDate: cycle.originalCloseDate, originalCloseDate: null },
+      // extensionNoticeSentAt is also cleared so a future re-extension can
+      // re-trigger the notice blast.
+      data: {
+        closeDate: cycle.originalCloseDate,
+        originalCloseDate: null,
+        extensionNoticeSentAt: null,
+      },
     });
     return withAuth(auth, redirect(`/hiring/lead/cycle/${params.id}?notice=extension-removed`));
+  }
+
+  if (intent === "resend-extension-notice") {
+    const result = await resendExtensionNotice(params.id!);
+    let notice: string;
+    if (result.outcome === "no_extension") {
+      notice = "extension-notice-no-extension";
+    } else if (result.outcome === "preflight_skipped") {
+      notice = "extension-notice-not-configured";
+    } else if (result.attempted === 0) {
+      notice = "extension-notice-noop";
+    } else if (result.succeeded === 0 && result.alreadySent === result.attempted) {
+      notice = "extension-notice-all-sent";
+    } else if (result.failed > 0) {
+      notice = "extension-notice-partial";
+    } else {
+      notice = "extension-notice-sent";
+    }
+    return withAuth(
+      auth,
+      redirect(`/hiring/lead/cycle/${params.id}?notice=${notice}&sent=${result.succeeded}&failed=${result.failed}&skipped=${result.alreadySent}`),
+    );
   }
 
   if (intent === "set-general-rubric") {
@@ -2558,6 +2593,12 @@ function CloseDateNotice() {
       tone: "warn",
     },
     "extension-removed": { text: "Extension removed — the close date is back to the original.", tone: "ok" },
+    "extension-notice-sent": { text: "Extension notice email sent to applicants who haven't submitted yet.", tone: "ok" },
+    "extension-notice-partial": { text: "Extension notice sent — some recipients failed (see server logs).", tone: "warn" },
+    "extension-notice-noop": { text: "No extension notice sent — no draft applicants in this cycle.", tone: "warn" },
+    "extension-notice-all-sent": { text: "Every draft applicant has already received the extension notice — nothing to resend.", tone: "ok" },
+    "extension-notice-no-extension": { text: "No extension is currently set on this cycle. Set an extension first.", tone: "warn" },
+    "extension-notice-not-configured": { text: "Extension notice not sent — no template is bound to the “Deadline Extension Notice” slot, or the gmail account isn't configured.", tone: "warn" },
   };
   const m = messages[notice];
   if (!m) return null;
@@ -2652,6 +2693,7 @@ function CloseDateCard({ cycle, cycleStatus }: { cycle: any; cycleStatus: string
             extensionMs={extensionMs}
             extensionActive={extensionActive}
             cycleStatus={cycleStatus}
+            extensionNoticeSentAt={cycle?.extensionNoticeSentAt ? new Date(cycle.extensionNoticeSentAt) : null}
           />
         </div>
       )}
@@ -2681,12 +2723,14 @@ function ExtensionSection({
   extensionMs,
   extensionActive,
   cycleStatus,
+  extensionNoticeSentAt,
 }: {
   cycleId: string;
   anchor: Date;
   extensionMs: number;
   extensionActive: boolean;
   cycleStatus: string;
+  extensionNoticeSentAt: Date | null;
 }) {
   const initial = describeExtension(extensionMs);
   const [amount, setAmount] = useState<number>(initial.amount);
@@ -2761,21 +2805,40 @@ function ExtensionSection({
         </div>
       </Form>
       {extensionActive && (
-        <Form
-          method="post"
-          preventScrollReset
-          ref={removeFormRef}
-          className="mt-2"
-          aria-label="Remove deadline extension"
-        >
-          <input type="hidden" name="intent" value="remove-extension" />
-          <button
-            type="submit"
-            className="text-xs text-red-700 hover:text-red-900 underline"
+        <div className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-2">
+          <Form
+            method="post"
+            preventScrollReset
+            aria-label="Resend deadline-extension email to draft applicants"
           >
-            Remove extension
-          </button>
-        </Form>
+            <input type="hidden" name="intent" value="resend-extension-notice" />
+            <button
+              type="submit"
+              className="text-xs font-medium text-blue-700 hover:text-blue-900 underline"
+            >
+              {extensionNoticeSentAt ? "Resend extension notice" : "Send extension notice now"}
+            </button>
+          </Form>
+          {extensionNoticeSentAt && (
+            <span className="text-xs text-muted-foreground">
+              Last sent {formatCloseInstant(extensionNoticeSentAt)}
+            </span>
+          )}
+          <Form
+            method="post"
+            preventScrollReset
+            ref={removeFormRef}
+            aria-label="Remove deadline extension"
+          >
+            <input type="hidden" name="intent" value="remove-extension" />
+            <button
+              type="submit"
+              className="text-xs text-red-700 hover:text-red-900 underline"
+            >
+              Remove extension
+            </button>
+          </Form>
+        </div>
       )}
       {showConfirm && (
         <Modal
@@ -3607,6 +3670,7 @@ function DecisionEmailPicker({ slot, binding, emailTemplates, locked }: {
 
 const NOTIFICATION_EMAIL_SLOTS: ReadonlyArray<{ type: NotificationSlotType; label: string; description: string }> = [
   { type: "ApplicationReceived", label: "Application Received", description: "Sent to the applicant when they first submit their application." },
+  { type: "ApplicationExtensionNotice", label: "Deadline Extension Notice", description: "Sent once to applicants with a draft (unsubmitted) application after the original close passes, when an extension is in effect." },
   { type: "InterviewInviteMentor", label: "Interview Invite (Interviewer)", description: "Sent to the assigned interviewer when an interview is booked or they are reassigned." },
   { type: "InterviewConfirmedApplicant", label: "Interview Confirmed (Applicant)", description: "Sent to the applicant when their interview is booked." },
   { type: "InterviewCancelledApplicant", label: "Interview Cancelled (Applicant)", description: "Sent to the applicant when their interview is cancelled." },

--- a/dali-api/app/lib/audit.ts
+++ b/dali-api/app/lib/audit.ts
@@ -10,6 +10,7 @@ export type AuditAction =
   | "decision.finalize"
   | "decision.release"
   | "email.send"
+  | "email.extension_notice"
   | "confidentiality.sign";
 
 export type AuditEvent = {

--- a/dali-api/app/lib/email.ts
+++ b/dali-api/app/lib/email.ts
@@ -10,6 +10,8 @@ export type InterpolationVars = {
   time?: string;
   location?: string;
   meetingUrl?: string;
+  originalCloseDate?: string;
+  newCloseDate?: string;
 };
 
 export function interpolate(text: string, vars: InterpolationVars): string {
@@ -19,7 +21,9 @@ export function interpolate(text: string, vars: InterpolationVars): string {
     .replace(/\{\{domain\}\}/g, () => vars.domain ?? "")
     .replace(/\{\{time\}\}/g, () => vars.time ?? "")
     .replace(/\{\{location\}\}/g, () => vars.location ?? "")
-    .replace(/\{\{meetingUrl\}\}/g, () => vars.meetingUrl ?? "");
+    .replace(/\{\{meetingUrl\}\}/g, () => vars.meetingUrl ?? "")
+    .replace(/\{\{originalCloseDate\}\}/g, () => vars.originalCloseDate ?? "")
+    .replace(/\{\{newCloseDate\}\}/g, () => vars.newCloseDate ?? "");
 }
 
 // Sanitization is part of the contract: template bodies are user-authored

--- a/dali-api/app/routes/portal.tsx
+++ b/dali-api/app/routes/portal.tsx
@@ -4,6 +4,7 @@ import type { Route } from "./+types/portal";
 import { prisma } from "~/lib/db";
 import { requireAuth, withAuth } from "~/lib/auth";
 import { getActiveCycle } from "~/hiring/lib/cycles";
+import { sendExtensionNoticeIfDue } from "~/hiring/lib/extension-notice";
 import {
   inferDomainApplicationStatus,
   domainApplicationStatusInclude,
@@ -51,6 +52,11 @@ export async function loader({ request }: Route.LoaderArgs) {
     cycleStatus = active.currentStatus as ApplicationCycleStatus;
     closeDate = active.closeDate ? active.closeDate.toISOString() : null;
     originalCloseDate = active.originalCloseDate ? active.originalCloseDate.toISOString() : null;
+    // Lazy trigger for the extension-notice blast — fires the first time a
+    // request hits this loader after the original close has passed (and an
+    // extension is in effect). Idempotent and best-effort (errors swallowed
+    // inside the function so loader latency is the only cost).
+    await sendExtensionNoticeIfDue(active.id);
   } else {
     const recentApp = await prisma.application.findFirst({
       where: { userId: auth.user.sub },
@@ -211,21 +217,25 @@ function formatRemaining(iso: string): { label: string; tone: "urgent" | "warn" 
 // browser's locale/timezone without producing an SSR/CSR text mismatch.
 function DeadlineLine({ closeDate, originalCloseDate }: { closeDate: string; originalCloseDate?: string | null }) {
   const [label, setLabel] = useState<string>("");
+  const [originalLabel, setOriginalLabel] = useState<string>("");
   const [remaining, setRemaining] = useState<{ label: string; tone: "urgent" | "warn" | "ok" } | null>(null);
-  // Tracks whether the original deadline has passed but the extended one
-  // hasn't — only true on the client to avoid SSR/CSR mismatch.
-  const [inExtensionWindow, setInExtensionWindow] = useState(false);
+  // True whenever an extension is configured and the new close hasn't
+  // passed — covers both the pre-original-close window (so applicants don't
+  // see the deadline jump silently) and the post-original-close window.
+  // Only true on the client to avoid SSR/CSR mismatch on the strikethrough.
+  const [showExtension, setShowExtension] = useState(false);
   useEffect(() => {
     setLabel(formatDeadline(closeDate));
+    setOriginalLabel(originalCloseDate ? formatDeadline(originalCloseDate) : "");
     const tick = () => {
       setRemaining(formatRemaining(closeDate));
       if (originalCloseDate) {
         const orig = new Date(originalCloseDate).getTime();
         const close = new Date(closeDate).getTime();
         const now = Date.now();
-        setInExtensionWindow(orig < close && now > orig && now < close);
+        setShowExtension(orig < close && now < close);
       } else {
-        setInExtensionWindow(false);
+        setShowExtension(false);
       }
     };
     tick();
@@ -240,8 +250,18 @@ function DeadlineLine({ closeDate, originalCloseDate }: { closeDate: string; ori
   };
   return (
     <div className={`text-sm mt-2 flex items-center gap-2 flex-wrap ${remaining ? toneStyles[remaining.tone] : "text-muted-foreground"}`}>
-      <span>Applications close on {label}</span>
-      {inExtensionWindow && (
+      <span>
+        Applications close on{" "}
+        {showExtension && originalLabel ? (
+          <>
+            <span className="line-through text-muted-foreground/70 mr-1">{originalLabel}</span>
+            <span className="font-semibold">{label}</span>
+          </>
+        ) : (
+          label
+        )}
+      </span>
+      {showExtension && (
         <span className="text-xs px-2.5 py-0.5 rounded-full font-semibold bg-amber-100 text-amber-800">
           Deadline extended
         </span>

--- a/dali-api/prisma/migrations/20260509130000_add_application_extension_notice/migration.sql
+++ b/dali-api/prisma/migrations/20260509130000_add_application_extension_notice/migration.sql
@@ -1,0 +1,9 @@
+-- Add the notification slot for the deadline-extension nudge that goes out to
+-- draft applicants once the original close passes (and the cycle is still
+-- open via an extension).
+ALTER TYPE "NotificationType" ADD VALUE 'ApplicationExtensionNotice';
+
+-- Idempotency marker for the extension-notice blast. Set when the notice is
+-- sent (lazy trigger or manual resend); cleared when the extension is
+-- removed so re-extending later can re-trigger the notice.
+ALTER TABLE "ApplicationCycle" ADD COLUMN "extensionNoticeSentAt" TIMESTAMP(3);

--- a/dali-api/prisma/migrations/20260509140000_add_cycle_notification_send/migration.sql
+++ b/dali-api/prisma/migrations/20260509140000_add_cycle_notification_send/migration.sql
@@ -1,0 +1,35 @@
+-- Per-recipient send tracking for notification email blasts. A row is
+-- created after a successful send so the resend path can skip recipients
+-- who already received the email — eliminates the duplicate-on-resend
+-- failure mode after a partial blast. Keyed on applicationId (not userId)
+-- because Application is unique per (userId, applicationCycleId), so the
+-- unique constraint also enforces one email per applicant per cycle per
+-- notification type even when the applicant has multiple DomainApplications.
+
+CREATE TABLE "CycleNotificationSend" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "applicationCycleId" TEXT NOT NULL,
+    "notificationType" "NotificationType" NOT NULL,
+    "applicationId" TEXT NOT NULL,
+
+    CONSTRAINT "CycleNotificationSend_pkey" PRIMARY KEY ("id")
+);
+
+-- Prisma auto-generated name; matches the identifier the client expects
+-- (Postgres truncates identifiers to 63 chars).
+CREATE UNIQUE INDEX "CycleNotificationSend_applicationCycleId_notificationType_a_key"
+  ON "CycleNotificationSend"("applicationCycleId", "notificationType", "applicationId");
+
+CREATE INDEX "CycleNotificationSend_applicationCycleId_notificationType_idx"
+  ON "CycleNotificationSend"("applicationCycleId", "notificationType");
+
+ALTER TABLE "CycleNotificationSend"
+  ADD CONSTRAINT "CycleNotificationSend_applicationCycleId_fkey"
+  FOREIGN KEY ("applicationCycleId") REFERENCES "ApplicationCycle"("id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "CycleNotificationSend"
+  ADD CONSTRAINT "CycleNotificationSend_applicationId_fkey"
+  FOREIGN KEY ("applicationId") REFERENCES "Application"("id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/dali-api/prisma/schema.prisma
+++ b/dali-api/prisma/schema.prisma
@@ -94,6 +94,14 @@ model ApplicationCycle {
   // current closeDate.
   originalCloseDate DateTime?
 
+  // Set the first time the extension-notice email blast goes out for this
+  // cycle (either via the lazy trigger after originalCloseDate passes, or
+  // via the lead's manual "resend" button). Stays set across further
+  // extensions so a single cycle can't accidentally double-blast applicants.
+  // Cleared when an extension is removed so a future re-extension can
+  // re-trigger the notice.
+  extensionNoticeSentAt DateTime?
+
   // Rubric for the general application form (reviewers score this alongside
   // the per-domain rubric set on DomainApplicationCycle).
   generalRubricVersionId String?
@@ -111,6 +119,7 @@ model ApplicationCycle {
   delibsSessions    DelibsSession[]
   decisionEmails    CycleDecisionEmail[]
   notificationEmails CycleNotificationEmail[]
+  notificationSends  CycleNotificationSend[]
 
   confidentialityBinding   CycleConfidentialityAgreement?
   confidentialitySignatures ConfidentialityAgreementSignature[]
@@ -155,6 +164,7 @@ model Application {
 
   statusUpdates      ApplicationStatusUpdate[]
   domainApplications DomainApplication[]
+  notificationSends  CycleNotificationSend[]
 
   @@unique([userId, applicationCycleId])
 }
@@ -761,6 +771,7 @@ model CycleDecisionEmail {
 // at any time.
 enum NotificationType {
   ApplicationReceived
+  ApplicationExtensionNotice
   InterviewInviteMentor
   InterviewConfirmedApplicant
   InterviewCancelledApplicant
@@ -778,6 +789,31 @@ model CycleNotificationEmail {
   emailTemplateVersion   EmailTemplateVersion @relation(fields: [emailTemplateVersionId], references: [id])
 
   @@id([applicationCycleId, notificationType])
+}
+
+// Per-recipient send tracking for one-shot notification blasts (today: just
+// ApplicationExtensionNotice). Created after a successful send so the resend
+// path skips recipients who already got the email — eliminates the
+// partial-failure-then-resend duplicate scenario.
+//
+// Keyed on applicationId rather than userId because Application is unique
+// per (userId, applicationCycleId), so this naturally guarantees one row
+// per applicant per cycle per notification type even though an applicant
+// can have multiple DomainApplications.
+model CycleNotificationSend {
+  id        String   @id @default(cuid())
+  createdAt DateTime @default(now())
+
+  applicationCycleId String
+  applicationCycle   ApplicationCycle @relation(fields: [applicationCycleId], references: [id])
+
+  notificationType NotificationType
+
+  applicationId String
+  application   Application @relation(fields: [applicationId], references: [id])
+
+  @@unique([applicationCycleId, notificationType, applicationId])
+  @@index([applicationCycleId, notificationType])
 }
 
 // ─── Audit Logging ───────────────────────────────────────────────────────────

--- a/dali-api/prisma/seed.ts
+++ b/dali-api/prisma/seed.ts
@@ -2637,11 +2637,16 @@ async function main() {
   console.log(`  ${reviewSpecs.length} ApplicationReviews + ${decisionSpecs.length * 3} Decisions + ${interviewBookings.length} booked interviews for Fall 2026`);
 
   // ── Email templates (versioned, keyed by EmailTemplateType) ─────────────────
-  const seedTemplates: { type: 'ApplicationReceived' | 'Rejected' | 'RejectedPostInterview' | 'InvitedToInterview' | 'InterviewInviteMentor' | 'InterviewConfirmedApplicant' | 'InterviewCancelledApplicant' | 'InterviewCancelledInterviewer' | 'InterviewLocationChanged' | 'Waitlisted' | 'Accepted'; subject: string; body: string }[] = [
+  const seedTemplates: { type: 'ApplicationReceived' | 'ApplicationExtensionNotice' | 'Rejected' | 'RejectedPostInterview' | 'InvitedToInterview' | 'InterviewInviteMentor' | 'InterviewConfirmedApplicant' | 'InterviewCancelledApplicant' | 'InterviewCancelledInterviewer' | 'InterviewLocationChanged' | 'Waitlisted' | 'Accepted'; subject: string; body: string }[] = [
     {
       type: 'ApplicationReceived',
       subject: 'We received your DALI application!',
       body: `Hi {{firstName}},\n\nThank you for applying to DALI! We've received your application and our team will be reviewing it over the coming weeks.\n\nWe'll reach out with updates as decisions are made. In the meantime, feel free to reach out to us at applications@dali.dartmouth.edu if you have any questions.\n\nBest,\nThe DALI Team`,
+    },
+    {
+      type: 'ApplicationExtensionNotice',
+      subject: 'DALI application deadline extended — finish your submission',
+      body: `Hi {{firstName}},\n\nWe noticed you started a DALI application but haven't submitted yet. Good news — the application deadline has been extended.\n\nOriginal deadline: {{originalCloseDate}}\nNew deadline: {{newCloseDate}}\n\nLog back into the portal to finish and submit your application before the new deadline. If you have any questions, reach out to us at applications@dali.dartmouth.edu.\n\nBest,\nThe DALI Team`,
     },
     {
       type: 'Rejected',
@@ -2761,7 +2766,7 @@ async function main() {
   }
 
   // Bind Fall 2026 to all NotificationType slots.
-  for (const nt of ['ApplicationReceived', 'InterviewInviteMentor', 'InterviewConfirmedApplicant', 'InterviewCancelledApplicant', 'InterviewCancelledInterviewer', 'InterviewLocationChanged'] as const) {
+  for (const nt of ['ApplicationReceived', 'ApplicationExtensionNotice', 'InterviewInviteMentor', 'InterviewConfirmedApplicant', 'InterviewCancelledApplicant', 'InterviewCancelledInterviewer', 'InterviewLocationChanged'] as const) {
     const version = await prisma.emailTemplateVersion.findFirst({
       where: { templateId: `tmpl_${nt.toLowerCase()}` },
       orderBy: { versionNumber: 'desc' },


### PR DESCRIPTION
* Add extension-notice email for unsubmitted applicants

When a hiring lead extends a cycle's deadline, applicants who have a draft application now receive a one-time email at the original close announcing the extension and nudging them to submit. Idempotent lazy trigger fires from the applicant portal and lead cycle loaders (no scheduler needed), mirroring the existing autoCloseIfExpired pattern. Manual "Resend extension notice" button on the lead cycle page provides a recovery path.

Also fixes the pre-original-close UX: the applicant portal previously showed only the new close date before the original passed, making the deadline appear to silently jump. Now it shows the original date with a strikethrough alongside the new one whenever an extension is configured.



* Register ApplicationExtensionNotice slot in lead notification picker

Without this, the new notification type doesn't appear in the per-cycle template-binding UI, so leads can't pick or change the template.



* Harden extension-notice send: preflight, per-recipient ledger, audit

- Preflight gmail token + cycle template binding BEFORE claiming the cycle marker. Previously a missing token or unbound template would permanently disable the auto-fire because the marker was set first and the blast then no-op'd.
- New CycleNotificationSend table records each successful send keyed on (cycle, notificationType, applicationId). The blast loop skips recipients with an existing row, so a partial-failure-followed-by- resend cannot duplicate emails to recipients who already got one. Application is unique per (user, cycle), so this also enforces one email per applicant regardless of how many DomainApplications they hold.
- Tighter recipient filter: applications with at least one selected DomainApplication and no historical Submitted/Withdrawn status update. Previously included applicants who clicked "Start" but never engaged.
- AuditLog entries on every actual blast (auto + manual) and on manual preflight failures, with succeeded/failed/alreadySent counts. Auto preflight skips are not logged to avoid spamming the audit table.
- Lead resend toast now distinguishes preflight failure, missing extension, all-already-sent, partial, full success.



* Fix migration: match Prisma's truncated index name

Prisma generates a 63-char-truncated unique-index name (`...notificationType_a_key`), and the client looks up the constraint by that exact name. The previous migration declared the full identifier, which Postgres further truncated to `...notificationType_appli` — a mismatch the migration-check workflow flagged as drift.



---------