### PR TITLE
Hide deselected domain applications and validate required questions o…

### DIFF
--- a/dali-api/app/hiring/routes/domain-lead.delibs.$id.tsx
+++ b/dali-api/app/hiring/routes/domain-lead.delibs.$id.tsx
@@ -52,6 +52,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 
   const domainApplications = await prisma.domainApplication.findMany({
     where: {
+      selected: true,
       challengeVersion: { domainId: session.domainId },
       application: {
         applicationCycleId: session.applicationCycleId,

--- a/dali-api/app/hiring/routes/domain-lead.tsx
+++ b/dali-api/app/hiring/routes/domain-lead.tsx
@@ -85,7 +85,7 @@ export async function loader({ request }: Route.LoaderArgs) {
               user: true,
               statusUpdates: { orderBy: { createdAt: "desc" }, take: 1 },
               domainApplications: {
-                where: { challengeVersion: { domainId: assignment.domainId } },
+                where: { selected: true, challengeVersion: { domainId: assignment.domainId } },
                 include: {
                   challengeVersion: { include: { domain: true } },
                   reviews: {

--- a/dali-api/app/hiring/routes/lead.cycle.$id.tsx
+++ b/dali-api/app/hiring/routes/lead.cycle.$id.tsx
@@ -130,6 +130,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
           user: true,
           statusUpdates: { orderBy: { createdAt: "desc" }, take: 1 },
           domainApplications: {
+            where: { selected: true },
             include: { challengeVersion: { include: { domain: true } } },
           },
         },

--- a/dali-api/app/hiring/routes/reviewer.application.$id.tsx
+++ b/dali-api/app/hiring/routes/reviewer.application.$id.tsx
@@ -72,6 +72,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     prisma.domainApplication.findMany({
       where: {
         applicationId: params.id,
+        selected: true,
         challengeVersion: { domainId: { in: reviewerDomainIds } },
       },
       include: {

--- a/dali-api/app/routes/__tests__/portal.apply.test.ts
+++ b/dali-api/app/routes/__tests__/portal.apply.test.ts
@@ -240,6 +240,62 @@ describe("POST /portal/apply (submit) word-count validation", () => {
   });
 });
 
+describe("POST /portal/apply (submit) required-question validation", () => {
+  it("rejects submission when a selected domain has unanswered required questions", async () => {
+    mockPrisma.application.findUnique.mockResolvedValue({
+      generalChallengeVersion: { questions: generalQuestions },
+    });
+    mockPrisma.domainApplication.findMany.mockResolvedValue([
+      {
+        id: DA_ID,
+        selected: true,
+        challengeVersion: { domainId: "domain-x", questions: domainQuestions },
+      },
+    ]);
+
+    const res = await action({
+      request: makeSubmitRequest({
+        answers: { story: "fine", name: "Ada" },
+        domainAnswers: [{ domainApplicationId: DA_ID, answers: {} }],
+        selectedDomainIds: ["domain-x"],
+      }),
+      params: {},
+      context: {},
+    } as any);
+
+    expect((res as any).error).toMatch(/required questions/i);
+    expect(mockPrisma.application.update).not.toHaveBeenCalled();
+    expect(mockPrisma.domainApplication.update).not.toHaveBeenCalled();
+    expect(mockPrisma.applicationStatusUpdate.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects submission when selected domain is omitted from domainAnswers entirely", async () => {
+    mockPrisma.application.findUnique.mockResolvedValue({
+      generalChallengeVersion: { questions: generalQuestions },
+    });
+    mockPrisma.domainApplication.findMany.mockResolvedValue([
+      {
+        id: DA_ID,
+        selected: true,
+        challengeVersion: { domainId: "domain-x", questions: domainQuestions },
+      },
+    ]);
+
+    const res = await action({
+      request: makeSubmitRequest({
+        answers: { story: "fine", name: "Ada" },
+        domainAnswers: [],
+        selectedDomainIds: ["domain-x"],
+      }),
+      params: {},
+      context: {},
+    } as any);
+
+    expect((res as any).error).toMatch(/required questions/i);
+    expect(mockPrisma.applicationStatusUpdate.create).not.toHaveBeenCalled();
+  });
+});
+
 // ─── create-draft / update-domains (multi-challenge support) ────────────────
 
 const CYCLE_ID = "cycle-1";

--- a/dali-api/app/routes/portal.apply.tsx
+++ b/dali-api/app/routes/portal.apply.tsx
@@ -350,9 +350,10 @@ export async function action({ request }: Route.ActionArgs) {
       url: string;
       type: "github_url" | "figma_url" | "drive_url";
     }[];
+    const selectedDomainIds = JSON.parse(formData.get("selectedDomainIds") as string) as string[];
 
-    // Validate word limits server-side before any writes. Trust the questions
-    // from the ChallengeVersion record, not anything in the request payload.
+    // Validate server-side before any writes. Trust the questions from the
+    // ChallengeVersion record, not anything in the request payload.
     const application = await prisma.application.findUnique({
       where: { id: applicationId },
       select: {
@@ -366,27 +367,54 @@ export async function action({ request }: Route.ActionArgs) {
     const generalQuestions =
       (application.generalChallengeVersion.questions as unknown as Question[]) ?? [];
 
-    const domainApps = domainAnswers.length
-      ? await prisma.domainApplication.findMany({
-          where: { id: { in: domainAnswers.map(da => da.domainApplicationId) } },
-          select: {
-            id: true,
-            challengeVersion: { select: { questions: true } },
-          },
-        })
-      : [];
+    const allDas = await prisma.domainApplication.findMany({
+      where: { applicationId },
+      include: {
+        challengeVersion: { select: { domainId: true, questions: true } },
+      },
+    });
 
     const wordCountErrors: Record<string, WordCountViolation> = {
       ...validateWordLimits(generalQuestions, answers),
     };
     for (const da of domainAnswers) {
-      const dbDa = domainApps.find(d => d.id === da.domainApplicationId);
+      const dbDa = allDas.find(d => d.id === da.domainApplicationId);
       if (!dbDa) continue;
       const questions = (dbDa.challengeVersion.questions as unknown as Question[]) ?? [];
       Object.assign(wordCountErrors, validateWordLimits(questions, da.answers));
     }
     if (Object.keys(wordCountErrors).length > 0) {
       return withAuth(auth, { wordCountErrors });
+    }
+
+    // Required-question validation. Client gates the review modal on this, but
+    // we re-check server-side so the DB cannot end up with a submitted-but-empty
+    // domain via a stale state, manual replay, or future refactor that loosens
+    // the client gate.
+    const missingRequired: string[] = [];
+    for (const q of generalQuestions) {
+      if (q.required && !isAnswered(answers[q.key], q)) {
+        missingRequired.push(q.data.label || q.key);
+      }
+    }
+    for (const domainId of selectedDomainIds) {
+      const dbDa = allDas.find(d => d.challengeVersion.domainId === domainId);
+      if (!dbDa) {
+        missingRequired.push(`selected domain has no application record`);
+        continue;
+      }
+      const questions = (dbDa.challengeVersion.questions as unknown as Question[]) ?? [];
+      const submitted = domainAnswers.find(da => da.domainApplicationId === dbDa.id)?.answers ?? {};
+      for (const q of questions) {
+        if (q.required && !isAnswered(submitted[q.key], q)) {
+          missingRequired.push(q.data.label || q.key);
+        }
+      }
+    }
+    if (missingRequired.length > 0) {
+      return withAuth(auth, {
+        error: `Please answer all required questions before submitting (${missingRequired.length} unanswered).`,
+      });
     }
 
     // Save final answers
@@ -403,11 +431,6 @@ export async function action({ request }: Route.ActionArgs) {
     }
 
     // Persist final domain selection state
-    const selectedDomainIds = JSON.parse(formData.get("selectedDomainIds") as string) as string[];
-    const allDas = await prisma.domainApplication.findMany({
-      where: { applicationId },
-      include: { challengeVersion: { select: { domainId: true } } },
-    });
     const toSelect = allDas.filter(da => selectedDomainIds.includes(da.challengeVersion.domainId!) && !da.selected);
     const toDeselect = allDas.filter(da => !selectedDomainIds.includes(da.challengeVersion.domainId!) && da.selected);
     if (toSelect.length > 0) {
@@ -1210,10 +1233,14 @@ export default function PortalApply() {
     }
   }
 
-  // Handle submit response (urlWarnings, wordCountErrors) — redirects are handled automatically by React Router
+  // Handle submit response (urlWarnings, wordCountErrors, error) — redirects are handled automatically by React Router
   useEffect(() => {
     if (submitFetcher.state === "idle" && submitFetcher.data) {
       setSubmitting(false);
+      if (submitFetcher.data.error) {
+        alert(submitFetcher.data.error);
+        return;
+      }
       if (submitFetcher.data.wordCountErrors) {
         setWordCountErrors(submitFetcher.data.wordCountErrors);
         setTimeout(() => warningBannerRef.current?.scrollIntoView({ behavior: "smooth", block: "nearest" }), 50);


### PR DESCRIPTION
…n submit (#474)

Two related fixes for empty/orphan domain applications appearing in the hiring UI:

- Hiring loaders (`lead.cycle.$id`, `domain-lead`, `domain-lead.delibs.$id`, `reviewer.application.$id`) now filter `domainApplications` on `selected: true`, so a domain the applicant deselected before submit no longer shows up alongside the domains they actually applied to. The applicant-facing loaders, analytics, and `portal.application` already had this filter; these four were the holdouts.

- The submit action in `portal.apply.tsx` now re-validates required questions server-side for every selected domain (and the general form), using the questions on the picked `ChallengeVersion`. Previously only word limits were checked server-side; required questions were enforced by the client modal gate alone, so a stale state, replay, or future client refactor could let a submission through with a selected-but-empty required domain.