### PR TITLE
Fix #470: allow ApplicationExtensionNotice in set-notification-email …

### DIFF
--- a/dali-api/app/hiring/routes/__tests__/lead.cycle.$id.test.ts
+++ b/dali-api/app/hiring/routes/__tests__/lead.cycle.$id.test.ts
@@ -503,4 +503,70 @@ describe("admin.cycle.$id action — hiring lead overrides", () => {
       expect(mockPrisma.applicationCycle.update).not.toHaveBeenCalled();
     });
   });
+
+  describe("set-notification-email", () => {
+    const TEMPLATE_VERSION_ID = "tv-1";
+
+    beforeEach(() => {
+      mockPrisma.cycleNotificationEmail = {
+        upsert: vi.fn().mockResolvedValue({}),
+        deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+      };
+    });
+
+    it("upserts an ApplicationExtensionNotice binding when a template is chosen", async () => {
+      // Regression: #470 — the slot was added to the UI in #467 but the action
+      // whitelist was not updated, so saves returned 400 silently.
+      const res = await callAction({
+        intent: "set-notification-email",
+        notificationType: "ApplicationExtensionNotice",
+        emailTemplateVersionId: TEMPLATE_VERSION_ID,
+      });
+
+      expect((res as Response).status).not.toBe(400);
+      expect(mockPrisma.cycleNotificationEmail.upsert).toHaveBeenCalledWith({
+        where: {
+          applicationCycleId_notificationType: {
+            applicationCycleId: CYCLE_ID,
+            notificationType: "ApplicationExtensionNotice",
+          },
+        },
+        update: { emailTemplateVersionId: TEMPLATE_VERSION_ID },
+        create: {
+          applicationCycleId: CYCLE_ID,
+          notificationType: "ApplicationExtensionNotice",
+          emailTemplateVersionId: TEMPLATE_VERSION_ID,
+        },
+      });
+      expect(mockPrisma.cycleNotificationEmail.deleteMany).not.toHaveBeenCalled();
+    });
+
+    it("deletes the ApplicationExtensionNotice binding when the template is cleared", async () => {
+      await callAction({
+        intent: "set-notification-email",
+        notificationType: "ApplicationExtensionNotice",
+        emailTemplateVersionId: "",
+      });
+
+      expect(mockPrisma.cycleNotificationEmail.deleteMany).toHaveBeenCalledWith({
+        where: {
+          applicationCycleId: CYCLE_ID,
+          notificationType: "ApplicationExtensionNotice",
+        },
+      });
+      expect(mockPrisma.cycleNotificationEmail.upsert).not.toHaveBeenCalled();
+    });
+
+    it("rejects an unknown notification type with 400", async () => {
+      const res = await callAction({
+        intent: "set-notification-email",
+        notificationType: "NotARealType",
+        emailTemplateVersionId: TEMPLATE_VERSION_ID,
+      });
+
+      expect((res as Response).status).toBe(400);
+      expect(mockPrisma.cycleNotificationEmail.upsert).not.toHaveBeenCalled();
+      expect(mockPrisma.cycleNotificationEmail.deleteMany).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/dali-api/app/hiring/routes/lead.cycle.$id.tsx
+++ b/dali-api/app/hiring/routes/lead.cycle.$id.tsx
@@ -569,7 +569,7 @@ export async function action({ request, params }: Route.ActionArgs) {
   if (intent === "set-notification-email") {
     const notificationType = formData.get("notificationType") as string;
     const emailTemplateVersionId = (formData.get("emailTemplateVersionId") as string) || null;
-    const validTypes = ["ApplicationReceived", "InterviewInviteMentor", "InterviewConfirmedApplicant", "InterviewCancelledApplicant", "InterviewCancelledInterviewer", "InterviewLocationChanged"] as const;
+    const validTypes = ["ApplicationReceived", "ApplicationExtensionNotice", "InterviewInviteMentor", "InterviewConfirmedApplicant", "InterviewCancelledApplicant", "InterviewCancelledInterviewer", "InterviewLocationChanged"] as const;
     if (!validTypes.includes(notificationType as (typeof validTypes)[number])) {
       return withAuth(auth, new Response(JSON.stringify({ error: "Invalid notification type" }), { status: 400, headers: { "Content-Type": "application/json" } }));
     }


### PR DESCRIPTION
…(#471)

The hiring lead UI exposes a Deadline Extension Notice slot (added in #467), but the action handler's validTypes whitelist omitted ApplicationExtensionNotice, so saves returned 400 silently and the template assignment never persisted. The Prisma enum and the slot list already include the type — only the validation tuple was out of sync.

Adds the type to the whitelist and locks the parity with three Vitest cases covering the upsert path, the delete path, and an unknown-type rejection.