### PR TITLE
Drop termId from DomainLeadAssignment (#492)

### DIFF
--- a/dali-api/app/routes/admin-console.domains.tsx
+++ b/dali-api/app/routes/admin-console.domains.tsx
@@ -3,7 +3,6 @@ import { redirect, useLoaderData, useFetcher } from "react-router";
 import type { Route } from "./+types/admin-console.domains";
 import { prisma } from "~/lib/db";
 import { requireAuth, withAuth } from "~/lib/auth";
-import { getCurrentTermId } from "~/lib/terms";
 import { isAdmin } from "~/lib/roles";
 import { describeDomainUsage } from "./api.domains.$domainId";
 import { ChevronDown, Trash2, Plus } from "lucide-react";
@@ -116,8 +115,7 @@ export async function action({ request }: Route.ActionArgs) {
   if (intent === "add-domain-lead") {
     const memberId = formData.get("memberId") as string;
     const domainId = formData.get("domainId") as string;
-    const termId = await getCurrentTermId();
-    await prisma.domainLeadAssignment.create({ data: { memberId, domainId, termId } });
+    await prisma.domainLeadAssignment.create({ data: { memberId, domainId } });
     return withAuth(auth, null);
   }
 

--- a/dali-api/app/routes/admin-console.members.tsx
+++ b/dali-api/app/routes/admin-console.members.tsx
@@ -3,7 +3,6 @@ import { redirect, useLoaderData } from "react-router";
 import type { Route } from "./+types/admin-console.members";
 import { prisma } from "~/lib/db";
 import { requireAuth, withAuth } from "~/lib/auth";
-import { getCurrentTermId } from "~/lib/terms";
 import { isAdmin } from "~/lib/roles";
 import { Users, Check } from "lucide-react";
 import {
@@ -78,8 +77,7 @@ export async function action({ request }: Route.ActionArgs) {
   if (intent === "add-domain-lead") {
     const memberId = formData.get("memberId") as string;
     const domainId = formData.get("domainId") as string;
-    const termId = await getCurrentTermId();
-    await prisma.domainLeadAssignment.create({ data: { memberId, domainId, termId } });
+    await prisma.domainLeadAssignment.create({ data: { memberId, domainId } });
     return withAuth(auth, null);
   }
 

--- a/dali-api/app/routes/api.domains.$domainId.leads.ts
+++ b/dali-api/app/routes/api.domains.$domainId.leads.ts
@@ -3,7 +3,6 @@ import { z } from "zod";
 import { prisma } from "~/lib/db";
 import { requireAuth, withAuth } from "~/lib/auth";
 import { isAdmin } from "~/lib/roles";
-import { getCurrentTermId } from "~/lib/terms";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { parseJson } from "~/lib/validate";
 
@@ -43,10 +42,9 @@ export async function action({ request, params }: Route.ActionArgs) {
     const postBody = await parseJson(request, AddLeadSchema);
     if (postBody instanceof Response) return withAuth(auth, withCors(request, postBody));
     const { memberId } = postBody;
-    const termId = await getCurrentTermId();
 
     const assignment = await prisma.domainLeadAssignment.create({
-      data: { memberId, domainId: params.domainId!, termId },
+      data: { memberId, domainId: params.domainId! },
       include: { member: { include: { user: true } }, domain: true },
     });
     return withAuth(auth, withCors(request, Response.json(assignment, { status: 201 })));

--- a/dali-api/prisma/migrations/20260512023900_drop_domain_lead_assignment_term/migration.sql
+++ b/dali-api/prisma/migrations/20260512023900_drop_domain_lead_assignment_term/migration.sql
@@ -1,0 +1,18 @@
+-- DomainLeadAssignment is no longer term-scoped. An assignment now persists
+-- across terms until manually removed.
+--
+-- Drop the old composite unique + term-related index, drop the FK, drop the
+-- column. Add a (memberId, domainId) unique so a member can only hold one
+-- assignment per domain.
+
+ALTER TABLE "DomainLeadAssignment" DROP CONSTRAINT "DomainLeadAssignment_termId_fkey";
+
+DROP INDEX "DomainLeadAssignment_memberId_domainId_termId_key";
+DROP INDEX "DomainLeadAssignment_domainId_termId_idx";
+
+ALTER TABLE "DomainLeadAssignment" DROP COLUMN "termId";
+
+CREATE UNIQUE INDEX "DomainLeadAssignment_memberId_domainId_key"
+  ON "DomainLeadAssignment"("memberId", "domainId");
+CREATE INDEX "DomainLeadAssignment_domainId_idx"
+  ON "DomainLeadAssignment"("domainId");

--- a/dali-api/prisma/schema.prisma
+++ b/dali-api/prisma/schema.prisma
@@ -978,7 +978,6 @@ model Term {
 
   projectAssignments    ProjectAssignment[]
   mentorshipPairs       MentorshipPair[]
-  domainLeadAssignments DomainLeadAssignment[]
   coreAssignments       CoreAssignment[]
   instructorAssignments InstructorAssignment[]
   staffingCycles        StaffingCycle[]
@@ -1071,14 +1070,12 @@ model DomainLeadAssignment {
 
   memberId String
   domainId String
-  termId   String
 
   member DALIMember @relation(fields: [memberId], references: [id])
   domain Domain     @relation(fields: [domainId], references: [id])
-  term   Term       @relation(fields: [termId], references: [id])
 
-  @@unique([memberId, domainId, termId])
-  @@index([domainId, termId])
+  @@unique([memberId, domainId])
+  @@index([domainId])
 }
 
 // ─── Core / Instructor / Admin ───────────────────────────────────────────────

--- a/dali-api/prisma/seed.ts
+++ b/dali-api/prisma/seed.ts
@@ -1859,7 +1859,6 @@ async function main() {
       id: "dla-eng-lead",
       memberId: engLeadMember.id,
       domainId: engDomain.id,
-      termId: currentTerm.id,
     },
   });
 
@@ -1895,7 +1894,6 @@ async function main() {
       id: "dla-jordan-eng",
       memberId: jordanMember.id,
       domainId: engDomain.id,
-      termId: currentTerm.id,
     },
   });
 


### PR DESCRIPTION
The expansion_v0 migration added `termId NOT NULL` to an already- populated DomainLeadAssignment table on staging, which fails at deploy time (postgres rejects backfilling NULLs into NOT NULL). The deeper issue is that scoping domain-lead assignments by term has no callers: the only path that ever resolved a term was a synthesized "current" term at create time, and no read site filters by termId.

This migration drops the column entirely. An assignment now persists across terms until manually removed.

- New migration drops the (memberId, domainId, termId) unique, the (domainId, termId) index, the FK to Term, and the termId column. Adds (memberId, domainId) unique + (domainId) index.
- Schema: removes termId field + Term relation; removes Term. domainLeadAssignments back-ref.
- Callers (admin-console.members, admin-console.domains, api.domains.$domainId.leads): drop getCurrentTermId() + termId arg.
- Seed: drop termId from both DomainLeadAssignment.upsert creates.

Staging deploy note: if existing rows have duplicates on (memberId, domainId) across distinct termIds, the new unique index creation will fail. Dedupe first by deleting the older rows.