### PR TITLE
Hide deselected domain applications and validate required questions on submit

### DIFF
--- a/dali-api/app/hiring/routes/domain-lead.delibs.$id.tsx
+++ b/dali-api/app/hiring/routes/domain-lead.delibs.$id.tsx
@@ -52,6 +52,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 
   const domainApplications = await prisma.domainApplication.findMany({
     where: {
+      selected: true,
       challengeVersion: { domainId: session.domainId },
       application: {
         applicationCycleId: session.applicationCycleId,

--- a/dali-api/app/hiring/routes/domain-lead.tsx
+++ b/dali-api/app/hiring/routes/domain-lead.tsx
@@ -85,7 +85,7 @@ export async function loader({ request }: Route.LoaderArgs) {
               user: true,
               statusUpdates: { orderBy: { createdAt: "desc" }, take: 1 },
               domainApplications: {
-                where: { challengeVersion: { domainId: assignment.domainId } },
+                where: { selected: true, challengeVersion: { domainId: assignment.domainId } },
                 include: {
                   challengeVersion: { include: { domain: true } },
                   reviews: {

--- a/dali-api/app/hiring/routes/lead.cycle.$id.tsx
+++ b/dali-api/app/hiring/routes/lead.cycle.$id.tsx
@@ -130,6 +130,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
           user: true,
           statusUpdates: { orderBy: { createdAt: "desc" }, take: 1 },
           domainApplications: {
+            where: { selected: true },
             include: { challengeVersion: { include: { domain: true } } },
           },
         },

--- a/dali-api/app/hiring/routes/reviewer.application.$id.tsx
+++ b/dali-api/app/hiring/routes/reviewer.application.$id.tsx
@@ -72,6 +72,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     prisma.domainApplication.findMany({
       where: {
         applicationId: params.id,
+        selected: true,
         challengeVersion: { domainId: { in: reviewerDomainIds } },
       },
       include: {

--- a/dali-api/app/routes/__tests__/portal.apply.test.ts
+++ b/dali-api/app/routes/__tests__/portal.apply.test.ts
@@ -240,6 +240,62 @@ describe("POST /portal/apply (submit) word-count validation", () => {
   });
 });
 
+describe("POST /portal/apply (submit) required-question validation", () => {
+  it("rejects submission when a selected domain has unanswered required questions", async () => {
+    mockPrisma.application.findUnique.mockResolvedValue({
+      generalChallengeVersion: { questions: generalQuestions },
+    });
+    mockPrisma.domainApplication.findMany.mockResolvedValue([
+      {
+        id: DA_ID,
+        selected: true,
+        challengeVersion: { domainId: "domain-x", questions: domainQuestions },
+      },
+    ]);
+
+    const res = await action({
+      request: makeSubmitRequest({
+        answers: { story: "fine", name: "Ada" },
+        domainAnswers: [{ domainApplicationId: DA_ID, answers: {} }],
+        selectedDomainIds: ["domain-x"],
+      }),
+      params: {},
+      context: {},
+    } as any);
+
+    expect((res as any).error).toMatch(/required questions/i);
+    expect(mockPrisma.application.update).not.toHaveBeenCalled();
+    expect(mockPrisma.domainApplication.update).not.toHaveBeenCalled();
+    expect(mockPrisma.applicationStatusUpdate.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects submission when selected domain is omitted from domainAnswers entirely", async () => {
+    mockPrisma.application.findUnique.mockResolvedValue({
+      generalChallengeVersion: { questions: generalQuestions },
+    });
+    mockPrisma.domainApplication.findMany.mockResolvedValue([
+      {
+        id: DA_ID,
+        selected: true,
+        challengeVersion: { domainId: "domain-x", questions: domainQuestions },
+      },
+    ]);
+
+    const res = await action({
+      request: makeSubmitRequest({
+        answers: { story: "fine", name: "Ada" },
+        domainAnswers: [],
+        selectedDomainIds: ["domain-x"],
+      }),
+      params: {},
+      context: {},
+    } as any);
+
+    expect((res as any).error).toMatch(/required questions/i);
+    expect(mockPrisma.applicationStatusUpdate.create).not.toHaveBeenCalled();
+  });
+});
+
 // ─── create-draft / update-domains (multi-challenge support) ────────────────
 
 const CYCLE_ID = "cycle-1";

--- a/dali-api/app/routes/portal.apply.tsx
+++ b/dali-api/app/routes/portal.apply.tsx
@@ -350,9 +350,10 @@ export async function action({ request }: Route.ActionArgs) {
       url: string;
       type: "github_url" | "figma_url" | "drive_url";
     }[];
+    const selectedDomainIds = JSON.parse(formData.get("selectedDomainIds") as string) as string[];
 
-    // Validate word limits server-side before any writes. Trust the questions
-    // from the ChallengeVersion record, not anything in the request payload.
+    // Validate server-side before any writes. Trust the questions from the
+    // ChallengeVersion record, not anything in the request payload.
     const application = await prisma.application.findUnique({
       where: { id: applicationId },
       select: {
@@ -366,27 +367,54 @@ export async function action({ request }: Route.ActionArgs) {
     const generalQuestions =
       (application.generalChallengeVersion.questions as unknown as Question[]) ?? [];
 
-    const domainApps = domainAnswers.length
-      ? await prisma.domainApplication.findMany({
-          where: { id: { in: domainAnswers.map(da => da.domainApplicationId) } },
-          select: {
-            id: true,
-            challengeVersion: { select: { questions: true } },
-          },
-        })
-      : [];
+    const allDas = await prisma.domainApplication.findMany({
+      where: { applicationId },
+      include: {
+        challengeVersion: { select: { domainId: true, questions: true } },
+      },
+    });
 
     const wordCountErrors: Record<string, WordCountViolation> = {
       ...validateWordLimits(generalQuestions, answers),
     };
     for (const da of domainAnswers) {
-      const dbDa = domainApps.find(d => d.id === da.domainApplicationId);
+      const dbDa = allDas.find(d => d.id === da.domainApplicationId);
       if (!dbDa) continue;
       const questions = (dbDa.challengeVersion.questions as unknown as Question[]) ?? [];
       Object.assign(wordCountErrors, validateWordLimits(questions, da.answers));
     }
     if (Object.keys(wordCountErrors).length > 0) {
       return withAuth(auth, { wordCountErrors });
+    }
+
+    // Required-question validation. Client gates the review modal on this, but
+    // we re-check server-side so the DB cannot end up with a submitted-but-empty
+    // domain via a stale state, manual replay, or future refactor that loosens
+    // the client gate.
+    const missingRequired: string[] = [];
+    for (const q of generalQuestions) {
+      if (q.required && !isAnswered(answers[q.key], q)) {
+        missingRequired.push(q.data.label || q.key);
+      }
+    }
+    for (const domainId of selectedDomainIds) {
+      const dbDa = allDas.find(d => d.challengeVersion.domainId === domainId);
+      if (!dbDa) {
+        missingRequired.push(`selected domain has no application record`);
+        continue;
+      }
+      const questions = (dbDa.challengeVersion.questions as unknown as Question[]) ?? [];
+      const submitted = domainAnswers.find(da => da.domainApplicationId === dbDa.id)?.answers ?? {};
+      for (const q of questions) {
+        if (q.required && !isAnswered(submitted[q.key], q)) {
+          missingRequired.push(q.data.label || q.key);
+        }
+      }
+    }
+    if (missingRequired.length > 0) {
+      return withAuth(auth, {
+        error: `Please answer all required questions before submitting (${missingRequired.length} unanswered).`,
+      });
     }
 
     // Save final answers
@@ -403,11 +431,6 @@ export async function action({ request }: Route.ActionArgs) {
     }
 
     // Persist final domain selection state
-    const selectedDomainIds = JSON.parse(formData.get("selectedDomainIds") as string) as string[];
-    const allDas = await prisma.domainApplication.findMany({
-      where: { applicationId },
-      include: { challengeVersion: { select: { domainId: true } } },
-    });
     const toSelect = allDas.filter(da => selectedDomainIds.includes(da.challengeVersion.domainId!) && !da.selected);
     const toDeselect = allDas.filter(da => !selectedDomainIds.includes(da.challengeVersion.domainId!) && da.selected);
     if (toSelect.length > 0) {
@@ -1210,10 +1233,14 @@ export default function PortalApply() {
     }
   }
 
-  // Handle submit response (urlWarnings, wordCountErrors) — redirects are handled automatically by React Router
+  // Handle submit response (urlWarnings, wordCountErrors, error) — redirects are handled automatically by React Router
   useEffect(() => {
     if (submitFetcher.state === "idle" && submitFetcher.data) {
       setSubmitting(false);
+      if (submitFetcher.data.error) {
+        alert(submitFetcher.data.error);
+        return;
+      }
       if (submitFetcher.data.wordCountErrors) {
         setWordCountErrors(submitFetcher.data.wordCountErrors);
         setTimeout(() => warningBannerRef.current?.scrollIntoView({ behavior: "smooth", block: "nearest" }), 50);


### PR DESCRIPTION
## Summary

Investigating a prod report of an application showing an "empty" domain
application surfaced two related correctness gaps in the apply →
hiring-review path. This PR closes both.

### 1. Hide deselected domains from hiring views

When an applicant deselects a domain mid-application, the server
intentionally keeps the `DomainApplication` row but flips
`selected = false` so answers survive a re-select (per the schema
comment on `DomainApplication.selected`). The applicant-facing loaders
(`portal`, `portal.application`) and `analytics` already filter on
`selected: true`, but four hiring-side loaders did not, so deselected
domains kept appearing in the lead/reviewer UIs:

- `app/hiring/routes/lead.cycle.$id.tsx`
- `app/hiring/routes/domain-lead.tsx`
- `app/hiring/routes/domain-lead.delibs.$id.tsx`
- `app/hiring/routes/reviewer.application.$id.tsx`

All four now scope `domainApplications` to `selected: true`.

### 2. Server-side required-question validation on submit

The submit action only validated word limits server-side; required
questions were enforced solely by the client's review-modal gate. That
means a selected-but-empty domain could reach the DB through a stale
client state, a manual replay, or a future client refactor that loosens
the gate — which is consistent with the prod row that prompted this
investigation (the affected domain has required questions, so the gate
*should* have caught it).

The submit action now re-checks every selected domain (and the general
form) against the required questions on the picked `ChallengeVersion`,
returning a generic `error` field that the client surfaces via alert.
This is defense-in-depth: the client gate continues to be the primary
UX, and submissions that satisfy it stay unaffected.

## Test plan

- [x] `npm test` — full suite (645 → 647 tests, all passing)
- [x] Two new unit tests in `portal.apply.test.ts` cover:
  - selected domain with empty `domainAnswers` payload → rejected
  - selected domain omitted from `domainAnswers` entirely → rejected
- [ ] Manual: deselect a partially-filled domain, submit with another, confirm the deselected one no longer appears in the lead cycle view, domain-lead view, delibs board, or reviewer view.
- [ ] Manual: leave a required field blank in a selected domain, attempt to bypass the client gate (e.g., DevTools), confirm the server rejects with a clear message.

## Notes for the existing prod row

This fix is forward-only. Existing rows in the offending state will be
hidden from the hiring UI by change (1) if the applicant in question
deselected the domain — which is the most likely path. If the row has
`selected: true` with empty answers, it'll need a one-off DB cleanup;
happy to follow up with a query once we look at the actual row.