### PR TITLE
Drop termId from DomainLeadAssignment

### DIFF
--- a/dali-api/app/routes/admin-console.domains.tsx
+++ b/dali-api/app/routes/admin-console.domains.tsx
@@ -3,7 +3,6 @@ import { redirect, useLoaderData, useFetcher } from "react-router";
 import type { Route } from "./+types/admin-console.domains";
 import { prisma } from "~/lib/db";
 import { requireAuth, withAuth } from "~/lib/auth";
-import { getCurrentTermId } from "~/lib/terms";
 import { isAdmin } from "~/lib/roles";
 import { describeDomainUsage } from "./api.domains.$domainId";
 import { ChevronDown, Trash2, Plus } from "lucide-react";
@@ -116,8 +115,7 @@ export async function action({ request }: Route.ActionArgs) {
   if (intent === "add-domain-lead") {
     const memberId = formData.get("memberId") as string;
     const domainId = formData.get("domainId") as string;
-    const termId = await getCurrentTermId();
-    await prisma.domainLeadAssignment.create({ data: { memberId, domainId, termId } });
+    await prisma.domainLeadAssignment.create({ data: { memberId, domainId } });
     return withAuth(auth, null);
   }
 

--- a/dali-api/app/routes/admin-console.members.tsx
+++ b/dali-api/app/routes/admin-console.members.tsx
@@ -3,7 +3,6 @@ import { redirect, useLoaderData } from "react-router";
 import type { Route } from "./+types/admin-console.members";
 import { prisma } from "~/lib/db";
 import { requireAuth, withAuth } from "~/lib/auth";
-import { getCurrentTermId } from "~/lib/terms";
 import { isAdmin } from "~/lib/roles";
 import { Users, Check } from "lucide-react";
 import {
@@ -78,8 +77,7 @@ export async function action({ request }: Route.ActionArgs) {
   if (intent === "add-domain-lead") {
     const memberId = formData.get("memberId") as string;
     const domainId = formData.get("domainId") as string;
-    const termId = await getCurrentTermId();
-    await prisma.domainLeadAssignment.create({ data: { memberId, domainId, termId } });
+    await prisma.domainLeadAssignment.create({ data: { memberId, domainId } });
     return withAuth(auth, null);
   }
 

--- a/dali-api/app/routes/api.domains.$domainId.leads.ts
+++ b/dali-api/app/routes/api.domains.$domainId.leads.ts
@@ -3,7 +3,6 @@ import { z } from "zod";
 import { prisma } from "~/lib/db";
 import { requireAuth, withAuth } from "~/lib/auth";
 import { isAdmin } from "~/lib/roles";
-import { getCurrentTermId } from "~/lib/terms";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { parseJson } from "~/lib/validate";
 
@@ -43,10 +42,9 @@ export async function action({ request, params }: Route.ActionArgs) {
     const postBody = await parseJson(request, AddLeadSchema);
     if (postBody instanceof Response) return withAuth(auth, withCors(request, postBody));
     const { memberId } = postBody;
-    const termId = await getCurrentTermId();
 
     const assignment = await prisma.domainLeadAssignment.create({
-      data: { memberId, domainId: params.domainId!, termId },
+      data: { memberId, domainId: params.domainId! },
       include: { member: { include: { user: true } }, domain: true },
     });
     return withAuth(auth, withCors(request, Response.json(assignment, { status: 201 })));

--- a/dali-api/prisma/migrations/20260512023900_drop_domain_lead_assignment_term/migration.sql
+++ b/dali-api/prisma/migrations/20260512023900_drop_domain_lead_assignment_term/migration.sql
@@ -1,0 +1,18 @@
+-- DomainLeadAssignment is no longer term-scoped. An assignment now persists
+-- across terms until manually removed.
+--
+-- Drop the old composite unique + term-related index, drop the FK, drop the
+-- column. Add a (memberId, domainId) unique so a member can only hold one
+-- assignment per domain.
+
+ALTER TABLE "DomainLeadAssignment" DROP CONSTRAINT "DomainLeadAssignment_termId_fkey";
+
+DROP INDEX "DomainLeadAssignment_memberId_domainId_termId_key";
+DROP INDEX "DomainLeadAssignment_domainId_termId_idx";
+
+ALTER TABLE "DomainLeadAssignment" DROP COLUMN "termId";
+
+CREATE UNIQUE INDEX "DomainLeadAssignment_memberId_domainId_key"
+  ON "DomainLeadAssignment"("memberId", "domainId");
+CREATE INDEX "DomainLeadAssignment_domainId_idx"
+  ON "DomainLeadAssignment"("domainId");

--- a/dali-api/prisma/schema.prisma
+++ b/dali-api/prisma/schema.prisma
@@ -978,7 +978,6 @@ model Term {
 
   projectAssignments    ProjectAssignment[]
   mentorshipPairs       MentorshipPair[]
-  domainLeadAssignments DomainLeadAssignment[]
   coreAssignments       CoreAssignment[]
   instructorAssignments InstructorAssignment[]
   staffingCycles        StaffingCycle[]
@@ -1071,14 +1070,12 @@ model DomainLeadAssignment {
 
   memberId String
   domainId String
-  termId   String
 
   member DALIMember @relation(fields: [memberId], references: [id])
   domain Domain     @relation(fields: [domainId], references: [id])
-  term   Term       @relation(fields: [termId], references: [id])
 
-  @@unique([memberId, domainId, termId])
-  @@index([domainId, termId])
+  @@unique([memberId, domainId])
+  @@index([domainId])
 }
 
 // ─── Core / Instructor / Admin ───────────────────────────────────────────────

--- a/dali-api/prisma/seed.ts
+++ b/dali-api/prisma/seed.ts
@@ -1859,7 +1859,6 @@ async function main() {
       id: "dla-eng-lead",
       memberId: engLeadMember.id,
       domainId: engDomain.id,
-      termId: currentTerm.id,
     },
   });
 
@@ -1895,7 +1894,6 @@ async function main() {
       id: "dla-jordan-eng",
       memberId: jordanMember.id,
       domainId: engDomain.id,
-      termId: currentTerm.id,
     },
   });
 


### PR DESCRIPTION
## Summary
- Drops `DomainLeadAssignment.termId` column, its `Term` FK, and the `(memberId, domainId, termId)` composite unique. Replaces with `(memberId, domainId)` unique.
- Removes `getCurrentTermId()` calls from three admin/console route actions.
- Seed updated.

## Why
The expansion_v0 migration added `termId NOT NULL` to an existing populated table, which crashes on staging deploy:
> ERROR: column "termId" of relation "DomainLeadAssignment" contains null values

The deeper issue is that no read path filters DomainLeadAssignment by termId. The only place `termId` was set was at create time, via a synthesized "current term" lookup. Dropping the column simplifies the model: an assignment persists until manually removed.

## Migration safety
The migration drops a NOT NULL FK column. On dev/staging/prod:
- **Dev** local: applies cleanly (table empty).
- **Staging**: previous deploy failed and left no rows mid-migration. After this PR, redeploy should resolve the failed migration. If staging's `DomainLeadAssignment` has multiple rows for the same `(memberId, domainId)` across distinct terms, the new unique index will fail; dedupe first.
- **Prod**: same caveat — check for `(memberId, domainId)` duplicates before promoting.

## Test plan
- [ ] `cd dali-api && npm run typecheck`
- [ ] `cd dali-api && npm test` (unit)
- [ ] `cd dali-api && npm run test:e2e` (covers admin-console + domain-lead role checks)
- [ ] On staging: after deploy, log in as admin and verify domain leads are listed; add/remove a lead through `/admin-console/members` and `/admin-console/domains`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)