### PR TITLE
Filter deselected DomainApplications out of reviewer surfaces

### DIFF
--- a/dali-api/app/hiring/routes/__tests__/api.domain-applications.$id.reviews.test.ts
+++ b/dali-api/app/hiring/routes/__tests__/api.domain-applications.$id.reviews.test.ts
@@ -40,6 +40,7 @@ beforeEach(() => {
   (mockPrisma as any).domainApplication = {
     findUniqueOrThrow: vi.fn().mockResolvedValue({
       id: DA_ID,
+      selected: true,
       application: { applicationCycleId: CYCLE_ID },
       challengeVersion: { domainId: DOMAIN_ID },
     }),
@@ -143,6 +144,7 @@ describe("POST /api/hiring/domain-applications/:id/reviews", () => {
   it("rejects a domain lead for a different domain (403)", async () => {
     mockPrisma.domainApplication.findUniqueOrThrow.mockResolvedValueOnce({
       id: DA_ID,
+      selected: true,
       application: { applicationCycleId: CYCLE_ID },
       challengeVersion: { domainId: OTHER_DOMAIN_ID },
     });
@@ -176,6 +178,25 @@ describe("POST /api/hiring/domain-applications/:id/reviews", () => {
     } as any);
 
     expect(res.status).toBe(403);
+    expect(mockPrisma.applicationReview.create).not.toHaveBeenCalled();
+  });
+
+  it("returns 409 when the domain application is deselected", async () => {
+    vi.mocked(isHiringLead).mockResolvedValue(true);
+    mockPrisma.domainApplication.findUniqueOrThrow.mockResolvedValueOnce({
+      id: DA_ID,
+      selected: false,
+      application: { applicationCycleId: CYCLE_ID },
+      challengeVersion: { domainId: DOMAIN_ID },
+    });
+
+    const res = await action({
+      request: makeRequest(),
+      params: { id: DA_ID },
+      context: {},
+    } as any);
+
+    expect(res.status).toBe(409);
     expect(mockPrisma.applicationReview.create).not.toHaveBeenCalled();
   });
 

--- a/dali-api/app/hiring/routes/api.cycles.$cycleId.available-slots.ts
+++ b/dali-api/app/hiring/routes/api.cycles.$cycleId.available-slots.ts
@@ -17,6 +17,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   if (!(await hasCycleAccess(auth.user.sub, params.cycleId!))) {
     const invited = await prisma.domainApplication.findFirst({
       where: {
+        selected: true,
         application: { userId: auth.user.sub, applicationCycleId: params.cycleId },
         decisions: { some: { type: "InvitedToInterview" } },
       },

--- a/dali-api/app/hiring/routes/api.cycles.$cycleId.domains.$domainId.auto-assign.ts
+++ b/dali-api/app/hiring/routes/api.cycles.$cycleId.domains.$domainId.auto-assign.ts
@@ -67,6 +67,7 @@ export async function action({ request, params }: Route.ActionArgs) {
 
   const domainApps = await prisma.domainApplication.findMany({
     where: {
+      selected: true,
       challengeVersion: { domainId: domainId! },
       application: {
         applicationCycleId: cycleId!,

--- a/dali-api/app/hiring/routes/api.cycles.$cycleId.status.ts
+++ b/dali-api/app/hiring/routes/api.cycles.$cycleId.status.ts
@@ -4,6 +4,7 @@ import { parseJson } from "~/lib/validate";
 import { requireAuth, withAuth } from "~/lib/auth";
 import { isHiringLead, hasCycleAccess } from "~/lib/roles";
 import { autoCloseIfExpired, findOtherActiveCycleId } from "~/hiring/lib/cycles";
+import { inReviewPipelineFilter } from "~/hiring/lib/application-pipeline-filter";
 import type { Route } from "./+types/api.cycles.$cycleId.status";
 
 const STATUS_ORDER = ["Draft", "Open", "UnderReview", "Completed"] as const;
@@ -115,7 +116,8 @@ export async function action({ request, params }: Route.ActionArgs) {
     });
     const undecided = await prisma.domainApplication.count({
       where: {
-        application: { applicationCycleId: params.cycleId! },
+        selected: true,
+        application: { applicationCycleId: params.cycleId!, ...inReviewPipelineFilter },
         decisions: {
           none: { stage: "Released", type: { in: ["Accepted", "Waitlisted", "Rejected"] } },
         },

--- a/dali-api/app/hiring/routes/api.domain-applications.$id.reviews.ts
+++ b/dali-api/app/hiring/routes/api.domain-applications.$id.reviews.ts
@@ -63,6 +63,12 @@ export async function action({ request, params }: Route.ActionArgs) {
     },
   });
 
+  // Refuse to assign reviewers to a domain the applicant deselected — the
+  // record only persists to preserve answers in case they re-select.
+  if (!domainApp.selected) {
+    return withAuth(auth, Response.json({ error: "Cannot assign reviewer to a deselected domain application" }, { status: 409 }));
+  }
+
   // ChallengeVersion.domainId is nullable because the general application form
   // is also a ChallengeVersion. A DomainApplication should never reference one,
   // so this is a data invariant error rather than a user-facing condition.

--- a/dali-api/app/hiring/routes/domain-lead.tsx
+++ b/dali-api/app/hiring/routes/domain-lead.tsx
@@ -228,6 +228,7 @@ export async function loader({ request }: Route.LoaderArgs) {
       const initialDelibsCount = cycle
         ? await prisma.domainApplication.count({
             where: {
+              selected: true,
               challengeVersion: { domainId: assignment.domainId },
               application: { applicationCycleId: cycle.id, ...inReviewPipelineFilter },
               reviews: { every: { submittedAt: { not: null } }, some: {} },
@@ -239,6 +240,7 @@ export async function loader({ request }: Route.LoaderArgs) {
       const finalDelibsCount = cycle
         ? await prisma.domainApplication.count({
             where: {
+              selected: true,
               challengeVersion: { domainId: assignment.domainId },
               application: { applicationCycleId: cycle.id, ...inReviewPipelineFilter },
               interviews: { some: { status: "Completed" } },

--- a/dali-api/app/hiring/routes/reviewer.tsx
+++ b/dali-api/app/hiring/routes/reviewer.tsx
@@ -175,6 +175,7 @@ export async function loader({ request }: Route.LoaderArgs) {
 
     const qualifying = await prisma.domainApplication.findMany({
       where: {
+        selected: true,
         challengeVersion: { domainId: session.domainId },
         application: {
           applicationCycleId: session.applicationCycleId,

--- a/dali-api/scripts/find-phantom-reviews.ts
+++ b/dali-api/scripts/find-phantom-reviews.ts
@@ -1,0 +1,100 @@
+// Find ApplicationReview rows tied to DomainApplications the applicant
+// deselected (selected = false). These are "phantom" reviews — the applicant
+// never submitted for that domain, but a reviewer was assigned to it (likely
+// via the auto-assign endpoint, which used to skip the `selected: true`
+// filter).
+//
+// Read-only by default. Pass `--delete` to remove phantom reviews that have
+// no review data entered. Phantoms with any data (scores, feedback,
+// recommendation, or submittedAt) are always reported but never auto-deleted —
+// decide manually.
+//
+// Run: DATABASE_URL=... npx tsx scripts/find-phantom-reviews.ts [--delete]
+
+import { PrismaClient } from "../app/generated/prisma/client.js";
+import { PrismaPg } from "@prisma/adapter-pg";
+
+const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL! });
+const prisma = new PrismaClient({ adapter });
+
+const shouldDelete = process.argv.includes("--delete");
+
+const phantoms = await prisma.applicationReview.findMany({
+  where: { domainApplication: { selected: false } },
+  include: {
+    domainApplication: {
+      include: {
+        application: {
+          include: {
+            user: { select: { firstName: true, lastName: true, dartmouthEmail: true, daliEmail: true, netId: true } },
+            applicationCycle: { select: { name: true } },
+          },
+        },
+        challengeVersion: { include: { domain: { select: { name: true } } } },
+      },
+    },
+    cycleReviewer: {
+      include: { daliMember: { select: { firstName: true, lastName: true, daliEmail: true } } },
+    },
+  },
+  orderBy: { createdAt: "asc" },
+});
+
+console.log(`Found ${phantoms.length} phantom review(s) (DomainApplication.selected = false).\n`);
+
+const safeToDelete: string[] = [];
+const hasData: typeof phantoms = [];
+
+for (const r of phantoms) {
+  const u = r.domainApplication.application.user;
+  const applicant = `${u.firstName} ${u.lastName} <${u.daliEmail ?? u.dartmouthEmail ?? u.netId ?? "?"}>`;
+  const domain = r.domainApplication.challengeVersion.domain?.name ?? "?";
+  const cycle = r.domainApplication.application.applicationCycle.name;
+  const m = r.cycleReviewer.daliMember;
+  const reviewer = `${m.firstName} ${m.lastName} <${m.daliEmail}>`;
+
+  const scores = r.scores as Record<string, unknown>;
+  const hasScores = scores && Object.keys(scores).length > 0;
+  const hasFeedback = r.feedback.trim().length > 0;
+  const hasRationale = r.rejectionRationale.trim().length > 0;
+  const hasRec = r.overallRecommendation !== null;
+  const annotations = r.annotations as unknown[];
+  const hasAnnotations = Array.isArray(annotations) && annotations.length > 0;
+  const hasAnyData = hasScores || hasFeedback || hasRationale || hasRec || hasAnnotations || r.submittedAt !== null;
+
+  console.log(`reviewId=${r.id}`);
+  console.log(`  cycle:    ${cycle}`);
+  console.log(`  domain:   ${domain}`);
+  console.log(`  applicant:${applicant}`);
+  console.log(`  reviewer: ${reviewer}`);
+  console.log(`  daId:     ${r.domainApplication.id}`);
+  console.log(`  data:     scores=${hasScores} feedback=${hasFeedback} rationale=${hasRationale} rec=${hasRec} annotations=${hasAnnotations} submitted=${r.submittedAt !== null}`);
+  console.log("");
+
+  if (hasAnyData) {
+    hasData.push(r);
+  } else {
+    safeToDelete.push(r.id);
+  }
+}
+
+console.log(`Summary: ${safeToDelete.length} safe to delete (no data), ${hasData.length} have data and need manual review.`);
+
+if (shouldDelete) {
+  if (hasData.length > 0) {
+    console.log(`\nWARNING: ${hasData.length} phantom review(s) contain data and will NOT be deleted automatically:`);
+    for (const r of hasData) console.log(`  - ${r.id}`);
+  }
+  if (safeToDelete.length > 0) {
+    const result = await prisma.applicationReview.deleteMany({
+      where: { id: { in: safeToDelete } },
+    });
+    console.log(`\nDeleted ${result.count} phantom review(s) with no data.`);
+  } else {
+    console.log("\nNothing to delete.");
+  }
+} else {
+  console.log("\n(read-only run — pass --delete to remove the empty phantom reviews)");
+}
+
+await prisma.$disconnect();


### PR DESCRIPTION
## Summary

When an applicant deselects a domain mid-draft, the `DomainApplication` row is preserved with `selected = false` (so answers survive re-selection). Several queries treated those rows as live, which caused **28 phantom `ApplicationReview` rows** in prod across UI/UX, Fullstack, and PM in Spring 2026 Hiring — reviewers were assigned to applicants who never submitted for their domain.

Root cause: the auto-assign endpoint queried `DomainApplication` filtered by the parent `Application`'s submission status but not by `selected`. Audit found five other surfaces with the same shape of bug.

## Fixes

| File | Fix |
|---|---|
| `auto-assign.ts` | `+ selected: true` on the DA query (root cause) |
| `reviewer.tsx` | `+ selected: true` on the delibs mirror query |
| `domain-lead.tsx` | `+ selected: true` on Initial + Final delibs counts |
| `api.cycles.$cycleId.status.ts` | `+ selected: true` and `+ inReviewPipelineFilter` on the cycle-completion `undecided` count (drafts were also leaking in) |
| `api.domain-applications.$id.reviews.ts` | Manual reviewer-create endpoint refuses `selected = false` DAs with 409 (defense in depth) |
| `api.cycles.$cycleId.available-slots.ts` | `+ selected: true` so a stale `InvitedToInterview` decision on a deselected DA can't grant slot-query access |

## Cleanup

Added `dali-api/scripts/find-phantom-reviews.ts` — read-only by default, with `--delete` to remove only empty phantom reviews. Any AR with `scores`/`feedback`/`rejectionRationale`/`overallRecommendation`/`annotations`/`submittedAt` is reported but never auto-deleted.

Already used to clean up the 28 prod phantoms (all empty — no review data lost). The underlying `DomainApplication` rows are intentionally left in place to preserve applicant draft answers.

## Considered but not changed

- `lead.cycle.$id.tsx:687` — "challenge version in use" check counts deselected DAs too. Arguably correct: removing a CV would orphan preserved answers if the applicant ever re-selects. Cycle must be `Draft` to reach this code, so blast radius is small.

## Test plan

- [ ] CI: typecheck, vitest, playwright, migration-check
- [ ] Manual: in a non-prod cycle, create a draft → select Domain A → deselect Domain A → select Domain B → submit. Run auto-assign on Domain A. Confirm zero new ApplicationReview rows for that applicant.
- [ ] Manual: confirm the deselected applicant does not appear in Domain A reviewer's queue or in Domain A's delibs count.
- [ ] Confirm cycle-completion validation no longer blocks on deselected DAs lacking decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)