### PR TITLE
Replace JWT auth with opaque session cookies (closes #407)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,123 @@
-# DALI-OS
+# DALI OS
 
+Internal operations platform for the DALI Lab. Single React Router 7 app (`dali-api/`) that serves the UI, the JSON API, and the Hocuspocus realtime collab server. Originally a hiring tool, now expanding to projects, members, partners, calendar, and education.
 
+## Stack
 
+| Layer | Tech |
+|---|---|
+| App | React Router 7 (full-stack), React 19, TypeScript |
+| DB | Postgres 16 on Neon, Prisma 7 (`@prisma/adapter-neon` / `@prisma/adapter-pg`) |
+| Realtime | Hocuspocus + Yjs + Tiptap, Redis for fan-out |
+| Auth | Google OAuth, Dartmouth CAS, opaque session cookies + Bearer headers |
+| Styling | Tailwind CSS 4 |
+| Runtime | Node 22, npm |
+| Tests | Vitest (unit), Playwright (e2e) |
+| Deploy | Fly.io, branches `dev` → `staging` → `prod` |
 
-## Quickstart with Docker Compose
-| Service | Image | Ports | Description |
-| -------- | -------- | -------- | ----------- |
-| db | postgres:16-alpine | 5432 | PostgreSQL database |
-| api | ./dali-api | 3001, 5555 | Runs Prisma migrate, API, and Prisma Studio |
+## Repo layout
 
-## Environment Variables (with Docker Compose)
-| Variable | Description | Default Value |
-| -------- | ----------- | ------------- |
-| GOOGLE_CLIENT_ID | Google OAuth ID | None | 
-| GOOGLE_CLIENT_SECRET | Google OAuth Secret | None |
-- When using Docker Compose locally, only the Google OAuth credentials (in the top level .env) are required
+```
+dali-api/
+  app/
+    hiring/          cycles, reviewers, interviews, delibs, decisions
+    admin-console/   members, domains, role assignment
+    projects/        project list, staffing
+    members/         directory, user profiles
+    partners/        partner portal
+    calendar/        scheduling
+    collab/          Hocuspocus server + Yjs persistence
+    routes/          shared routes (auth, portal, oauth, uploads)
+    components/      shared UI
+    lib/             db client, auth, server utilities
+  prisma/            schema.prisma, migrations/, seed.ts
+  e2e/               Playwright specs
+.github/workflows/   CI/CD
+docker-compose.yml   local Postgres + API + Prisma Studio
+```
+
+## Local dev
+
+Prereqs: Docker, Node 22, a repo-root `.env` containing `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET`.
+
+```bash
+docker compose up
+```
+
+Brings up Postgres, runs `prisma db push --force-reset && prisma db seed`, then starts the dev server on `:3001`, the collab server on `:3002`, and Prisma Studio on `:5555`.
+
+Bare metal (your own Postgres):
+
+```bash
+cd dali-api
+npm install
+npm run db:reset:local   # destroys local DB
+npm run dev
+```
+
+Skip login during dev at `/dev-login` (dev-only route, gated to non-prod builds).
+
+## Commands
+
+Run from `dali-api/`.
+
+| Task | Command |
+|---|---|
+| Unit tests | `npm test` |
+| E2E tests | `npm run test:e2e` (needs a seeded Postgres) |
+| Typecheck | `npm run typecheck` |
+| Build | `npm run build` |
+| Dev server | `npm run dev` |
+| Reset local DB | `npm run db:reset:local` |
+
+No ESLint/Prettier is wired up.
+
+## Environments
+
+| Env | Branch | Fly app | Neon branch | DB on deploy |
+|---|---|---|---|---|
+| Dev | `dev` | `dali-api-dev` | `development` | wipe → migrate → seed |
+| Staging | `staging` | `dali-api-staging` | `staging` | restore from prod → migrate |
+| Prod | `prod` | `dali-api-prod` | `production` | migrate only |
+
+Promotion is staged: PRs merge to `dev`, then `promote-to-staging.yml` and `promote-to-prod.yml` move code forward. Per-PR previews spin up their own Neon branch + Fly app via `preview-deploy.yml` and tear down on close.
+
+## Database & migrations
+
+Authoring rules:
+
+- Edit `prisma/schema.prisma`, then `npx prisma migrate dev --name <change>`.
+- Commit schema and migration in the same PR.
+- Never edit or delete an applied migration. Fix forward with a new one.
+- Flag data-losing migrations (drops, non-null without default) in the PR description.
+
+Runtime uses the pooled `DATABASE_URL`. `prisma migrate` needs a non-pooled URL (advisory locks don't survive PgBouncer transaction pooling); `prisma.config.ts` auto-derives it from `DATABASE_URL` or honors an explicit `DIRECT_URL`. Full detail: `dali-api/prisma/MIGRATIONS.md`.
+
+## CI gates
+
+Failures on these block merge:
+
+- `test.yml` — Vitest + Playwright against a real Postgres service container.
+- `build-check.yml` — Docker build via flyctl.
+- `migration-check.yml` — schema/migration drift, deleted-migration guard, pgfence safety analysis.
+- `codeql.yml` — static security scan.
+- `preview-deploy.yml` — per-PR Neon + Fly preview (only blocks if it fails specifically).
+
+## Auth surface
+
+- `/login` — Google OAuth or Dartmouth CAS.
+- `/portal/*` — applicant portal (lighter layout, no internal nav).
+- `/oauth/*` — DALI OS acts as an OAuth provider for the `dali-os-mcp` integration (`authorize`, `token`, `revoke`, `callback/*`).
+- Browser auth uses the `__dali_sid` HttpOnly cookie; API/MCP clients send `Authorization: Bearer <session_id>`. Both resolve to one indexed lookup against the `Session` table (`app/lib/session.ts`). See `SESSION_AUTH_PLAN.md` for the model. Never log session ids, OAuth codes, or `.env` contents.
+
+## Realtime / collab
+
+Tiptap documents are CRDT-synced through the Hocuspocus server (`app/collab/server.ts`) using Yjs, with Redis for multi-instance fan-out and Postgres for persistence. Schema changes to collaboratively edited documents can pass tests locally and still break document sync in prod — flag any such change in the PR description.
+
+## Pointers
+
+- `CLAUDE.md` — conventions for Claude-driven PRs.
+- `dali-api/prisma/MIGRATIONS.md` — full migration/Neon URL detail.
+- `dali-api/README.md` — deploy detail + per-endpoint rate limits.
+- `expansion_plan.md`, `CYCLE_REDESIGN_SPEC.md`, `SCHEDULING.md` — design docs.
+- `dali-os-mcp.md` — MCP integration.

--- a/SESSION_AUTH_PLAN.md
+++ b/SESSION_AUTH_PLAN.md
@@ -1,0 +1,464 @@
+# Session Auth Refactor — Implementation Plan
+
+**Status:** Pre-implementation. Supersedes the auth model implied by issue #407 and updates the auth section of `dali-os-mcp.md`. Lands as a single coordinated change before the MCP track begins, because the MCP foundation depends on this.
+
+## Goal in one sentence
+
+Replace the current JWT access token + rotating refresh token scheme with **opaque session ids stored in a `Session` table**, used uniformly for browser logins (cookie) and OAuth-issued MCP grants (`Authorization: Bearer` header).
+
+## Why this document exists
+
+Issue #407 proposed switching browser auth from JWT/RT to opaque sessions. That proposal is sound on its own, but it predates the OAuth-for-MCP direction in `dali-os-mcp.md`. Implementing #407 as-written would create a second auth surface for MCP six months later. This doc unifies both — one auth concept, one table, one validation path — and lays out the work to get there.
+
+## Current state (what we're replacing)
+
+| File | Role | LOC |
+|---|---|---|
+| `app/lib/auth.ts` | JWT sign/verify, `requireAuth` with silent refresh, `withAuth` glue | 217 |
+| `app/lib/oauth.ts` | Token issuing, RT rotation with family detection, OAuth provider session (PKCE) | 337 |
+| `app/lib/cookies.ts` | `__dali_at` + `__dali_rt` cookie helpers | 65 |
+| `RefreshToken` model | tokenHash, family, expiresAt, familyCreatedAt — rotation state | (schema) |
+| `OAuthSession` model | PKCE/authorize-step state for the OAuth provider | (schema, kept) |
+
+**Behavior:**
+- Login issues a 15-minute HS256 JWT (in `__dali_at` cookie) and a 7-day opaque refresh token (in `__dali_rt` cookie, hashed at rest).
+- Refresh tokens rotate on use within a `family`; reuse is detected and revokes the family.
+- `requireAuth` verifies the JWT; on expiry, it transparently swaps the RT for a new AT/RT pair and the route's loader/action returns the response through `withAuth(auth, response)` so the new `Set-Cookie` headers get attached.
+- Absolute session cap of 30 days from `familyCreatedAt` (added in `2c01467` to prevent infinite chains).
+- 111 files in `app/` import `withAuth`.
+
+**Pain points that motivated #407:**
+- Silent refresh requires `withAuth` on every loader/action return. Forgetting it silently breaks the UX. Caused incident `1757c2a` (users bounced every 15 min).
+- `inFlightRefreshes` dedup map in `auth.ts` exists only to keep parallel loaders from tripping RT reuse detection.
+- Two cookies, two expiries, two clear paths, family revocation, `JWT_SECRET` rotation, etc.
+- Revoking a refresh token leaves the access token live for up to 15 minutes.
+- The justifications for the JWT/RT split (stateless hot path, side-channel asymmetry, scale) don't apply to this codebase. See `Alternatives considered` below.
+
+## Target state (what we're moving to)
+
+One `Session` row backs every authenticated request — browser or MCP. Validation is one indexed PK lookup.
+
+### Schema (new)
+
+```prisma
+model Session {
+  // SHA-256 hash (base64url) of the raw session id. The raw id is what
+  // travels in cookies and Bearer headers; we never store it directly.
+  // PK lookup stays indexed and O(1). Mirrors the RefreshToken.tokenHash
+  // precedent — defense in depth against a DB read leaking live sessions.
+  id                 String   @id
+  userId             String
+  // Null for cookie logins. Set for OAuth-issued (MCP) sessions, linking
+  // the session to the OAuthGrant that authorized it.
+  //
+  // Intentionally a plain String? in this PR — no FK target until the
+  // OAuthGrant model lands in the MCP foundation track. That migration
+  // adds the foreign-key constraint and the OAuthGrant? relation. Until
+  // then, grantId is unused at runtime (issueSession always omits it for
+  // cookie logins).
+  grantId            String?
+  createdAt          DateTime @default(now())
+  // Updated on every successful auth lookup. Drives the rolling expiry
+  // and powers per-session telemetry (last seen, idle revocation).
+  lastUsedAt         DateTime @default(now())
+  // Rolling expiry: extended on use up to absoluteExpiresAt.
+  expiresAt          DateTime
+  // Hard cap: never extended. Equivalent to today's familyCreatedAt + 30d.
+  absoluteExpiresAt  DateTime
+  // Soft delete. Sessions are never hard-deleted so audit log stays whole.
+  revokedAt          DateTime?
+  // Optional, populated at issuance for audit / "active sessions" UI.
+  userAgent          String?
+  ip                 String?
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId, revokedAt])
+  @@index([grantId])
+  @@index([expiresAt])
+}
+```
+
+Reverse relation on `User`:
+```prisma
+sessions Session[]
+```
+
+**Hashed-at-rest convention:**
+- Issuance: generate `raw = base64url(crypto.randomBytes(32))`. Insert a row with `id = sha256(raw)`. Return `raw` to the caller.
+- Lookup: receive `raw` from cookie or Bearer header. Compute `sha256(raw)`. `findUnique({ where: { id: sha256(raw) } })`.
+- The raw id never hits the database. A read-only DB leak surfaces hashes, not live credentials.
+- Same hashing convention as today's `RefreshToken.tokenHash`. No new cryptographic primitives.
+
+### Schema (dropped)
+
+- `RefreshToken` model — and its `User.refreshTokens` reverse relation.
+
+### Schema (unchanged)
+
+- `OAuthSession` — still backs the authorize→callback→exchange round-trip for the OAuth provider surface. This is the *PKCE state*, distinct from the new `Session` model (which is the *resulting credential*).
+
+### Cookie
+
+One cookie: `__dali_sid`. HttpOnly, `SameSite=Lax`, `Secure` in production, `Path=/`. Value is the session id verbatim.
+
+### Bearer header
+
+`Authorization: Bearer <session_id>`. The same id that goes in the cookie. No JWT, no separate format.
+
+### `requireAuth` (new shape)
+
+```ts
+async function requireAuth(request: Request): Promise<AuthResult> {
+  const raw = parseSessionId(request); // cookie first, header fallback
+  if (!raw) return { ok: false, reason: "no_session" };
+
+  const session = await prisma.session.findUnique({
+    where: { id: sha256(raw) },
+    include: { user: true },
+    // grant lookup comes back when the OAuthGrant model lands; for this
+    // PR session.grantId is unused at runtime
+  });
+
+  if (!session) return { ok: false, reason: "not_found" };
+  if (session.revokedAt) return { ok: false, reason: "revoked" };
+  const now = new Date();
+  if (session.expiresAt < now || session.absoluteExpiresAt < now) {
+    return { ok: false, reason: "expired" };
+  }
+
+  // Roll the expiry. Fire-and-forget — a failed update doesn't block the request.
+  rollSession(session.id).catch(() => {});
+
+  return { ok: true, user: { sub: session.userId, ...session.user }, sessionId: session.id };
+}
+```
+
+No silent refresh. No `withAuth` wrapper — loaders and actions just return data.
+
+**Return shape compatibility:** the `auth.user.sub` field is preserved so the codemod is purely a `withAuth` strip. Today's callers (`auth.user.sub` is used in `app/calendar/`, `app/collab/server.ts`, etc.) keep working unchanged. The plan does not rename or restructure the user object as part of this PR — that would conflate concerns. If a future cleanup wants to surface `userId` directly instead of `sub`, it's a separate PR.
+
+### Issuance
+
+```ts
+async function issueSession(params: {
+  userId: string;
+  grantId?: string;
+  ttlMs?: number;          // default ROLLING_TTL_MS
+  absoluteTtlMs?: number;  // default ABSOLUTE_TTL_MS
+  userAgent?: string;
+  ip?: string;
+}): Promise<string> // returns raw session id
+```
+
+Called by:
+- `/auth/callback/google` and `/auth/callback/cas` (cookie login) — `grantId` omitted.
+- `/oauth/token` (MCP) — `grantId` set to the `OAuthGrant.id`.
+- `/dev-login-as` — same as cookie login.
+
+### Token endpoint behavior
+
+`/oauth/token` with `grant_type=authorization_code` returns:
+```json
+{
+  "access_token": "<session_id>",
+  "token_type": "Bearer",
+  "expires_in": <seconds until rolling expiry>,
+  "user": { ... }
+}
+```
+
+`grant_type=refresh_token` becomes a no-op or is removed entirely. Sessions auto-extend on use; MCP clients keep using their bearer until they get a 401, then re-run the authorization flow. RFC 6749 permits omitting `refresh_token` — many native MCP clients don't use it anyway.
+
+### Revocation
+
+- **Logout**: `UPDATE session SET revokedAt = NOW() WHERE id = $1`. Instant. Cookie cleared on the response.
+- **Sign out everywhere**: `UPDATE session SET revokedAt = NOW() WHERE userId = $1 AND revokedAt IS NULL`. One statement.
+- **Revoke an MCP grant**: `UPDATE oauth_grant SET revokedAt = NOW() WHERE id = $1; UPDATE session SET revokedAt = NOW() WHERE grantId = $1`. Atomic via transaction.
+- **Compromised user**: same as sign-out-everywhere. No 15-minute stale window.
+
+## Alternatives considered
+
+### A. Status quo (keep JWT + rotating RT)
+
+**Pros:** zero migration risk; well-trodden OAuth pattern.
+
+**Cons:** the issue #407 list — silent-refresh footgun, two recent bugs, `withAuth` glue on every route, 15-min revocation lag, `JWT_SECRET` rotation story. Also conflicts with MCP plans for instant grant revocation.
+
+**Rejected because:** the complexity is producing bugs and the design justifications don't apply here. Same-origin app, both credentials on cookies, DB hit per request anyway for role checks.
+
+### B. Sessions for browser only (issue #407 as-written)
+
+**Pros:** all of A's wins, no MCP-related design work yet.
+
+**Cons:** MCP will need a separate Bearer-token validation path within ~6 months. Builds the same simplification twice. The "API access goes away" con in #407 directly contradicts the OAuth-MCP plan.
+
+**Rejected because:** suboptimal sequencing. Doing it once for both is strictly less work than doing it twice.
+
+### C. Hybrid — sessions for browser, JWTs for Bearer
+
+**Pros:** keeps the OAuth standard's familiar AT/RT shape for MCP clients.
+
+**Cons:** two validation paths, two issuance paths, two revocation stories, two cookies-vs-headers reconciliations. All the costs of both designs.
+
+**Rejected because:** JWTs aren't required by OAuth. RFC 6750 (Bearer tokens) doesn't mandate any token format. The resource server is the same app as the issuer, so stateless validation is wasted. Spec-compliant opaque bearers are simpler and equivalent.
+
+### D. Unified sessions (chosen)
+
+**Pros:**
+- One concept, one table, one validation path, one cookie (or header), no JWT machinery, no silent refresh, no `withAuth` glue, no `JWT_SECRET`.
+- Instant revocation everywhere.
+- MCP-ready by construction.
+- Less code (estimated ~500 lines deleted on net).
+- Same operational hygiene wins for MCP (per-grant last-used, per-grant revoke) that #407 gives the browser.
+
+**Cons:**
+- One indexed DB lookup per authenticated request. Negligible at our scale, already amortized against the role-check lookups that happen anyway.
+- Loses the rotating-RT "reuse detection" alarm. Mitigated by short rolling expiry + `lastUsedAt` audit. We can add anomaly checks (impossible-travel, UA flip) later if motivated.
+- Migration touches 111 files (mechanical: removing `withAuth` wrappers).
+
+**Why this is the right call:** the JWT/RT design is overkill for a same-origin internal web app at our scale, and it's actively obstructing the MCP track. The simplification reduces lines of code, eliminates a known class of bugs, and unblocks the next feature in the same move.
+
+## Implementation phases
+
+This is implemented as one PR. The work cleanly splits internally but doesn't split well across multiple PRs — leaving the system half-converted creates a dual-auth state that's worse than either endpoint. Phases below describe the order of work *within* the PR, not separate deliverables.
+
+### Phase 1 — Schema + `Session` library
+
+1. Prisma migration:
+   - Create `Session` table per the schema above.
+   - Add `User.sessions` relation.
+   - **Drop `RefreshToken` table and `User.refreshTokens` relation.**
+   - Migration is data-losing for `RefreshToken`. This is acceptable because the cutover forces re-login anyway.
+2. New `app/lib/session.ts`:
+   - `generateSessionId()` — 32 bytes from `crypto.randomBytes`, base64url.
+   - `issueSession(params)` → returns raw id, writes row.
+   - `lookupSession(id)` → returns row with user + grant, or null.
+   - `rollSession(id)` → bumps `lastUsedAt` and `expiresAt` (capped at `absoluteExpiresAt`).
+   - `revokeSession(id)`, `revokeAllForUser(userId)`, `revokeAllForGrant(grantId)`.
+   - Constants: `ROLLING_TTL_MS = 30d`, `ABSOLUTE_TTL_MS = 30d` (matches current behavior; both knobs adjustable).
+
+### Phase 2 — Rewrite `auth.ts` and `cookies.ts`
+
+3. `app/lib/cookies.ts`:
+   - Remove `setTokenCookies`, `clearTokenCookies`, `parseRefreshToken`.
+   - Add `setSessionCookie(headers, sessionId)` (HttpOnly, SameSite=Lax, Secure in prod, Path=/, Max-Age = `ROLLING_TTL_MS`).
+   - Add `clearSessionCookie(headers)`.
+   - Add `parseSessionCookie(request)`.
+4. `app/lib/auth.ts`:
+   - Delete `signAccessToken`, `verifyAccessToken`, `JWT_SECRET` usage, `inFlightRefreshes`, the silent-refresh path inside `requireAuth`, and the `withAuth` helper.
+   - Keep `requireAuth` signature; rewrite body per the "new shape" above.
+   - Keep `validateCasTicket` (unrelated).
+   - Add `parseBearerHeader(request): string | null` and have `parseSessionId` try cookie first, header second.
+   - Drop the `jose` import; remove `jose` from `package.json` if no other consumer remains (`grep` to verify).
+5. `app/lib/oauth.ts`:
+   - Delete `signAccessToken` import.
+   - Delete `issueTokens`, `refreshTokens`, the `createTokenPair` internal helper, the `RefreshToken` Prisma calls, `revokeToken` in its current form.
+   - Keep the OAuth provider surface: `createOAuthSession`, `getOAuthSession`, `generateAuthorizationCode`, `exchangeAuthorizationCode`, `verifyPKCE`, `VALID_CLIENT_IDS` (this becomes the registry lookup later; for this PR keep the constant). `OAuthError` stays.
+   - Replace what `exchangeAuthorizationCode`'s callers do — they used to call `issueTokens`; now they call `issueSession` (Phase 4).
+
+### Phase 3 — Strip `withAuth` from callers
+
+6. Mechanical change across 111 files: every `withAuth(auth, value)` becomes `value`. Replace `withAuth(auth, redirect("/login"))` with `redirect("/login")`, etc.
+   - Do this with `find` + `sed` or an AST codemod, then a hand review of diffs that don't look mechanical.
+   - Drop the `withAuth` import line in each file.
+7. `requireAuth` return type tightens — no more `headers` field. Anything reading `auth.headers` (there shouldn't be much outside `withAuth`) gets cleaned up.
+
+### Phase 4 — Wire issuance into login flows
+
+8. `routes/auth.callback.google.ts`:
+   - Replace `issueTokens(user.id, authType)` + `setTokenCookies(headers, at, rt)` with:
+     ```ts
+     const sid = await issueSession({
+       userId: user.id,
+       userAgent: request.headers.get("user-agent") ?? undefined,
+       ip: getClientIp(request),
+     });
+     setSessionCookie(headers, sid);
+     ```
+9. `routes/auth.callback.cas.ts`: same change.
+10. `routes/dev-login.ts`, `routes/dev-login-as.ts`: same change. Guard remains non-prod-only.
+11. `routes/logout.ts`: read the session id from the cookie, call `revokeSession(id)`, then `clearSessionCookie(headers)`.
+
+### Phase 5 — Wire issuance into OAuth provider
+
+12. `routes/oauth.token.ts`:
+    - For `grant_type=authorization_code`: call `exchangeAuthorizationCode`, then `issueSession({ userId, ... })`. Return `{ access_token: sid, token_type: "Bearer", expires_in, user }`. (`grantId` plumbed through in the MCP foundation track; for this PR it's omitted.)
+    - For `grant_type=refresh_token`: **remove this branch**. Document the removal in the PR description. (Today no one calls it externally; the cookie-login path that used it is now session-based.)
+13. `routes/oauth.revoke.ts`:
+    - Accept a session id (either via cookie or body `token`), call `revokeSession`, clear the cookie. Functionally equivalent today; ready for MCP grant-revoke once grants land.
+
+### Phase 5.5 — Collab server (Hocuspocus)
+
+The collab server has its own auth path and is **not** caught by the `withAuth` codemod. Missing this would silently break Tiptap document editing on the deploy.
+
+Current shape:
+- `app/collab/auth.ts` re-exports `verifyAccessToken` as `verifyCollabToken`.
+- `app/collab/server.ts:78` calls `verifyCollabToken(token)` inside Hocuspocus `onAuthenticate`. The token comes from the client via the WS handshake.
+- Loaders in `hiring/routes/reviewer.application.$id.tsx`, `hiring/routes/interviewer.interview.$interviewId.tsx` (and any others that render a `CollaborativeEditor`) currently call `parseAccessToken(request)` to pull the JWT out of the cookie and pass it through loader data as `collabToken`.
+
+Changes:
+
+14. `app/collab/auth.ts`:
+    - Replace the `verifyAccessToken` re-export with a session-backed `verifyCollabToken(raw: string)` that does the same lookup `requireAuth` does (hash → `findUnique` → check `revokedAt` / `expiresAt`) and returns `{ sub: userId }` so `collab/server.ts` consumers (`user.sub`) keep working unchanged.
+    - Optionally `rollSession` here too — every collab handshake counts as activity.
+15. **All loaders that pass `collabToken` through loader data** (grep for `parseAccessToken` and for `collabToken` in the JSX):
+    - Replace `parseAccessToken(request)` with `parseSessionCookie(request)`. The variable name `collabToken` can stay or rename to `collabSessionId` — non-load-bearing.
+    - The `token` prop on `CollaborativeEditor` / `PresenceProvider` is now the raw session id instead of a JWT. Same string shape from the client's perspective.
+16. **Threat-model note** — the WS handshake already carries the same credential as the HTTP cookie (today: the JWT; after refactor: the session id). Blast radius unchanged. If we want to tighten this later, the right move is to issue short-lived, document-scoped collab tokens; that's a separate concern and explicitly out of scope here.
+
+### Phase 6 — Tests
+
+17. Delete and rewrite:
+    - `app/lib/__tests__/auth.test.ts` — sign/verify/refresh tests gone; cookie+header parsing, expiry, revoked, rolling expiry, sign-out-everywhere, hash-at-rest (raw in cookie, hashed in DB).
+    - `app/lib/__tests__/oauth.test.ts` — keep PKCE / authorize-session tests; delete token-pair tests; add `issueSession` tests there or in a new `session.test.ts`.
+    - `app/lib/__tests__/cookies.test.ts` — rewrite for single cookie.
+    - `app/lib/__tests__/dev-login.test.ts` — light update; cookie name changes.
+15. E2E (`e2e/`):
+    - `fixtures.ts` / `reviewer.spec.ts` use `/dev-login-as` — should still work; verify session cookie is set, no second cookie.
+    - Add an E2E that exercises Bearer-header auth against a known-protected route. Doesn't need MCP infra — just curl with `Authorization: Bearer $(get-session-id)`.
+
+### Phase 7 — Cleanup
+
+19. Search for stale references:
+    - `grep -r "__dali_at\|__dali_rt\|JWT_SECRET\|refreshTokens\|signAccessToken\|verifyAccessToken\|verifyCollabToken\|parseAccessToken\|withAuth\|RefreshToken" app/ e2e/` — should return only intentional matches (e.g., audit-log strings if any).
+    - Drop `JWT_SECRET` from `docker-compose.yml`, `fly.*.toml`.
+    - Drop `jose` from `package.json` if unused.
+20. Update docs:
+    - `dali-os-mcp.md` — change the schema section to use `Session` (with `grantId` set) instead of `RefreshToken`. Update flow description: `/oauth/token` returns a session id, not a JWT.
+    - `README.md` — auth surface section briefly notes session-cookie + Bearer-header model.
+
+## Cutover plan
+
+**Hard cutover.** Forced re-login for everyone, single deploy.
+
+**Why not dual-read:**
+- Dual-read means temporarily running *both* validation paths simultaneously — the riskiest moment in the migration is also the moment with the most surface area.
+- The drop of `RefreshToken` is irreversible without restoring from backup. A dual-read intermediate doesn't actually buy reversibility.
+- User-facing effect of hard cutover is *one click* to log in again. Low cost for an internal tool with hundreds of members.
+
+**Sequence:**
+1. Open PR. Run tests + Playwright in CI.
+2. Land on `dev`. Burn in on the dev Neon branch for ~24 hours. Confirm: no auth-related errors in logs, dev-login-as still works, manual smoke covers all three login providers + logout.
+3. Promote to `staging`. Staging has a prod snapshot — verify the migration drops `RefreshToken` cleanly against real data shapes.
+4. Post a heads-up in `#dali-eng` (or wherever) ~24 hours ahead: *"Auth refactor lands tomorrow at 4pm; you'll be logged out once and need to sign in again. Bear with us."*
+5. Promote to `prod` outside of a hiring-cycle deadline window. Cycle activity (open/release) should not be the same hour.
+6. Monitor: login success rate, auth-error rate, `lastUsedAt` updates flowing on `Session`. 30-minute attentive window post-deploy.
+
+**Rollback:**
+- If detected pre-`prod`: revert PR, redeploy. `RefreshToken` table still exists on prod.
+- If detected post-`prod`: hard. The migration drops `RefreshToken`; rolling back requires restoring from Neon's point-in-time recovery, which kicks everyone off again. For all but a catastrophic auth break, the right move is *fix forward*. Have a hotfix branch ready (e.g., revert the session lookup to a permissive mode) before deploying to prod.
+
+## Testing strategy
+
+### Unit (Vitest)
+
+Cover, at minimum:
+- `issueSession` writes a row with the right TTLs. Stored `id` is the hash; returned id is the raw.
+- `lookupSession` returns `null` for missing / revoked / past-`expiresAt` / past-`absoluteExpiresAt`. Verify a raw id with no matching hash returns `null` (not an error).
+- `rollSession` advances `expiresAt` but never past `absoluteExpiresAt`.
+- `revokeSession`, `revokeAllForUser`, `revokeAllForGrant` flip the right rows. (`revokeAllForGrant` ships now; takes effect once `OAuthGrant` lands.)
+- `requireAuth` accepts cookie, accepts Bearer, prefers cookie when both present.
+- `requireAuth` returns the expected `reason` for each failure mode (used by upstream error handling).
+- `requireAuth` returns `auth.user.sub` matching the session's `userId` (regression guard for the codemod).
+- Logout clears the cookie and revokes the session.
+- `verifyCollabToken` resolves the same raw session id as `requireAuth` and returns `{ sub }` in the legacy shape.
+
+### Integration (Vitest against Postgres service container, per `test.yml`)
+
+- Full login flow: hit `/login` → mock provider callback → assert one row in `Session`, one `Set-Cookie`, no other cookies.
+- OAuth token flow: simulate `/oauth/authorize` + `/oauth/token` end-to-end, assert the returned `access_token` corresponds to a `Session` row.
+
+### E2E (Playwright)
+
+- Existing `dev-login-as` flow continues to pass.
+- New: smoke for the Bearer header (curl-style with a known session id).
+- New: log out from one tab, verify the other tab is immediately unauthenticated on next request.
+
+### Manual smoke (before promoting to prod)
+
+- All three login paths (Google member, Google partner via `@dartmouth.edu`, CAS).
+- Logout.
+- Wait 30+ minutes idle, refresh — should still be logged in (rolling extends), no "bounced every 15 min" regression.
+- Revoke a session row directly in Prisma Studio → next request 302s to `/login`.
+- **Collab smoke**: open a Tiptap-backed document (reviewer application or interviewer interview), confirm presence indicator appears, type and confirm content persists after refresh. Open the same doc from a second browser session and confirm cursors sync. This catches the `collab/auth.ts` path.
+
+## Risks and mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Auth bug ships, users locked out | Low | High | Burn-in on dev for 24h; staging mirrors prod data; deploy outside cycle deadlines; rollback plan documented |
+| Session ID guessable | Very low | High | 32 bytes (256 bits) from `crypto.randomBytes`, base64url. Industry standard. |
+| DB lookup latency adds up | Low | Low | Indexed PK lookup; same Postgres already serves role checks per-request. Add a SLI on `requireAuth` latency post-deploy if concerned. |
+| Cookie leaks across context | Very low | High | HttpOnly + SameSite=Lax + Secure in prod (same as today). |
+| `RefreshToken` drop is irreversible | Certain | Medium | Accepted — re-login is one click. Schedule outside high-activity hours. |
+| 111-file mechanical edit misses a spot | Medium | Low-Medium | Codemod + grep verify; CI catches type errors from leftover `withAuth` imports. |
+| `withAuth` removal breaks a non-obvious side effect | Low | Medium | `withAuth` only did two things: pass-through, or attach Set-Cookie. Pass-through is null-op. Set-Cookie is gone because silent refresh is gone. There's no other side effect to lose. |
+| OAuth provider tests still reference `issueTokens` | Medium | Low | Caught by Vitest; rewrite test setup helpers. |
+| Anomaly detection lost (rotating-RT reuse alarm) | n/a | Low | Threat model is an internal tool; `lastUsedAt` + IP/UA on the row is enough. Add anomaly checks if motivated. |
+| Collab path missed (Hocuspocus `onAuthenticate` keeps verifying JWT) | Medium | High | Tiptap docs would stop authenticating mid-deploy. Phase 5.5 covers `collab/auth.ts` + loader `parseAccessToken` → `parseSessionCookie` swap. Manual smoke confirms a doc loads end-to-end on staging. |
+| `auth.user.sub` shape silently changes | Low | Medium | Preserved by design (see locked-in decisions). Vitest assertion `result.user.sub === session.userId` in `auth.test.ts` is a regression guard. |
+
+## Out of scope (intentionally deferred)
+
+- **"Active sessions" UI** for members to see and revoke their own sessions. Easy to add later — the data is on the row. Punted because v1 of MCP doesn't need it and browser users get instant revocation via logout already.
+- **Anomaly detection** (impossible-travel, UA flip). Add when motivated by a real incident.
+- **Document-scoped collab tokens.** The collab WS handshake carries the same credential as the HTTP cookie (today's JWT, post-refactor: the session id). Same blast radius as today; not made worse. A future refactor could issue short-lived, document-scoped tokens specifically for collab — that's its own track.
+- **API keys / non-MCP programmatic access.** Separate concern; sessions issued via OAuth grants cover the MCP need.
+- **Scope vocabulary for MCP.** Lives in `dali-os-mcp.md`; orthogonal to this work.
+
+## Open decisions to make before merging
+
+1. **Drop `refresh_token` grant from `/oauth/token` entirely, or stub it?** RFC 6749 permits omitting it. Stubbing means returning the same session id as both `access_token` and `refresh_token`, which is a lie but is compatible with naive clients. **Recommendation: drop entirely.** MCP clients we care about (Claude Desktop, Claude Code) don't require it.
+2. **Cookie name.** `__dali_sid` proposed. Worth bikeshedding once, then never again.
+3. **TTLs.** Current: AT 15m, RT 7d sliding, 30d absolute. Proposed: rolling 30d, absolute 30d (matches today's RT behavior, drops the AT concept). Could shorten rolling for paranoia. **Recommendation: 30d rolling, 30d absolute.** Same effective security as today.
+4. **Capture `userAgent` / `ip` from day one?** Cheap; useful for the future "active sessions" UI and incident forensics. **Recommendation: yes.**
+5. **Where does `getClientIp(request)` come from?** Fly forwards via `Fly-Client-IP`; fall back to `X-Forwarded-For`. Trivial helper.
+
+**Locked-in design decisions** (resolved during review, no longer open):
+
+- **Hash session ids at rest.** `Session.id` stores `sha256(raw_id)`; raw id travels in cookies/Bearer headers; lookups are `findUnique({ where: { id: sha256(input) } })`. PK lookup stays indexed and O(1). Mirrors the `RefreshToken.tokenHash` precedent.
+- **`grantId String?` without FK in this PR.** Column ships now; the FK constraint and `OAuthGrant?` relation land in the MCP foundation track's migration.
+- **`auth.user.sub` preserved.** The `requireAuth` return shape keeps the `user.sub` field so the 111-file edit is purely about removing `withAuth`. Renaming to `userId` (if ever wanted) is a separate concern, separate PR.
+
+## How this enables the MCP track
+
+After this lands, the MCP foundation work described in `dali-os-mcp.md` becomes shorter:
+
+| MCP foundation step (from `dali-os-mcp.md`) | Status after this refactor |
+|---|---|
+| Client registry (`OAuthClient` model) | Still needed |
+| Per-client redirect URIs + loopback matching | Still needed |
+| Existing-session shortcut on `/oauth/authorize` | Still needed; trivially "is there a valid `__dali_sid` cookie?" |
+| **Bearer-token acceptance in `requireAuth`** | **Done by this refactor.** |
+| Scope plumbing (session → access token claim → middleware enforcement) | Now: scope plumbing → `Session.scopes` column → middleware. Cleaner than JWT claims. |
+| `OAuthGrant` model + consent screen | Still needed; `Session.grantId` already wired. |
+| `.well-known/oauth-authorization-server` | Still needed |
+| Settings > Connected apps UI | Still needed; reads from `OAuthGrant` joined to `Session` for last-used. |
+
+`Session.scopes` (a `String[]` column added during the MCP track) replaces the JWT scope claim and is enforced in the MCP middleware. The MCP server's auth layer reduces to: `requireAuth(request) → check session.scopes → dispatch`.
+
+## Estimated effort
+
+| Phase | Effort |
+|---|---|
+| 1 — Schema + session lib | 0.5 day |
+| 2 — Rewrite auth/cookies/oauth lib | 1 day |
+| 3 — Strip `withAuth` across 111 files | 0.5 day (codemod + review) |
+| 4 — Login-flow wiring | 0.5 day |
+| 5 — OAuth provider wiring | 0.5 day |
+| 5.5 — Collab server (Hocuspocus) + loader `parseAccessToken` swap | 0.5 day |
+| 6 — Tests | 1 day |
+| 7 — Cleanup + docs | 0.5 day |
+| Burn-in / staging verify / prod deploy | 1 day across calendar time |
+| **Total** | **~5.5 focused days + 1 calendar day for safe deploy** |
+
+This is meaningfully less than the cost of building the MCP foundation on top of the existing JWT/RT scheme and *then* doing #407 later.
+
+## Cross-references
+
+- Issue #407 — the original sessions proposal. This doc supersedes it.
+- `dali-os-mcp.md` — the MCP plan. After this refactor lands, update its schema section to use `Session` instead of `RefreshToken`.
+- `app/lib/auth.ts:24-176` — current JWT + silent-refresh implementation (replaced).
+- `app/lib/oauth.ts:228-330` — current `issueTokens` / `refreshTokens` / `revokeToken` (replaced).
+- `app/lib/cookies.ts` — current cookie helpers (replaced).

--- a/dali-api/.env.example
+++ b/dali-api/.env.example
@@ -7,9 +7,6 @@ GOOGLE_CLIENT_ID="your-client-id.apps.googleusercontent.com"
 GOOGLE_CLIENT_SECRET="your-client-secret"
 GOOGLE_REDIRECT_URI=http://localhost:5173/auth/google/callback
 
-# jwt key — must be at least 32 bytes (HS256 minimum per RFC 7518)
-JWT_SECRET="random-secret-at-least-32-bytes!"
-
 # dartmouth sso url
 CAS_BASE_URL="https://login.dartmouth.edu/cas"
 

--- a/dali-api/app/admin-console/__tests__/api.domains.create.test.ts
+++ b/dali-api/app/admin-console/__tests__/api.domains.create.test.ts
@@ -3,7 +3,6 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 vi.mock("~/lib/db");
 vi.mock("~/lib/auth", () => ({
   requireAuth: vi.fn(),
-  withAuth: <T,>(_auth: unknown, value: T) => value,
 }));
 vi.mock("~/lib/roles");
 vi.mock("~/lib/cors", () => ({

--- a/dali-api/app/admin-console/__tests__/api.domains.delete.test.ts
+++ b/dali-api/app/admin-console/__tests__/api.domains.delete.test.ts
@@ -3,7 +3,6 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 vi.mock("~/lib/db");
 vi.mock("~/lib/auth", () => ({
   requireAuth: vi.fn(),
-  withAuth: <T,>(_auth: unknown, value: T) => value,
 }));
 vi.mock("~/lib/roles");
 

--- a/dali-api/app/admin-console/__tests__/api.members.roles.test.ts
+++ b/dali-api/app/admin-console/__tests__/api.members.roles.test.ts
@@ -3,7 +3,6 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 vi.mock("~/lib/db");
 vi.mock("~/lib/auth", () => ({
   requireAuth: vi.fn(),
-  withAuth: <T,>(_auth: unknown, value: T) => value,
 }));
 vi.mock("~/lib/roles");
 vi.mock("~/lib/audit", () => ({ logAuditEvent: vi.fn() }));

--- a/dali-api/app/admin-console/routes/admin-console.domains.tsx
+++ b/dali-api/app/admin-console/routes/admin-console.domains.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { redirect, useLoaderData, useFetcher } from "react-router";
 import type { Route } from "./+types/admin-console.domains";
 import { prisma } from "~/lib/db";
-import { requireAuth, withAuth } from "~/lib/auth";
+import { requireAuth } from "~/lib/auth";
 import { isAdmin } from "~/lib/roles";
 import { describeDomainUsage } from "./api.domains.$domainId";
 import { ChevronDown, Trash2, Plus } from "lucide-react";
@@ -17,9 +17,9 @@ export const meta: Route.MetaFunction = () => [{ title: "Domains · Admin consol
 
 export async function loader({ request }: Route.LoaderArgs) {
   const auth = await requireAuth(request);
-  if (!auth.ok) return withAuth(auth, redirect("/login"));
+  if (!auth.ok) return redirect("/login");
   const admin = await isAdmin(auth.user.sub);
-  if (!admin) return withAuth(auth, redirect("/admin-console/members"));
+  if (!admin) return redirect("/admin-console/members");
 
   const [members, domains] = await Promise.all([
     prisma.dALIMember.findMany({
@@ -54,28 +54,28 @@ export async function loader({ request }: Route.LoaderArgs) {
     }),
   ]);
 
-  return withAuth(auth, { members, domains });
+  return { members, domains };
 }
 
 export async function action({ request }: Route.ActionArgs) {
   const auth = await requireAuth(request);
   if (!auth.ok) return auth.response;
   const admin = await isAdmin(auth.user.sub);
-  if (!admin) return withAuth(auth, Response.json({ error: "Forbidden" }, { status: 403 }));
+  if (!admin) return Response.json({ error: "Forbidden" }, { status: 403 });
 
   const formData = await request.formData();
   const intent = formData.get("intent") as string;
 
   if (intent === "create-domain") {
     const name = String(formData.get("name") ?? "").trim();
-    if (!name) return withAuth(auth, Response.json({ error: "Name is required" }, { status: 400 }));
+    if (!name) return Response.json({ error: "Name is required" }, { status: 400 });
     await prisma.domain.create({ data: { name } });
-    return withAuth(auth, null);
+    return null;
   }
 
   if (intent === "delete-domain") {
     const domainId = String(formData.get("domainId") ?? "");
-    if (!domainId) return withAuth(auth, Response.json({ error: "domainId is required" }, { status: 400 }));
+    if (!domainId) return Response.json({ error: "domainId is required" }, { status: 400 });
 
     const result = await prisma.$transaction(async (tx) => {
       const domain = await tx.domain.findUnique({
@@ -101,31 +101,31 @@ export async function action({ request }: Route.ActionArgs) {
     });
 
     if (result.kind === "not-found") {
-      return withAuth(auth, Response.json({ error: "Domain not found" }, { status: 404 }));
+      return Response.json({ error: "Domain not found" }, { status: 404 });
     }
     if (result.kind === "in-use") {
-      return withAuth(auth, Response.json(
+      return Response.json(
               { error: `Cannot delete: domain is in use by ${result.blocking.join(", ")}.` },
               { status: 409 },
-            ));
+            );
     }
-    return withAuth(auth, null);
+    return null;
   }
 
   if (intent === "add-domain-lead") {
     const memberId = formData.get("memberId") as string;
     const domainId = formData.get("domainId") as string;
     await prisma.domainLeadAssignment.create({ data: { memberId, domainId } });
-    return withAuth(auth, null);
+    return null;
   }
 
   if (intent === "remove-domain-lead") {
     const assignmentId = formData.get("assignmentId") as string;
     await prisma.domainLeadAssignment.delete({ where: { id: assignmentId } });
-    return withAuth(auth, null);
+    return null;
   }
 
-  return withAuth(auth, null);
+  return null;
 }
 
 function AddDomainLeadForMemberButton({ domainId, member, onAdded }: { domainId: string; member: Member; onAdded: () => void }) {

--- a/dali-api/app/admin-console/routes/admin-console.members.tsx
+++ b/dali-api/app/admin-console/routes/admin-console.members.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { redirect, useLoaderData } from "react-router";
 import type { Route } from "./+types/admin-console.members";
 import { prisma } from "~/lib/db";
-import { requireAuth, withAuth } from "~/lib/auth";
+import { requireAuth } from "~/lib/auth";
 import { isAdmin } from "~/lib/roles";
 import { Users, Check } from "lucide-react";
 import {
@@ -15,9 +15,9 @@ export const meta: Route.MetaFunction = () => [{ title: "Members · Admin consol
 
 export async function loader({ request }: Route.LoaderArgs) {
   const auth = await requireAuth(request);
-  if (!auth.ok) return withAuth(auth, redirect("/login"));
+  if (!auth.ok) return redirect("/login");
   const admin = await isAdmin(auth.user.sub);
-  if (!admin) return withAuth(auth, redirect("/"));
+  if (!admin) return redirect("/");
 
   const [members, domains] = await Promise.all([
     prisma.dALIMember.findMany({
@@ -33,7 +33,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     }),
   ]);
 
-  return withAuth(auth, { members, domains });
+  return { members, domains };
 }
 
 export async function action({ request }: Route.ActionArgs) {
@@ -41,7 +41,7 @@ export async function action({ request }: Route.ActionArgs) {
   if (!auth.ok) return auth.response;
   const admin = await isAdmin(auth.user.sub);
   if (!admin)
-    return withAuth(auth, Response.json({ error: "Forbidden" }, { status: 403 }));
+    return Response.json({ error: "Forbidden" }, { status: 403 });
 
   const formData = await request.formData();
   const intent = formData.get("intent") as string;
@@ -57,7 +57,7 @@ export async function action({ request }: Route.ActionArgs) {
       ? [...new Set([...member.roles, "Admin" as const])]
       : member.roles.filter((r) => r !== "Admin");
     await prisma.dALIMember.update({ where: { id: memberId }, data: { roles } });
-    return withAuth(auth, null);
+    return null;
   }
 
   if (intent === "set-hiring-lead") {
@@ -71,23 +71,23 @@ export async function action({ request }: Route.ActionArgs) {
       ? [...new Set([...member.roles, "HiringLead" as const])]
       : member.roles.filter((r) => r !== "HiringLead");
     await prisma.dALIMember.update({ where: { id: memberId }, data: { roles } });
-    return withAuth(auth, null);
+    return null;
   }
 
   if (intent === "add-domain-lead") {
     const memberId = formData.get("memberId") as string;
     const domainId = formData.get("domainId") as string;
     await prisma.domainLeadAssignment.create({ data: { memberId, domainId } });
-    return withAuth(auth, null);
+    return null;
   }
 
   if (intent === "remove-domain-lead") {
     const assignmentId = formData.get("assignmentId") as string;
     await prisma.domainLeadAssignment.delete({ where: { id: assignmentId } });
-    return withAuth(auth, null);
+    return null;
   }
 
-  return withAuth(auth, null);
+  return null;
 }
 
 type RoleFilter = "all" | "admin" | "hiringLead";

--- a/dali-api/app/admin-console/routes/api.audit-logs.ts
+++ b/dali-api/app/admin-console/routes/api.audit-logs.ts
@@ -1,6 +1,6 @@
 import type { Route } from "./+types/api.audit-logs";
 import { prisma } from "~/lib/db";
-import { requireAuth, withAuth } from "~/lib/auth";
+import { requireAuth } from "~/lib/auth";
 import { isAdmin } from "~/lib/roles";
 import { withCors, handlePreflight } from "~/lib/cors";
 
@@ -14,7 +14,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   const auth = await requireAuth(request);
   if (!auth.ok) return withCors(request, auth.response);
   if (!(await isAdmin(auth.user.sub)))
-    return withAuth(auth, withCors(request, Response.json({ error: "Forbidden" }, { status: 403 })));
+    return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
 
   const url = new URL(request.url);
   const limit = Math.min(Number(url.searchParams.get("limit") ?? DEFAULT_LIMIT) || DEFAULT_LIMIT, MAX_LIMIT);
@@ -29,5 +29,5 @@ export async function loader({ request }: Route.LoaderArgs) {
     prisma.auditLog.count(),
   ]);
 
-  return withAuth(auth, withCors(request, Response.json({ total, limit, offset, entries })));
+  return withCors(request, Response.json({ total, limit, offset, entries }));
 }

--- a/dali-api/app/admin-console/routes/api.domains.$domainId.leads.ts
+++ b/dali-api/app/admin-console/routes/api.domains.$domainId.leads.ts
@@ -1,7 +1,7 @@
 import type { Route } from "./+types/api.domains.$domainId.leads";
 import { z } from "zod";
 import { prisma } from "~/lib/db";
-import { requireAuth, withAuth } from "~/lib/auth";
+import { requireAuth } from "~/lib/auth";
 import { isAdmin } from "~/lib/roles";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { parseJson } from "~/lib/validate";
@@ -20,14 +20,14 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 
   const auth = await requireAuth(request);
   if (!auth.ok) return withCors(request, auth.response);
-  if (!(await isAdmin(auth.user.sub))) return withAuth(auth, withCors(request, Response.json({ error: "Forbidden" }, { status: 403 })));
+  if (!(await isAdmin(auth.user.sub))) return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
 
   const leads = await prisma.domainLeadAssignment.findMany({
     where: { domainId: params.domainId },
     include: { member: { include: { user: true } }, domain: true },
   });
 
-  return withAuth(auth, withCors(request, Response.json(leads)));
+  return withCors(request, Response.json(leads));
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
@@ -36,27 +36,27 @@ export async function action({ request, params }: Route.ActionArgs) {
 
   const auth = await requireAuth(request);
   if (!auth.ok) return withCors(request, auth.response);
-  if (!(await isAdmin(auth.user.sub))) return withAuth(auth, withCors(request, Response.json({ error: "Forbidden" }, { status: 403 })));
+  if (!(await isAdmin(auth.user.sub))) return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
 
   if (request.method === "POST") {
     const postBody = await parseJson(request, AddLeadSchema);
-    if (postBody instanceof Response) return withAuth(auth, withCors(request, postBody));
+    if (postBody instanceof Response) return withCors(request, postBody);
     const { memberId } = postBody;
 
     const assignment = await prisma.domainLeadAssignment.create({
       data: { memberId, domainId: params.domainId! },
       include: { member: { include: { user: true } }, domain: true },
     });
-    return withAuth(auth, withCors(request, Response.json(assignment, { status: 201 })));
+    return withCors(request, Response.json(assignment, { status: 201 }));
   }
 
   if (request.method === "DELETE") {
     const delBody = await parseJson(request, RemoveLeadSchema);
-    if (delBody instanceof Response) return withAuth(auth, withCors(request, delBody));
+    if (delBody instanceof Response) return withCors(request, delBody);
     const { assignmentId } = delBody;
     await prisma.domainLeadAssignment.delete({ where: { id: assignmentId } });
-    return withAuth(auth, withCors(request, Response.json({ ok: true })));
+    return withCors(request, Response.json({ ok: true }));
   }
 
-  return withAuth(auth, withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 })));
+  return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));
 }

--- a/dali-api/app/admin-console/routes/api.domains.$domainId.ts
+++ b/dali-api/app/admin-console/routes/api.domains.$domainId.ts
@@ -1,6 +1,6 @@
 import type { Route } from "./+types/api.domains.$domainId";
 import { prisma } from "~/lib/db";
-import { requireAuth, withAuth } from "~/lib/auth";
+import { requireAuth } from "~/lib/auth";
 import { isAdmin } from "~/lib/roles";
 import { withCors, handlePreflight } from "~/lib/cors";
 
@@ -35,10 +35,10 @@ export async function action({ request, params }: Route.ActionArgs) {
   const auth = await requireAuth(request);
   if (!auth.ok) return withCors(request, auth.response);
   if (!(await isAdmin(auth.user.sub)))
-    return withAuth(auth, withCors(request, Response.json({ error: "Forbidden" }, { status: 403 })));
+    return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
 
   if (request.method !== "DELETE") {
-    return withAuth(auth, withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 })));
+    return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));
   }
 
   const domainId = params.domainId!;
@@ -70,16 +70,16 @@ export async function action({ request, params }: Route.ActionArgs) {
   });
 
   if (result.kind === "not-found") {
-    return withAuth(auth, withCors(request, Response.json({ error: "Domain not found" }, { status: 404 })));
+    return withCors(request, Response.json({ error: "Domain not found" }, { status: 404 }));
   }
   if (result.kind === "in-use") {
-    return withAuth(auth, withCors(
+    return withCors(
           request,
           Response.json(
             { error: `Cannot delete: domain is in use by ${result.blocking.join(", ")}.` },
             { status: 409 },
           ),
-        ));
+        );
   }
-  return withAuth(auth, withCors(request, Response.json({ ok: true })));
+  return withCors(request, Response.json({ ok: true }));
 }

--- a/dali-api/app/admin-console/routes/api.domains.ts
+++ b/dali-api/app/admin-console/routes/api.domains.ts
@@ -1,7 +1,7 @@
 import type { Route } from "./+types/api.domains";
 import { z } from "zod";
 import { prisma } from "~/lib/db";
-import { requireAuth, withAuth } from "~/lib/auth";
+import { requireAuth } from "~/lib/auth";
 import { isHiringLead, isDomainLead, isAdmin } from "~/lib/roles";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { parseJson } from "~/lib/validate";
@@ -23,7 +23,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     isAdmin(auth.user.sub),
   ]);
   if (!hl && !dl && !admin)
-    return withAuth(auth, withCors(request, Response.json({ error: "Forbidden" }, { status: 403 })));
+    return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
 
   const domains = await prisma.domain.findMany({
     orderBy: { name: "asc" },
@@ -44,7 +44,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     },
   });
 
-  return withAuth(auth, withCors(request, Response.json(domains)));
+  return withCors(request, Response.json(domains));
 }
 
 export async function action({ request }: Route.ActionArgs) {
@@ -53,16 +53,16 @@ export async function action({ request }: Route.ActionArgs) {
 
   const auth = await requireAuth(request);
   if (!auth.ok) return withCors(request, auth.response);
-  if (!(await isAdmin(auth.user.sub))) return withAuth(auth, withCors(request, Response.json({ error: "Forbidden" }, { status: 403 })));
+  if (!(await isAdmin(auth.user.sub))) return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
 
   if (request.method !== "POST") {
-    return withAuth(auth, withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 })));
+    return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));
   }
 
   const body = await parseJson(request, CreateDomainSchema);
-  if (body instanceof Response) return withAuth(auth, withCors(request, body));
+  if (body instanceof Response) return withCors(request, body);
   const { name } = body;
 
   const domain = await prisma.domain.create({ data: { name } });
-  return withAuth(auth, withCors(request, Response.json(domain, { status: 201 })));
+  return withCors(request, Response.json(domain, { status: 201 }));
 }

--- a/dali-api/app/admin-console/routes/api.members.$memberId.roles.ts
+++ b/dali-api/app/admin-console/routes/api.members.$memberId.roles.ts
@@ -1,7 +1,7 @@
 import type { Route } from "./+types/api.members.$memberId.roles";
 import { z } from "zod";
 import { prisma } from "~/lib/db";
-import { requireAuth, withAuth } from "~/lib/auth";
+import { requireAuth } from "~/lib/auth";
 import { isAdmin } from "~/lib/roles";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { parseJson } from "~/lib/validate";
@@ -19,14 +19,14 @@ export async function action({ request, params }: Route.ActionArgs) {
 
   const auth = await requireAuth(request);
   if (!auth.ok) return withCors(request, auth.response);
-  if (!(await isAdmin(auth.user.sub))) return withAuth(auth, withCors(request, Response.json({ error: "Forbidden" }, { status: 403 })));
+  if (!(await isAdmin(auth.user.sub))) return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
 
   if (request.method !== "PATCH") {
-    return withAuth(auth, withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 })));
+    return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));
   }
 
   const body = await parseJson(request, RolesPatchSchema);
-  if (body instanceof Response) return withAuth(auth, withCors(request, body));
+  if (body instanceof Response) return withCors(request, body);
   const { roles } = body;
 
   const before = await prisma.dALIMember.findUnique({
@@ -52,5 +52,5 @@ export async function action({ request, params }: Route.ActionArgs) {
     request,
   });
 
-  return withAuth(auth, withCors(request, Response.json(member)));
+  return withCors(request, Response.json(member));
 }

--- a/dali-api/app/admin-console/routes/api.members.ts
+++ b/dali-api/app/admin-console/routes/api.members.ts
@@ -1,6 +1,6 @@
 import type { Route } from "./+types/api.members";
 import { prisma } from "~/lib/db";
-import { requireAuth, withAuth } from "~/lib/auth";
+import { requireAuth } from "~/lib/auth";
 import { isAdmin, isHiringLead, isDomainLead } from "~/lib/roles";
 import { withCors, handlePreflight } from "~/lib/cors";
 
@@ -11,7 +11,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   const auth = await requireAuth(request);
   if (!auth.ok) return withCors(request, auth.response);
   const [admin, hiringLead, domainLead] = await Promise.all([isAdmin(auth.user.sub), isHiringLead(auth.user.sub), isDomainLead(auth.user.sub)]);
-  if (!admin && !hiringLead && !domainLead) return withAuth(auth, withCors(request, Response.json({ error: "Forbidden" }, { status: 403 })));
+  if (!admin && !hiringLead && !domainLead) return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
 
   const members = await prisma.dALIMember.findMany({
     orderBy: { createdAt: "asc" },
@@ -25,5 +25,5 @@ export async function loader({ request }: Route.LoaderArgs) {
     },
   });
 
-  return withAuth(auth, withCors(request, Response.json(members)));
+  return withCors(request, Response.json(members));
 }

--- a/dali-api/app/calendar/routes/api.google-calendar.busy.ts
+++ b/dali-api/app/calendar/routes/api.google-calendar.busy.ts
@@ -1,5 +1,5 @@
 import type { Route } from "./+types/api.google-calendar.busy";
-import { requireAuth, withAuth } from "~/lib/auth";
+import { requireAuth } from "~/lib/auth";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { fetchBusyEvents } from "~/lib/google-calendar";
 
@@ -15,13 +15,13 @@ export async function loader({ request }: Route.LoaderArgs) {
   const end = url.searchParams.get("end");
 
   if (!start || !end) {
-    return withAuth(auth, withCors(request, Response.json({ error: "start and end query params required" }, { status: 400 })));
+    return withCors(request, Response.json({ error: "start and end query params required" }, { status: 400 }));
   }
 
   try {
     const busy = await fetchBusyEvents(auth.user.sub, new Date(start), new Date(end));
-    return withAuth(auth, withCors(request, Response.json(busy)));
+    return withCors(request, Response.json(busy));
   } catch (err: any) {
-    return withAuth(auth, withCors(request, Response.json({ error: err.message }, { status: 500 })));
+    return withCors(request, Response.json({ error: err.message }, { status: 500 }));
   }
 }

--- a/dali-api/app/calendar/routes/calendar.tsx
+++ b/dali-api/app/calendar/routes/calendar.tsx
@@ -14,7 +14,7 @@ import {
   Copy,
   ChevronDown,
 } from "lucide-react";
-import { requireAuth, withAuth } from "~/lib/auth";
+import { requireAuth } from "~/lib/auth";
 import { prisma } from "~/lib/db";
 import { computeFreeIntervals, type Interval } from "~/lib/availability";
 import { CalendarActionSchema } from "~/lib/calendar-schemas";
@@ -112,8 +112,8 @@ function currentWeekWindow(timezone: string): { start: Date; end: Date } {
 
 export async function loader({ request }: Route.LoaderArgs) {
   const auth = await requireAuth(request);
-  if (!auth.ok) return withAuth(auth, redirect("/login"));
-  if (auth.user.type === "applicant") return withAuth(auth, redirect("/portal"));
+  if (!auth.ok) return redirect("/login");
+  if (auth.user.type === "applicant") return redirect("/portal");
 
   const userId = auth.user.sub;
 
@@ -230,14 +230,14 @@ export async function loader({ request }: Route.LoaderArgs) {
     })),
     ingestionError,
   };
-  return withAuth(auth, data);
+  return data;
 }
 
 export async function action({ request }: Route.ActionArgs) {
   const auth = await requireAuth(request);
   if (!auth.ok) return auth.response;
   if (auth.user.type === "applicant")
-    return withAuth(auth, Response.json({ error: "Forbidden" }, { status: 403 }));
+    return Response.json({ error: "Forbidden" }, { status: 403 });
 
   const userId = auth.user.sub;
   const form = await request.formData();
@@ -247,20 +247,14 @@ export async function action({ request }: Route.ActionArgs) {
   const candidate = coerceFormToAction(raw);
   const parsed = CalendarActionSchema.safeParse(candidate);
   if (!parsed.success) {
-    return withAuth(
-      auth,
-      Response.json({ error: "Invalid input", details: parsed.error.flatten() }, { status: 400 }),
-    );
+    return Response.json({ error: "Invalid input", details: parsed.error.flatten() }, { status: 400 });
   }
   const input = parsed.data;
 
   switch (input.intent) {
     case "update-working-hours-day": {
       if (input.enabled && input.startMinute >= input.endMinute) {
-        return withAuth(
-          auth,
-          Response.json({ error: "startMinute must be < endMinute" }, { status: 400 }),
-        );
+        return Response.json({ error: "startMinute must be < endMinute" }, { status: 400 });
       }
       await prisma.workingHoursDay.upsert({
         where: { userId_dayOfWeek: { userId, dayOfWeek: input.dayOfWeek } },
@@ -279,14 +273,14 @@ export async function action({ request }: Route.ActionArgs) {
           location: input.location,
         },
       });
-      return withAuth(auth, null);
+      return null;
     }
 
     case "copy-weekdays": {
       const monday = await prisma.workingHoursDay.findUnique({
         where: { userId_dayOfWeek: { userId, dayOfWeek: 1 } },
       });
-      if (!monday) return withAuth(auth, null);
+      if (!monday) return null;
       const tuesToFri = [2, 3, 4, 5];
       await Promise.all(
         tuesToFri.map((dow) =>
@@ -309,12 +303,12 @@ export async function action({ request }: Route.ActionArgs) {
           }),
         ),
       );
-      return withAuth(auth, null);
+      return null;
     }
 
     case "reset-working-hours": {
       await prisma.workingHoursDay.deleteMany({ where: { userId } });
-      return withAuth(auth, null);
+      return null;
     }
 
     case "set-event-buffer": {
@@ -323,17 +317,14 @@ export async function action({ request }: Route.ActionArgs) {
         create: { userId, defaultEventBufferMin: input.defaultEventBufferMin },
         update: { defaultEventBufferMin: input.defaultEventBufferMin },
       });
-      return withAuth(auth, null);
+      return null;
     }
 
     case "add-manual-block": {
       const startTime = new Date(input.startTime);
       const endTime = new Date(input.endTime);
       if (endTime <= startTime) {
-        return withAuth(
-          auth,
-          Response.json({ error: "endTime must be after startTime" }, { status: 400 }),
-        );
+        return Response.json({ error: "endTime must be after startTime" }, { status: 400 });
       }
       await prisma.manualBlock.create({
         data: {
@@ -345,21 +336,18 @@ export async function action({ request }: Route.ActionArgs) {
           recurrenceRule: input.recurrenceRule ?? null,
         },
       });
-      return withAuth(auth, null);
+      return null;
     }
 
     case "update-manual-block": {
       const existing = await prisma.manualBlock.findUnique({ where: { id: input.id } });
       if (!existing || existing.userId !== userId) {
-        return withAuth(auth, Response.json({ error: "Not found" }, { status: 404 }));
+        return Response.json({ error: "Not found" }, { status: 404 });
       }
       const startTime = input.startTime ? new Date(input.startTime) : existing.startTime;
       const endTime = input.endTime ? new Date(input.endTime) : existing.endTime;
       if (endTime <= startTime) {
-        return withAuth(
-          auth,
-          Response.json({ error: "endTime must be after startTime" }, { status: 400 }),
-        );
+        return Response.json({ error: "endTime must be after startTime" }, { status: 400 });
       }
       await prisma.manualBlock.update({
         where: { id: input.id },
@@ -372,31 +360,31 @@ export async function action({ request }: Route.ActionArgs) {
             input.recurrenceRule === undefined ? existing.recurrenceRule : input.recurrenceRule,
         },
       });
-      return withAuth(auth, null);
+      return null;
     }
 
     case "remove-manual-block": {
       const existing = await prisma.manualBlock.findUnique({ where: { id: input.id } });
       if (!existing || existing.userId !== userId) {
-        return withAuth(auth, Response.json({ error: "Not found" }, { status: 404 }));
+        return Response.json({ error: "Not found" }, { status: 404 });
       }
       await prisma.manualBlock.delete({ where: { id: input.id } });
-      return withAuth(auth, null);
+      return null;
     }
 
     case "remove-calendar-link": {
       const link = await prisma.userCalendarLink.findUnique({ where: { id: input.linkId } });
       if (!link || link.userId !== userId) {
-        return withAuth(auth, Response.json({ error: "Not found" }, { status: 404 }));
+        return Response.json({ error: "Not found" }, { status: 404 });
       }
       await prisma.userCalendarLink.delete({ where: { id: input.linkId } });
-      return withAuth(auth, null);
+      return null;
     }
 
     case "toggle-sub-calendar": {
       const link = await prisma.userCalendarLink.findUnique({ where: { id: input.linkId } });
       if (!link || link.userId !== userId) {
-        return withAuth(auth, Response.json({ error: "Not found" }, { status: 404 }));
+        return Response.json({ error: "Not found" }, { status: 404 });
       }
       const current = new Set(link.subCalendarIds);
       if (input.enabled) current.add(input.calendarId);
@@ -405,7 +393,7 @@ export async function action({ request }: Route.ActionArgs) {
         where: { id: input.linkId },
         data: { subCalendarIds: Array.from(current) },
       });
-      return withAuth(auth, null);
+      return null;
     }
   }
 }

--- a/dali-api/app/collab/auth.ts
+++ b/dali-api/app/collab/auth.ts
@@ -1,4 +1,21 @@
-import { verifyAccessToken } from "~/lib/auth";
+import { lookupSession, rollSession } from "~/lib/session";
 
-/** Verify a JWT token for WebSocket authentication. Reuses the main app auth. */
-export const verifyCollabToken = verifyAccessToken;
+// Hocuspocus onAuthenticate handler — verifies a raw session id passed
+// through the WS handshake. Returns the legacy `{ sub }` shape so the
+// rest of collab/server.ts (which reads `user.sub` for authz and connection
+// accounting) continues to work without per-call edits.
+//
+// The handshake credential is the same string that travels in the
+// __dali_sid cookie. See SESSION_AUTH_PLAN.md § Phase 5.5.
+export async function verifyCollabToken(rawSessionId: string): Promise<{ sub: string }> {
+  const session = await lookupSession(rawSessionId);
+  if (!session) throw new Error("Invalid session");
+  if (session.revokedAt) throw new Error("Session revoked");
+  const now = new Date();
+  if (session.expiresAt < now || session.absoluteExpiresAt < now) {
+    throw new Error("Session expired");
+  }
+  // Every successful collab handshake counts as activity for rolling expiry.
+  rollSession(session.id).catch(() => {});
+  return { sub: session.userId };
+}

--- a/dali-api/app/hiring/lib/__tests__/api.cycles.cycleId.status.test.ts
+++ b/dali-api/app/hiring/lib/__tests__/api.cycles.cycleId.status.test.ts
@@ -3,7 +3,6 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 vi.mock("~/lib/db");
 vi.mock("~/lib/auth", () => ({
   requireAuth: vi.fn(),
-  withAuth: <T,>(_auth: unknown, value: T) => value,
 }));
 vi.mock("~/lib/roles");
 vi.mock("~/hiring/lib/cycles");

--- a/dali-api/app/hiring/lib/__tests__/api.decisions.lineage.test.ts
+++ b/dali-api/app/hiring/lib/__tests__/api.decisions.lineage.test.ts
@@ -3,7 +3,6 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 vi.mock("~/lib/db");
 vi.mock("~/lib/auth", () => ({
   requireAuth: vi.fn(),
-  withAuth: <T,>(_auth: unknown, value: T) => value,
 }));
 vi.mock("~/lib/roles");
 vi.mock("~/lib/gmail");

--- a/dali-api/app/hiring/lib/__tests__/api.decisions.release.test.ts
+++ b/dali-api/app/hiring/lib/__tests__/api.decisions.release.test.ts
@@ -3,7 +3,6 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 vi.mock("~/lib/db");
 vi.mock("~/lib/auth", () => ({
   requireAuth: vi.fn(),
-  withAuth: <T,>(_auth: unknown, value: T) => value,
 }));
 vi.mock("~/lib/roles");
 vi.mock("~/lib/gmail");

--- a/dali-api/app/hiring/lib/__tests__/api.delibs.close.test.ts
+++ b/dali-api/app/hiring/lib/__tests__/api.delibs.close.test.ts
@@ -3,7 +3,6 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 vi.mock("~/lib/db");
 vi.mock("~/lib/auth", () => ({
   requireAuth: vi.fn(),
-  withAuth: <T,>(_auth: unknown, value: T) => value,
 }));
 vi.mock("~/lib/roles");
 

--- a/dali-api/app/hiring/lib/__tests__/api.delibs.id.moves.test.ts
+++ b/dali-api/app/hiring/lib/__tests__/api.delibs.id.moves.test.ts
@@ -3,7 +3,6 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 vi.mock("~/lib/db");
 vi.mock("~/lib/auth", () => ({
   requireAuth: vi.fn(),
-  withAuth: <T,>(_auth: unknown, value: T) => value,
 }));
 vi.mock("~/lib/roles");
 

--- a/dali-api/app/hiring/lib/__tests__/api.my-interview.cancel.test.ts
+++ b/dali-api/app/hiring/lib/__tests__/api.my-interview.cancel.test.ts
@@ -3,7 +3,6 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 vi.mock("~/lib/db");
 vi.mock("~/lib/auth", () => ({
   requireAuth: vi.fn(),
-  withAuth: <T,>(_auth: unknown, value: T) => value,
 }));
 vi.mock("~/lib/cors", () => ({
   handlePreflight: () => null,

--- a/dali-api/app/hiring/lib/__tests__/api.my-interview.reschedule.test.ts
+++ b/dali-api/app/hiring/lib/__tests__/api.my-interview.reschedule.test.ts
@@ -3,7 +3,6 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 vi.mock("~/lib/db");
 vi.mock("~/lib/auth", () => ({
   requireAuth: vi.fn(),
-  withAuth: <T,>(_auth: unknown, value: T) => value,
 }));
 vi.mock("~/hiring/lib/scheduling");
 vi.mock("~/lib/cors", () => ({

--- a/dali-api/app/hiring/lib/__tests__/lead.cycle.final-decisions-loader.test.ts
+++ b/dali-api/app/hiring/lib/__tests__/lead.cycle.final-decisions-loader.test.ts
@@ -3,7 +3,6 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 vi.mock("~/lib/db");
 vi.mock("~/lib/auth", () => ({
   requireAuth: vi.fn(),
-  withAuth: <T,>(_auth: unknown, value: T) => value,
 }));
 vi.mock("~/lib/roles");
 

--- a/dali-api/app/hiring/routes/__tests__/OpenApplicationsConfirmModal.test.tsx
+++ b/dali-api/app/hiring/routes/__tests__/OpenApplicationsConfirmModal.test.tsx
@@ -5,7 +5,6 @@ import { renderToStaticMarkup } from "react-dom/server";
 vi.mock("~/lib/db");
 vi.mock("~/lib/auth", () => ({
   requireAuth: vi.fn(),
-  withAuth: <T,>(_auth: unknown, value: T) => value,
 }));
 vi.mock("~/lib/roles");
 vi.mock("~/lib/email");

--- a/dali-api/app/hiring/routes/__tests__/analytics.test.ts
+++ b/dali-api/app/hiring/routes/__tests__/analytics.test.ts
@@ -3,7 +3,6 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 vi.mock("~/lib/db");
 vi.mock("~/lib/auth", () => ({
   requireAuth: vi.fn(),
-  withAuth: <T,>(_auth: unknown, value: T) => value,
 }));
 vi.mock("~/lib/roles");
 

--- a/dali-api/app/hiring/routes/__tests__/api.auto-assign.test.ts
+++ b/dali-api/app/hiring/routes/__tests__/api.auto-assign.test.ts
@@ -3,7 +3,6 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 vi.mock("~/lib/db");
 vi.mock("~/lib/auth", () => ({
   requireAuth: vi.fn(),
-  withAuth: <T,>(_auth: unknown, value: T) => value,
 }));
 vi.mock("~/lib/roles");
 vi.mock("~/hiring/lib/confidentiality", () => ({

--- a/dali-api/app/hiring/routes/__tests__/api.cycles.$cycleId.status.test.ts
+++ b/dali-api/app/hiring/routes/__tests__/api.cycles.$cycleId.status.test.ts
@@ -3,7 +3,6 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 vi.mock("~/lib/db");
 vi.mock("~/lib/auth", () => ({
   requireAuth: vi.fn(),
-  withAuth: <T,>(_auth: unknown, value: T) => value,
 }));
 vi.mock("~/lib/roles");
 vi.mock("~/hiring/lib/cycles");

--- a/dali-api/app/hiring/routes/__tests__/api.cycles.interview-config.test.ts
+++ b/dali-api/app/hiring/routes/__tests__/api.cycles.interview-config.test.ts
@@ -3,7 +3,6 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 vi.mock("~/lib/db");
 vi.mock("~/lib/auth", () => ({
   requireAuth: vi.fn(),
-  withAuth: <T,>(_auth: unknown, value: T) => value,
 }));
 vi.mock("~/lib/roles");
 

--- a/dali-api/app/hiring/routes/__tests__/api.cycles.interviewers.delete.test.ts
+++ b/dali-api/app/hiring/routes/__tests__/api.cycles.interviewers.delete.test.ts
@@ -3,7 +3,6 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 vi.mock("~/lib/db");
 vi.mock("~/lib/auth", () => ({
   requireAuth: vi.fn(),
-  withAuth: <T,>(_auth: unknown, value: T) => value,
 }));
 vi.mock("~/lib/roles");
 

--- a/dali-api/app/hiring/routes/__tests__/api.cycles.my-availability.test.ts
+++ b/dali-api/app/hiring/routes/__tests__/api.cycles.my-availability.test.ts
@@ -3,7 +3,6 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 vi.mock("~/lib/db");
 vi.mock("~/lib/auth", () => ({
   requireAuth: vi.fn(),
-  withAuth: <T,>(_auth: unknown, value: T) => value,
 }));
 vi.mock("~/lib/cors", () => ({
   handlePreflight: () => null,

--- a/dali-api/app/hiring/routes/__tests__/api.cycles.reviewers.delete.test.ts
+++ b/dali-api/app/hiring/routes/__tests__/api.cycles.reviewers.delete.test.ts
@@ -3,7 +3,6 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 vi.mock("~/lib/db");
 vi.mock("~/lib/auth", () => ({
   requireAuth: vi.fn(),
-  withAuth: <T,>(_auth: unknown, value: T) => value,
 }));
 vi.mock("~/lib/cors", () => ({
   handlePreflight: () => null,

--- a/dali-api/app/hiring/routes/__tests__/api.domain-applications.$id.reviews.test.ts
+++ b/dali-api/app/hiring/routes/__tests__/api.domain-applications.$id.reviews.test.ts
@@ -3,7 +3,6 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 vi.mock("~/lib/db");
 vi.mock("~/lib/auth", () => ({
   requireAuth: vi.fn(),
-  withAuth: <T,>(_auth: unknown, value: T) => value,
 }));
 vi.mock("~/lib/roles");
 

--- a/dali-api/app/hiring/routes/__tests__/api.domain-applications.full-context.test.ts
+++ b/dali-api/app/hiring/routes/__tests__/api.domain-applications.full-context.test.ts
@@ -3,7 +3,6 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 vi.mock("~/lib/db");
 vi.mock("~/lib/auth", () => ({
   requireAuth: vi.fn(),
-  withAuth: <T,>(_auth: unknown, value: T) => value,
 }));
 vi.mock("~/lib/roles");
 

--- a/dali-api/app/hiring/routes/__tests__/api.reviews.$id.test.ts
+++ b/dali-api/app/hiring/routes/__tests__/api.reviews.$id.test.ts
@@ -3,7 +3,6 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 vi.mock("~/lib/db");
 vi.mock("~/lib/auth", () => ({
   requireAuth: vi.fn(),
-  withAuth: <T,>(_auth: unknown, value: T) => value,
 }));
 vi.mock("~/lib/roles");
 

--- a/dali-api/app/hiring/routes/__tests__/domain-lead.test.ts
+++ b/dali-api/app/hiring/routes/__tests__/domain-lead.test.ts
@@ -3,7 +3,6 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 vi.mock("~/lib/db");
 vi.mock("~/lib/auth", () => ({
   requireAuth: vi.fn(),
-  withAuth: <T,>(_auth: unknown, value: T) => value,
 }));
 
 import { prisma } from "~/lib/db";

--- a/dali-api/app/hiring/routes/__tests__/lead.cycle.$id.test.ts
+++ b/dali-api/app/hiring/routes/__tests__/lead.cycle.$id.test.ts
@@ -3,7 +3,6 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 vi.mock("~/lib/db");
 vi.mock("~/lib/auth", () => ({
   requireAuth: vi.fn(),
-  withAuth: <T,>(_auth: unknown, value: T) => value,
 }));
 vi.mock("~/lib/roles");
 

--- a/dali-api/app/hiring/routes/__tests__/reviewer.application.$id.test.ts
+++ b/dali-api/app/hiring/routes/__tests__/reviewer.application.$id.test.ts
@@ -3,7 +3,6 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 vi.mock("~/lib/db");
 vi.mock("~/lib/auth", () => ({
   requireAuth: vi.fn(),
-  withAuth: <T,>(_auth: unknown, value: T) => value,
 }));
 vi.mock("~/lib/roles");
 

--- a/dali-api/app/hiring/routes/__tests__/reviewer.loader.test.ts
+++ b/dali-api/app/hiring/routes/__tests__/reviewer.loader.test.ts
@@ -3,7 +3,6 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 vi.mock("~/lib/db");
 vi.mock("~/lib/auth", () => ({
   requireAuth: vi.fn(),
-  withAuth: <T,>(_auth: unknown, value: T) => value,
 }));
 vi.mock("~/hiring/lib/cycles", async (importOriginal) => {
   const actual = await importOriginal<typeof import("~/hiring/lib/cycles")>();

--- a/dali-api/app/hiring/routes/analytics.tsx
+++ b/dali-api/app/hiring/routes/analytics.tsx
@@ -1,7 +1,7 @@
 import { redirect, useLoaderData } from "react-router";
 import type { Route } from "./+types/analytics";
 import { prisma } from "~/lib/db";
-import { requireAuth, withAuth } from "~/lib/auth";
+import { requireAuth } from "~/lib/auth";
 import { getUserRoles } from "~/lib/roles";
 import {
   inferDomainApplicationStatus,
@@ -53,10 +53,10 @@ const STATUS_ORDER: AnalyticsStatus[] = [
 
 export async function loader({ request }: Route.LoaderArgs) {
   const auth = await requireAuth(request);
-  if (!auth.ok) return withAuth(auth, redirect("/login"));
+  if (!auth.ok) return redirect("/login");
 
   const roles = await getUserRoles(auth.user.sub);
-  if (!roles.isHiringLead && !roles.isDomainLead) return withAuth(auth, redirect("/"));
+  if (!roles.isHiringLead && !roles.isDomainLead) return redirect("/");
 
   // Cycles for the selector
   const allCycles = await prisma.applicationCycle.findMany({
@@ -73,7 +73,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   }));
 
   if (cycles.length === 0) {
-    return withAuth(auth, {
+    return {
       cycles: [],
       selectedCycleId: "",
       cycleStatus: "",
@@ -83,7 +83,7 @@ export async function loader({ request }: Route.LoaderArgs) {
       slices: [],
       rows: [],
       confidentialityRequired: null as null | "no_agreement" | "unsigned",
-    });
+    };
   }
 
   const url = new URL(request.url);
@@ -136,7 +136,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     confState.status === "signed" ? null : confState.status;
 
   if (confidentialityRequired) {
-    return withAuth(auth, {
+    return {
       cycles,
       selectedCycleId: cycleId,
       cycleStatus,
@@ -146,7 +146,7 @@ export async function loader({ request }: Route.LoaderArgs) {
       slices: [],
       rows: [],
       confidentialityRequired,
-    });
+    };
   }
 
   // ─── Fetch all selected domain applications with the relations needed
@@ -256,7 +256,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     .map(({ rawStatus: _r, ...rest }) => rest)
     .sort((a, b) => a.applicantName.localeCompare(b.applicantName));
 
-  return withAuth(auth, {
+  return {
     cycles,
     selectedCycleId: cycleId,
     cycleStatus,
@@ -266,7 +266,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     slices,
     rows,
     confidentialityRequired: null as null | "no_agreement" | "unsigned",
-  });
+  };
 }
 
 export default function AnalyticsDashboard() {

--- a/dali-api/app/hiring/routes/api.cycles.$cycleId.available-slots.ts
+++ b/dali-api/app/hiring/routes/api.cycles.$cycleId.available-slots.ts
@@ -1,6 +1,6 @@
 import type { Route } from "./+types/api.cycles.$cycleId.available-slots";
 import { prisma } from "~/lib/db";
-import { requireAuth, withAuth } from "~/lib/auth";
+import { requireAuth } from "~/lib/auth";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { hasCycleAccess } from "~/lib/roles";
 import { computeAvailableSlots } from "~/hiring/lib/scheduling";
@@ -24,18 +24,18 @@ export async function loader({ request, params }: Route.LoaderArgs) {
       select: { id: true },
     });
     if (!invited)
-      return withAuth(auth, withCors(request, Response.json({ error: "Forbidden" }, { status: 403 })));
+      return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
   }
 
   const url = new URL(request.url);
   const domainIds = url.searchParams.getAll("domainId");
 
   if (domainIds.length === 0) {
-    return withAuth(auth, withCors(request, Response.json({ error: "At least one domainId query param required" }, { status: 400 })));
+    return withCors(request, Response.json({ error: "At least one domainId query param required" }, { status: 400 }));
   }
 
   const mode = url.searchParams.get("mode") === "in-person" ? "in-person" as const : "online" as const;
   const slots = await computeAvailableSlots(params.cycleId, domainIds, mode);
 
-  return withAuth(auth, withCors(request, Response.json(slots)));
+  return withCors(request, Response.json(slots));
 }

--- a/dali-api/app/hiring/routes/api.cycles.$cycleId.delibs.ts
+++ b/dali-api/app/hiring/routes/api.cycles.$cycleId.delibs.ts
@@ -1,7 +1,7 @@
 import type { Route } from "./+types/api.cycles.$cycleId.delibs";
 import { z } from "zod";
 import { prisma } from "~/lib/db";
-import { requireAuth, withAuth } from "~/lib/auth";
+import { requireAuth } from "~/lib/auth";
 import { isHiringLead, isDomainLead, hasCycleAccess } from "~/lib/roles";
 import { parseJson } from "~/lib/validate";
 import { requireApiSignedOrForbidden } from "~/hiring/lib/confidentiality";
@@ -16,7 +16,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   if (!auth.ok) return auth.response;
 
   if (!(await hasCycleAccess(auth.user.sub, params.cycleId!)))
-    return withAuth(auth, Response.json({ error: "Forbidden" }, { status: 403 }));
+    return Response.json({ error: "Forbidden" }, { status: 403 });
 
   const gate = await requireApiSignedOrForbidden(auth.user.sub, params.cycleId!);
   if (gate) return gate;
@@ -26,7 +26,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     orderBy: { createdAt: "desc" },
   });
 
-  return withAuth(auth, Response.json(sessions));
+  return Response.json(sessions);
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
@@ -34,13 +34,13 @@ export async function action({ request, params }: Route.ActionArgs) {
   if (!auth.ok) return auth.response;
 
   if (request.method !== "POST") {
-    return withAuth(auth, Response.json({ error: "Method not allowed" }, { status: 405 }));
+    return Response.json({ error: "Method not allowed" }, { status: 405 });
   }
 
   const hiringLead = await isHiringLead(auth.user.sub);
   const domainLead = await isDomainLead(auth.user.sub);
   if (!hiringLead && !domainLead) {
-    return withAuth(auth, Response.json({ error: "Forbidden" }, { status: 403 }));
+    return Response.json({ error: "Forbidden" }, { status: 403 });
   }
 
   const gate = await requireApiSignedOrForbidden(auth.user.sub, params.cycleId!);
@@ -50,11 +50,11 @@ export async function action({ request, params }: Route.ActionArgs) {
     where: { userId: auth.user.sub },
   });
   if (!member) {
-    return withAuth(auth, Response.json({ error: "Not a DALI member" }, { status: 403 }));
+    return Response.json({ error: "Not a DALI member" }, { status: 403 });
   }
 
   const body = await parseJson(request, CreateDelibsSchema);
-  if (body instanceof Response) return withAuth(auth, body);
+  if (body instanceof Response) return body;
   const { domainId, type } = body;
 
   // Upsert: reopen if previously closed, create if new
@@ -78,5 +78,5 @@ export async function action({ request, params }: Route.ActionArgs) {
     },
   });
 
-  return withAuth(auth, Response.json(session, { status: 201 }));
+  return Response.json(session, { status: 201 });
 }

--- a/dali-api/app/hiring/routes/api.cycles.$cycleId.domains.$domainId.auto-assign.ts
+++ b/dali-api/app/hiring/routes/api.cycles.$cycleId.domains.$domainId.auto-assign.ts
@@ -1,6 +1,6 @@
 import type { Route } from "./+types/api.cycles.$cycleId.domains.$domainId.auto-assign";
 import { prisma } from "~/lib/db";
-import { requireAuth, withAuth } from "~/lib/auth";
+import { requireAuth } from "~/lib/auth";
 import { isHiringLead, isDomainLead } from "~/lib/roles";
 import { requireApiSignedOrForbidden } from "~/hiring/lib/confidentiality";
 import { inReviewPipelineFilter } from "~/hiring/lib/application-pipeline-filter";
@@ -10,13 +10,13 @@ export async function action({ request, params }: Route.ActionArgs) {
   if (!auth.ok) return auth.response;
 
   if (request.method !== "POST") {
-    return withAuth(auth, Response.json({ error: "Method not allowed" }, { status: 405 }));
+    return Response.json({ error: "Method not allowed" }, { status: 405 });
   }
 
   const hiringLead = await isHiringLead(auth.user.sub);
   const domainLead = await isDomainLead(auth.user.sub);
   if (!hiringLead && !domainLead) {
-    return withAuth(auth, Response.json({ error: "Forbidden" }, { status: 403 }));
+    return Response.json({ error: "Forbidden" }, { status: 403 });
   }
 
   const { cycleId, domainId } = params;
@@ -41,17 +41,17 @@ export async function action({ request, params }: Route.ActionArgs) {
     where: { id: cycleId! },
   });
   if (!cycle.generalRubricVersionId) {
-    return withAuth(auth, Response.json({ error: "A general application rubric must be set before assigning reviewers to applications" }, { status: 400 }));
+    return Response.json({ error: "A general application rubric must be set before assigning reviewers to applications" }, { status: 400 });
   }
 
   const domainCycle = await prisma.domainApplicationCycle.findUnique({
     where: { domainId_applicationCycleId: { domainId: domainId!, applicationCycleId: cycleId! } },
   });
   if (!domainCycle) {
-    return withAuth(auth, Response.json({ error: "Domain not part of this cycle" }, { status: 404 }));
+    return Response.json({ error: "Domain not part of this cycle" }, { status: 404 });
   }
   if (!domainCycle.rubricVersionId) {
-    return withAuth(auth, Response.json({ error: "A domain rubric must be set before assigning reviewers to applications" }, { status: 400 }));
+    return Response.json({ error: "A domain rubric must be set before assigning reviewers to applications" }, { status: 400 });
   }
 
   const targetCount = domainCycle.reviewersPerApplication;
@@ -62,7 +62,7 @@ export async function action({ request, params }: Route.ActionArgs) {
   });
 
   if (reviewers.length === 0) {
-    return withAuth(auth, Response.json({ error: "No reviewers assigned to this domain" }, { status: 400 }));
+    return Response.json({ error: "No reviewers assigned to this domain" }, { status: 400 });
   }
 
   const domainApps = await prisma.domainApplication.findMany({
@@ -114,5 +114,5 @@ export async function action({ request, params }: Route.ActionArgs) {
     }
   }
 
-  return withAuth(auth, Response.json({ assigned }));
+  return Response.json({ assigned });
 }

--- a/dali-api/app/hiring/routes/api.cycles.$cycleId.interview-config.ts
+++ b/dali-api/app/hiring/routes/api.cycles.$cycleId.interview-config.ts
@@ -1,7 +1,7 @@
 import type { Route } from "./+types/api.cycles.$cycleId.interview-config";
 import { z } from "zod";
 import { prisma } from "~/lib/db";
-import { requireAuth, withAuth } from "~/lib/auth";
+import { requireAuth } from "~/lib/auth";
 import { isHiringLead, hasCycleAccess } from "~/lib/roles";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { parseJson } from "~/lib/validate";
@@ -39,13 +39,13 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   if (!auth.ok) return withCors(request, auth.response);
 
   if (!(await hasCycleAccess(auth.user.sub, params.cycleId!)))
-    return withAuth(auth, withCors(request, Response.json({ error: "Forbidden" }, { status: 403 })));
+    return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
 
   const config = await prisma.interviewConfig.findUnique({
     where: { applicationCycleId: params.cycleId },
   });
 
-  return withAuth(auth, withCors(request, Response.json(config)));
+  return withCors(request, Response.json(config));
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
@@ -54,17 +54,17 @@ export async function action({ request, params }: Route.ActionArgs) {
 
   const auth = await requireAuth(request);
   if (!auth.ok) return withCors(request, auth.response);
-  if (!(await isHiringLead(auth.user.sub))) return withAuth(auth, withCors(request, Response.json({ error: "Forbidden" }, { status: 403 })));
+  if (!(await isHiringLead(auth.user.sub))) return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
 
   if (request.method !== "POST") {
-    return withAuth(auth, withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 })));
+    return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));
   }
 
   const body = await parseJson(request, InterviewConfigSchema);
-  if (body instanceof Response) return withAuth(auth, withCors(request, body));
+  if (body instanceof Response) return withCors(request, body);
 
   if (body.timezone !== undefined && !isValidTimezone(body.timezone)) {
-    return withAuth(auth, withCors(request, Response.json({ error: "Invalid timezone" }, { status: 400 })));
+    return withCors(request, Response.json({ error: "Invalid timezone" }, { status: 400 }));
   }
 
   const config = await prisma.interviewConfig.upsert({
@@ -94,5 +94,5 @@ export async function action({ request, params }: Route.ActionArgs) {
     },
   });
 
-  return withAuth(auth, withCors(request, Response.json(config)));
+  return withCors(request, Response.json(config));
 }

--- a/dali-api/app/hiring/routes/api.cycles.$cycleId.interviewers.ts
+++ b/dali-api/app/hiring/routes/api.cycles.$cycleId.interviewers.ts
@@ -1,7 +1,7 @@
 import type { Route } from "./+types/api.cycles.$cycleId.interviewers";
 import { z } from "zod";
 import { prisma } from "~/lib/db";
-import { requireAuth, withAuth } from "~/lib/auth";
+import { requireAuth } from "~/lib/auth";
 import { isHiringLead, isDomainLead, hasCycleAccess } from "~/lib/roles";
 import { parseJson } from "~/lib/validate";
 
@@ -19,7 +19,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   if (!auth.ok) return auth.response;
 
   if (!(await hasCycleAccess(auth.user.sub, params.cycleId!)))
-    return withAuth(auth, Response.json({ error: "Forbidden" }, { status: 403 }));
+    return Response.json({ error: "Forbidden" }, { status: 403 });
 
   const interviewers = await prisma.cycleInterviewer.findMany({
     where: { applicationCycleId: params.cycleId },
@@ -30,7 +30,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     orderBy: { createdAt: "asc" },
   });
 
-  return withAuth(auth, Response.json(interviewers));
+  return Response.json(interviewers);
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
@@ -40,12 +40,12 @@ export async function action({ request, params }: Route.ActionArgs) {
   const hiringLead = await isHiringLead(auth.user.sub);
   const domainLead = await isDomainLead(auth.user.sub);
   if (!hiringLead && !domainLead) {
-    return withAuth(auth, Response.json({ error: "Forbidden" }, { status: 403 }));
+    return Response.json({ error: "Forbidden" }, { status: 403 });
   }
 
   if (request.method === "POST") {
     const body = await parseJson(request, CreateInterviewerSchema);
-    if (body instanceof Response) return withAuth(auth, body);
+    if (body instanceof Response) return body;
     const { daliMemberId, domainId } = body;
 
     const interviewer = await prisma.cycleInterviewer.create({
@@ -56,12 +56,12 @@ export async function action({ request, params }: Route.ActionArgs) {
       },
     });
 
-    return withAuth(auth, Response.json(interviewer, { status: 201 }));
+    return Response.json(interviewer, { status: 201 });
   }
 
   if (request.method === "DELETE") {
     const body = await parseJson(request, DeleteInterviewerSchema);
-    if (body instanceof Response) return withAuth(auth, body);
+    if (body instanceof Response) return body;
     const { interviewerId } = body;
 
     // InterviewAssignment FK to CycleInterviewer is non-cascading (audit-bearing).
@@ -77,15 +77,12 @@ export async function action({ request, params }: Route.ActionArgs) {
       },
     });
     if (scheduledActive > 0) {
-      return withAuth(
-        auth,
-        Response.json(
+      return Response.json(
           {
             error: `This interviewer has ${scheduledActive} scheduled interview${scheduledActive === 1 ? "" : "s"} — reassign or cancel ${scheduledActive === 1 ? "it" : "them"} first.`,
           },
           { status: 409 },
-        ),
-      );
+        );
     }
 
     try {
@@ -99,13 +96,13 @@ export async function action({ request, params }: Route.ActionArgs) {
       });
     } catch (e: any) {
       if (e?.code === "P2025") {
-        return withAuth(auth, Response.json({ error: "Interviewer not found" }, { status: 404 }));
+        return Response.json({ error: "Interviewer not found" }, { status: 404 });
       }
-      return withAuth(auth, Response.json({ error: "Failed to remove interviewer" }, { status: 500 }));
+      return Response.json({ error: "Failed to remove interviewer" }, { status: 500 });
     }
 
-    return withAuth(auth, Response.json({ deleted: true }));
+    return Response.json({ deleted: true });
   }
 
-  return withAuth(auth, Response.json({ error: "Method not allowed" }, { status: 405 }));
+  return Response.json({ error: "Method not allowed" }, { status: 405 });
 }

--- a/dali-api/app/hiring/routes/api.cycles.$cycleId.interviews.ts
+++ b/dali-api/app/hiring/routes/api.cycles.$cycleId.interviews.ts
@@ -1,6 +1,6 @@
 import type { Route } from "./+types/api.cycles.$cycleId.interviews";
 import { prisma } from "~/lib/db";
-import { requireAuth, withAuth } from "~/lib/auth";
+import { requireAuth } from "~/lib/auth";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { hasCycleAccess } from "~/lib/roles";
 import { requireApiSignedOrForbidden } from "~/hiring/lib/confidentiality";
@@ -13,7 +13,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   if (!auth.ok) return withCors(request, auth.response);
 
   if (!(await hasCycleAccess(auth.user.sub, params.cycleId!)))
-    return withAuth(auth, withCors(request, Response.json({ error: "Forbidden" }, { status: 403 })));
+    return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
 
   const gate = await requireApiSignedOrForbidden(auth.user.sub, params.cycleId!);
   if (gate) return withCors(request, gate);
@@ -45,5 +45,5 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     orderBy: { startTime: "asc" },
   });
 
-  return withAuth(auth, withCors(request, Response.json(interviews)));
+  return withCors(request, Response.json(interviews));
 }

--- a/dali-api/app/hiring/routes/api.cycles.$cycleId.my-availability.ts
+++ b/dali-api/app/hiring/routes/api.cycles.$cycleId.my-availability.ts
@@ -1,7 +1,7 @@
 import type { Route } from "./+types/api.cycles.$cycleId.my-availability";
 import { z } from "zod";
 import { prisma } from "~/lib/db";
-import { requireAuth, withAuth } from "~/lib/auth";
+import { requireAuth } from "~/lib/auth";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { parseJson } from "~/lib/validate";
 import { getZonedYMD, zonedDayStartUtc } from "~/lib/timezone";
@@ -68,7 +68,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 
   const interviewers = await findCycleInterviewers(auth.user.sub, params.cycleId!);
   if (interviewers.length === 0) {
-    return withAuth(auth, withCors(request, Response.json([])));
+    return withCors(request, Response.json([]));
   }
 
   // All of the member's rows should hold the same availability set after a
@@ -79,7 +79,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     orderBy: { startTime: "asc" },
   });
 
-  return withAuth(auth, withCors(request, Response.json(blocks)));
+  return withCors(request, Response.json(blocks));
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
@@ -95,11 +95,11 @@ export async function action({ request, params }: Route.ActionArgs) {
 
   const interviewers = await findCycleInterviewers(auth.user.sub, params.cycleId!);
   if (interviewers.length === 0) {
-    return withAuth(auth, withCors(request, Response.json({ error: "Not an interviewer for this cycle" }, { status: 404 })));
+    return withCors(request, Response.json({ error: "Not an interviewer for this cycle" }, { status: 404 }));
   }
 
   const body = await parseJson(request, AvailabilitySchema);
-  if (body instanceof Response) return withAuth(auth, withCors(request, body));
+  if (body instanceof Response) return withCors(request, body);
   const parsedBlocks = body.blocks.map((b) => ({
     startTime: new Date(b.startTime),
     endTime: new Date(b.endTime),
@@ -147,5 +147,5 @@ export async function action({ request, params }: Route.ActionArgs) {
     orderBy: { startTime: "asc" },
   });
 
-  return withAuth(auth, withCors(request, Response.json(updated)));
+  return withCors(request, Response.json(updated));
 }

--- a/dali-api/app/hiring/routes/api.cycles.$cycleId.my-interviews.$interviewId.decline.ts
+++ b/dali-api/app/hiring/routes/api.cycles.$cycleId.my-interviews.$interviewId.decline.ts
@@ -1,6 +1,6 @@
 import type { Route } from "./+types/api.cycles.$cycleId.my-interviews.$interviewId.decline";
 import { prisma } from "~/lib/db";
-import { requireAuth, withAuth } from "~/lib/auth";
+import { requireAuth } from "~/lib/auth";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { reassignInterviewer, isNoReplacementError } from "~/hiring/lib/scheduling";
 import { requireApiSignedOrForbidden } from "~/hiring/lib/confidentiality";
@@ -13,7 +13,7 @@ export async function action({ request, params }: Route.ActionArgs) {
   if (!auth.ok) return withCors(request, auth.response);
 
   if (request.method !== "POST") {
-    return withAuth(auth, withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 })));
+    return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));
   }
 
   const gate = await requireApiSignedOrForbidden(auth.user.sub, params.cycleId!);
@@ -21,7 +21,7 @@ export async function action({ request, params }: Route.ActionArgs) {
 
   const member = await prisma.dALIMember.findFirst({ where: { userId: auth.user.sub } });
   if (!member) {
-    return withAuth(auth, withCors(request, Response.json({ error: "Not a DALI member" }, { status: 403 })));
+    return withCors(request, Response.json({ error: "Not a DALI member" }, { status: 403 }));
   }
 
   // A member can have multiple CycleInterviewer rows in the same cycle (one
@@ -32,7 +32,7 @@ export async function action({ request, params }: Route.ActionArgs) {
     select: { id: true },
   });
   if (interviewerRows.length === 0) {
-    return withAuth(auth, withCors(request, Response.json({ error: "Not an interviewer for this cycle" }, { status: 403 })));
+    return withCors(request, Response.json({ error: "Not an interviewer for this cycle" }, { status: 403 }));
   }
 
   const assignment = await prisma.interviewAssignment.findFirst({
@@ -44,15 +44,15 @@ export async function action({ request, params }: Route.ActionArgs) {
   });
 
   if (!assignment) {
-    return withAuth(auth, withCors(request, Response.json({ error: "No active assignment found" }, { status: 404 })));
+    return withCors(request, Response.json({ error: "No active assignment found" }, { status: 404 }));
   }
 
   try {
     const result = await reassignInterviewer(params.interviewId!, assignment.id);
-    return withAuth(auth, withCors(request, Response.json(result)));
+    return withCors(request, Response.json(result));
   } catch (err) {
     if (isNoReplacementError(err)) {
-      return withAuth(auth, withCors(
+      return withCors(
               request,
               Response.json(
                 {
@@ -61,7 +61,7 @@ export async function action({ request, params }: Route.ActionArgs) {
                 },
                 { status: 409 },
               ),
-            ));
+            );
     }
     throw err;
   }

--- a/dali-api/app/hiring/routes/api.cycles.$cycleId.my-interviews.$interviewId.notes.ts
+++ b/dali-api/app/hiring/routes/api.cycles.$cycleId.my-interviews.$interviewId.notes.ts
@@ -1,7 +1,7 @@
 import type { Route } from "./+types/api.cycles.$cycleId.my-interviews.$interviewId.notes";
 import { z } from "zod";
 import { prisma } from "~/lib/db";
-import { requireAuth, withAuth } from "~/lib/auth";
+import { requireAuth } from "~/lib/auth";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { parseJson } from "~/lib/validate";
 import { requireApiSignedOrForbidden } from "~/hiring/lib/confidentiality";
@@ -34,7 +34,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 
   const assignment = await getAssignment(auth.user.sub, params.cycleId!, params.interviewId!);
   if (!assignment) {
-    return withAuth(auth, withCors(request, Response.json({ error: "Assignment not found" }, { status: 404 })));
+    return withCors(request, Response.json({ error: "Assignment not found" }, { status: 404 }));
   }
 
   const gate = await requireApiSignedOrForbidden(auth.user.sub, params.cycleId!);
@@ -45,7 +45,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     orderBy: { createdAt: "desc" },
   });
 
-  return withAuth(auth, withCors(request, Response.json(versions)));
+  return withCors(request, Response.json(versions));
 }
 
 // POST: append a new note version (auto-save)
@@ -62,19 +62,19 @@ export async function action({ request, params }: Route.ActionArgs) {
 
   const assignment = await getAssignment(auth.user.sub, params.cycleId!, params.interviewId!);
   if (!assignment) {
-    return withAuth(auth, withCors(request, Response.json({ error: "Assignment not found" }, { status: 404 })));
+    return withCors(request, Response.json({ error: "Assignment not found" }, { status: 404 }));
   }
 
   const gate = await requireApiSignedOrForbidden(auth.user.sub, params.cycleId!);
   if (gate) return withCors(request, gate);
 
   const body = await parseJson(request, NoteVersionSchema);
-  if (body instanceof Response) return withAuth(auth, withCors(request, body));
+  if (body instanceof Response) return withCors(request, body);
   const { content } = body;
 
   const version = await prisma.interviewNoteVersion.create({
     data: { interviewAssignmentId: assignment.id, content },
   });
 
-  return withAuth(auth, withCors(request, Response.json(version, { status: 201 })));
+  return withCors(request, Response.json(version, { status: 201 }));
 }

--- a/dali-api/app/hiring/routes/api.cycles.$cycleId.my-interviews.ts
+++ b/dali-api/app/hiring/routes/api.cycles.$cycleId.my-interviews.ts
@@ -1,6 +1,6 @@
 import type { Route } from "./+types/api.cycles.$cycleId.my-interviews";
 import { prisma } from "~/lib/db";
-import { requireAuth, withAuth } from "~/lib/auth";
+import { requireAuth } from "~/lib/auth";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { requireApiSignedOrForbidden } from "~/hiring/lib/confidentiality";
 
@@ -12,12 +12,12 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   if (!auth.ok) return withCors(request, auth.response);
 
   const member = await prisma.dALIMember.findFirst({ where: { userId: auth.user.sub } });
-  if (!member) return withAuth(auth, withCors(request, Response.json([])));
+  if (!member) return withCors(request, Response.json([]));
 
   const interviewer = await prisma.cycleInterviewer.findFirst({
     where: { daliMemberId: member.id, applicationCycleId: params.cycleId },
   });
-  if (!interviewer) return withAuth(auth, withCors(request, Response.json([])));
+  if (!interviewer) return withCors(request, Response.json([]));
 
   const gate = await requireApiSignedOrForbidden(auth.user.sub, params.cycleId!);
   if (gate) return withCors(request, gate);
@@ -58,5 +58,5 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     orderBy: { interview: { startTime: "asc" } },
   });
 
-  return withAuth(auth, withCors(request, Response.json(assignments)));
+  return withCors(request, Response.json(assignments));
 }

--- a/dali-api/app/hiring/routes/api.cycles.$cycleId.reviewers.$reviewerId.ts
+++ b/dali-api/app/hiring/routes/api.cycles.$cycleId.reviewers.$reviewerId.ts
@@ -1,7 +1,7 @@
 import type { Route } from "./+types/api.cycles.$cycleId.reviewers.$reviewerId";
 import { z } from "zod";
 import { prisma } from "~/lib/db";
-import { requireAuth, withAuth } from "~/lib/auth";
+import { requireAuth } from "~/lib/auth";
 import { isHiringLead, isDomainLead } from "~/lib/roles";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { parseJson } from "~/lib/validate";
@@ -16,11 +16,11 @@ export async function action({ request, params }: Route.ActionArgs) {
 
   const auth = await requireAuth(request);
   if (!auth.ok) return withCors(request, auth.response);
-  if (!(await isHiringLead(auth.user.sub)) && !(await isDomainLead(auth.user.sub))) return withAuth(auth, withCors(request, Response.json({ error: "Forbidden" }, { status: 403 })));
+  if (!(await isHiringLead(auth.user.sub)) && !(await isDomainLead(auth.user.sub))) return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
 
   if (request.method === "PATCH") {
     const body = await parseJson(request, PatchReviewerSchema);
-    if (body instanceof Response) return withAuth(auth, withCors(request, body));
+    if (body instanceof Response) return withCors(request, body);
     const reviewer = await prisma.cycleReviewer.update({
       where: { id: params.reviewerId },
       data: {
@@ -31,7 +31,7 @@ export async function action({ request, params }: Route.ActionArgs) {
         domain: true,
       },
     });
-    return withAuth(auth, withCors(request, Response.json(reviewer)));
+    return withCors(request, Response.json(reviewer));
   }
 
   if (request.method === "DELETE") {
@@ -49,12 +49,12 @@ export async function action({ request, params }: Route.ActionArgs) {
       });
     } catch (e: any) {
       if (e?.code === "P2025") {
-        return withAuth(auth, withCors(request, Response.json({ error: "Reviewer not found" }, { status: 404 })));
+        return withCors(request, Response.json({ error: "Reviewer not found" }, { status: 404 }));
       }
-      return withAuth(auth, withCors(request, Response.json({ error: "Failed to remove reviewer" }, { status: 500 })));
+      return withCors(request, Response.json({ error: "Failed to remove reviewer" }, { status: 500 }));
     }
-    return withAuth(auth, withCors(request, Response.json({ ok: true })));
+    return withCors(request, Response.json({ ok: true }));
   }
 
-  return withAuth(auth, withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 })));
+  return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));
 }

--- a/dali-api/app/hiring/routes/api.cycles.$cycleId.reviewers.ts
+++ b/dali-api/app/hiring/routes/api.cycles.$cycleId.reviewers.ts
@@ -1,7 +1,7 @@
 import type { Route } from "./+types/api.cycles.$cycleId.reviewers";
 import { z } from "zod";
 import { prisma } from "~/lib/db";
-import { requireAuth, withAuth } from "~/lib/auth";
+import { requireAuth } from "~/lib/auth";
 import { isHiringLead, isDomainLead, hasCycleAccess } from "~/lib/roles";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { parseJson } from "~/lib/validate";
@@ -19,7 +19,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   if (!auth.ok) return withCors(request, auth.response);
 
   if (!(await hasCycleAccess(auth.user.sub, params.cycleId!)))
-    return withAuth(auth, withCors(request, Response.json({ error: "Forbidden" }, { status: 403 })));
+    return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
 
   const reviewers = await prisma.cycleReviewer.findMany({
     where: { applicationCycleId: params.cycleId },
@@ -29,7 +29,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     },
   });
 
-  return withAuth(auth, withCors(request, Response.json(reviewers)));
+  return withCors(request, Response.json(reviewers));
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
@@ -38,14 +38,14 @@ export async function action({ request, params }: Route.ActionArgs) {
 
   const auth = await requireAuth(request);
   if (!auth.ok) return withCors(request, auth.response);
-  if (!(await isHiringLead(auth.user.sub)) && !(await isDomainLead(auth.user.sub))) return withAuth(auth, withCors(request, Response.json({ error: "Forbidden" }, { status: 403 })));
+  if (!(await isHiringLead(auth.user.sub)) && !(await isDomainLead(auth.user.sub))) return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
 
   if (request.method !== "POST") {
-    return withAuth(auth, withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 })));
+    return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));
   }
 
   const body = await parseJson(request, CreateReviewerSchema);
-  if (body instanceof Response) return withAuth(auth, withCors(request, body));
+  if (body instanceof Response) return withCors(request, body);
   const { daliMemberId, domainId } = body;
 
   // Ensure domain is linked to cycle
@@ -67,5 +67,5 @@ export async function action({ request, params }: Route.ActionArgs) {
     },
   });
 
-  return withAuth(auth, withCors(request, Response.json(reviewer, { status: 201 })));
+  return withCors(request, Response.json(reviewer, { status: 201 }));
 }

--- a/dali-api/app/hiring/routes/api.cycles.$cycleId.status.ts
+++ b/dali-api/app/hiring/routes/api.cycles.$cycleId.status.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { prisma } from "~/lib/db";
 import { parseJson } from "~/lib/validate";
-import { requireAuth, withAuth } from "~/lib/auth";
+import { requireAuth } from "~/lib/auth";
 import { isHiringLead, hasCycleAccess } from "~/lib/roles";
 import { autoCloseIfExpired, findOtherActiveCycleId } from "~/hiring/lib/cycles";
 import { inReviewPipelineFilter } from "~/hiring/lib/application-pipeline-filter";
@@ -19,7 +19,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   if (!auth.ok) return auth.response;
 
   if (!(await hasCycleAccess(auth.user.sub, params.cycleId!)))
-    return withAuth(auth, Response.json({ error: "Forbidden" }, { status: 403 }));
+    return Response.json({ error: "Forbidden" }, { status: 403 });
 
   await autoCloseIfExpired(params.cycleId!);
 
@@ -28,7 +28,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     orderBy: { createdAt: "desc" },
     take: 1,
   });
-  return withAuth(auth, Response.json({ currentStatus: updates[0]?.newStatus ?? "Draft" }));
+  return Response.json({ currentStatus: updates[0]?.newStatus ?? "Draft" });
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
@@ -38,24 +38,24 @@ export async function action({ request, params }: Route.ActionArgs) {
 
   const auth = await requireAuth(request);
   if (!auth.ok) return auth.response;
-  if (!(await isHiringLead(auth.user.sub))) return withAuth(auth, new Response(JSON.stringify({ error: "Forbidden" }), { status: 403, headers: { "Content-Type": "application/json" } }));
+  if (!(await isHiringLead(auth.user.sub))) return new Response(JSON.stringify({ error: "Forbidden" }), { status: 403, headers: { "Content-Type": "application/json" } });
 
   const body = await parseJson(request, StatusUpdateSchema);
-  if (body instanceof Response) return withAuth(auth, body);
+  if (body instanceof Response) return body;
   const { newStatus, force } = body;
 
   // Single-active-cycle invariant: only one cycle can be Open or UnderReview at a time.
   if (newStatus === "Open" || newStatus === "UnderReview") {
     const otherActiveId = await findOtherActiveCycleId(params.cycleId!);
     if (otherActiveId) {
-      return withAuth(auth, Response.json(
+      return Response.json(
               {
                 error:
                   "Another cycle is already active. Only one cycle can be Open or UnderReview at a time. Move the existing active cycle to Completed first.",
                 activeCycleId: otherActiveId,
               },
               { status: 409 },
-            ));
+            );
     }
   }
 
@@ -72,11 +72,11 @@ export async function action({ request, params }: Route.ActionArgs) {
 
     const currentStatus = cycle.statusUpdates[0]?.newStatus ?? "Draft";
     if (currentStatus !== "Draft") {
-      return withAuth(auth, Response.json({ error: "Cycle is not in Draft" }, { status: 409 }));
+      return Response.json({ error: "Cycle is not in Draft" }, { status: 409 });
     }
 
     if (!cycle.closeDate) {
-      return withAuth(auth, Response.json({ error: "Close date must be set before opening" }, { status: 400 }));
+      return Response.json({ error: "Close date must be set before opening" }, { status: 400 });
     }
 
     const domainIds = new Set(cycle.domains.map((d) => d.domainId));
@@ -92,20 +92,20 @@ export async function action({ request, params }: Route.ActionArgs) {
       const coveredDomainIds = new Set(challengeVersions.map((cv) => cv.domainId));
       for (const domainId of domainIds) {
         if (!coveredDomainIds.has(domainId)) {
-          return withAuth(auth, Response.json(
+          return Response.json(
                       { error: "Every domain must have a challenge version linked before opening" },
                       { status: 400 },
-                    ));
+                    );
         }
       }
     }
 
     // Every domain must be marked ready by its domain lead (or hiring lead override)
     if (cycle.domains.length === 0 || !cycle.domains.every((d) => d.isReady)) {
-      return withAuth(auth, Response.json(
+      return Response.json(
               { error: "Every domain must be marked ready before opening" },
               { status: 400 },
-            ));
+            );
     }
   }
 
@@ -124,14 +124,14 @@ export async function action({ request, params }: Route.ActionArgs) {
       },
     });
     if (pendingInterviews > 0 || undecided > 0) {
-      return withAuth(auth, Response.json(
+      return Response.json(
               {
                 error: "Not all work is complete. Use force completion to override.",
                 pendingInterviews,
                 undecidedApplications: undecided,
               },
               { status: 409 },
-            ));
+            );
     }
   }
 
@@ -143,5 +143,5 @@ export async function action({ request, params }: Route.ActionArgs) {
     },
   });
 
-  return withAuth(auth, Response.json({ currentStatus: newStatus }));
+  return Response.json({ currentStatus: newStatus });
 }

--- a/dali-api/app/hiring/routes/api.decisions.$id.finalize.ts
+++ b/dali-api/app/hiring/routes/api.decisions.$id.finalize.ts
@@ -1,6 +1,6 @@
 import type { Route } from "./+types/api.decisions.$id.finalize";
 import { prisma } from "~/lib/db";
-import { requireAuth, withAuth } from "~/lib/auth";
+import { requireAuth } from "~/lib/auth";
 import { isHiringLead, isDomainLead } from "~/lib/roles";
 import { logAuditEvent } from "~/lib/audit";
 import { requireApiSignedOrForbidden } from "~/hiring/lib/confidentiality";
@@ -10,18 +10,18 @@ export async function action({ request, params }: Route.ActionArgs) {
   if (!auth.ok) return auth.response;
 
   if (request.method !== "POST") {
-    return withAuth(auth, Response.json({ error: "Method not allowed" }, { status: 405 }));
+    return Response.json({ error: "Method not allowed" }, { status: 405 });
   }
 
   const hiringLead = await isHiringLead(auth.user.sub);
   const domainLead = await isDomainLead(auth.user.sub);
   if (!hiringLead && !domainLead) {
-    return withAuth(auth, Response.json({ error: "Forbidden" }, { status: 403 }));
+    return Response.json({ error: "Forbidden" }, { status: 403 });
   }
 
   const member = await prisma.dALIMember.findFirst({ where: { userId: auth.user.sub } });
   if (!member) {
-    return withAuth(auth, Response.json({ error: "Not a DALI member" }, { status: 403 }));
+    return Response.json({ error: "Not a DALI member" }, { status: 403 });
   }
 
   const decision = await prisma.decision.findUnique({
@@ -29,10 +29,10 @@ export async function action({ request, params }: Route.ActionArgs) {
     include: { domainApplication: { select: { application: { select: { applicationCycleId: true } } } } },
   });
   if (!decision) {
-    return withAuth(auth, Response.json({ error: "Decision not found" }, { status: 404 }));
+    return Response.json({ error: "Decision not found" }, { status: 404 });
   }
   if (decision.stage !== "Draft") {
-    return withAuth(auth, Response.json({ error: "Only Draft decisions can be finalized" }, { status: 409 }));
+    return Response.json({ error: "Only Draft decisions can be finalized" }, { status: 409 });
   }
 
   const gate = await requireApiSignedOrForbidden(
@@ -66,5 +66,5 @@ export async function action({ request, params }: Route.ActionArgs) {
     request,
   });
 
-  return withAuth(auth, Response.json(finalized, { status: 201 }));
+  return Response.json(finalized, { status: 201 });
 }

--- a/dali-api/app/hiring/routes/api.decisions.$id.release.ts
+++ b/dali-api/app/hiring/routes/api.decisions.$id.release.ts
@@ -1,6 +1,6 @@
 import type { Route } from "./+types/api.decisions.$id.release";
 import { prisma } from "~/lib/db";
-import { requireAuth, withAuth } from "~/lib/auth";
+import { requireAuth } from "~/lib/auth";
 import { isHiringLead } from "~/lib/roles";
 import { sendEmail } from "~/lib/gmail";
 import { renderForSlot, decisionSlot } from "~/hiring/lib/email-variables";
@@ -14,34 +14,34 @@ export async function action({ request, params }: Route.ActionArgs) {
   if (!auth.ok) return auth.response;
 
   if (request.method !== "POST") {
-    return withAuth(auth, Response.json({ error: "Method not allowed" }, { status: 405 }));
+    return Response.json({ error: "Method not allowed" }, { status: 405 });
   }
 
   if (!(await isHiringLead(auth.user.sub))) {
-    return withAuth(auth, Response.json(
+    return Response.json(
           { error: "Only hiring leads can release decisions" },
           { status: 403 }
-        ));
+        );
   }
 
   const member = await prisma.dALIMember.findFirst({
     where: { userId: auth.user.sub },
   });
   if (!member) {
-    return withAuth(auth, Response.json({ error: "Not a DALI member" }, { status: 403 }));
+    return Response.json({ error: "Not a DALI member" }, { status: 403 });
   }
 
   const decision = await prisma.decision.findUnique({
     where: { id: params.id },
   });
   if (!decision) {
-    return withAuth(auth, Response.json({ error: "Decision not found" }, { status: 404 }));
+    return Response.json({ error: "Decision not found" }, { status: 404 });
   }
   if (decision.stage !== "Final") {
-    return withAuth(auth, Response.json(
+    return Response.json(
           { error: "Only Final decisions can be released" },
           { status: 409 }
-        ));
+        );
   }
 
   const domainApp = await prisma.domainApplication.findUnique({
@@ -64,17 +64,17 @@ export async function action({ request, params }: Route.ActionArgs) {
     },
   });
   if (!domainApp) {
-    return withAuth(auth, Response.json(
+    return Response.json(
           { error: "Domain application not found" },
           { status: 404 }
-        ));
+        );
   }
 
   const gate = await requireApiSignedOrForbidden(
     auth.user.sub,
     domainApp.application.applicationCycleId,
   );
-  if (gate) return withAuth(auth, gate);
+  if (gate) return gate;
 
   const binding = await prisma.cycleDecisionEmail.findUnique({
     where: {
@@ -86,12 +86,12 @@ export async function action({ request, params }: Route.ActionArgs) {
     include: { emailTemplateVersion: true },
   });
   if (!binding) {
-    return withAuth(auth, Response.json(
+    return Response.json(
           {
             error: `No email template is bound to ${decision.type} in this cycle. Bind one on the Setup tab before releasing.`,
           },
           { status: 409 }
-        ));
+        );
   }
 
   const released = await prisma.decision.create({
@@ -159,5 +159,5 @@ export async function action({ request, params }: Route.ActionArgs) {
     request,
   });
 
-  return withAuth(auth, Response.json(released, { status: 201 }));
+  return Response.json(released, { status: 201 });
 }

--- a/dali-api/app/hiring/routes/api.delibs.$id.moves.ts
+++ b/dali-api/app/hiring/routes/api.delibs.$id.moves.ts
@@ -1,7 +1,7 @@
 import type { Route } from "./+types/api.delibs.$id.moves";
 import { z } from "zod";
 import { prisma } from "~/lib/db";
-import { requireAuth, withAuth } from "~/lib/auth";
+import { requireAuth } from "~/lib/auth";
 import { isHiringLead, isDomainLead, hasCycleAccess } from "~/lib/roles";
 import { INITIAL_COLUMNS, FINAL_COLUMNS } from "~/hiring/lib/delibs";
 import { parseJson } from "~/lib/validate";
@@ -18,13 +18,13 @@ export async function action({ request, params }: Route.ActionArgs) {
   if (!auth.ok) return auth.response;
 
   if (request.method !== "POST") {
-    return withAuth(auth, Response.json({ error: "Method not allowed" }, { status: 405 }));
+    return Response.json({ error: "Method not allowed" }, { status: 405 });
   }
 
   const hiringLead = await isHiringLead(auth.user.sub);
   const domainLead = await isDomainLead(auth.user.sub);
   if (!hiringLead && !domainLead) {
-    return withAuth(auth, Response.json({ error: "Forbidden" }, { status: 403 }));
+    return Response.json({ error: "Forbidden" }, { status: 403 });
   }
 
 
@@ -33,10 +33,10 @@ export async function action({ request, params }: Route.ActionArgs) {
     select: { applicationCycleId: true },
   });
   if (!sessionForAuth) {
-    return withAuth(auth, Response.json({ error: "Not found" }, { status: 404 }));
+    return Response.json({ error: "Not found" }, { status: 404 });
   }
   if (!(await hasCycleAccess(auth.user.sub, sessionForAuth.applicationCycleId))) {
-    return withAuth(auth, Response.json({ error: "Forbidden" }, { status: 403 }));
+    return Response.json({ error: "Forbidden" }, { status: 403 });
   }
 
   const gate = await requireApiSignedOrForbidden(
@@ -46,14 +46,14 @@ export async function action({ request, params }: Route.ActionArgs) {
   if (gate) return gate;
 
   const body = await parseJson(request, MoveSchema);
-  if (body instanceof Response) return withAuth(auth, body);
+  if (body instanceof Response) return body;
   const { cardId, toColumn, position } = body;
 
   if (!cardId || typeof cardId !== "string") {
-    return withAuth(auth, Response.json({ error: "cardId is required" }, { status: 400 }));
+    return Response.json({ error: "cardId is required" }, { status: 400 });
   }
   if (!toColumn || typeof toColumn !== "string") {
-    return withAuth(auth, Response.json({ error: "toColumn is required" }, { status: 400 }));
+    return Response.json({ error: "toColumn is required" }, { status: 400 });
   }
 
   try {
@@ -101,16 +101,16 @@ export async function action({ request, params }: Route.ActionArgs) {
       { isolationLevel: "Serializable" },
     );
 
-    return withAuth(auth, Response.json(updated));
+    return Response.json(updated);
   } catch (err: any) {
     if (err?.message === "__NOT_FOUND__") {
-      return withAuth(auth, Response.json({ error: "Not found" }, { status: 404 }));
+      return Response.json({ error: "Not found" }, { status: 404 });
     }
     if (err?.message === "__CLOSED__") {
-      return withAuth(auth, Response.json({ error: "Session is closed" }, { status: 409 }));
+      return Response.json({ error: "Session is closed" }, { status: 409 });
     }
     if (err?.message === "__INVALID_COLUMN__") {
-      return withAuth(auth, Response.json({ error: "Invalid column" }, { status: 400 }));
+      return Response.json({ error: "Invalid column" }, { status: 400 });
     }
     throw err;
   }

--- a/dali-api/app/hiring/routes/api.delibs.$id.ts
+++ b/dali-api/app/hiring/routes/api.delibs.$id.ts
@@ -1,7 +1,7 @@
 import type { Route } from "./+types/api.delibs.$id";
 import { z } from "zod";
 import { prisma } from "~/lib/db";
-import { requireAuth, withAuth } from "~/lib/auth";
+import { requireAuth } from "~/lib/auth";
 import { isHiringLead, isDomainLead, hasCycleAccess } from "~/lib/roles";
 import { parseJson } from "~/lib/validate";
 import { requireApiSignedOrForbidden } from "~/hiring/lib/confidentiality";
@@ -19,11 +19,11 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   });
 
   if (!session) {
-    return withAuth(auth, Response.json({ error: "Not found" }, { status: 404 }));
+    return Response.json({ error: "Not found" }, { status: 404 });
   }
 
   if (!(await hasCycleAccess(auth.user.sub, session.applicationCycleId)))
-    return withAuth(auth, Response.json({ error: "Forbidden" }, { status: 403 }));
+    return Response.json({ error: "Forbidden" }, { status: 403 });
 
   const gate = await requireApiSignedOrForbidden(
     auth.user.sub,
@@ -31,7 +31,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   );
   if (gate) return gate;
 
-  return withAuth(auth, Response.json(session));
+  return Response.json(session);
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
@@ -41,7 +41,7 @@ export async function action({ request, params }: Route.ActionArgs) {
   const hiringLead = await isHiringLead(auth.user.sub);
   const domainLead = await isDomainLead(auth.user.sub);
   if (!hiringLead && !domainLead) {
-    return withAuth(auth, Response.json({ error: "Forbidden" }, { status: 403 }));
+    return Response.json({ error: "Forbidden" }, { status: 403 });
   }
 
   const sessionForGate = await prisma.delibsSession.findUnique({
@@ -59,7 +59,7 @@ export async function action({ request, params }: Route.ActionArgs) {
 
   if (request.method === "POST") {
     const body = await parseJson(request, DelibsActionSchema);
-    if (body instanceof Response) return withAuth(auth, body);
+    if (body instanceof Response) return body;
     const { intent } = body;
 
     if (intent === "close") {
@@ -67,14 +67,14 @@ export async function action({ request, params }: Route.ActionArgs) {
         where: { userId: auth.user.sub },
       });
       if (!member) {
-        return withAuth(auth, Response.json({ error: "Not a DALI member" }, { status: 403 }));
+        return Response.json({ error: "Not a DALI member" }, { status: 403 });
       }
 
       const session = await prisma.delibsSession.findUnique({
         where: { id: params.id },
       });
       if (!session) {
-        return withAuth(auth, Response.json({ error: "Not found" }, { status: 404 }));
+        return Response.json({ error: "Not found" }, { status: 404 });
       }
 
       const columnOrder = session.columnOrder as Record<string, string[]>;
@@ -122,9 +122,9 @@ export async function action({ request, params }: Route.ActionArgs) {
         });
       });
 
-      return withAuth(auth, Response.json({ closed: true, decisionsCreated: decisions.length }));
+      return Response.json({ closed: true, decisionsCreated: decisions.length });
     }
   }
 
-  return withAuth(auth, Response.json({ error: "Invalid request" }, { status: 400 }));
+  return Response.json({ error: "Invalid request" }, { status: 400 });
 }

--- a/dali-api/app/hiring/routes/api.domain-applications.$id.decisions.ts
+++ b/dali-api/app/hiring/routes/api.domain-applications.$id.decisions.ts
@@ -1,7 +1,7 @@
 import type { Route } from "./+types/api.domain-applications.$id.decisions";
 import { z } from "zod";
 import { prisma } from "~/lib/db";
-import { requireAuth, withAuth } from "~/lib/auth";
+import { requireAuth } from "~/lib/auth";
 import { isHiringLead, isDomainLead, hasCycleAccess } from "~/lib/roles";
 import { parseJson } from "~/lib/validate";
 import { requireApiSignedOrForbidden } from "~/hiring/lib/confidentiality";
@@ -21,9 +21,9 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     where: { id: params.id },
     select: { application: { select: { applicationCycleId: true } } },
   });
-  if (!domainApp) return withAuth(auth, Response.json({ error: "Not found" }, { status: 404 }));
+  if (!domainApp) return Response.json({ error: "Not found" }, { status: 404 });
   if (!(await hasCycleAccess(auth.user.sub, domainApp.application.applicationCycleId)))
-    return withAuth(auth, Response.json({ error: "Forbidden" }, { status: 403 }));
+    return Response.json({ error: "Forbidden" }, { status: 403 });
 
   const gate = await requireApiSignedOrForbidden(
     auth.user.sub,
@@ -42,7 +42,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     },
   });
 
-  return withAuth(auth, Response.json(decisions));
+  return Response.json(decisions);
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
@@ -50,11 +50,11 @@ export async function action({ request, params }: Route.ActionArgs) {
   if (!auth.ok) return auth.response;
 
   if (request.method !== "POST") {
-    return withAuth(auth, Response.json({ error: "Method not allowed" }, { status: 405 }));
+    return Response.json({ error: "Method not allowed" }, { status: 405 });
   }
 
   const body = await parseJson(request, DecisionSchema);
-  if (body instanceof Response) return withAuth(auth, body);
+  if (body instanceof Response) return body;
   const { type, stage, notes, waitlistRank } = body;
 
   const da = await prisma.domainApplication.findUnique({
@@ -72,7 +72,7 @@ export async function action({ request, params }: Route.ActionArgs) {
     where: { userId: auth.user.sub },
   });
   if (!member) {
-    return withAuth(auth, Response.json({ error: "Not a DALI member" }, { status: 403 }));
+    return Response.json({ error: "Not a DALI member" }, { status: 403 });
   }
 
   // Stage-based authorization:
@@ -80,13 +80,13 @@ export async function action({ request, params }: Route.ActionArgs) {
   // Released = hiring lead only
   if (stage === "Released") {
     if (!(await isHiringLead(auth.user.sub))) {
-      return withAuth(auth, Response.json({ error: "Only hiring leads can release decisions" }, { status: 403 }));
+      return Response.json({ error: "Only hiring leads can release decisions" }, { status: 403 });
     }
   } else {
     const hiringLead = await isHiringLead(auth.user.sub);
     const domainLead = await isDomainLead(auth.user.sub);
     if (!hiringLead && !domainLead) {
-      return withAuth(auth, Response.json({ error: "Forbidden" }, { status: 403 }));
+      return Response.json({ error: "Forbidden" }, { status: 403 });
     }
   }
 
@@ -101,5 +101,5 @@ export async function action({ request, params }: Route.ActionArgs) {
     },
   });
 
-  return withAuth(auth, Response.json(decision, { status: 201 }));
+  return Response.json(decision, { status: 201 });
 }

--- a/dali-api/app/hiring/routes/api.domain-applications.$id.full-context.ts
+++ b/dali-api/app/hiring/routes/api.domain-applications.$id.full-context.ts
@@ -1,6 +1,6 @@
 import type { Route } from "./+types/api.domain-applications.$id.full-context";
 import { prisma } from "~/lib/db";
-import { requireAuth, withAuth } from "~/lib/auth";
+import { requireAuth } from "~/lib/auth";
 import { hasCycleAccess } from "~/lib/roles";
 import { requireApiSignedOrForbidden } from "~/hiring/lib/confidentiality";
 
@@ -41,9 +41,9 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     },
   });
 
-  if (!da) return withAuth(auth, Response.json({ error: "Not found" }, { status: 404 }));
+  if (!da) return Response.json({ error: "Not found" }, { status: 404 });
   if (!(await hasCycleAccess(auth.user.sub, da.application.applicationCycleId))) {
-    return withAuth(auth, Response.json({ error: "Forbidden" }, { status: 403 }));
+    return Response.json({ error: "Forbidden" }, { status: 403 });
   }
 
   const gate = await requireApiSignedOrForbidden(
@@ -73,7 +73,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
       : Promise.resolve(null),
   ]);
 
-  return withAuth(auth, Response.json({
+  return Response.json({
       domainApplication: {
         id: da.id,
         answers: da.answers,
@@ -92,5 +92,5 @@ export async function loader({ request, params }: Route.LoaderArgs) {
         generalCriteria: generalRubric?.criteria ?? [],
         domainCriteria: domainCycle?.rubricVersion?.criteria ?? [],
       },
-    }));
+    });
 }

--- a/dali-api/app/hiring/routes/api.domain-applications.$id.reviews.ts
+++ b/dali-api/app/hiring/routes/api.domain-applications.$id.reviews.ts
@@ -1,7 +1,7 @@
 import type { Route } from "./+types/api.domain-applications.$id.reviews";
 import { z } from "zod";
 import { prisma } from "~/lib/db";
-import { requireAuth, withAuth } from "~/lib/auth";
+import { requireAuth } from "~/lib/auth";
 import { isHiringLead, hasCycleAccess } from "~/lib/roles";
 import { parseJson } from "~/lib/validate";
 import { requireApiSignedOrForbidden } from "~/hiring/lib/confidentiality";
@@ -18,9 +18,9 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     where: { id: params.id },
     select: { application: { select: { applicationCycleId: true } } },
   });
-  if (!domainApp) return withAuth(auth, Response.json({ error: "Not found" }, { status: 404 }));
+  if (!domainApp) return Response.json({ error: "Not found" }, { status: 404 });
   if (!(await hasCycleAccess(auth.user.sub, domainApp.application.applicationCycleId)))
-    return withAuth(auth, Response.json({ error: "Forbidden" }, { status: 403 }));
+    return Response.json({ error: "Forbidden" }, { status: 403 });
 
   const gate = await requireApiSignedOrForbidden(
     auth.user.sub,
@@ -40,7 +40,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     orderBy: { createdAt: "asc" },
   });
 
-  return withAuth(auth, Response.json(reviews));
+  return Response.json(reviews);
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
@@ -48,11 +48,11 @@ export async function action({ request, params }: Route.ActionArgs) {
   if (!auth.ok) return auth.response;
 
   if (request.method !== "POST") {
-    return withAuth(auth, Response.json({ error: "Method not allowed" }, { status: 405 }));
+    return Response.json({ error: "Method not allowed" }, { status: 405 });
   }
 
   const body = await parseJson(request, CreateReviewSchema);
-  if (body instanceof Response) return withAuth(auth, body);
+  if (body instanceof Response) return body;
   const { cycleReviewerId } = body;
 
   const domainApp = await prisma.domainApplication.findUniqueOrThrow({
@@ -66,7 +66,7 @@ export async function action({ request, params }: Route.ActionArgs) {
   // Refuse to assign reviewers to a domain the applicant deselected — the
   // record only persists to preserve answers in case they re-select.
   if (!domainApp.selected) {
-    return withAuth(auth, Response.json({ error: "Cannot assign reviewer to a deselected domain application" }, { status: 409 }));
+    return Response.json({ error: "Cannot assign reviewer to a deselected domain application" }, { status: 409 });
   }
 
   // ChallengeVersion.domainId is nullable because the general application form
@@ -74,7 +74,7 @@ export async function action({ request, params }: Route.ActionArgs) {
   // so this is a data invariant error rather than a user-facing condition.
   const domainId = domainApp.challengeVersion.domainId;
   if (!domainId) {
-    return withAuth(auth, Response.json({ error: "Domain application is linked to a non-domain challenge version" }, { status: 500 }));
+    return Response.json({ error: "Domain application is linked to a non-domain challenge version" }, { status: 500 });
   }
 
   const gate = await requireApiSignedOrForbidden(
@@ -92,7 +92,7 @@ export async function action({ request, params }: Route.ActionArgs) {
       select: { id: true },
     });
     if (!domainLeadForThisDomain) {
-      return withAuth(auth, Response.json({ error: "Forbidden" }, { status: 403 }));
+      return Response.json({ error: "Forbidden" }, { status: 403 });
     }
   }
 
@@ -100,14 +100,14 @@ export async function action({ request, params }: Route.ActionArgs) {
     where: { id: domainApp.application.applicationCycleId },
   });
   if (!cycle.generalRubricVersionId) {
-    return withAuth(auth, Response.json({ error: "A general application rubric must be set before assigning reviewers to applications" }, { status: 400 }));
+    return Response.json({ error: "A general application rubric must be set before assigning reviewers to applications" }, { status: 400 });
   }
 
   const domainCycle = await prisma.domainApplicationCycle.findUnique({
     where: { domainId_applicationCycleId: { domainId, applicationCycleId: cycle.id } },
   });
   if (!domainCycle?.rubricVersionId) {
-    return withAuth(auth, Response.json({ error: "A domain rubric must be set before assigning reviewers to applications in this domain" }, { status: 400 }));
+    return Response.json({ error: "A domain rubric must be set before assigning reviewers to applications in this domain" }, { status: 400 });
   }
 
   const review = await prisma.applicationReview.create({
@@ -117,5 +117,5 @@ export async function action({ request, params }: Route.ActionArgs) {
     },
   });
 
-  return withAuth(auth, Response.json(review, { status: 201 }));
+  return Response.json(review, { status: 201 });
 }

--- a/dali-api/app/hiring/routes/api.domain-applications.$id.schedule-interview.ts
+++ b/dali-api/app/hiring/routes/api.domain-applications.$id.schedule-interview.ts
@@ -1,7 +1,7 @@
 import type { Route } from "./+types/api.domain-applications.$id.schedule-interview";
 import { z } from "zod";
 import { prisma } from "~/lib/db";
-import { requireAuth, withAuth } from "~/lib/auth";
+import { requireAuth } from "~/lib/auth";
 import { assignInterviewers } from "~/hiring/lib/scheduling";
 // import { provisionZoomMeeting } from "~/lib/zoom"; // S2S Zoom not configured yet
 import { parseJson } from "~/lib/validate";
@@ -17,11 +17,11 @@ export async function action({ request, params }: Route.ActionArgs) {
   if (!auth.ok) return auth.response;
 
   if (request.method !== "POST") {
-    return withAuth(auth, Response.json({ error: "Method not allowed" }, { status: 405 }));
+    return Response.json({ error: "Method not allowed" }, { status: 405 });
   }
 
   const body = await parseJson(request, ScheduleInterviewSchema);
-  if (body instanceof Response) return withAuth(auth, body);
+  if (body instanceof Response) return body;
   const { startTime, mode } = body;
   const interviewMode = mode === "in-person" ? "in-person" as const : "online" as const;
 
@@ -37,11 +37,11 @@ export async function action({ request, params }: Route.ActionArgs) {
   });
 
   if (!da) {
-    return withAuth(auth, Response.json({ error: "Domain application not found" }, { status: 404 }));
+    return Response.json({ error: "Domain application not found" }, { status: 404 });
   }
 
   if (da.application.userId !== auth.user.sub) {
-    return withAuth(auth, Response.json({ error: "Not your application" }, { status: 403 }));
+    return Response.json({ error: "Not your application" }, { status: 403 });
   }
 
   const latestDecision = await prisma.decision.findFirst({
@@ -49,11 +49,11 @@ export async function action({ request, params }: Route.ActionArgs) {
     orderBy: { createdAt: "desc" },
   });
   if (!latestDecision || latestDecision.type !== "InvitedToInterview") {
-    return withAuth(auth, Response.json({ error: "Not invited to interview" }, { status: 403 }));
+    return Response.json({ error: "Not invited to interview" }, { status: 403 });
   }
 
   if (da.interviews.length > 0) {
-    return withAuth(auth, Response.json({ error: "Interview already scheduled" }, { status: 409 }));
+    return Response.json({ error: "Interview already scheduled" }, { status: 409 });
   }
 
   // DomainApplications always attach to a domain-scoped challenge version.
@@ -61,14 +61,14 @@ export async function action({ request, params }: Route.ActionArgs) {
   // rows are never created for general forms — defensive guard in case that
   // invariant ever breaks.
   if (!da.challengeVersion.domainId) {
-    return withAuth(auth, Response.json({ error: "Domain application is not attached to a domain" }, { status: 400 }));
+    return Response.json({ error: "Domain application is not attached to a domain" }, { status: 400 });
   }
 
   const config = await prisma.interviewConfig.findUnique({
     where: { applicationCycleId: da.application.applicationCycleId },
   });
   if (!config) {
-    return withAuth(auth, Response.json({ error: "No interview config for this cycle" }, { status: 400 }));
+    return Response.json({ error: "No interview config for this cycle" }, { status: 400 });
   }
 
   const slotStart = new Date(startTime);
@@ -97,8 +97,8 @@ export async function action({ request, params }: Route.ActionArgs) {
     // Best-effort: send calendar invites to applicant + interviewers
     sendInterviewInviteEmails(interview.id, da.id).catch(() => {});
 
-    return withAuth(auth, Response.json(interview, { status: 201 }));
+    return Response.json(interview, { status: 201 });
   } catch (err: any) {
-    return withAuth(auth, Response.json({ error: err.message }, { status: 409 }));
+    return Response.json({ error: err.message }, { status: 409 });
   }
 }

--- a/dali-api/app/hiring/routes/api.interview-assignments.$id.notes.ts
+++ b/dali-api/app/hiring/routes/api.interview-assignments.$id.notes.ts
@@ -1,7 +1,7 @@
 import type { Route } from "./+types/api.interview-assignments.$id.notes";
 import { z } from "zod";
 import { prisma } from "~/lib/db";
-import { requireAuth, withAuth } from "~/lib/auth";
+import { requireAuth } from "~/lib/auth";
 import { hasCycleAccess } from "~/lib/roles";
 import { parseJson } from "~/lib/validate";
 import { requireApiSignedOrForbidden } from "~/hiring/lib/confidentiality";
@@ -18,9 +18,9 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     where: { id: params.id },
     select: { interview: { select: { applicationCycleId: true } } },
   });
-  if (!assignment) return withAuth(auth, Response.json({ error: "Not found" }, { status: 404 }));
+  if (!assignment) return Response.json({ error: "Not found" }, { status: 404 });
   if (!(await hasCycleAccess(auth.user.sub, assignment.interview.applicationCycleId)))
-    return withAuth(auth, Response.json({ error: "Forbidden" }, { status: 403 }));
+    return Response.json({ error: "Forbidden" }, { status: 403 });
 
   const gate = await requireApiSignedOrForbidden(
     auth.user.sub,
@@ -33,7 +33,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     orderBy: { createdAt: "desc" },
   });
 
-  return withAuth(auth, Response.json(versions));
+  return Response.json(versions);
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
@@ -41,7 +41,7 @@ export async function action({ request, params }: Route.ActionArgs) {
   if (!auth.ok) return auth.response;
 
   if (request.method !== "POST") {
-    return withAuth(auth, Response.json({ error: "Method not allowed" }, { status: 405 }));
+    return Response.json({ error: "Method not allowed" }, { status: 405 });
   }
 
   // Verify the assignment belongs to the current user's CycleInterviewer
@@ -56,11 +56,11 @@ export async function action({ request, params }: Route.ActionArgs) {
   });
 
   if (!assignment) {
-    return withAuth(auth, Response.json({ error: "Assignment not found" }, { status: 404 }));
+    return Response.json({ error: "Assignment not found" }, { status: 404 });
   }
 
   if (assignment.cycleInterviewer.daliMember.userId !== auth.user.sub) {
-    return withAuth(auth, Response.json({ error: "Not your assignment" }, { status: 403 }));
+    return Response.json({ error: "Not your assignment" }, { status: 403 });
   }
 
   const gate = await requireApiSignedOrForbidden(
@@ -70,7 +70,7 @@ export async function action({ request, params }: Route.ActionArgs) {
   if (gate) return gate;
 
   const body = await parseJson(request, NoteVersionSchema);
-  if (body instanceof Response) return withAuth(auth, body);
+  if (body instanceof Response) return body;
   const { content } = body;
 
   const version = await prisma.interviewNoteVersion.create({
@@ -80,5 +80,5 @@ export async function action({ request, params }: Route.ActionArgs) {
     },
   });
 
-  return withAuth(auth, Response.json(version, { status: 201 }));
+  return Response.json(version, { status: 201 });
 }

--- a/dali-api/app/hiring/routes/api.interviews.$id.complete.ts
+++ b/dali-api/app/hiring/routes/api.interviews.$id.complete.ts
@@ -1,7 +1,7 @@
 import type { Route } from "./+types/api.interviews.$id.complete";
 import { z } from "zod";
 import { prisma } from "~/lib/db";
-import { requireAuth, withAuth } from "~/lib/auth";
+import { requireAuth } from "~/lib/auth";
 import { parseJson } from "~/lib/validate";
 import { requireApiSignedOrForbidden } from "~/hiring/lib/confidentiality";
 import { isHiringLead } from "~/lib/roles";
@@ -18,12 +18,12 @@ export async function action({ request, params }: Route.ActionArgs) {
   if (!auth.ok) return auth.response;
 
   if (request.method !== "POST" && request.method !== "DELETE") {
-    return withAuth(auth, Response.json({ error: "Method not allowed" }, { status: 405 }));
+    return Response.json({ error: "Method not allowed" }, { status: 405 });
   }
 
   const member = await prisma.dALIMember.findFirst({ where: { userId: auth.user.sub } });
   if (!member) {
-    return withAuth(auth, Response.json({ error: "Not a DALI member" }, { status: 403 }));
+    return Response.json({ error: "Not a DALI member" }, { status: 403 });
   }
 
   // Verify the caller is an active interviewer on this interview
@@ -35,44 +35,44 @@ export async function action({ request, params }: Route.ActionArgs) {
     },
   });
   if (!assignment) {
-    return withAuth(auth, Response.json({ error: "You are not an active interviewer for this interview" }, { status: 403 }));
+    return Response.json({ error: "You are not an active interviewer for this interview" }, { status: 403 });
   }
 
   const interview = await prisma.interview.findUnique({ where: { id: params.id } });
   if (!interview) {
-    return withAuth(auth, Response.json({ error: "Interview not found" }, { status: 404 }));
+    return Response.json({ error: "Interview not found" }, { status: 404 });
   }
 
   const gate = await requireApiSignedOrForbidden(
     auth.user.sub,
     interview.applicationCycleId,
   );
-  if (gate) return withAuth(auth, gate);
+  if (gate) return gate;
 
   // DELETE = reopen a completed interview (flip status back to Scheduled).
   // Preserves recommendation + recommendationNotes so the interviewer can
   // re-submit the same values or edit them before marking complete again.
   if (request.method === "DELETE") {
     if (!(await isHiringLead(auth.user.sub))) {
-      return withAuth(auth, Response.json({ error: "Only hiring leads can reopen interviews" }, { status: 403 }));
+      return Response.json({ error: "Only hiring leads can reopen interviews" }, { status: 403 });
     }
     if (interview.status !== "Completed") {
-      return withAuth(auth, Response.json({ error: "Interview is not completed" }, { status: 409 }));
+      return Response.json({ error: "Interview is not completed" }, { status: 409 });
     }
     const updated = await prisma.interview.update({
       where: { id: params.id },
       data: { status: "Scheduled" },
     });
-    return withAuth(auth, Response.json(updated));
+    return Response.json(updated);
   }
 
   // POST = mark the interview complete.
   const body = await parseJson(request, CompleteSchema);
-  if (body instanceof Response) return withAuth(auth, body);
+  if (body instanceof Response) return body;
   const { recommendation, recommendationNotes } = body;
 
   if (interview.status === "Completed") {
-    return withAuth(auth, Response.json({ error: "Interview is already completed" }, { status: 409 }));
+    return Response.json({ error: "Interview is already completed" }, { status: 409 });
   }
 
   const updated = await prisma.interview.update({
@@ -84,5 +84,5 @@ export async function action({ request, params }: Route.ActionArgs) {
     },
   });
 
-  return withAuth(auth, Response.json(updated));
+  return Response.json(updated);
 }

--- a/dali-api/app/hiring/routes/api.interviews.$id.location.ts
+++ b/dali-api/app/hiring/routes/api.interviews.$id.location.ts
@@ -1,6 +1,6 @@
 import type { Route } from "./+types/api.interviews.$id.location";
 import { prisma } from "~/lib/db";
-import { requireAuth, withAuth } from "~/lib/auth";
+import { requireAuth } from "~/lib/auth";
 import { hasCycleAccess } from "~/lib/roles";
 // import { provisionZoomMeeting, deprovisionZoomMeeting } from "~/lib/zoom"; // S2S Zoom not configured yet
 import { sendLocationChangeEmails } from "~/hiring/lib/interview-emails";
@@ -12,21 +12,21 @@ export async function action({ request, params }: Route.ActionArgs) {
   if (!auth.ok) return auth.response;
 
   if (request.method !== "PATCH") {
-    return withAuth(auth, Response.json({ error: "Method not allowed" }, { status: 405 }));
+    return Response.json({ error: "Method not allowed" }, { status: 405 });
   }
 
   const body = await request.json();
   const { location, meetingUrl } = body;
 
   if (!location || !VALID_LOCATIONS.includes(location)) {
-    return withAuth(auth, Response.json(
+    return Response.json(
       { error: `location must be one of: ${VALID_LOCATIONS.join(", ")}` },
       { status: 400 },
-    ));
+    );
   }
 
   if (meetingUrl !== undefined && typeof meetingUrl !== "string") {
-    return withAuth(auth, Response.json({ error: "meetingUrl must be a string" }, { status: 400 }));
+    return Response.json({ error: "meetingUrl must be a string" }, { status: 400 });
   }
 
   const interview = await prisma.interview.findUnique({
@@ -34,18 +34,18 @@ export async function action({ request, params }: Route.ActionArgs) {
   });
 
   if (!interview) {
-    return withAuth(auth, Response.json({ error: "Interview not found" }, { status: 404 }));
+    return Response.json({ error: "Interview not found" }, { status: 404 });
   }
 
   if (!(await hasCycleAccess(auth.user.sub, interview.applicationCycleId))) {
-    return withAuth(auth, Response.json({ error: "Forbidden" }, { status: 403 }));
+    return Response.json({ error: "Forbidden" }, { status: 403 });
   }
 
   if (interview.status !== "Scheduled") {
-    return withAuth(auth, Response.json(
+    return Response.json(
       { error: "Can only change location of scheduled interviews" },
       { status: 400 },
-    ));
+    );
   }
 
   // Conflict check + update in one serializable transaction to prevent
@@ -83,13 +83,13 @@ export async function action({ request, params }: Route.ActionArgs) {
     // Best-effort: notify applicant + interviewers of location change
     sendLocationChangeEmails(interview.id, interview.domainApplicationId).catch(() => {});
 
-    return withAuth(auth, Response.json(updated));
+    return Response.json(updated);
   } catch (err: any) {
     if (err?.message === "__POD_OCCUPIED__") {
-      return withAuth(auth, Response.json(
+      return Response.json(
         { error: `${location === "PodAppa" ? "Pod Appa" : "Pod Momo"} is already occupied at this time` },
         { status: 409 },
-      ));
+      );
     }
     throw err;
   }

--- a/dali-api/app/hiring/routes/api.interviews.$id.reassign.ts
+++ b/dali-api/app/hiring/routes/api.interviews.$id.reassign.ts
@@ -1,7 +1,7 @@
 import type { Route } from "./+types/api.interviews.$id.reassign";
 import { z } from "zod";
 import { prisma } from "~/lib/db";
-import { requireAuth, withAuth } from "~/lib/auth";
+import { requireAuth } from "~/lib/auth";
 import { isHiringLead } from "~/lib/roles";
 import { parseJson } from "~/lib/validate";
 import { requireApiSignedOrForbidden } from "~/hiring/lib/confidentiality";
@@ -17,15 +17,15 @@ export async function action({ request, params }: Route.ActionArgs) {
   if (!auth.ok) return auth.response;
 
   if (request.method !== "POST") {
-    return withAuth(auth, Response.json({ error: "Method not allowed" }, { status: 405 }));
+    return Response.json({ error: "Method not allowed" }, { status: 405 });
   }
 
   if (!(await isHiringLead(auth.user.sub))) {
-    return withAuth(auth, Response.json({ error: "Forbidden" }, { status: 403 }));
+    return Response.json({ error: "Forbidden" }, { status: 403 });
   }
 
   const body = await parseJson(request, ReassignSchema);
-  if (body instanceof Response) return withAuth(auth, body);
+  if (body instanceof Response) return body;
   const { assignmentId, newCycleInterviewerId } = body;
 
   const assignment = await prisma.interviewAssignment.findUnique({
@@ -33,14 +33,14 @@ export async function action({ request, params }: Route.ActionArgs) {
     include: { interview: true },
   });
   if (!assignment || assignment.interview.id !== params.id) {
-    return withAuth(auth, Response.json({ error: "Assignment not found" }, { status: 404 }));
+    return Response.json({ error: "Assignment not found" }, { status: 404 });
   }
 
   const gate = await requireApiSignedOrForbidden(
     auth.user.sub,
     assignment.interview.applicationCycleId,
   );
-  if (gate) return withAuth(auth, gate);
+  if (gate) return gate;
 
   const interview = assignment.interview;
 
@@ -52,7 +52,7 @@ export async function action({ request, params }: Route.ActionArgs) {
     select: { daliMemberId: true },
   });
   if (!newCI) {
-    return withAuth(auth, Response.json({ error: "Interviewer not found" }, { status: 404 }));
+    return Response.json({ error: "Interviewer not found" }, { status: 404 });
   }
 
   // Conflict check + reassign in one serializable transaction to prevent
@@ -98,10 +98,10 @@ export async function action({ request, params }: Route.ActionArgs) {
     }, { isolationLevel: "Serializable" });
   } catch (err: any) {
     if (err?.message === "__CONFLICT__") {
-      return withAuth(auth, Response.json(
+      return Response.json(
         { error: "This interviewer is already assigned to another interview at this time" },
         { status: 409 },
-      ));
+      );
     }
     throw err;
   }
@@ -114,5 +114,5 @@ export async function action({ request, params }: Route.ActionArgs) {
     newCycleInterviewerId,
   ).catch(() => {});
 
-  return withAuth(auth, Response.json({ success: true }));
+  return Response.json({ success: true });
 }

--- a/dali-api/app/hiring/routes/api.my-interview.cancel.ts
+++ b/dali-api/app/hiring/routes/api.my-interview.cancel.ts
@@ -1,7 +1,7 @@
 import type { Route } from "./+types/api.my-interview.cancel";
 import { z } from "zod";
 import { prisma } from "~/lib/db";
-import { requireAuth, withAuth } from "~/lib/auth";
+import { requireAuth } from "~/lib/auth";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { parseJson } from "~/lib/validate";
 // import { deprovisionZoomMeeting } from "~/lib/zoom"; // S2S Zoom not configured yet
@@ -19,11 +19,11 @@ export async function action({ request }: Route.ActionArgs) {
   if (!auth.ok) return withCors(request, auth.response);
 
   if (request.method !== "POST") {
-    return withAuth(auth, withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 })));
+    return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));
   }
 
   const body = await parseJson(request, CancelSchema);
-  if (body instanceof Response) return withAuth(auth, withCors(request, body));
+  if (body instanceof Response) return withCors(request, body);
   const { domainApplicationId } = body;
 
   const interview = await prisma.interview.findFirst({
@@ -35,7 +35,7 @@ export async function action({ request }: Route.ActionArgs) {
   });
 
   if (!interview) {
-    return withAuth(auth, withCors(request, Response.json({ error: "No active interview found" }, { status: 404 })));
+    return withCors(request, Response.json({ error: "No active interview found" }, { status: 404 }));
   }
 
   const config = await prisma.interviewConfig.findUnique({
@@ -45,10 +45,10 @@ export async function action({ request }: Route.ActionArgs) {
   if (cancelNoticeHours > 0) {
     const cutoff = new Date(interview.startTime.getTime() - cancelNoticeHours * 60 * 60_000);
     if (new Date() > cutoff) {
-      return withAuth(auth, withCors(request, Response.json(
+      return withCors(request, Response.json(
         { error: "Too late to cancel — please contact the DALI team" },
         { status: 403 },
-      )));
+      ));
     }
   }
 
@@ -71,5 +71,5 @@ export async function action({ request }: Route.ActionArgs) {
   // Best-effort: send cancellation ICS to applicant + interviewers
   sendInterviewCancelEmails(interview.id, domainApplicationId).catch(() => {});
 
-  return withAuth(auth, withCors(request, Response.json(updated)));
+  return withCors(request, Response.json(updated));
 }

--- a/dali-api/app/hiring/routes/api.my-interview.reschedule.ts
+++ b/dali-api/app/hiring/routes/api.my-interview.reschedule.ts
@@ -1,7 +1,7 @@
 import type { Route } from "./+types/api.my-interview.reschedule";
 import { z } from "zod";
 import { prisma } from "~/lib/db";
-import { requireAuth, withAuth } from "~/lib/auth";
+import { requireAuth } from "~/lib/auth";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { parseJson } from "~/lib/validate";
 import { assignInterviewers } from "~/hiring/lib/scheduling";
@@ -27,11 +27,11 @@ export async function action({ request }: Route.ActionArgs) {
   if (!auth.ok) return withCors(request, auth.response);
 
   if (request.method !== "POST") {
-    return withAuth(auth, withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 })));
+    return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));
   }
 
   const body = await parseJson(request, RescheduleSchema);
-  if (body instanceof Response) return withAuth(auth, withCors(request, body));
+  if (body instanceof Response) return withCors(request, body);
   const { newStart, newEnd, domainApplicationId, mode } = body;
   const interviewMode = mode === "in-person" ? "in-person" as const : "online" as const;
 
@@ -115,14 +115,14 @@ export async function action({ request }: Route.ActionArgs) {
     sendInterviewCancelEmails(oldInterviewId, domainApplicationId).catch(() => {});
     sendInterviewInviteEmails(newInterview.id, domainApplicationId).catch(() => {});
 
-    return withAuth(auth, withCors(request, Response.json(newInterview, { status: 201 })));
+    return withCors(request, Response.json(newInterview, { status: 201 }));
   } catch (err: any) {
     if (err?.message === "__NO_ACTIVE_INTERVIEW__") {
-      return withAuth(auth, withCors(request, Response.json({ error: "No active interview found" }, { status: 404 })));
+      return withCors(request, Response.json({ error: "No active interview found" }, { status: 404 }));
     }
     if (err?.message === "__TOO_LATE_TO_RESCHEDULE__") {
-      return withAuth(auth, withCors(request, Response.json({ error: "Too late to reschedule — please contact the DALI team" }, { status: 403 })));
+      return withCors(request, Response.json({ error: "Too late to reschedule — please contact the DALI team" }, { status: 403 }));
     }
-    return withAuth(auth, withCors(request, Response.json({ error: err?.message ?? "Failed to reschedule" }, { status: 409 })));
+    return withCors(request, Response.json({ error: err?.message ?? "Failed to reschedule" }, { status: 409 }));
   }
 }

--- a/dali-api/app/hiring/routes/api.my-interview.ts
+++ b/dali-api/app/hiring/routes/api.my-interview.ts
@@ -1,6 +1,6 @@
 import type { Route } from "./+types/api.my-interview";
 import { prisma } from "~/lib/db";
-import { requireAuth, withAuth } from "~/lib/auth";
+import { requireAuth } from "~/lib/auth";
 import { withCors, handlePreflight } from "~/lib/cors";
 
 export async function loader({ request }: Route.LoaderArgs) {
@@ -24,5 +24,5 @@ export async function loader({ request }: Route.LoaderArgs) {
     orderBy: { startTime: "desc" },
   });
 
-  return withAuth(auth, withCors(request, Response.json(interview)));
+  return withCors(request, Response.json(interview));
 }

--- a/dali-api/app/hiring/routes/api.reviews.$id.submit.ts
+++ b/dali-api/app/hiring/routes/api.reviews.$id.submit.ts
@@ -1,6 +1,6 @@
 import type { Route } from "./+types/api.reviews.$id.submit";
 import { prisma } from "~/lib/db";
-import { requireAuth, withAuth } from "~/lib/auth";
+import { requireAuth } from "~/lib/auth";
 import { isHiringLead, isDomainLead } from "~/lib/roles";
 import { requireApiSignedOrForbidden } from "~/hiring/lib/confidentiality";
 
@@ -9,14 +9,14 @@ export async function action({ request, params }: Route.ActionArgs) {
   if (!auth.ok) return auth.response;
 
   if (request.method !== "POST") {
-    return withAuth(auth, Response.json({ error: "Method not allowed" }, { status: 405 }));
+    return Response.json({ error: "Method not allowed" }, { status: 405 });
   }
 
   const member = await prisma.dALIMember.findFirst({
     where: { userId: auth.user.sub },
   });
   if (!member) {
-    return withAuth(auth, Response.json({ error: "Not a DALI member" }, { status: 403 }));
+    return Response.json({ error: "Not a DALI member" }, { status: 403 });
   }
 
   const review = await prisma.applicationReview.findUnique({
@@ -24,10 +24,10 @@ export async function action({ request, params }: Route.ActionArgs) {
     include: { cycleReviewer: true },
   });
   if (!review) {
-    return withAuth(auth, Response.json({ error: "Review not found" }, { status: 404 }));
+    return Response.json({ error: "Review not found" }, { status: 404 });
   }
   if (review.submittedAt) {
-    return withAuth(auth, Response.json({ error: "Review already submitted" }, { status: 409 }));
+    return Response.json({ error: "Review already submitted" }, { status: 409 });
   }
 
   const gate = await requireApiSignedOrForbidden(
@@ -40,7 +40,7 @@ export async function action({ request, params }: Route.ActionArgs) {
   const isLead = await isDomainLead(auth.user.sub);
   const isHL = await isHiringLead(auth.user.sub);
   if (!isOwner && !isLead && !isHL) {
-    return withAuth(auth, Response.json({ error: "Forbidden" }, { status: 403 }));
+    return Response.json({ error: "Forbidden" }, { status: 403 });
   }
 
   const updated = await prisma.applicationReview.update({
@@ -51,5 +51,5 @@ export async function action({ request, params }: Route.ActionArgs) {
     },
   });
 
-  return withAuth(auth, Response.json(updated));
+  return Response.json(updated);
 }

--- a/dali-api/app/hiring/routes/api.reviews.$id.ts
+++ b/dali-api/app/hiring/routes/api.reviews.$id.ts
@@ -1,6 +1,6 @@
 import type { Route } from "./+types/api.reviews.$id";
 import { prisma } from "~/lib/db";
-import { requireAuth, withAuth } from "~/lib/auth";
+import { requireAuth } from "~/lib/auth";
 import { isHiringLead, isDomainLead } from "~/lib/roles";
 import { safeJson } from "~/lib/safe-json";
 import { requireApiSignedOrForbidden } from "~/hiring/lib/confidentiality";
@@ -153,7 +153,7 @@ export async function action({ request, params }: Route.ActionArgs) {
     include: { cycleReviewer: true },
   });
   if (!review) {
-    return withAuth(auth, Response.json({ error: "Review not found" }, { status: 404 }));
+    return Response.json({ error: "Review not found" }, { status: 404 });
   }
 
   const gate = await requireApiSignedOrForbidden(
@@ -164,7 +164,7 @@ export async function action({ request, params }: Route.ActionArgs) {
 
   if (request.method === "PATCH") {
     if (review.submittedAt) {
-      return withAuth(auth, Response.json({ error: "Cannot edit a submitted review. Unsubmit first." }, { status: 409 }));
+      return Response.json({ error: "Cannot edit a submitted review. Unsubmit first." }, { status: 409 });
     }
 
     const member = await prisma.dALIMember.findFirst({ where: { userId: auth.user.sub } });
@@ -172,11 +172,11 @@ export async function action({ request, params }: Route.ActionArgs) {
     const isLead = await isDomainLead(auth.user.sub);
     const isHL = await isHiringLead(auth.user.sub);
     if (!isOwner && !isLead && !isHL) {
-      return withAuth(auth, Response.json({ error: "Forbidden" }, { status: 403 }));
+      return Response.json({ error: "Forbidden" }, { status: 403 });
     }
 
     const body = await safeJson<Record<string, unknown>>(request);
-    if (body instanceof Response) return withAuth(auth, body);
+    if (body instanceof Response) return body;
     const data: Record<string, unknown> = {};
     if (body.scores !== undefined) data.scores = body.scores;
     if (body.feedback !== undefined) data.feedback = body.feedback;
@@ -186,29 +186,29 @@ export async function action({ request, params }: Route.ActionArgs) {
 
     const result = validateReviewPatch(body);
     if (!result.ok) {
-      return withAuth(auth, Response.json({ error: result.error }, { status: 400 }));
+      return Response.json({ error: result.error }, { status: 400 });
     }
     const updated = await prisma.applicationReview.update({
       where: { id: params.id },
       data: result.data,
     });
 
-    return withAuth(auth, Response.json(updated));
+    return Response.json(updated);
   }
 
   if (request.method === "DELETE") {
     const isLead = await isDomainLead(auth.user.sub);
     const isHL = await isHiringLead(auth.user.sub);
     if (!isLead && !isHL) {
-      return withAuth(auth, Response.json({ error: "Forbidden" }, { status: 403 }));
+      return Response.json({ error: "Forbidden" }, { status: 403 });
     }
 
     // Submitted reviews are allowed to be deleted by domain/hiring leads —
     // the client is expected to confirm with the user first since this
     // destroys the submitted scores/feedback.
     await prisma.applicationReview.delete({ where: { id: params.id } });
-    return withAuth(auth, Response.json({ deleted: true }));
+    return Response.json({ deleted: true });
   }
 
-  return withAuth(auth, Response.json({ error: "Method not allowed" }, { status: 405 }));
+  return Response.json({ error: "Method not allowed" }, { status: 405 });
 }

--- a/dali-api/app/hiring/routes/api.reviews.$id.unsubmit.ts
+++ b/dali-api/app/hiring/routes/api.reviews.$id.unsubmit.ts
@@ -1,6 +1,6 @@
 import type { Route } from "./+types/api.reviews.$id.unsubmit";
 import { prisma } from "~/lib/db";
-import { requireAuth, withAuth } from "~/lib/auth";
+import { requireAuth } from "~/lib/auth";
 import { isHiringLead, isDomainLead } from "~/lib/roles";
 import { requireApiSignedOrForbidden } from "~/hiring/lib/confidentiality";
 
@@ -9,7 +9,7 @@ export async function action({ request, params }: Route.ActionArgs) {
   if (!auth.ok) return auth.response;
 
   if (request.method !== "POST") {
-    return withAuth(auth, Response.json({ error: "Method not allowed" }, { status: 405 }));
+    return Response.json({ error: "Method not allowed" }, { status: 405 });
   }
 
   const review = await prisma.applicationReview.findUnique({
@@ -17,10 +17,10 @@ export async function action({ request, params }: Route.ActionArgs) {
     include: { cycleReviewer: true },
   });
   if (!review) {
-    return withAuth(auth, Response.json({ error: "Review not found" }, { status: 404 }));
+    return Response.json({ error: "Review not found" }, { status: 404 });
   }
   if (!review.submittedAt) {
-    return withAuth(auth, Response.json({ error: "Review is not submitted" }, { status: 409 }));
+    return Response.json({ error: "Review is not submitted" }, { status: 409 });
   }
 
   const gate = await requireApiSignedOrForbidden(
@@ -34,7 +34,7 @@ export async function action({ request, params }: Route.ActionArgs) {
   const isLead = await isDomainLead(auth.user.sub);
   const isHL = await isHiringLead(auth.user.sub);
   if (!isOwner && !isLead && !isHL) {
-    return withAuth(auth, Response.json({ error: "Forbidden" }, { status: 403 }));
+    return Response.json({ error: "Forbidden" }, { status: 403 });
   }
 
   const updated = await prisma.applicationReview.update({
@@ -45,5 +45,5 @@ export async function action({ request, params }: Route.ActionArgs) {
     },
   });
 
-  return withAuth(auth, Response.json(updated));
+  return Response.json(updated);
 }

--- a/dali-api/app/hiring/routes/challenges.$id.tsx
+++ b/dali-api/app/hiring/routes/challenges.$id.tsx
@@ -1,7 +1,7 @@
 import { redirect } from "react-router";
 import type { Route } from "./+types/challenges.$id";
 import { prisma } from "~/lib/db";
-import { requireAuth, withAuth } from "~/lib/auth";
+import { requireAuth } from "~/lib/auth";
 import { isHiringLead, isDomainLead, isAdmin } from "~/lib/roles";
 import { ChallengeDetail } from "~/hiring/components/ChallengeDetail";
 
@@ -12,8 +12,8 @@ export const meta: Route.MetaFunction = ({ data }) => {
 
 export async function loader({ request, params }: Route.LoaderArgs) {
   const auth = await requireAuth(request);
-  if (!auth.ok) return withAuth(auth, redirect("/login"));
-  if (!(await isHiringLead(auth.user.sub)) && !(await isDomainLead(auth.user.sub)) && !(await isAdmin(auth.user.sub))) return withAuth(auth, redirect("/"));
+  if (!auth.ok) return redirect("/login");
+  if (!(await isHiringLead(auth.user.sub)) && !(await isDomainLead(auth.user.sub)) && !(await isAdmin(auth.user.sub))) return redirect("/");
   const [challenge, domains] = await Promise.all([
     prisma.challenge.findUniqueOrThrow({
       where: { id: params.id },
@@ -30,16 +30,16 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     prisma.domain.findMany({ orderBy: { name: "asc" } }),
   ]);
 
-  return withAuth(auth, { challenge, domains });
+  return { challenge, domains };
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
   const auth = await requireAuth(request);
   if (!auth.ok) return auth.response;
-  if (!(await isHiringLead(auth.user.sub)) && !(await isDomainLead(auth.user.sub)) && !(await isAdmin(auth.user.sub))) return withAuth(auth, new Response(JSON.stringify({ error: "Forbidden" }), { status: 403, headers: { "Content-Type": "application/json" } }));
+  if (!(await isHiringLead(auth.user.sub)) && !(await isDomainLead(auth.user.sub)) && !(await isAdmin(auth.user.sub))) return new Response(JSON.stringify({ error: "Forbidden" }), { status: 403, headers: { "Content-Type": "application/json" } });
 
   const user = await prisma.user.findUnique({ where: { id: auth.user.sub } });
-  if (!user) return withAuth(auth, new Response(JSON.stringify({ error: "User not found" }), { status: 401 }));
+  if (!user) return new Response(JSON.stringify({ error: "User not found" }), { status: 401 });
 
   const formData = await request.formData();
   const intent = formData.get("intent") as string;
@@ -62,10 +62,10 @@ export async function action({ request, params }: Route.ActionArgs) {
       },
     });
 
-    return withAuth(auth, redirect(`/hiring/challenges/${params.id}`));
+    return redirect(`/hiring/challenges/${params.id}`);
   }
 
-  return withAuth(auth, null);
+  return null;
 }
 
 export default ChallengeDetail;

--- a/dali-api/app/hiring/routes/challenges.tsx
+++ b/dali-api/app/hiring/routes/challenges.tsx
@@ -1,7 +1,7 @@
 import { redirect } from "react-router";
 import type { Route } from "./+types/challenges";
 import { prisma } from "~/lib/db";
-import { requireAuth, withAuth } from "~/lib/auth";
+import { requireAuth } from "~/lib/auth";
 import { isHiringLead, isDomainLead, isAdmin } from "~/lib/roles";
 import Challenges from "~/hiring/components/Challenges";
 
@@ -9,8 +9,8 @@ export const meta: Route.MetaFunction = () => [{ title: "Challenges · DALI OS" 
 
 export async function loader({ request }: Route.LoaderArgs) {
   const auth = await requireAuth(request);
-  if (!auth.ok) return withAuth(auth, redirect("/login"));
-  if (!(await isHiringLead(auth.user.sub)) && !(await isDomainLead(auth.user.sub)) && !(await isAdmin(auth.user.sub))) return withAuth(auth, redirect("/"));
+  if (!auth.ok) return redirect("/login");
+  if (!(await isHiringLead(auth.user.sub)) && !(await isDomainLead(auth.user.sub)) && !(await isAdmin(auth.user.sub))) return redirect("/");
   const [domains, challenges] = await Promise.all([
     prisma.domain.findMany({ orderBy: { name: "asc" } }),
     prisma.challenge.findMany({
@@ -23,13 +23,13 @@ export async function loader({ request }: Route.LoaderArgs) {
       orderBy: { createdAt: "desc" },
     }),
   ]);
-  return withAuth(auth, { domains, challenges });
+  return { domains, challenges };
 }
 
 export async function action({ request }: Route.ActionArgs) {
   const auth = await requireAuth(request);
-  if (!auth.ok) return withAuth(auth, redirect("/login"));
-  if (!(await isHiringLead(auth.user.sub)) && !(await isDomainLead(auth.user.sub)) && !(await isAdmin(auth.user.sub))) return withAuth(auth, redirect("/"));
+  if (!auth.ok) return redirect("/login");
+  if (!(await isHiringLead(auth.user.sub)) && !(await isDomainLead(auth.user.sub)) && !(await isAdmin(auth.user.sub))) return redirect("/");
 
   const formData = await request.formData();
   const intent = formData.get("intent") as string;
@@ -38,7 +38,7 @@ export async function action({ request }: Route.ActionArgs) {
     const name = (formData.get("name") as string)?.trim();
     const domainId = formData.get("domainId") as string | null;
     const isGeneral = formData.get("general") === "1";
-    if (!name) return withAuth(auth, { error: "Name is required" });
+    if (!name) return { error: "Name is required" };
 
     const challenge = await prisma.challenge.create({ data: { name } });
     const dest = isGeneral
@@ -46,7 +46,7 @@ export async function action({ request }: Route.ActionArgs) {
       : domainId
         ? `/hiring/challenges/${challenge.id}?domainId=${domainId}`
         : `/hiring/challenges/${challenge.id}`;
-    return withAuth(auth, redirect(dest));
+    return redirect(dest);
   }
 
   if (intent === "delete") {
@@ -54,10 +54,10 @@ export async function action({ request }: Route.ActionArgs) {
     // Delete all versions first (cascade not set in schema)
     await prisma.challengeVersion.deleteMany({ where: { challengeId: id } });
     await prisma.challenge.delete({ where: { id } });
-    return withAuth(auth, null);
+    return null;
   }
 
-  return withAuth(auth, null);
+  return null;
 }
 
 export default Challenges;

--- a/dali-api/app/hiring/routes/domain-lead.application.$id.tsx
+++ b/dali-api/app/hiring/routes/domain-lead.application.$id.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { Link, redirect, useLoaderData } from "react-router";
 import type { Route } from "./+types/domain-lead.application.$id";
 import { prisma } from "~/lib/db";
-import { requireAuth, withAuth } from "~/lib/auth";
+import { requireAuth } from "~/lib/auth";
 import { requirePageSignedOrRedirect } from "~/hiring/lib/confidentiality";
 import { presignAnswers } from "~/hiring/lib/presign";
 import { ChevronDown } from "lucide-react";
@@ -55,7 +55,7 @@ export const meta: Route.MetaFunction = ({ data }) => {
 
 export async function loader({ request, params }: Route.LoaderArgs) {
   const auth = await requireAuth(request);
-  if (!auth.ok) return withAuth(auth, redirect("/login"));
+  if (!auth.ok) return redirect("/login");
 
   const member = await prisma.dALIMember.findFirst({
     where: { userId: auth.user.sub },
@@ -63,7 +63,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   });
 
   if (!member || member.domainLeadAssignments.length === 0) {
-    return withAuth(auth, redirect("/hiring/reviewer"));
+    return redirect("/hiring/reviewer");
   }
 
   const leadDomainIds = member.domainLeadAssignments.map((a) => a.domainId);
@@ -113,8 +113,8 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     },
   });
 
-  if (!da) return withAuth(auth, redirect("/hiring/domain-lead"));
-  if (!leadDomainIds.includes(da.challengeVersion.domainId!)) return withAuth(auth, redirect("/hiring/domain-lead"));
+  if (!da) return redirect("/hiring/domain-lead");
+  if (!leadDomainIds.includes(da.challengeVersion.domainId!)) return redirect("/hiring/domain-lead");
 
   const confRedirect = await requirePageSignedOrRedirect(
     auth.user.sub,
@@ -162,13 +162,13 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     da.answers as Record<string, string>,
   );
 
-  return withAuth(auth, {
+  return {
       domainApplication: { ...da, answers: presignedChallengeAnswers },
       application: { ...da.application, answers: presignedGeneralAnswers },
       inferredStatus,
       domainRubricCriteria: (dac?.rubricVersion?.criteria as any[]) ?? [],
       generalRubricCriteria: (generalRubric?.generalRubricVersion?.criteria as any[]) ?? [],
-    });
+    };
 }
 
 export default function DomainLeadApplicationView() {

--- a/dali-api/app/hiring/routes/domain-lead.delibs.$id.tsx
+++ b/dali-api/app/hiring/routes/domain-lead.delibs.$id.tsx
@@ -2,7 +2,7 @@ import { useState, useCallback, useRef } from "react";
 import { redirect, useLoaderData, useNavigate } from "react-router";
 import type { Route } from "./+types/domain-lead.delibs.$id";
 import { prisma } from "~/lib/db";
-import { requireAuth, withAuth } from "~/lib/auth";
+import { requireAuth } from "~/lib/auth";
 import { isDomainLead } from "~/lib/roles";
 import { requirePageSignedOrRedirect } from "~/hiring/lib/confidentiality";
 import { ArrowLeft, GripVertical, X, Check } from "lucide-react";
@@ -17,8 +17,8 @@ export const meta: Route.MetaFunction = ({ data }) => {
 
 export async function loader({ request, params }: Route.LoaderArgs) {
   const auth = await requireAuth(request);
-  if (!auth.ok) return withAuth(auth, redirect("/login"));
-  if (!(await isDomainLead(auth.user.sub))) return withAuth(auth, redirect("/"));
+  if (!auth.ok) return redirect("/login");
+  if (!(await isDomainLead(auth.user.sub))) return redirect("/");
 
   const session = await prisma.delibsSession.findUniqueOrThrow({
     where: { id: params.id },
@@ -86,7 +86,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     },
   });
 
-  return withAuth(auth, { session, domainApplications });
+  return { session, domainApplications };
 }
 
 type LoaderResult = {

--- a/dali-api/app/hiring/routes/domain-lead.tsx
+++ b/dali-api/app/hiring/routes/domain-lead.tsx
@@ -3,7 +3,7 @@ import { Form, Link, useLoaderData, useSearchParams, useRevalidator, useSubmit }
 import { redirect } from "react-router";
 import type { Route } from "./+types/domain-lead";
 import { prisma } from "~/lib/db";
-import { requireAuth, withAuth } from "~/lib/auth";
+import { requireAuth } from "~/lib/auth";
 import { CheckCircle, Plus, Trash2, Check, Clock, X, CircleDashed, ChevronDown, Eye, Send, Search, ChevronUp } from "lucide-react";
 import { inferDomainApplicationStatus } from "~/hiring/lib/domain-application-status";
 import { inReviewPipelineFilter } from "~/hiring/lib/application-pipeline-filter";
@@ -49,14 +49,14 @@ export const meta: Route.MetaFunction = () => [{ title: "Domain lead · DALI OS"
 
 export async function loader({ request }: Route.LoaderArgs) {
   const auth = await requireAuth(request);
-  if (!auth.ok) return withAuth(auth, { domainData: [] });
+  if (!auth.ok) return { domainData: [] };
 
   const member = await prisma.dALIMember.findFirst({
     where: { userId: auth.user.sub },
   });
 
   if (!member) {
-    return withAuth(auth, { domainData: [] });
+    return { domainData: [] };
   }
 
   const assignments = await prisma.domainLeadAssignment.findMany({
@@ -363,7 +363,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     })
   );
 
-  return withAuth(auth, { domainData: domainData.flat() });
+  return { domainData: domainData.flat() };
 }
 
 export async function action({ request }: Route.ActionArgs) {

--- a/dali-api/app/hiring/routes/email-templates.$id.tsx
+++ b/dali-api/app/hiring/routes/email-templates.$id.tsx
@@ -1,7 +1,7 @@
 import { redirect } from 'react-router'
 import type { Route } from './+types/email-templates.$id'
 import { prisma } from '~/lib/db'
-import { requireAuth, withAuth } from '~/lib/auth'
+import { requireAuth } from "~/lib/auth";
 import { isHiringLead } from '~/lib/roles'
 import { EmailTemplateDetail } from '~/hiring/components/EmailTemplateDetail'
 
@@ -12,8 +12,8 @@ export const meta: Route.MetaFunction = ({ data }) => {
 
 export async function loader({ request, params }: Route.LoaderArgs) {
   const auth = await requireAuth(request)
-  if (!auth.ok) return withAuth(auth, redirect('/login'))
-  if (!(await isHiringLead(auth.user.sub))) return withAuth(auth, redirect('/'))
+  if (!auth.ok) return redirect('/login')
+  if (!(await isHiringLead(auth.user.sub))) return redirect('/')
 
   const template = await prisma.emailTemplate.findUniqueOrThrow({
     where: { id: params.id },
@@ -25,18 +25,18 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     },
   })
 
-  return withAuth(auth, { template })
+  return { template }
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
   const auth = await requireAuth(request)
-  if (!auth.ok) return withAuth(auth, redirect('/login'))
-  if (!(await isHiringLead(auth.user.sub))) return withAuth(auth, redirect('/'))
+  if (!auth.ok) return redirect('/login')
+  if (!(await isHiringLead(auth.user.sub))) return redirect('/')
 
   const member = await prisma.dALIMember.findFirst({
     where: { userId: auth.user.sub },
   })
-  if (!member) return withAuth(auth, redirect('/login'))
+  if (!member) return redirect('/login')
 
   const formData = await request.formData()
   const intent = formData.get('intent') as string
@@ -44,7 +44,7 @@ export async function action({ request, params }: Route.ActionArgs) {
   if (intent === 'create-version') {
     const subject = (formData.get('subject') as string)?.trim()
     const body = (formData.get('body') as string) ?? ''
-    if (!subject) return withAuth(auth, { error: 'Subject is required' })
+    if (!subject) return { error: 'Subject is required' }
 
     const lastVersion = await prisma.emailTemplateVersion.findFirst({
       where: { templateId: params.id },
@@ -62,20 +62,20 @@ export async function action({ request, params }: Route.ActionArgs) {
       },
     })
 
-    return withAuth(auth, redirect(`/hiring/emails/${params.id}`))
+    return redirect(`/hiring/emails/${params.id}`)
   }
 
   if (intent === 'rename') {
     const name = (formData.get('name') as string)?.trim()
-    if (!name) return withAuth(auth, { error: 'Name is required' })
+    if (!name) return { error: 'Name is required' }
     await prisma.emailTemplate.update({
       where: { id: params.id },
       data: { name },
     })
-    return withAuth(auth, redirect(`/hiring/emails/${params.id}`))
+    return redirect(`/hiring/emails/${params.id}`)
   }
 
-  return withAuth(auth, null)
+  return null
 }
 
 export default EmailTemplateDetail

--- a/dali-api/app/hiring/routes/email-templates.tsx
+++ b/dali-api/app/hiring/routes/email-templates.tsx
@@ -1,7 +1,7 @@
 import { redirect } from 'react-router'
 import type { Route } from './+types/email-templates'
 import { prisma } from '~/lib/db'
-import { requireAuth, withAuth } from '~/lib/auth'
+import { requireAuth } from "~/lib/auth";
 import { isHiringLead } from '~/lib/roles'
 import EmailTemplatesList from '~/hiring/components/EmailTemplates'
 
@@ -9,8 +9,8 @@ export const meta: Route.MetaFunction = () => [{ title: 'Email templates · DALI
 
 export async function loader({ request }: Route.LoaderArgs) {
   const auth = await requireAuth(request)
-  if (!auth.ok) return withAuth(auth, redirect('/login'))
-  if (!(await isHiringLead(auth.user.sub))) return withAuth(auth, redirect('/'))
+  if (!auth.ok) return redirect('/login')
+  if (!(await isHiringLead(auth.user.sub))) return redirect('/')
 
   const [templates, gmailUser] = await Promise.all([
     prisma.emailTemplate.findMany({
@@ -27,25 +27,25 @@ export async function loader({ request }: Route.LoaderArgs) {
       select: { googleRefreshToken: true },
     }),
   ])
-  return withAuth(auth, { templates, gmailConnected: !!gmailUser?.googleRefreshToken })
+  return { templates, gmailConnected: !!gmailUser?.googleRefreshToken }
 }
 
 export async function action({ request }: Route.ActionArgs) {
   const auth = await requireAuth(request)
-  if (!auth.ok) return withAuth(auth, redirect('/login'))
-  if (!(await isHiringLead(auth.user.sub))) return withAuth(auth, redirect('/'))
+  if (!auth.ok) return redirect('/login')
+  if (!(await isHiringLead(auth.user.sub))) return redirect('/')
 
   const formData = await request.formData()
   const intent = formData.get('intent') as string
 
   if (intent === 'create') {
     const name = (formData.get('name') as string)?.trim()
-    if (!name) return withAuth(auth, { error: 'Name is required' })
+    if (!name) return { error: 'Name is required' }
     const template = await prisma.emailTemplate.create({ data: { name } })
-    return withAuth(auth, redirect(`/hiring/emails/${template.id}`))
+    return redirect(`/hiring/emails/${template.id}`)
   }
 
-  return withAuth(auth, null)
+  return null
 }
 
 export default EmailTemplatesList

--- a/dali-api/app/hiring/routes/interviewer.interview.$interviewId.tsx
+++ b/dali-api/app/hiring/routes/interviewer.interview.$interviewId.tsx
@@ -14,8 +14,8 @@ import {
   MessageSquare,
 } from 'lucide-react'
 import { prisma } from '~/lib/db'
-import { requireAuth, withAuth } from '~/lib/auth'
-import { parseAccessToken } from '~/lib/cookies'
+import { requireAuth } from "~/lib/auth";
+import { parseSessionCookie } from '~/lib/cookies'
 import { requirePageSignedOrRedirect } from '~/hiring/lib/confidentiality'
 import { presignAnswers } from '~/hiring/lib/presign'
 import { CollaborativeEditor } from '~/components/CollaborativeEditor'
@@ -122,7 +122,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     }
   }
 
-  const collabToken = parseAccessToken(request)
+  const collabToken = parseSessionCookie(request)
 
   // Presign file-type answers so interviewers can download uploads instead of
   // staring at raw S3 keys.
@@ -153,13 +153,13 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   // Build user display name for cursors
   const userName = [member.firstName, member.lastName].filter(Boolean).join(' ') || auth.user.email
 
-  return withAuth(auth, {
+  return {
       interview: interviewWithPresignedAnswers,
       myAssignment,
       rubricCriteria,
       collabToken,
       userName,
-    })
+    }
 }
 
 export default function InterviewDetailPage() {

--- a/dali-api/app/hiring/routes/interviewer.tsx
+++ b/dali-api/app/hiring/routes/interviewer.tsx
@@ -4,7 +4,7 @@ import { redirect } from 'react-router'
 import { Clock, Check, Video, AlertTriangle, ChevronDown } from 'lucide-react'
 import CalendarGrid from '~/hiring/components/CalendarGrid'
 import { prisma } from '~/lib/db'
-import { requireAuth, withAuth } from '~/lib/auth'
+import { requireAuth } from "~/lib/auth";
 import { getActiveCycle } from '~/hiring/lib/cycles'
 import { getCycleConfidentialityState } from '~/hiring/lib/confidentiality'
 import { ConfidentialityGate } from '~/hiring/components/ConfidentialityGate'
@@ -42,10 +42,10 @@ export async function loader({ request }: Route.LoaderArgs) {
   const member = await prisma.dALIMember.findFirst({
     where: { userId: auth.user.sub },
   })
-  if (!member) return withAuth(auth, empty)
+  if (!member) return empty
 
   const active = await getActiveCycle()
-  if (!active) return withAuth(auth, empty)
+  if (!active) return empty
 
   // Find CycleInterviewer records for this member in the active cycle
   const cycleInterviewers = await prisma.cycleInterviewer.findMany({
@@ -58,7 +58,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     },
   })
 
-  if (cycleInterviewers.length === 0) return withAuth(auth, empty)
+  if (cycleInterviewers.length === 0) return empty
 
   const cycleInterviewerIds = cycleInterviewers.map((ci) => ci.id)
 
@@ -106,7 +106,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     where: { applicationCycleId: active.id },
   })
 
-  return withAuth(auth, {
+  return {
       isInterviewer: true as const,
       activeCycle: { id: active.id, name: active.name },
       assignments,
@@ -121,7 +121,7 @@ export async function loader({ request }: Route.LoaderArgs) {
       savedAvailability,
       confidentialityRequired:
         confState.status === "signed" ? null : confState.status,
-    })
+    }
 }
 
 export default function InterviewerDashboard() {

--- a/dali-api/app/hiring/routes/lead.cycle.$id.tsx
+++ b/dali-api/app/hiring/routes/lead.cycle.$id.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback, useRef } from 'react'
 import { Form, Link, useParams, useLoaderData, redirect } from 'react-router'
 import type { Route } from "./+types/lead.cycle.$id";
 import { prisma } from "~/lib/db";
-import { requireAuth, withAuth } from "~/lib/auth";
+import { requireAuth } from "~/lib/auth";
 import { isHiringLead } from "~/lib/roles";
 import { renderEmail } from "~/lib/email";
 import {
@@ -99,8 +99,8 @@ export const meta: Route.MetaFunction = ({ data }) => {
 
 export async function loader({ request, params }: Route.LoaderArgs) {
   const auth = await requireAuth(request);
-  if (!auth.ok) return withAuth(auth, redirect("/login"));
-  if (!(await isHiringLead(auth.user.sub))) return withAuth(auth, redirect("/"));
+  if (!auth.ok) return redirect("/login");
+  if (!(await isHiringLead(auth.user.sub))) return redirect("/");
 
   // Hiring leads must be able to reach this page to bind a confidentiality
   // agreement to the cycle, so we don't redirect when unsigned. Instead, the
@@ -315,7 +315,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     })),
   };
 
-  return withAuth(auth, {
+  return {
       cycle: cycleWithCvNumbers,
       allDomains,
       finalDecisions,
@@ -333,7 +333,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
       currentConfidentialityBinding,
       confidentialitySignatures,
       confidentialityRequired,
-    });
+    };
 }
 
 // ─── Action ──────────────────────────────────────────────────────────────────
@@ -365,10 +365,10 @@ async function reopenIfNeeded(
 export async function action({ request, params }: Route.ActionArgs) {
   const auth = await requireAuth(request);
   if (!auth.ok) return auth.response;
-  if (!(await isHiringLead(auth.user.sub))) return withAuth(auth, new Response(JSON.stringify({ error: "Forbidden" }), { status: 403, headers: { "Content-Type": "application/json" } }));
+  if (!(await isHiringLead(auth.user.sub))) return new Response(JSON.stringify({ error: "Forbidden" }), { status: 403, headers: { "Content-Type": "application/json" } });
 
   const user = await prisma.user.findUnique({ where: { id: auth.user.sub } });
-  if (!user) return withAuth(auth, new Response(JSON.stringify({ error: "User not found" }), { status: 401 }));
+  if (!user) return new Response(JSON.stringify({ error: "User not found" }), { status: 401 });
 
   const formData = await request.formData();
   const intent = formData.get("intent");
@@ -407,7 +407,7 @@ export async function action({ request, params }: Route.ActionArgs) {
     const notice = parsedClose
       ? (reopened ? "deadline-set-reopened" : "deadline-set")
       : "deadline-cleared";
-    return withAuth(auth, redirect(`/hiring/lead/cycle/${params.id}?notice=${notice}`));
+    return redirect(`/hiring/lead/cycle/${params.id}?notice=${notice}`);
   }
 
   if (intent === "extend-close-date") {
@@ -415,17 +415,17 @@ export async function action({ request, params }: Route.ActionArgs) {
     const unit = formData.get("unit") as string;
     const amount = Number(amountRaw);
     if (!Number.isFinite(amount) || amount <= 0) {
-      return withAuth(auth, new Response(JSON.stringify({ error: "Extension amount must be positive." }), { status: 400, headers: { "Content-Type": "application/json" } }));
+      return new Response(JSON.stringify({ error: "Extension amount must be positive." }), { status: 400, headers: { "Content-Type": "application/json" } });
     }
     if (unit !== "hours" && unit !== "days") {
-      return withAuth(auth, new Response(JSON.stringify({ error: "Extension unit must be hours or days." }), { status: 400, headers: { "Content-Type": "application/json" } }));
+      return new Response(JSON.stringify({ error: "Extension unit must be hours or days." }), { status: 400, headers: { "Content-Type": "application/json" } });
     }
     const cycle = await prisma.applicationCycle.findUnique({
       where: { id: params.id },
       include: { statusUpdates: { orderBy: { createdAt: "desc" }, take: 1 } },
     });
     if (!cycle?.closeDate) {
-      return withAuth(auth, new Response(JSON.stringify({ error: "Set a close date before extending." }), { status: 400, headers: { "Content-Type": "application/json" } }));
+      return new Response(JSON.stringify({ error: "Set a close date before extending." }), { status: 400, headers: { "Content-Type": "application/json" } });
     }
     // Set-total semantics: the amount is the *total* extension from the
     // original anchor, not additive. So calling extend(48h) twice in a row is
@@ -442,7 +442,7 @@ export async function action({ request, params }: Route.ActionArgs) {
       return await reopenIfNeeded(tx, params.id!, cycle, nextClose, auth.user.sub);
     });
     const notice = reopened ? "extended-reopened" : "extended";
-    return withAuth(auth, redirect(`/hiring/lead/cycle/${params.id}?notice=${notice}`));
+    return redirect(`/hiring/lead/cycle/${params.id}?notice=${notice}`);
   }
 
   if (intent === "remove-extension") {
@@ -451,7 +451,7 @@ export async function action({ request, params }: Route.ActionArgs) {
     });
     if (!cycle?.originalCloseDate) {
       // No extension to remove — just no-op.
-      return withAuth(auth, redirect(`/hiring/lead/cycle/${params.id}`));
+      return redirect(`/hiring/lead/cycle/${params.id}`);
     }
     await prisma.applicationCycle.update({
       where: { id: params.id },
@@ -464,7 +464,7 @@ export async function action({ request, params }: Route.ActionArgs) {
         extensionNoticeSentAt: null,
       },
     });
-    return withAuth(auth, redirect(`/hiring/lead/cycle/${params.id}?notice=extension-removed`));
+    return redirect(`/hiring/lead/cycle/${params.id}?notice=extension-removed`);
   }
 
   if (intent === "resend-extension-notice") {
@@ -483,10 +483,7 @@ export async function action({ request, params }: Route.ActionArgs) {
     } else {
       notice = "extension-notice-sent";
     }
-    return withAuth(
-      auth,
-      redirect(`/hiring/lead/cycle/${params.id}?notice=${notice}&sent=${result.succeeded}&failed=${result.failed}&skipped=${result.alreadySent}`),
-    );
+    return redirect(`/hiring/lead/cycle/${params.id}?notice=${notice}&sent=${result.succeeded}&failed=${result.failed}&skipped=${result.alreadySent}`);
   }
 
   if (intent === "set-general-rubric") {
@@ -499,13 +496,13 @@ export async function action({ request, params }: Route.ActionArgs) {
       },
     });
     if (hasAssignedReviews > 0) {
-      return withAuth(auth, redirect(`/hiring/lead/cycle/${params.id}`));
+      return redirect(`/hiring/lead/cycle/${params.id}`);
     }
     await prisma.applicationCycle.update({
       where: { id: params.id },
       data: { generalRubricVersionId: rubricVersionId },
     });
-    return withAuth(auth, redirect(`/hiring/lead/cycle/${params.id}`));
+    return redirect(`/hiring/lead/cycle/${params.id}`);
   }
 
   if (intent === "set-confidentiality-agreement") {
@@ -533,7 +530,7 @@ export async function action({ request, params }: Route.ActionArgs) {
     const emailTemplateVersionId = (formData.get("emailTemplateVersionId") as string) || null;
     const validTypes = ["Rejected", "InvitedToInterview", "Accepted", "Waitlisted"] as const;
     if (!validTypes.includes(decisionType as (typeof validTypes)[number])) {
-      return withAuth(auth, new Response(JSON.stringify({ error: "Invalid decision type" }), { status: 400, headers: { "Content-Type": "application/json" } }));
+      return new Response(JSON.stringify({ error: "Invalid decision type" }), { status: 400, headers: { "Content-Type": "application/json" } });
     }
     // Lock once a Released decision of this type exists for this cycle.
     const alreadyReleased = await prisma.decision.count({
@@ -544,7 +541,7 @@ export async function action({ request, params }: Route.ActionArgs) {
       },
     });
     if (alreadyReleased > 0) {
-      return withAuth(auth, redirect(`/hiring/lead/cycle/${params.id}`));
+      return redirect(`/hiring/lead/cycle/${params.id}`);
     }
     if (emailTemplateVersionId) {
       await prisma.cycleDecisionEmail.upsert({
@@ -569,7 +566,7 @@ export async function action({ request, params }: Route.ActionArgs) {
         },
       });
     }
-    return withAuth(auth, redirect(`/hiring/lead/cycle/${params.id}`));
+    return redirect(`/hiring/lead/cycle/${params.id}`);
   }
 
   if (intent === "set-notification-email") {
@@ -577,7 +574,7 @@ export async function action({ request, params }: Route.ActionArgs) {
     const emailTemplateVersionId = (formData.get("emailTemplateVersionId") as string) || null;
     const validTypes = ["ApplicationReceived", "ApplicationExtensionNotice", "InterviewInviteMentor", "InterviewConfirmedApplicant", "InterviewCancelledApplicant", "InterviewCancelledInterviewer", "InterviewLocationChanged"] as const;
     if (!validTypes.includes(notificationType as (typeof validTypes)[number])) {
-      return withAuth(auth, new Response(JSON.stringify({ error: "Invalid notification type" }), { status: 400, headers: { "Content-Type": "application/json" } }));
+      return new Response(JSON.stringify({ error: "Invalid notification type" }), { status: 400, headers: { "Content-Type": "application/json" } });
     }
     if (emailTemplateVersionId) {
       await prisma.cycleNotificationEmail.upsert({
@@ -602,13 +599,13 @@ export async function action({ request, params }: Route.ActionArgs) {
         },
       });
     }
-    return withAuth(auth, redirect(`/hiring/lead/cycle/${params.id}`));
+    return redirect(`/hiring/lead/cycle/${params.id}`);
   }
 
   if (intent === "link-general-form") {
     const challengeVersionId = formData.get("challengeVersionId") as string;
     if (!challengeVersionId) {
-      return withAuth(auth, redirect(`/hiring/lead/cycle/${params.id}`));
+      return redirect(`/hiring/lead/cycle/${params.id}`);
     }
     // Remove any existing general form link (domainId is null)
     const existing = await prisma.challengeVersionApplicationCycle.findMany({
@@ -626,14 +623,14 @@ export async function action({ request, params }: Route.ActionArgs) {
     await prisma.challengeVersionApplicationCycle.create({
       data: { challengeVersionId, applicationCycleId: params.id },
     });
-    return withAuth(auth, redirect(`/hiring/lead/cycle/${params.id}`));
+    return redirect(`/hiring/lead/cycle/${params.id}`);
   }
 
   if (intent === "hl-add-domain-challenge") {
     const domainId = formData.get("domainId") as string;
     const challengeVersionId = formData.get("challengeVersionId") as string;
     if (!domainId || !challengeVersionId) {
-      return withAuth(auth, redirect(`/hiring/lead/cycle/${params.id}`));
+      return redirect(`/hiring/lead/cycle/${params.id}`);
     }
     // Hiring lead override mirrors domain lead's window: challenge edits are
     // Draft-only because applicants see the form once the cycle is Open.
@@ -642,13 +639,13 @@ export async function action({ request, params }: Route.ActionArgs) {
       orderBy: { createdAt: "desc" },
     });
     if ((latestUpdate?.newStatus ?? "Draft") !== "Draft") {
-      return withAuth(auth, redirect(`/hiring/lead/cycle/${params.id}`));
+      return redirect(`/hiring/lead/cycle/${params.id}`);
     }
     // Confirm the chosen version belongs to the named domain — guard against
     // form tampering linking a different domain's challenge.
     const cv = await prisma.challengeVersion.findUnique({ where: { id: challengeVersionId } });
     if (!cv || cv.domainId !== domainId) {
-      return withAuth(auth, redirect(`/hiring/lead/cycle/${params.id}`));
+      return redirect(`/hiring/lead/cycle/${params.id}`);
     }
     // Prevent linking two versions of the same underlying challenge in one cycle.
     const sameChallenge = await prisma.challengeVersionApplicationCycle.findFirst({
@@ -658,7 +655,7 @@ export async function action({ request, params }: Route.ActionArgs) {
       },
     });
     if (sameChallenge) {
-      return withAuth(auth, redirect(`/hiring/lead/cycle/${params.id}`));
+      return redirect(`/hiring/lead/cycle/${params.id}`);
     }
     const existing = await prisma.challengeVersionApplicationCycle.findUnique({
       where: { challengeVersionId_applicationCycleId: { challengeVersionId, applicationCycleId: params.id! } },
@@ -668,20 +665,20 @@ export async function action({ request, params }: Route.ActionArgs) {
         data: { challengeVersionId, applicationCycleId: params.id! },
       });
     }
-    return withAuth(auth, redirect(`/hiring/lead/cycle/${params.id}`));
+    return redirect(`/hiring/lead/cycle/${params.id}`);
   }
 
   if (intent === "hl-remove-domain-challenge") {
     const challengeVersionId = formData.get("challengeVersionId") as string;
     if (!challengeVersionId) {
-      return withAuth(auth, redirect(`/hiring/lead/cycle/${params.id}`));
+      return redirect(`/hiring/lead/cycle/${params.id}`);
     }
     const latestUpdate = await prisma.applicationCycleStatusUpdate.findFirst({
       where: { applicationCycleId: params.id },
       orderBy: { createdAt: "desc" },
     });
     if ((latestUpdate?.newStatus ?? "Draft") !== "Draft") {
-      return withAuth(auth, redirect(`/hiring/lead/cycle/${params.id}`));
+      return redirect(`/hiring/lead/cycle/${params.id}`);
     }
     // Refuse to remove if any DomainApplication in this cycle picked this CV.
     const inUse = await prisma.domainApplication.count({
@@ -691,19 +688,19 @@ export async function action({ request, params }: Route.ActionArgs) {
       },
     });
     if (inUse > 0) {
-      return withAuth(auth, redirect(`/hiring/lead/cycle/${params.id}`));
+      return redirect(`/hiring/lead/cycle/${params.id}`);
     }
     await prisma.challengeVersionApplicationCycle.deleteMany({
       where: { challengeVersionId, applicationCycleId: params.id! },
     });
-    return withAuth(auth, redirect(`/hiring/lead/cycle/${params.id}`));
+    return redirect(`/hiring/lead/cycle/${params.id}`);
   }
 
   if (intent === "hl-set-domain-rubric") {
     const domainId = formData.get("domainId") as string;
     const rubricVersionId = (formData.get("rubricVersionId") as string) || null;
     if (!domainId) {
-      return withAuth(auth, redirect(`/hiring/lead/cycle/${params.id}`));
+      return redirect(`/hiring/lead/cycle/${params.id}`);
     }
     // Once any review is assigned for this domain in this cycle, the rubric
     // is locked: changing it would silently invalidate prior scores.
@@ -716,14 +713,14 @@ export async function action({ request, params }: Route.ActionArgs) {
       },
     });
     if (hasAssignedReviews > 0) {
-      return withAuth(auth, redirect(`/hiring/lead/cycle/${params.id}`));
+      return redirect(`/hiring/lead/cycle/${params.id}`);
     }
     if (rubricVersionId) {
       const rv = await prisma.rubricVersion.findUnique({
         where: { id: rubricVersionId },
       });
       if (!rv) {
-        return withAuth(auth, redirect(`/hiring/lead/cycle/${params.id}`));
+        return redirect(`/hiring/lead/cycle/${params.id}`);
       }
     }
     await prisma.domainApplicationCycle.upsert({
@@ -731,21 +728,21 @@ export async function action({ request, params }: Route.ActionArgs) {
       update: { rubricVersionId },
       create: { domainId, applicationCycleId: params.id, rubricVersionId },
     });
-    return withAuth(auth, redirect(`/hiring/lead/cycle/${params.id}`));
+    return redirect(`/hiring/lead/cycle/${params.id}`);
   }
 
   if (intent === "hl-force-mark-ready" || intent === "hl-force-unmark-ready") {
     const domainId = formData.get("domainId") as string;
     const confirm = formData.get("confirm");
     if (!domainId || confirm !== "true") {
-      return withAuth(auth, redirect(`/hiring/lead/cycle/${params.id}`));
+      return redirect(`/hiring/lead/cycle/${params.id}`);
     }
     const latestUpdate = await prisma.applicationCycleStatusUpdate.findFirst({
       where: { applicationCycleId: params.id },
       orderBy: { createdAt: "desc" },
     });
     if ((latestUpdate?.newStatus ?? "Draft") !== "Draft") {
-      return withAuth(auth, redirect(`/hiring/lead/cycle/${params.id}`));
+      return redirect(`/hiring/lead/cycle/${params.id}`);
     }
     const isReady = intent === "hl-force-mark-ready";
     if (isReady) {
@@ -759,7 +756,7 @@ export async function action({ request, params }: Route.ActionArgs) {
         },
       });
       if (hasChallenge === 0) {
-        return withAuth(auth, redirect(`/hiring/lead/cycle/${params.id}`));
+        return redirect(`/hiring/lead/cycle/${params.id}`);
       }
     }
     await prisma.domainApplicationCycle.upsert({
@@ -767,7 +764,7 @@ export async function action({ request, params }: Route.ActionArgs) {
       update: { isReady },
       create: { domainId, applicationCycleId: params.id, isReady },
     });
-    return withAuth(auth, redirect(`/hiring/lead/cycle/${params.id}`));
+    return redirect(`/hiring/lead/cycle/${params.id}`);
   }
 
   if (intent === "remove-domain" || intent === "add-domain") {
@@ -776,7 +773,7 @@ export async function action({ request, params }: Route.ActionArgs) {
       orderBy: { createdAt: "desc" },
     });
     if ((latestUpdate?.newStatus ?? "Draft") !== "Draft") {
-      return withAuth(auth, new Response(JSON.stringify({ error: "Domains can only be modified in Draft" }), { status: 409, headers: { "Content-Type": "application/json" } }));
+      return new Response(JSON.stringify({ error: "Domains can only be modified in Draft" }), { status: 409, headers: { "Content-Type": "application/json" } });
     }
     const domainId = formData.get("domainId") as string;
     if (intent === "remove-domain") {
@@ -788,7 +785,7 @@ export async function action({ request, params }: Route.ActionArgs) {
         data: { domainId, applicationCycleId: params.id },
       });
     }
-    return withAuth(auth, redirect(`/hiring/lead/cycle/${params.id}`));
+    return redirect(`/hiring/lead/cycle/${params.id}`);
   }
 
   if (intent === "advance-status") {
@@ -803,7 +800,7 @@ export async function action({ request, params }: Route.ActionArgs) {
 
     const currentStatus = cycle.statusUpdates[0]?.newStatus ?? "Draft";
     const next = nextStatus(currentStatus as CycleStatus);
-    if (!next) return withAuth(auth, null);
+    if (!next) return null;
 
     if (currentStatus === "Draft") {
       const hasCloseDate = !!cycle.closeDate;
@@ -811,7 +808,7 @@ export async function action({ request, params }: Route.ActionArgs) {
         cycle.challengeVersions.map((cv) => cv.challengeVersion.domainId)
       );
       const allDomainsCovered = cycle.domains.length > 0 && cycle.domains.every((d) => coveredDomainIds.has(d.domainId));
-      if (!hasCloseDate || !allDomainsCovered) return withAuth(auth, null);
+      if (!hasCloseDate || !allDomainsCovered) return null;
     }
 
     await prisma.applicationCycleStatusUpdate.create({
@@ -823,7 +820,7 @@ export async function action({ request, params }: Route.ActionArgs) {
     });
   }
 
-  return withAuth(auth, redirect(`/hiring/lead/cycle/${params.id}`));
+  return redirect(`/hiring/lead/cycle/${params.id}`);
 }
 
 const DURATION_OPTIONS = [15, 20, 25, 30, 45, 60]

--- a/dali-api/app/hiring/routes/lead.tsx
+++ b/dali-api/app/hiring/routes/lead.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { Form, Link, redirect, useLoaderData } from "react-router";
 import type { Route } from "./+types/lead";
 import { prisma } from "~/lib/db";
-import { requireAuth, withAuth } from "~/lib/auth";
+import { requireAuth } from "~/lib/auth";
 import { isHiringLead } from "~/lib/roles";
 import { ChevronRight, ChevronDown, Plus, X } from "lucide-react";
 
@@ -24,8 +24,8 @@ export const meta: Route.MetaFunction = () => [{ title: "Hiring lead · DALI OS"
 
 export async function loader({ request }: Route.LoaderArgs) {
   const auth = await requireAuth(request);
-  if (!auth.ok) return withAuth(auth, redirect("/login"));
-  if (!(await isHiringLead(auth.user.sub))) return withAuth(auth, redirect("/"));
+  if (!auth.ok) return redirect("/login");
+  if (!(await isHiringLead(auth.user.sub))) return redirect("/");
 
   const cycles = await prisma.applicationCycle.findMany({
     include: {
@@ -36,7 +36,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     orderBy: { createdAt: "desc" },
   });
 
-  return withAuth(auth, { cycles });
+  return { cycles };
 }
 
 export async function action({ request }: Route.ActionArgs) {
@@ -46,7 +46,7 @@ export async function action({ request }: Route.ActionArgs) {
 
   const auth = await requireAuth(request);
   if (!auth.ok) return auth.response;
-  if (!(await isHiringLead(auth.user.sub))) return withAuth(auth, redirect("/"));
+  if (!(await isHiringLead(auth.user.sub))) return redirect("/");
   const adminUser = await prisma.user.findUniqueOrThrow({
     where: { id: auth.user.sub },
   });
@@ -60,7 +60,7 @@ export async function action({ request }: Route.ActionArgs) {
     },
   });
 
-  return withAuth(auth, redirect(`/hiring/lead/cycle/${cycle.id}`));
+  return redirect(`/hiring/lead/cycle/${cycle.id}`);
 }
 
 export default function HiringLeadDashboard() {

--- a/dali-api/app/hiring/routes/reviewer.application.$id.tsx
+++ b/dali-api/app/hiring/routes/reviewer.application.$id.tsx
@@ -2,9 +2,9 @@ import { useState, useEffect, useRef } from 'react'
 import { Link, redirect, useLoaderData, useSubmit } from 'react-router'
 import { ArrowLeft, HelpCircle, X, Check } from 'lucide-react'
 import { prisma } from '~/lib/db'
-import { requireAuth, withAuth } from '~/lib/auth'
+import { requireAuth } from "~/lib/auth";
 import { hasCycleAccess } from '~/lib/roles'
-import { parseAccessToken } from '~/lib/cookies'
+import { parseSessionCookie } from '~/lib/cookies'
 import { requirePageSignedOrRedirect } from '~/hiring/lib/confidentiality'
 import { presignAnswers } from '~/hiring/lib/presign'
 import type { Route } from './+types/reviewer.application.$id'
@@ -23,7 +23,7 @@ export const meta: Route.MetaFunction = ({ data }) => {
 
 export async function loader({ request, params }: Route.LoaderArgs) {
   const auth = await requireAuth(request)
-  if (!auth.ok) return withAuth(auth, redirect('/login'))
+  if (!auth.ok) return redirect('/login')
 
   const applicationBase = await prisma.application.findUniqueOrThrow({
     where: { id: params.id },
@@ -146,15 +146,15 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   }
 
   // Pass JWT for WebSocket auth
-  const collabToken = parseAccessToken(request)
+  const collabToken = parseSessionCookie(request)
   const userName = [reviewer.firstName, reviewer.lastName].filter(Boolean).join(' ') || auth.user.email
 
-  return withAuth(auth, { application, reviewer, existingReview: review, collabToken, userName })
+  return { application, reviewer, existingReview: review, collabToken, userName }
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
   const auth = await requireAuth(request)
-  if (!auth.ok) return withAuth(auth, redirect('/login'))
+  if (!auth.ok) return redirect('/login')
 
   const formData = await request.formData()
   const intent = formData.get('intent') as string
@@ -179,7 +179,7 @@ export async function action({ request, params }: Route.ActionArgs) {
     }
   }
 
-  return withAuth(auth, null)
+  return null
 }
 
 const RECOMMENDATIONS = ['Strong Hire', 'Hire', 'Lean Hire', 'Lean No Hire', 'No Hire'] as const

--- a/dali-api/app/hiring/routes/reviewer.tsx
+++ b/dali-api/app/hiring/routes/reviewer.tsx
@@ -27,7 +27,7 @@ function isoToLocalMidnightInTz(iso: string, timezone: string): Date {
   return new Date(year, month - 1, day)
 }
 import { prisma } from '~/lib/db'
-import { requireAuth, withAuth } from '~/lib/auth'
+import { requireAuth } from "~/lib/auth";
 import { inReviewPipelineFilter } from '~/hiring/lib/application-pipeline-filter'
 import type { Route } from './+types/reviewer'
 
@@ -48,24 +48,24 @@ export async function loader({ request }: Route.LoaderArgs) {
   }
 
   const auth = await requireAuth(request)
-  if (!auth.ok) return withAuth(auth, empty)
+  if (!auth.ok) return empty
 
   const member = await prisma.dALIMember.findFirst({ where: { userId: auth.user.sub } })
-  if (!member) return withAuth(auth, { ...empty, reviewerUserId: auth.user.sub })
+  if (!member) return { ...empty, reviewerUserId: auth.user.sub }
 
   // Anchor on the single active cycle (invariant: at most one cycle is in
   // Open/UnderReview at a time). Older code here picked "most recent cycle
   // that ever had an Open/UnderReview status update", which matched completed
   // cycles that had historically passed through UnderReview.
   const active = await getActiveCycle()
-  if (!active) return withAuth(auth, { ...empty, reviewerUserId: auth.user.sub })
+  if (!active) return { ...empty, reviewerUserId: auth.user.sub }
 
   // Fetch all CycleReviewer records for this member in this cycle (may span multiple domains)
   const myReviewerIds = await prisma.cycleReviewer.findMany({
     where: { daliMemberId: member.id, applicationCycleId: active.id },
     select: { id: true, domainId: true },
   })
-  if (myReviewerIds.length === 0) return withAuth(auth, { ...empty, reviewerUserId: auth.user.sub })
+  if (myReviewerIds.length === 0) return { ...empty, reviewerUserId: auth.user.sub }
   const reviewerIds = myReviewerIds.map(r => r.id)
   const myDomainIds = Array.from(new Set(myReviewerIds.map(r => r.domainId)))
 
@@ -127,7 +127,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   // Only load when signed — the session cards show applicant names.
   // Initial sessions are blinded; Final sessions show real names.
   if (confidentialityRequired) {
-    return withAuth(auth, {
+    return {
       activeCycle: { id: active.id, name: active.name },
       currentStage,
       reviewerUserId: auth.user.sub,
@@ -138,7 +138,7 @@ export async function loader({ request }: Route.LoaderArgs) {
       delibsSessions: [],
       delibsApplications: [],
       confidentialityRequired,
-    })
+    }
   }
 
   const delibsSessionsRaw = await prisma.delibsSession.findMany({
@@ -217,7 +217,7 @@ export async function loader({ request }: Route.LoaderArgs) {
 
   const delibsApplications = Array.from(hydratedDaIds).map(id => daIdToSummary.get(id));
 
-  return withAuth(auth, {
+  return {
       activeCycle: { id: active.id, name: active.name },
       currentStage,
       reviewerUserId: auth.user.sub,
@@ -228,7 +228,7 @@ export async function loader({ request }: Route.LoaderArgs) {
       delibsSessions,
       delibsApplications,
       confidentialityRequired: null as null | "no_agreement" | "unsigned",
-    })
+    }
 }
 
 export default function ReviewerDashboard() {

--- a/dali-api/app/hiring/routes/rubrics.$id.tsx
+++ b/dali-api/app/hiring/routes/rubrics.$id.tsx
@@ -1,7 +1,7 @@
 import { redirect } from 'react-router'
 import type { Route } from './+types/rubrics.$id'
 import { prisma } from '~/lib/db'
-import { requireAuth, withAuth } from '~/lib/auth'
+import { requireAuth } from "~/lib/auth";
 import { isHiringLead, isDomainLead, isAdmin } from '~/lib/roles'
 import { RubricDetail } from '~/hiring/components/RubricDetail'
 
@@ -12,8 +12,8 @@ export const meta: Route.MetaFunction = ({ data }) => {
 
 export async function loader({ request, params }: Route.LoaderArgs) {
   const auth = await requireAuth(request)
-  if (!auth.ok) return withAuth(auth, redirect('/login'))
-  if (!(await isHiringLead(auth.user.sub)) && !(await isDomainLead(auth.user.sub)) && !(await isAdmin(auth.user.sub))) return withAuth(auth, redirect('/'))
+  if (!auth.ok) return redirect('/login')
+  if (!(await isHiringLead(auth.user.sub)) && !(await isDomainLead(auth.user.sub)) && !(await isAdmin(auth.user.sub))) return redirect('/')
 
   const rubric = await prisma.rubric.findUniqueOrThrow({
     where: { id: params.id },
@@ -25,16 +25,16 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     },
   })
 
-  return withAuth(auth, { rubric })
+  return { rubric }
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
   const auth = await requireAuth(request)
-  if (!auth.ok) return withAuth(auth, redirect('/login'))
-  if (!(await isHiringLead(auth.user.sub)) && !(await isDomainLead(auth.user.sub)) && !(await isAdmin(auth.user.sub))) return withAuth(auth, redirect('/'))
+  if (!auth.ok) return redirect('/login')
+  if (!(await isHiringLead(auth.user.sub)) && !(await isDomainLead(auth.user.sub)) && !(await isAdmin(auth.user.sub))) return redirect('/')
 
   const user = await prisma.user.findUnique({ where: { id: auth.user.sub } })
-  if (!user) return withAuth(auth, redirect('/login'))
+  if (!user) return redirect('/login')
 
   const formData = await request.formData()
   const intent = formData.get('intent') as string
@@ -58,10 +58,10 @@ export async function action({ request, params }: Route.ActionArgs) {
       },
     })
 
-    return withAuth(auth, redirect(`/hiring/rubrics/${params.id}`))
+    return redirect(`/hiring/rubrics/${params.id}`)
   }
 
-  return withAuth(auth, null)
+  return null
 }
 
 export default RubricDetail

--- a/dali-api/app/hiring/routes/rubrics.tsx
+++ b/dali-api/app/hiring/routes/rubrics.tsx
@@ -1,7 +1,7 @@
 import { redirect } from 'react-router'
 import type { Route } from './+types/rubrics'
 import { prisma } from '~/lib/db'
-import { requireAuth, withAuth } from '~/lib/auth'
+import { requireAuth } from "~/lib/auth";
 import { isHiringLead, isDomainLead, isAdmin } from '~/lib/roles'
 import RubricsList from '~/hiring/components/Rubrics'
 
@@ -9,8 +9,8 @@ export const meta: Route.MetaFunction = () => [{ title: 'Rubrics · DALI OS' }]
 
 export async function loader({ request }: Route.LoaderArgs) {
   const auth = await requireAuth(request)
-  if (!auth.ok) return withAuth(auth, redirect('/login'))
-  if (!(await isHiringLead(auth.user.sub)) && !(await isDomainLead(auth.user.sub)) && !(await isAdmin(auth.user.sub))) return withAuth(auth, redirect('/'))
+  if (!auth.ok) return redirect('/login')
+  if (!(await isHiringLead(auth.user.sub)) && !(await isDomainLead(auth.user.sub)) && !(await isAdmin(auth.user.sub))) return redirect('/')
 
   const rubrics = await prisma.rubric.findMany({
     include: {
@@ -21,27 +21,27 @@ export async function loader({ request }: Route.LoaderArgs) {
     },
     orderBy: { createdAt: 'desc' },
   })
-  return withAuth(auth, { rubrics })
+  return { rubrics }
 }
 
 export async function action({ request }: Route.ActionArgs) {
   const auth = await requireAuth(request)
-  if (!auth.ok) return withAuth(auth, redirect('/login'))
-  if (!(await isHiringLead(auth.user.sub)) && !(await isDomainLead(auth.user.sub)) && !(await isAdmin(auth.user.sub))) return withAuth(auth, redirect('/'))
+  if (!auth.ok) return redirect('/login')
+  if (!(await isHiringLead(auth.user.sub)) && !(await isDomainLead(auth.user.sub)) && !(await isAdmin(auth.user.sub))) return redirect('/')
 
   const formData = await request.formData()
   const intent = formData.get('intent') as string
 
   if (intent === 'create') {
     const name = (formData.get('name') as string)?.trim()
-    if (!name) return withAuth(auth, { error: 'Name is required' })
+    if (!name) return { error: 'Name is required' }
     const rubric = await prisma.rubric.create({
       data: { name },
     })
-    return withAuth(auth, redirect(`/hiring/rubrics/${rubric.id}`))
+    return redirect(`/hiring/rubrics/${rubric.id}`)
   }
 
-  return withAuth(auth, null)
+  return null
 }
 
 export default RubricsList

--- a/dali-api/app/lib/__mocks__/db.ts
+++ b/dali-api/app/lib/__mocks__/db.ts
@@ -7,7 +7,7 @@ export const prisma = {
     update: vi.fn(),
     delete: vi.fn(),
   },
-  refreshToken: {
+  session: {
     create: vi.fn(),
     findUnique: vi.fn(),
     update: vi.fn(),

--- a/dali-api/app/lib/__tests__/auth.test.ts
+++ b/dali-api/app/lib/__tests__/auth.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 
 vi.mock("~/lib/audit", () => ({
   logAuditEvent: vi.fn(),
@@ -6,19 +6,11 @@ vi.mock("~/lib/audit", () => ({
 vi.mock("~/lib/db");
 
 import { prisma } from "~/lib/db";
-import { logAuditEvent } from "~/lib/audit";
-import {
-  signAccessToken,
-  verifyAccessToken,
-  requireAuth,
-  withAuth,
-  validateCasTicket,
-} from "~/lib/auth";
-import { setTokenCookies } from "~/lib/cookies";
+import { requireAuth, validateCasTicket } from "~/lib/auth";
+import { hashSessionId, ROLLING_TTL_MS, ABSOLUTE_TTL_MS } from "~/lib/session";
 
 const mockPrisma = prisma as unknown as {
-  user: { findUnique: ReturnType<typeof vi.fn> };
-  refreshToken: {
+  session: {
     create: ReturnType<typeof vi.fn>;
     findUnique: ReturnType<typeof vi.fn>;
     update: ReturnType<typeof vi.fn>;
@@ -26,406 +18,228 @@ const mockPrisma = prisma as unknown as {
   };
 };
 
-beforeAll(() => {
-  process.env.JWT_SECRET = "test-secret-at-least-32-chars-long!!";
-});
+function makeSessionRow(overrides: Partial<{
+  id: string;
+  userId: string;
+  grantId: string | null;
+  expiresAt: Date;
+  absoluteExpiresAt: Date;
+  revokedAt: Date | null;
+  user: {
+    id: string;
+    daliEmail: string | null;
+    dartmouthEmail: string | null;
+    netId: string | null;
+    firstName: string;
+    lastName: string;
+  };
+}> = {}) {
+  const userId = overrides.userId ?? "user-1";
+  return {
+    id: overrides.id ?? hashSessionId("raw-1"),
+    userId,
+    grantId: overrides.grantId ?? null,
+    createdAt: new Date(),
+    lastUsedAt: new Date(),
+    expiresAt: overrides.expiresAt ?? new Date(Date.now() + ROLLING_TTL_MS),
+    absoluteExpiresAt:
+      overrides.absoluteExpiresAt ?? new Date(Date.now() + ABSOLUTE_TTL_MS),
+    revokedAt: overrides.revokedAt ?? null,
+    userAgent: null,
+    ip: null,
+    user: overrides.user ?? {
+      id: userId,
+      daliEmail: "u@dali.dartmouth.edu",
+      dartmouthEmail: null,
+      netId: null,
+      firstName: "U",
+      lastName: "Ser",
+    },
+  };
+}
 
 beforeEach(() => {
   vi.clearAllMocks();
-});
-
-describe("getSecret validation", () => {
-  it("throws when JWT_SECRET is shorter than 32 bytes", async () => {
-    vi.stubEnv("JWT_SECRET", "too-short");
-    await expect(
-      signAccessToken({ sub: "u", email: "e@e.com", type: "member" }),
-    ).rejects.toThrow("JWT_SECRET must be at least 32 bytes for HS256 security");
-    vi.unstubAllEnvs();
-  });
-
-  it("throws when JWT_SECRET is unset", async () => {
-    vi.stubEnv("JWT_SECRET", "");
-    await expect(
-      signAccessToken({ sub: "u", email: "e@e.com", type: "member" }),
-    ).rejects.toThrow("JWT_SECRET not set");
-    vi.unstubAllEnvs();
-  });
-
-  it("accepts a 32+ byte secret", async () => {
-    // beforeAll secret is 36 bytes; this asserts the happy path explicitly
-    const token = await signAccessToken({
-      sub: "u",
-      email: "e@e.com",
-      type: "member",
-    });
-    expect(typeof token).toBe("string");
-  });
-});
-
-describe("signAccessToken / verifyAccessToken", () => {
-  it("round-trips a token", async () => {
-    const token = await signAccessToken({
-      sub: "user1",
-      email: "a@b.com",
-      type: "member",
-    });
-    const payload = await verifyAccessToken(token);
-    expect(payload.sub).toBe("user1");
-    expect(payload.email).toBe("a@b.com");
-    expect(payload.type).toBe("member");
-  });
-
-  it("rejects an expired token", async () => {
-    // sign a token in the past so it's already expired at real time
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date(Date.now() - 60 * 60 * 1000)); // 1 hour ago
-    const token = await signAccessToken({
-      sub: "user1",
-      email: "a@b.com",
-      type: "member",
-    });
-    vi.useRealTimers();
-
-    await expect(verifyAccessToken(token)).rejects.toThrow();
-  });
+  mockPrisma.session ??= {
+    create: vi.fn(),
+    findUnique: vi.fn(),
+    update: vi.fn(),
+    updateMany: vi.fn(),
+  } as any;
+  mockPrisma.session.update.mockResolvedValue({});
 });
 
 describe("requireAuth", () => {
-  it("returns 401 when no token is present", async () => {
-    const req = new Request("http://localhost/api/test");
+  it("returns no_session when no cookie and no header", async () => {
+    const req = new Request("http://localhost");
     const result = await requireAuth(req);
     expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.response.status).toBe(401);
-    }
-    // No DB write when no token at all.
-    expect(mockPrisma.refreshToken.findUnique).not.toHaveBeenCalled();
+    if (!result.ok) expect(result.reason).toBe("no_session");
   });
 
-  it("returns user when valid cookie is present and does not touch the DB", async () => {
-    const token = await signAccessToken({
-      sub: "u1",
-      email: "e@e.com",
-      type: "member",
+  it("returns not_found when the session row is missing", async () => {
+    mockPrisma.session.findUnique.mockResolvedValue(null);
+    const req = new Request("http://localhost", {
+      headers: { Cookie: "__dali_sid=ghost" },
     });
-    const req = new Request("http://localhost/api/test", {
-      headers: { Cookie: `__dali_at=${token}` },
+    const result = await requireAuth(req);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("not_found");
+  });
+
+  it("returns revoked when the session has a revokedAt timestamp", async () => {
+    mockPrisma.session.findUnique.mockResolvedValue(
+      makeSessionRow({ revokedAt: new Date() }),
+    );
+    const req = new Request("http://localhost", {
+      headers: { Cookie: "__dali_sid=raw-1" },
+    });
+    const result = await requireAuth(req);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("revoked");
+  });
+
+  it("returns expired when expiresAt has passed", async () => {
+    mockPrisma.session.findUnique.mockResolvedValue(
+      makeSessionRow({ expiresAt: new Date(Date.now() - 1000) }),
+    );
+    const req = new Request("http://localhost", {
+      headers: { Cookie: "__dali_sid=raw-1" },
+    });
+    const result = await requireAuth(req);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("expired");
+  });
+
+  it("returns expired when absoluteExpiresAt has passed", async () => {
+    mockPrisma.session.findUnique.mockResolvedValue(
+      makeSessionRow({
+        // rolling not yet expired but absolute cap has passed
+        expiresAt: new Date(Date.now() + 1000),
+        absoluteExpiresAt: new Date(Date.now() - 1000),
+      }),
+    );
+    const req = new Request("http://localhost", {
+      headers: { Cookie: "__dali_sid=raw-1" },
+    });
+    const result = await requireAuth(req);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("expired");
+  });
+
+  it("succeeds with a valid cookie session and preserves auth.user.sub", async () => {
+    mockPrisma.session.findUnique.mockResolvedValue(makeSessionRow());
+    const req = new Request("http://localhost", {
+      headers: { Cookie: "__dali_sid=raw-1" },
     });
     const result = await requireAuth(req);
     expect(result.ok).toBe(true);
     if (result.ok) {
-      expect(result.user.sub).toBe("u1");
-      expect(result.setCookies).toBeUndefined();
+      expect(result.user.sub).toBe("user-1");
+      expect(result.user.email).toBe("u@dali.dartmouth.edu");
+      expect(result.user.type).toBe("member");
     }
-    expect(mockPrisma.refreshToken.findUnique).not.toHaveBeenCalled();
   });
 
-  it("returns user when valid Bearer header is present", async () => {
-    const token = await signAccessToken({
-      sub: "u2",
-      email: "f@f.com",
-      type: "dartmouth",
-    });
-    const req = new Request("http://localhost/api/test", {
-      headers: { Authorization: `Bearer ${token}` },
+  it("accepts a Bearer header when no cookie is present", async () => {
+    mockPrisma.session.findUnique.mockResolvedValue(makeSessionRow());
+    const req = new Request("http://localhost", {
+      headers: { Authorization: "Bearer raw-1" },
     });
     const result = await requireAuth(req);
     expect(result.ok).toBe(true);
-    if (result.ok) {
-      expect(result.user.sub).toBe("u2");
-    }
   });
 
-  it("returns 401 on tampered token without attempting refresh", async () => {
-    const req = new Request("http://localhost/api/test", {
-      headers: { Cookie: "__dali_at=garbage; __dali_rt=anything" },
+  it("prefers the cookie over a Bearer header when both are present", async () => {
+    mockPrisma.session.findUnique.mockImplementation(async ({ where }: any) => {
+      // Only the cookie's hash should match
+      if (where.id === hashSessionId("cookie-raw")) {
+        return makeSessionRow({
+          id: hashSessionId("cookie-raw"),
+          userId: "user-cookie",
+        });
+      }
+      return null;
     });
-    const result = await requireAuth(req);
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.response.status).toBe(401);
-    }
-    // Tampered AT — no refresh attempt, audit logged.
-    expect(mockPrisma.refreshToken.findUnique).not.toHaveBeenCalled();
-    expect(logAuditEvent).toHaveBeenCalledWith(
-      expect.objectContaining({ action: "auth.token.invalid" }),
-    );
-  });
-
-  it("silently refreshes when AT is expired but RT is valid", async () => {
-    // Sign an already-expired AT.
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date(Date.now() - 60 * 60 * 1000));
-    const expiredToken = await signAccessToken({
-      sub: "u3",
-      email: "g@g.com",
-      type: "member",
+    const req = new Request("http://localhost", {
+      headers: {
+        Cookie: "__dali_sid=cookie-raw",
+        Authorization: "Bearer header-raw",
+      },
     });
-    vi.useRealTimers();
-
-    mockPrisma.refreshToken.findUnique.mockResolvedValue({
-      id: "rt-1",
-      tokenHash: "doesnt-matter",
-      userId: "u3",
-      family: "fam-1",
-      expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
-      revokedAt: null,
-      familyCreatedAt: new Date(Date.now() - 24 * 60 * 60 * 1000), // 1 day old
-    });
-    mockPrisma.refreshToken.update.mockResolvedValue({});
-    mockPrisma.refreshToken.create.mockResolvedValue({});
-    mockPrisma.user.findUnique.mockResolvedValue({
-      id: "u3",
-      daliEmail: "g@dali.dartmouth.edu",
-      dartmouthEmail: null,
-      netId: null,
-      firstName: "Test",
-      lastName: "User",
-    });
-
-    const req = new Request("http://localhost/api/test", {
-      headers: { Cookie: `__dali_at=${expiredToken}; __dali_rt=valid-rt` },
-    });
-
     const result = await requireAuth(req);
     expect(result.ok).toBe(true);
-    if (result.ok) {
-      expect(result.user.sub).toBe("u3");
-      expect(result.setCookies).toBeDefined();
-      expect(result.setCookies!.length).toBe(2);
-      // New AT and RT are issued.
-      expect(result.setCookies!.some((c) => c.startsWith("__dali_at="))).toBe(
-        true,
-      );
-      expect(result.setCookies!.some((c) => c.startsWith("__dali_rt="))).toBe(
-        true,
-      );
-      // RT cookie path is `/` so the browser sends it on every request.
-      expect(result.setCookies!.some((c) => /__dali_rt=.*Path=\//.test(c))).toBe(
-        true,
-      );
-    }
-    // Old RT was revoked, new one created.
-    expect(mockPrisma.refreshToken.update).toHaveBeenCalled();
-    expect(mockPrisma.refreshToken.create).toHaveBeenCalled();
+    if (result.ok) expect(result.user.sub).toBe("user-cookie");
   });
 
-  it("clears cookies and 401s when RT was already revoked (reuse detected)", async () => {
-    mockPrisma.refreshToken.findUnique.mockResolvedValue({
-      id: "rt-2",
-      tokenHash: "x",
-      userId: "u4",
-      family: "fam-2",
-      expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
-      revokedAt: new Date(),
-      familyCreatedAt: new Date(Date.now() - 24 * 60 * 60 * 1000),
+  it("looks up sessions by sha256(raw), never the raw value", async () => {
+    mockPrisma.session.findUnique.mockResolvedValue(makeSessionRow());
+    const req = new Request("http://localhost", {
+      headers: { Cookie: "__dali_sid=raw-1" },
     });
-    mockPrisma.refreshToken.updateMany.mockResolvedValue({ count: 3 });
+    await requireAuth(req);
+    expect(mockPrisma.session.findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: hashSessionId("raw-1") },
+      }),
+    );
+  });
 
-    const req = new Request("http://localhost/api/test", {
-      headers: { Cookie: "__dali_rt=reused-rt" },
+  it("derives auth.user.type as member, dartmouth, or partner based on user columns", async () => {
+    mockPrisma.session.findUnique.mockResolvedValue(
+      makeSessionRow({
+        user: {
+          id: "user-1",
+          daliEmail: null,
+          dartmouthEmail: null,
+          netId: "abc123",
+          firstName: "Net",
+          lastName: "Id",
+        },
+      }),
+    );
+    const req = new Request("http://localhost", {
+      headers: { Cookie: "__dali_sid=raw-1" },
     });
-
     const result = await requireAuth(req);
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.response.status).toBe(401);
-      const cleared = result.response.headers.getSetCookie();
-      expect(cleared.length).toBe(2);
-      expect(cleared.some((c) => /__dali_at=;.*Max-Age=0/.test(c))).toBe(true);
-      expect(cleared.some((c) => /__dali_rt=;.*Max-Age=0/.test(c))).toBe(true);
-    }
-    // The whole family was revoked.
-    expect(mockPrisma.refreshToken.updateMany).toHaveBeenCalledWith(
-      expect.objectContaining({ where: { family: "fam-2" } }),
-    );
-  });
-
-  it("clears cookies and 401s when session exceeds 30-day absolute cap", async () => {
-    mockPrisma.refreshToken.findUnique.mockResolvedValue({
-      id: "rt-old",
-      tokenHash: "x",
-      userId: "u6",
-      family: "fam-old",
-      expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
-      revokedAt: null,
-      familyCreatedAt: new Date(Date.now() - 31 * 24 * 60 * 60 * 1000), // 31 days ago
-    });
-    mockPrisma.refreshToken.updateMany.mockResolvedValue({ count: 0 });
-
-    const req = new Request("http://localhost/api/test", {
-      headers: { Cookie: "__dali_rt=old-session-rt" },
-    });
-
-    const result = await requireAuth(req);
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.response.status).toBe(401);
-      const cleared = result.response.headers.getSetCookie();
-      expect(cleared.length).toBe(2);
-      expect(cleared.some((c) => /__dali_at=;.*Max-Age=0/.test(c))).toBe(true);
-      expect(cleared.some((c) => /__dali_rt=;.*Max-Age=0/.test(c))).toBe(true);
-    }
-  });
-
-  it("clears cookies and 401s when RT is unknown", async () => {
-    mockPrisma.refreshToken.findUnique.mockResolvedValue(null);
-
-    const req = new Request("http://localhost/api/test", {
-      headers: { Cookie: "__dali_rt=ghost" },
-    });
-
-    const result = await requireAuth(req);
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.response.status).toBe(401);
-      expect(result.response.headers.getSetCookie().length).toBe(2);
-    }
-  });
-
-  it("de-duplicates concurrent refreshes that present the same RT", async () => {
-    // Make findUnique resolve only after both calls have been made, so we
-    // know the dedup map has had both lookups land on the same in-flight
-    // promise.
-    let resolveFind: (v: any) => void;
-    mockPrisma.refreshToken.findUnique.mockImplementation(
-      () =>
-        new Promise((res) => {
-          resolveFind = res;
-        }),
-    );
-    mockPrisma.refreshToken.update.mockResolvedValue({});
-    mockPrisma.refreshToken.create.mockResolvedValue({});
-    mockPrisma.user.findUnique.mockResolvedValue({
-      id: "u5",
-      daliEmail: "h@dali.dartmouth.edu",
-      dartmouthEmail: null,
-      netId: null,
-      firstName: "T",
-      lastName: "U",
-    });
-
-    const headers = { Cookie: "__dali_rt=shared-rt" };
-    const r1 = requireAuth(new Request("http://localhost/a", { headers }));
-    const r2 = requireAuth(new Request("http://localhost/b", { headers }));
-
-    // Resolve the in-flight DB lookup with a valid RT row.
-    resolveFind!({
-      id: "rt-3",
-      tokenHash: "x",
-      userId: "u5",
-      family: "fam-3",
-      expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
-      revokedAt: null,
-      familyCreatedAt: new Date(Date.now() - 24 * 60 * 60 * 1000),
-    });
-
-    const [a, b] = await Promise.all([r1, r2]);
-    expect(a.ok).toBe(true);
-    expect(b.ok).toBe(true);
-    // findUnique was called once (the dedup map collapsed both into one
-    // refresh) — without dedup, the second caller would see `revokedAt` set
-    // by the first caller's update and trip reuse detection.
-    expect(mockPrisma.refreshToken.findUnique).toHaveBeenCalledTimes(1);
-  });
-});
-
-describe("withAuth", () => {
-  it("is a no-op when no setCookies are present", () => {
-    const auth = { ok: true as const, user: { sub: "u", email: "e", type: "m" } };
-    const value = { foo: "bar" };
-    expect(withAuth(auth, value)).toBe(value);
-
-    const resp = new Response("ok");
-    expect(withAuth(auth, resp)).toBe(resp);
-    expect(resp.headers.getSetCookie()).toEqual([]);
-  });
-
-  it("appends Set-Cookie headers onto a Response on success", () => {
-    const headers = new Headers();
-    setTokenCookies(headers, "new-at", "new-rt");
-    const setCookies = headers.getSetCookie();
-
-    const auth = {
-      ok: true as const,
-      user: { sub: "u", email: "e", type: "m" },
-      setCookies,
-    };
-    const resp = Response.json({ hello: "world" });
-    const out = withAuth(auth, resp);
-
-    expect(out).toBe(resp);
-    expect(resp.headers.getSetCookie().length).toBe(2);
-    expect(resp.headers.getSetCookie()).toEqual(setCookies);
-  });
-
-  it("forwards cleared cookies from a failure response", () => {
-    // Build a failure auth result whose response carries cleared cookies.
-    const inner = new Response(JSON.stringify({ error: "Unauthorized" }), {
-      status: 401,
-    });
-    inner.headers.append(
-      "Set-Cookie",
-      "__dali_at=; Max-Age=0; Path=/; HttpOnly; SameSite=Lax",
-    );
-    inner.headers.append(
-      "Set-Cookie",
-      "__dali_rt=; Max-Age=0; Path=/; HttpOnly; SameSite=Lax",
-    );
-    const auth = { ok: false as const, response: inner };
-
-    const redirected = new Response(null, {
-      status: 302,
-      headers: { Location: "/login" },
-    });
-    const out = withAuth(auth, redirected);
-    expect(out).toBe(redirected);
-    const cleared = redirected.headers.getSetCookie();
-    expect(cleared.length).toBe(2);
-    expect(cleared.some((c) => /__dali_at=;.*Max-Age=0/.test(c))).toBe(true);
-    expect(cleared.some((c) => /__dali_rt=;.*Max-Age=0/.test(c))).toBe(true);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.user.type).toBe("dartmouth");
   });
 });
 
 describe("validateCasTicket", () => {
-  it("parses a successful CAS response", async () => {
-    const xml = `<cas:serviceResponse>
-      <cas:authenticationSuccess>
-        <cas:user>d12345a</cas:user>
-        <cas:netid>d12345a</cas:netid>
-        <cas:name>Jane Doe</cas:name>
-      </cas:authenticationSuccess>
-    </cas:serviceResponse>`;
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
 
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue(new Response(xml)),
-    );
-
-    const result = await validateCasTicket("ST-ticket", "http://localhost/cb");
-    expect(result.netId).toBe("d12345a");
-    expect(result.firstName).toBe("Jane");
-    expect(result.lastName).toBe("Doe");
-
+  it("returns netId, firstName, lastName from CAS XML", async () => {
+    const xml = `<?xml version="1.0"?>
+<cas:serviceResponse xmlns:cas="http://www.yale.edu/tp/cas">
+  <cas:authenticationSuccess>
+    <cas:user>abc123</cas:user>
+    <cas:netid>abc123</cas:netid>
+    <cas:name>Test User</cas:name>
+  </cas:authenticationSuccess>
+</cas:serviceResponse>`;
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(
+      new Response(xml, { status: 200 }),
+    ));
+    const out = await validateCasTicket("ticket-x", "https://example.com/cb");
+    expect(out.netId).toBe("abc123");
+    expect(out.firstName).toBe("Test");
+    expect(out.lastName).toBe("User");
     vi.unstubAllGlobals();
   });
 
-  it("throws on CAS failure response", async () => {
-    const xml = `<cas:serviceResponse>
-      <cas:authenticationFailure code="INVALID_TICKET">
-        Ticket not recognized
-      </cas:authenticationFailure>
-    </cas:serviceResponse>`;
-
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue(new Response(xml)),
-    );
-
-    await expect(
-      validateCasTicket("bad-ticket", "http://localhost/cb"),
-    ).rejects.toThrow("CAS authentication failed");
-
+  it("throws when CAS returns a failure document", async () => {
+    const xml = `<?xml version="1.0"?>
+<cas:serviceResponse xmlns:cas="http://www.yale.edu/tp/cas">
+  <cas:authenticationFailure code="INVALID_TICKET">no such ticket</cas:authenticationFailure>
+</cas:serviceResponse>`;
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(
+      new Response(xml, { status: 200 }),
+    ));
+    await expect(validateCasTicket("bad", "https://x")).rejects.toThrow();
     vi.unstubAllGlobals();
   });
 });

--- a/dali-api/app/lib/__tests__/cookies.test.ts
+++ b/dali-api/app/lib/__tests__/cookies.test.ts
@@ -1,68 +1,93 @@
 import { describe, it, expect } from "vitest";
 import {
-  parseAccessToken,
-  parseRefreshToken,
-  setTokenCookies,
-  clearTokenCookies,
+  parseSessionCookie,
+  parseBearerHeader,
+  parseSessionId,
+  setSessionCookie,
+  clearSessionCookie,
 } from "~/lib/cookies";
 
-describe("parseAccessToken", () => {
-  it("extracts __dali_at from cookie header", () => {
+describe("parseSessionCookie", () => {
+  it("extracts __dali_sid from cookie header", () => {
     const req = new Request("http://localhost", {
-      headers: { Cookie: "__dali_at=abc123; __dali_rt=xyz" },
+      headers: { Cookie: "__dali_sid=abc123; other=xyz" },
     });
-    expect(parseAccessToken(req)).toBe("abc123");
+    expect(parseSessionCookie(req)).toBe("abc123");
   });
 
   it("returns null when cookie is missing", () => {
     const req = new Request("http://localhost");
-    expect(parseAccessToken(req)).toBeNull();
+    expect(parseSessionCookie(req)).toBeNull();
   });
 });
 
-describe("parseRefreshToken", () => {
-  it("extracts __dali_rt from cookie header", () => {
+describe("parseBearerHeader", () => {
+  it("extracts the token from an Authorization: Bearer header", () => {
     const req = new Request("http://localhost", {
-      headers: { Cookie: "__dali_at=abc; __dali_rt=refresh456" },
+      headers: { Authorization: "Bearer sess-id-123" },
     });
-    expect(parseRefreshToken(req)).toBe("refresh456");
+    expect(parseBearerHeader(req)).toBe("sess-id-123");
   });
 
-  it("returns null when cookie is missing", () => {
+  it("returns null without an Authorization header", () => {
     const req = new Request("http://localhost");
-    expect(parseRefreshToken(req)).toBeNull();
+    expect(parseBearerHeader(req)).toBeNull();
+  });
+
+  it("returns null for a non-Bearer scheme", () => {
+    const req = new Request("http://localhost", {
+      headers: { Authorization: "Basic abc=" },
+    });
+    expect(parseBearerHeader(req)).toBeNull();
   });
 });
 
-describe("setTokenCookies", () => {
-  it("appends correct Set-Cookie headers", () => {
+describe("parseSessionId", () => {
+  it("prefers the cookie when both cookie and header are present", () => {
+    const req = new Request("http://localhost", {
+      headers: {
+        Cookie: "__dali_sid=cookie-id",
+        Authorization: "Bearer header-id",
+      },
+    });
+    expect(parseSessionId(req)).toBe("cookie-id");
+  });
+
+  it("falls back to the Bearer header when no cookie", () => {
+    const req = new Request("http://localhost", {
+      headers: { Authorization: "Bearer header-id" },
+    });
+    expect(parseSessionId(req)).toBe("header-id");
+  });
+
+  it("returns null when neither is present", () => {
+    const req = new Request("http://localhost");
+    expect(parseSessionId(req)).toBeNull();
+  });
+});
+
+describe("setSessionCookie", () => {
+  it("appends one Set-Cookie header for __dali_sid", () => {
     const headers = new Headers();
-    setTokenCookies(headers, "at_value", "rt_value");
+    setSessionCookie(headers, "raw-session-id");
 
     const cookies = headers.getSetCookie();
-    expect(cookies).toHaveLength(2);
-    expect(cookies[0]).toContain("__dali_at=at_value");
-    expect(cookies[0]).toContain("Max-Age=900");
+    expect(cookies).toHaveLength(1);
+    expect(cookies[0]).toContain("__dali_sid=raw-session-id");
     expect(cookies[0]).toContain("Path=/");
     expect(cookies[0]).toContain("HttpOnly");
-    expect(cookies[1]).toContain("__dali_rt=rt_value");
-    expect(cookies[1]).toContain("Max-Age=604800");
-    // RT cookie path is `/` so the silent refresh in `requireAuth` sees it on
-    // every request — not just calls into /oauth/*.
-    expect(cookies[1]).toContain("Path=/");
+    expect(cookies[0]).toContain("SameSite=Lax");
   });
 });
 
-describe("clearTokenCookies", () => {
-  it("appends clearing Set-Cookie headers with Max-Age=0", () => {
+describe("clearSessionCookie", () => {
+  it("appends a clearing Set-Cookie header with Max-Age=0", () => {
     const headers = new Headers();
-    clearTokenCookies(headers);
+    clearSessionCookie(headers);
 
     const cookies = headers.getSetCookie();
-    expect(cookies).toHaveLength(2);
-    expect(cookies[0]).toContain("__dali_at=");
+    expect(cookies).toHaveLength(1);
+    expect(cookies[0]).toContain("__dali_sid=");
     expect(cookies[0]).toContain("Max-Age=0");
-    expect(cookies[1]).toContain("__dali_rt=");
-    expect(cookies[1]).toContain("Max-Age=0");
   });
 });

--- a/dali-api/app/lib/__tests__/linking.test.ts
+++ b/dali-api/app/lib/__tests__/linking.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 
 vi.mock("~/lib/db");
 
@@ -11,14 +11,10 @@ const mockPrisma = prisma as unknown as {
     update: ReturnType<typeof vi.fn>;
     delete: ReturnType<typeof vi.fn>;
   };
-  refreshToken: { updateMany: ReturnType<typeof vi.fn> };
+  session: { updateMany: ReturnType<typeof vi.fn> };
   oAuthSession: { updateMany: ReturnType<typeof vi.fn> };
   $transaction: ReturnType<typeof vi.fn>;
 };
-
-beforeAll(() => {
-  process.env.JWT_SECRET = "test-secret-at-least-32-chars-long!!";
-});
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -53,7 +49,7 @@ describe("linkCasToGoogleUser", () => {
     mockPrisma.$transaction.mockImplementation(async (fn: any) => {
       // provide a mock tx with the same methods
       const tx = {
-        refreshToken: { updateMany: vi.fn().mockResolvedValue({}) },
+        session: { updateMany: vi.fn().mockResolvedValue({}) },
         oAuthSession: { updateMany: vi.fn().mockResolvedValue({}) },
         user: {
           delete: vi.fn().mockResolvedValue({}),

--- a/dali-api/app/lib/__tests__/oauth.test.ts
+++ b/dali-api/app/lib/__tests__/oauth.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 
 const mockVerifyIdToken = vi.hoisted(() => vi.fn());
 const mockGetPayload = vi.hoisted(() => vi.fn());
@@ -17,30 +17,22 @@ import {
   getAllowedRedirectUris,
   exchangeAuthorizationCode,
   exchangeGoogleCode,
-  refreshTokens,
-  revokeToken,
+  buildUserInfo,
 } from "~/lib/oauth";
 
 const mockPrisma = prisma as unknown as {
-  user: { findUnique: ReturnType<typeof vi.fn> };
-  refreshToken: {
-    create: ReturnType<typeof vi.fn>;
-    findUnique: ReturnType<typeof vi.fn>;
-    update: ReturnType<typeof vi.fn>;
-    updateMany: ReturnType<typeof vi.fn>;
-  };
   oAuthSession: {
     findUnique: ReturnType<typeof vi.fn>;
     update: ReturnType<typeof vi.fn>;
   };
 };
 
-beforeAll(() => {
-  process.env.JWT_SECRET = "test-secret-at-least-32-chars-long!!";
-});
-
 beforeEach(() => {
   vi.clearAllMocks();
+  mockPrisma.oAuthSession = {
+    findUnique: vi.fn(),
+    update: vi.fn().mockResolvedValue({}),
+  } as any;
 });
 
 describe("verifyPKCE", () => {
@@ -80,6 +72,59 @@ describe("getAllowedRedirectUris", () => {
   it("returns frontend login URI", () => {
     const uris = getAllowedRedirectUris();
     expect(uris).toContain("http://localhost:5173/login");
+  });
+});
+
+describe("buildUserInfo", () => {
+  it("derives type from user columns when not provided", () => {
+    expect(
+      buildUserInfo({
+        id: "u",
+        daliEmail: "a@dali.dartmouth.edu",
+        dartmouthEmail: null,
+        netId: null,
+        firstName: "A",
+        lastName: "B",
+      }).type,
+    ).toBe("member");
+
+    expect(
+      buildUserInfo({
+        id: "u",
+        daliEmail: null,
+        dartmouthEmail: null,
+        netId: "x",
+        firstName: "A",
+        lastName: "B",
+      }).type,
+    ).toBe("dartmouth");
+
+    expect(
+      buildUserInfo({
+        id: "u",
+        daliEmail: null,
+        dartmouthEmail: "x@example.com",
+        netId: null,
+        firstName: "A",
+        lastName: "B",
+      }).type,
+    ).toBe("partner");
+  });
+
+  it("uses an explicit authType when supplied", () => {
+    expect(
+      buildUserInfo(
+        {
+          id: "u",
+          daliEmail: "a@dali.dartmouth.edu",
+          dartmouthEmail: null,
+          netId: null,
+          firstName: "A",
+          lastName: "B",
+        },
+        "dartmouth",
+      ).type,
+    ).toBe("dartmouth");
   });
 });
 
@@ -170,7 +215,6 @@ describe("exchangeAuthorizationCode", () => {
       provider: "cas",
       accountType: "dartmouth",
     });
-    mockPrisma.oAuthSession.update.mockResolvedValue({});
 
     await expect(exchangeAuthorizationCode(baseParams)).rejects.toThrow(
       "Session has no user",
@@ -194,7 +238,6 @@ describe("exchangeAuthorizationCode", () => {
       provider: "cas",
       accountType: "dartmouth",
     });
-    mockPrisma.oAuthSession.update.mockResolvedValue({});
 
     const result = await exchangeAuthorizationCode(baseParams);
     expect(result).toEqual({
@@ -202,123 +245,6 @@ describe("exchangeAuthorizationCode", () => {
       provider: "cas",
       accountType: "dartmouth",
     });
-  });
-});
-
-describe("refreshTokens", () => {
-  const mockUser = {
-    id: "u1",
-    daliEmail: "a@dali.dartmouth.edu",
-    dartmouthEmail: null,
-    netId: "d12345a",
-    firstName: "Jane",
-    lastName: "Doe",
-  };
-
-  it("throws when token not found", async () => {
-    mockPrisma.refreshToken.findUnique.mockResolvedValue(null);
-    await expect(refreshTokens("unknown-token")).rejects.toThrow(
-      "Invalid refresh token",
-    );
-  });
-
-  it("revokes family on token reuse", async () => {
-    mockPrisma.refreshToken.findUnique.mockResolvedValue({
-      id: "rt1",
-      family: "fam1",
-      revokedAt: new Date(),
-      expiresAt: new Date(Date.now() + 60000),
-      userId: "u1",
-    });
-
-    await expect(refreshTokens("reused-token")).rejects.toThrow(
-      "family revoked",
-    );
-    expect(mockPrisma.refreshToken.updateMany).toHaveBeenCalledWith({
-      where: { family: "fam1" },
-      data: { revokedAt: expect.any(Date) },
-    });
-  });
-
-  it("throws when token is expired", async () => {
-    mockPrisma.refreshToken.findUnique.mockResolvedValue({
-      id: "rt1",
-      family: "fam1",
-      revokedAt: null,
-      expiresAt: new Date(Date.now() - 60000),
-      userId: "u1",
-    });
-    await expect(refreshTokens("expired-token")).rejects.toThrow(
-      "Refresh token expired",
-    );
-  });
-
-  it("succeeds with token rotation", async () => {
-    const familyCreatedAt = new Date(Date.now() - 24 * 60 * 60 * 1000);
-    mockPrisma.refreshToken.findUnique.mockResolvedValue({
-      id: "rt1",
-      family: "fam1",
-      revokedAt: null,
-      expiresAt: new Date(Date.now() + 60000),
-      userId: "u1",
-      familyCreatedAt,
-    });
-    mockPrisma.refreshToken.update.mockResolvedValue({});
-    mockPrisma.user.findUnique.mockResolvedValue(mockUser);
-    mockPrisma.refreshToken.create.mockResolvedValue({});
-
-    const result = await refreshTokens("valid-token");
-    expect(result.access_token).toBeDefined();
-    expect(result.refresh_token).toBeDefined();
-    expect(result.token_type).toBe("Bearer");
-    expect(result.expires_in).toBe(900);
-    expect(result.userInfo.id).toBe("u1");
-
-    // old token was revoked
-    expect(mockPrisma.refreshToken.update).toHaveBeenCalledWith({
-      where: { id: "rt1" },
-      data: { revokedAt: expect.any(Date) },
-    });
-    // familyCreatedAt propagated to new token
-    expect(mockPrisma.refreshToken.create).toHaveBeenCalledWith(
-      expect.objectContaining({ data: expect.objectContaining({ familyCreatedAt }) }),
-    );
-  });
-
-  it("throws when session exceeds 30-day absolute cap", async () => {
-    mockPrisma.refreshToken.findUnique.mockResolvedValue({
-      id: "rt1",
-      family: "fam1",
-      revokedAt: null,
-      expiresAt: new Date(Date.now() + 60000),
-      userId: "u1",
-      familyCreatedAt: new Date(Date.now() - 31 * 24 * 60 * 60 * 1000),
-    });
-    await expect(refreshTokens("old-session-token")).rejects.toThrow(
-      "Session expired",
-    );
-  });
-});
-
-describe("revokeToken", () => {
-  it("revokes the token family", async () => {
-    mockPrisma.refreshToken.findUnique.mockResolvedValue({
-      id: "rt1",
-      family: "fam1",
-    });
-    mockPrisma.refreshToken.updateMany.mockResolvedValue({});
-
-    await revokeToken("some-token");
-    expect(mockPrisma.refreshToken.updateMany).toHaveBeenCalledWith({
-      where: { family: "fam1" },
-      data: { revokedAt: expect.any(Date) },
-    });
-  });
-
-  it("is a no-op for unknown token", async () => {
-    mockPrisma.refreshToken.findUnique.mockResolvedValue(null);
-    await revokeToken("unknown-token");
-    expect(mockPrisma.refreshToken.updateMany).not.toHaveBeenCalled();
   });
 });
 

--- a/dali-api/app/lib/__tests__/session.test.ts
+++ b/dali-api/app/lib/__tests__/session.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("~/lib/db");
+
+import { prisma } from "~/lib/db";
+import {
+  issueSession,
+  lookupSession,
+  rollSession,
+  revokeSession,
+  revokeAllForUser,
+  revokeAllForGrant,
+  hashSessionId,
+  ROLLING_TTL_MS,
+  ABSOLUTE_TTL_MS,
+} from "~/lib/session";
+
+const mockPrisma = prisma as unknown as {
+  session: {
+    create: ReturnType<typeof vi.fn>;
+    findUnique: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+    updateMany: ReturnType<typeof vi.fn>;
+  };
+};
+
+beforeEach(() => {
+  mockPrisma.session = {
+    create: vi.fn().mockResolvedValue({}),
+    findUnique: vi.fn(),
+    update: vi.fn().mockResolvedValue({}),
+    updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+  } as any;
+});
+
+describe("hashSessionId", () => {
+  it("produces a base64url SHA-256 digest", () => {
+    const hash = hashSessionId("raw");
+    expect(hash).toMatch(/^[A-Za-z0-9_-]+$/);
+    // 32-byte SHA-256 → 43 base64url chars (no padding)
+    expect(hash.length).toBe(43);
+  });
+
+  it("is deterministic", () => {
+    expect(hashSessionId("x")).toBe(hashSessionId("x"));
+  });
+});
+
+describe("issueSession", () => {
+  it("stores the hashed id, never the raw, and returns the raw to caller", async () => {
+    const result = await issueSession({ userId: "u-1" });
+    expect(result.rawId).toMatch(/^[A-Za-z0-9_-]+$/);
+
+    const args = mockPrisma.session.create.mock.calls[0][0];
+    expect(args.data.id).toBe(hashSessionId(result.rawId));
+    expect(args.data.id).not.toBe(result.rawId);
+    expect(args.data.userId).toBe("u-1");
+  });
+
+  it("sets expiresAt to now + ROLLING_TTL_MS", async () => {
+    const before = Date.now();
+    await issueSession({ userId: "u-1" });
+    const after = Date.now();
+    const args = mockPrisma.session.create.mock.calls[0][0];
+    const exp = (args.data.expiresAt as Date).getTime();
+    expect(exp).toBeGreaterThanOrEqual(before + ROLLING_TTL_MS - 50);
+    expect(exp).toBeLessThanOrEqual(after + ROLLING_TTL_MS + 50);
+  });
+
+  it("sets absoluteExpiresAt to now + ABSOLUTE_TTL_MS", async () => {
+    const before = Date.now();
+    await issueSession({ userId: "u-1" });
+    const after = Date.now();
+    const args = mockPrisma.session.create.mock.calls[0][0];
+    const exp = (args.data.absoluteExpiresAt as Date).getTime();
+    expect(exp).toBeGreaterThanOrEqual(before + ABSOLUTE_TTL_MS - 50);
+    expect(exp).toBeLessThanOrEqual(after + ABSOLUTE_TTL_MS + 50);
+  });
+
+  it("threads userAgent, ip, and grantId through to the row", async () => {
+    await issueSession({
+      userId: "u-1",
+      grantId: "grant-1",
+      userAgent: "ua",
+      ip: "1.2.3.4",
+    });
+    const args = mockPrisma.session.create.mock.calls[0][0];
+    expect(args.data.userAgent).toBe("ua");
+    expect(args.data.ip).toBe("1.2.3.4");
+    expect(args.data.grantId).toBe("grant-1");
+  });
+});
+
+describe("lookupSession", () => {
+  it("returns null when the raw id is empty", async () => {
+    expect(await lookupSession("")).toBeNull();
+    expect(mockPrisma.session.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("returns null when no row matches the hashed id", async () => {
+    mockPrisma.session.findUnique.mockResolvedValue(null);
+    expect(await lookupSession("raw")).toBeNull();
+    expect(mockPrisma.session.findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: hashSessionId("raw") } }),
+    );
+  });
+
+  it("returns the row when present", async () => {
+    const row = { id: hashSessionId("raw"), userId: "u-1", user: {} };
+    mockPrisma.session.findUnique.mockResolvedValue(row);
+    expect(await lookupSession("raw")).toBe(row);
+  });
+});
+
+describe("rollSession", () => {
+  it("extends expiresAt up to the absolute cap", async () => {
+    const absoluteExpiresAt = new Date(Date.now() + ROLLING_TTL_MS * 2);
+    mockPrisma.session.findUnique.mockResolvedValue({ absoluteExpiresAt });
+    await rollSession(hashSessionId("x"));
+    const args = mockPrisma.session.update.mock.calls[0][0];
+    expect(args.data.expiresAt).toBeInstanceOf(Date);
+    expect((args.data.expiresAt as Date).getTime()).toBeLessThanOrEqual(
+      absoluteExpiresAt.getTime(),
+    );
+  });
+
+  it("never extends past absoluteExpiresAt", async () => {
+    const absoluteExpiresAt = new Date(Date.now() + 1000);
+    mockPrisma.session.findUnique.mockResolvedValue({ absoluteExpiresAt });
+    await rollSession(hashSessionId("x"));
+    const args = mockPrisma.session.update.mock.calls[0][0];
+    expect((args.data.expiresAt as Date).getTime()).toBe(
+      absoluteExpiresAt.getTime(),
+    );
+  });
+
+  it("is a no-op when the session row doesn't exist", async () => {
+    mockPrisma.session.findUnique.mockResolvedValue(null);
+    await rollSession(hashSessionId("x"));
+    expect(mockPrisma.session.update).not.toHaveBeenCalled();
+  });
+});
+
+describe("revokeSession", () => {
+  it("flips revokedAt on the row matching the hashed raw id", async () => {
+    await revokeSession("raw");
+    const args = mockPrisma.session.updateMany.mock.calls[0][0];
+    expect(args.where.id).toBe(hashSessionId("raw"));
+    expect(args.data.revokedAt).toBeInstanceOf(Date);
+  });
+
+  it("accepts an already-hashed id with { hashed: true }", async () => {
+    await revokeSession(hashSessionId("raw"), { hashed: true });
+    const args = mockPrisma.session.updateMany.mock.calls[0][0];
+    expect(args.where.id).toBe(hashSessionId("raw"));
+  });
+});
+
+describe("revokeAllForUser", () => {
+  it("revokes only this user's active sessions", async () => {
+    mockPrisma.session.updateMany.mockResolvedValue({ count: 3 });
+    const n = await revokeAllForUser("u-1");
+    expect(n).toBe(3);
+    const args = mockPrisma.session.updateMany.mock.calls[0][0];
+    expect(args.where.userId).toBe("u-1");
+    expect(args.where.revokedAt).toBeNull();
+  });
+});
+
+describe("revokeAllForGrant", () => {
+  it("revokes only sessions tied to this grant", async () => {
+    mockPrisma.session.updateMany.mockResolvedValue({ count: 2 });
+    const n = await revokeAllForGrant("grant-1");
+    expect(n).toBe(2);
+    const args = mockPrisma.session.updateMany.mock.calls[0][0];
+    expect(args.where.grantId).toBe("grant-1");
+    expect(args.where.revokedAt).toBeNull();
+  });
+});

--- a/dali-api/app/lib/auth.ts
+++ b/dali-api/app/lib/auth.ts
@@ -1,69 +1,38 @@
-import { SignJWT, jwtVerify, errors as joseErrors } from "jose";
-import { data } from "react-router";
-import {
-  parseAccessToken,
-  parseRefreshToken,
-  setTokenCookies,
-  clearTokenCookies,
-} from "~/lib/cookies";
+import { clearSessionCookie, parseSessionId } from "~/lib/cookies";
 import { logAuditEvent } from "~/lib/audit";
-import { refreshTokens } from "~/lib/oauth";
+import { lookupSession, rollSession, hashSessionId } from "~/lib/session";
 
-// jwt helper functions
+// Session-backed auth middleware. See SESSION_AUTH_PLAN.md for design.
+// The `user.sub` shape is preserved from the legacy JWT payload so existing
+// callers (`auth.user.sub` is used across calendar/, collab/, etc.) keep
+// working without per-file edits.
 
-function getSecret() {
-  const secret = process.env.JWT_SECRET;
-  if (!secret) throw new Error("JWT_SECRET not set");
-  const encoded = new TextEncoder().encode(secret);
-  if (encoded.length < 32) {
-    throw new Error("JWT_SECRET must be at least 32 bytes for HS256 security");
-  }
-  return encoded;
-}
-
-export async function signAccessToken(payload: {
-  sub: string;
-  email: string;
-  type: string;
-  firstName?: string;
-  lastName?: string;
-}) {
-  return new SignJWT(payload)
-    .setProtectedHeader({ alg: "HS256" })
-    .setIssuedAt()
-    .setExpirationTime("15m")
-    .sign(getSecret());
-}
-
-export async function verifyAccessToken(token: string) {
-  const { payload } = await jwtVerify(token, getSecret());
-  return payload as {
-    sub: string;
-    email: string;
-    type: string;
-    firstName?: string;
-    lastName?: string;
-  };
-}
-
-// auth middleware
-
-type AuthUser = {
+export type AuthUser = {
   sub: string;
   email: string;
   type: string;
   firstName?: string;
   lastName?: string;
 };
+
 type AuthSuccess = {
   ok: true;
   user: AuthUser;
-  // Set-Cookie strings to attach to the outgoing response, set when
-  // requireAuth performed a silent refresh. Use `withAuth(auth, response)` to
-  // forward them to the browser.
-  setCookies?: string[];
+  sessionId: string; // hashed PK; not the raw credential
 };
-type AuthFailure = { ok: false; response: Response };
+
+type AuthFailureReason =
+  | "no_session"
+  | "not_found"
+  | "revoked"
+  | "expired";
+
+type AuthFailure = {
+  ok: false;
+  response: Response;
+  reason: AuthFailureReason;
+};
+
 export type AuthResult = AuthSuccess | AuthFailure;
 
 function unauthorized(): Response {
@@ -75,123 +44,78 @@ function unauthorized(): Response {
 
 function unauthorizedClearingCookies(): Response {
   const headers = new Headers({ "Content-Type": "application/json" });
-  clearTokenCookies(headers);
+  clearSessionCookie(headers);
   return new Response(JSON.stringify({ error: "Unauthorized" }), {
     status: 401,
     headers,
   });
 }
 
-// Per-request de-dup so two parallel loaders don't both burn a single RT.
-// The first call rotates the RT; the second awaits the same in-flight promise
-// and reuses its newly-issued tokens, instead of presenting the now-revoked RT
-// and tripping reuse detection.
-type RefreshOutcome =
-  | { ok: true; user: AuthUser; setCookies: string[] }
-  | { ok: false };
-const inFlightRefreshes = new Map<string, Promise<RefreshOutcome>>();
+function deriveAuthType(user: {
+  daliEmail: string | null;
+  netId: string | null;
+}): string {
+  if (user.daliEmail) return "member";
+  if (user.netId) return "dartmouth";
+  return "partner";
+}
 
-async function performRefresh(rawRT: string): Promise<RefreshOutcome> {
-  const existing = inFlightRefreshes.get(rawRT);
-  if (existing) return existing;
-
-  const promise = (async (): Promise<RefreshOutcome> => {
-    try {
-      const refreshed = await refreshTokens(rawRT);
-      const headers = new Headers();
-      setTokenCookies(headers, refreshed.access_token, refreshed.refresh_token);
-      return {
-        ok: true,
-        user: {
-          sub: refreshed.userInfo.id,
-          email: refreshed.userInfo.email,
-          type: refreshed.userInfo.type,
-          firstName: refreshed.userInfo.firstName,
-          lastName: refreshed.userInfo.lastName,
-        },
-        setCookies: headers.getSetCookie(),
-      };
-    } catch {
-      return { ok: false };
-    }
-  })();
-
-  inFlightRefreshes.set(rawRT, promise);
-  try {
-    return await promise;
-  } finally {
-    inFlightRefreshes.delete(rawRT);
-  }
+function buildAuthUser(user: {
+  id: string;
+  daliEmail: string | null;
+  dartmouthEmail: string | null;
+  netId: string | null;
+  firstName: string;
+  lastName: string;
+}): AuthUser {
+  return {
+    sub: user.id,
+    email:
+      user.daliEmail ?? user.dartmouthEmail ?? `${user.netId}@dartmouth.edu`,
+    type: deriveAuthType(user),
+    firstName: user.firstName,
+    lastName: user.lastName,
+  };
 }
 
 export async function requireAuth(request: Request): Promise<AuthResult> {
-  // try cookie first, fall back to authorization header if not present
-  let token = parseAccessToken(request);
-
-  // don't strictly need this yet but good to have support if we want to support API access later
-  if (!token) {
-    const authHeader = request.headers.get("Authorization");
-    if (authHeader?.startsWith("Bearer ")) {
-      token = authHeader.slice(7);
-    }
+  const raw = parseSessionId(request);
+  if (!raw) {
+    return { ok: false, response: unauthorized(), reason: "no_session" };
   }
 
-  if (token) {
-    try {
-      const user = await verifyAccessToken(token);
-      return { ok: true, user };
-    } catch (e) {
-      if (!(e instanceof joseErrors.JWTExpired)) {
-        // Tampered or otherwise malformed AT — don't try to refresh.
-        await logAuditEvent({
-          action: "auth.token.invalid",
-          request,
-        });
-        return { ok: false, response: unauthorized() };
-      }
-      // AT is just expired — fall through to silent refresh.
-    }
+  const session = await lookupSession(raw);
+  if (!session) {
+    await logAuditEvent({ action: "auth.token.invalid", request });
+    return { ok: false, response: unauthorizedClearingCookies(), reason: "not_found" };
   }
 
-  // Silent refresh: trade a valid RT for a fresh AT/RT pair without bouncing
-  // the user to /login. Bearer-token API callers (no RT cookie) still 401.
-  const rawRT = parseRefreshToken(request);
-  if (!rawRT) {
-    return { ok: false, response: unauthorized() };
+  if (session.revokedAt) {
+    return { ok: false, response: unauthorizedClearingCookies(), reason: "revoked" };
   }
 
-  const outcome = await performRefresh(rawRT);
-  if (outcome.ok) {
-    return { ok: true, user: outcome.user, setCookies: outcome.setCookies };
+  const now = new Date();
+  if (session.expiresAt < now || session.absoluteExpiresAt < now) {
+    return { ok: false, response: unauthorizedClearingCookies(), reason: "expired" };
   }
 
-  // Refresh failed — RT is invalid, expired, revoked, or its family was
-  // revoked due to reuse. Clear cookies so the browser stops resending them.
-  return { ok: false, response: unauthorizedClearingCookies() };
+  // Fire-and-forget — a failed roll doesn't break the request.
+  rollSession(session.id).catch(() => {});
+
+  return {
+    ok: true,
+    user: buildAuthUser(session.user),
+    sessionId: session.id,
+  };
 }
 
-// Forward Set-Cookie headers from `requireAuth` (silent refresh on success,
-// cleared cookies after a failed refresh) onto the outgoing response. No-op
-// when there are no cookies to forward, so it's safe to wrap unconditionally.
-export function withAuth<T>(auth: AuthResult, value: T): T;
-export function withAuth(auth: AuthResult, value: Response): Response;
-export function withAuth(auth: AuthResult, value: unknown): unknown {
-  const cookies = auth.ok
-    ? auth.setCookies
-    : auth.response.headers.getSetCookie();
-  if (!cookies || cookies.length === 0) return value;
-
-  if (value instanceof Response) {
-    for (const c of cookies) value.headers.append("Set-Cookie", c);
-    return value;
-  }
-
-  const headers = new Headers();
-  for (const c of cookies) headers.append("Set-Cookie", c);
-  return data(value, { headers });
+// Convenience used by routes that need to surface the hashed session id
+// without going through the full auth flow.
+export function sessionIdHash(raw: string): string {
+  return hashSessionId(raw);
 }
 
-// dartmouth cas (sso) ticket validation
+// dartmouth cas (sso) ticket validation — unrelated to session auth
 
 export async function validateCasTicket(ticket: string, serviceUrl: string) {
   const casBase = process.env.CAS_BASE_URL ?? "https://login.dartmouth.edu/cas";

--- a/dali-api/app/lib/cookies.ts
+++ b/dali-api/app/lib/cookies.ts
@@ -1,15 +1,20 @@
 // Cookie helpers for the single session credential. See SESSION_AUTH_PLAN.md.
 
-import { ROLLING_TTL_MS } from "~/lib/session";
-
 export const COOKIE_SID = "__dali_sid";
+
+// 30 days in seconds — same horizon as ROLLING_TTL_MS in `lib/session.ts`,
+// kept local so this module doesn't transitively import the Prisma client.
+// The cookie Max-Age and the DB rolling TTL are independently enforced:
+// the server is the source of truth, and an expired DB session 302s to
+// /login on the next request regardless of the cookie's lifetime.
+const SESSION_COOKIE_MAX_AGE_SECONDS = 30 * 24 * 60 * 60;
 
 const isProduction = process.env.NODE_ENV === "production";
 
 export function setSessionCookie(headers: Headers, rawSessionId: string) {
   const parts = [
     `${COOKIE_SID}=${rawSessionId}`,
-    `Max-Age=${Math.floor(ROLLING_TTL_MS / 1000)}`,
+    `Max-Age=${SESSION_COOKIE_MAX_AGE_SECONDS}`,
     "Path=/",
     "HttpOnly",
     "SameSite=Lax",

--- a/dali-api/app/lib/cookies.ts
+++ b/dali-api/app/lib/cookies.ts
@@ -1,21 +1,16 @@
-// cookie helpers for httpOnly authentication tokens
+// Cookie helpers for the single session credential. See SESSION_AUTH_PLAN.md.
 
-const COOKIE_AT = "__dali_at";
-const COOKIE_RT = "__dali_rt";
+import { ROLLING_TTL_MS } from "~/lib/session";
+
+export const COOKIE_SID = "__dali_sid";
 
 const isProduction = process.env.NODE_ENV === "production";
 
-function setCookie(
-  headers: Headers,
-  name: string,
-  value: string,
-  maxAge: number,
-  path = "/",
-) {
+export function setSessionCookie(headers: Headers, rawSessionId: string) {
   const parts = [
-    `${name}=${value}`,
-    `Max-Age=${maxAge}`,
-    `Path=${path}`,
+    `${COOKIE_SID}=${rawSessionId}`,
+    `Max-Age=${Math.floor(ROLLING_TTL_MS / 1000)}`,
+    "Path=/",
     "HttpOnly",
     "SameSite=Lax",
   ];
@@ -23,26 +18,10 @@ function setCookie(
   headers.append("Set-Cookie", parts.join("; "));
 }
 
-export function setTokenCookies(
-  headers: Headers,
-  accessToken: string,
-  refreshToken: string,
-) {
-  setCookie(headers, COOKIE_AT, accessToken, 900);
-  // RT path is `/` so it is sent to every request — required for the silent
-  // refresh in `requireAuth`. Theft defence is the family-revocation reuse
-  // detection in `refreshTokens`, plus HttpOnly + SameSite=Lax + Secure-in-prod.
-  setCookie(headers, COOKIE_RT, refreshToken, 604800);
-}
-
-export function clearTokenCookies(headers: Headers) {
+export function clearSessionCookie(headers: Headers) {
   headers.append(
     "Set-Cookie",
-    `${COOKIE_AT}=; Max-Age=0; Path=/; HttpOnly; SameSite=Lax`,
-  );
-  headers.append(
-    "Set-Cookie",
-    `${COOKIE_RT}=; Max-Age=0; Path=/; HttpOnly; SameSite=Lax`,
+    `${COOKIE_SID}=; Max-Age=0; Path=/; HttpOnly; SameSite=Lax`,
   );
 }
 
@@ -56,10 +35,18 @@ function parseCookies(request: Request): Record<string, string> {
   return entries;
 }
 
-export function parseAccessToken(request: Request): string | null {
-  return parseCookies(request)[COOKIE_AT] ?? null;
+export function parseSessionCookie(request: Request): string | null {
+  return parseCookies(request)[COOKIE_SID] ?? null;
 }
 
-export function parseRefreshToken(request: Request): string | null {
-  return parseCookies(request)[COOKIE_RT] ?? null;
+export function parseBearerHeader(request: Request): string | null {
+  const header = request.headers.get("Authorization");
+  if (!header) return null;
+  if (!header.startsWith("Bearer ")) return null;
+  return header.slice(7).trim() || null;
+}
+
+// Cookie first, Bearer header second. Cookie wins if both present.
+export function parseSessionId(request: Request): string | null {
+  return parseSessionCookie(request) ?? parseBearerHeader(request);
 }

--- a/dali-api/app/lib/linking.ts
+++ b/dali-api/app/lib/linking.ts
@@ -21,8 +21,8 @@ export async function linkCasToGoogleUser(googleUserId: string, netId: string) {
     return prisma.$transaction(async (tx) => {
       const daliEmail = googleUser.daliEmail;
 
-      // migrate refresh tokens to the surviving user
-      await tx.refreshToken.updateMany({
+      // migrate sessions to the surviving user
+      await tx.session.updateMany({
         where: { userId: googleUser.id },
         data: { userId: casUser.id },
       });

--- a/dali-api/app/lib/oauth.ts
+++ b/dali-api/app/lib/oauth.ts
@@ -1,7 +1,6 @@
 import { createHash, randomBytes } from "node:crypto";
 import { OAuth2Client } from "google-auth-library";
 import { prisma } from "~/lib/db";
-import { signAccessToken } from "~/lib/auth";
 
 // types
 
@@ -30,9 +29,6 @@ export class OAuthError extends Error {
 
 const SESSION_TTL_MS = 10 * 60 * 1000; // 10 min for the authorize→callback→exchange round-trip
 const AUTH_CODE_TTL_MS = 60 * 1000; // 1 min for code→token exchange
-const REFRESH_TOKEN_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days sliding
-const SESSION_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000; // 30 days absolute cap
-const ACCESS_TOKEN_EXPIRES_IN = 900; // 15 min
 
 export const VALID_CLIENT_IDS = ["dali-api"] as const;
 
@@ -61,7 +57,7 @@ function deriveAuthType(user: {
   return "partner";
 }
 
-function buildUserInfo(
+export function buildUserInfo(
   user: {
     id: string;
     daliEmail: string | null;
@@ -70,59 +66,16 @@ function buildUserInfo(
     firstName: string;
     lastName: string;
   },
-  authType: string,
+  authType?: string,
 ): UserInfo {
+  const resolvedType = authType ?? deriveAuthType(user);
   return {
     id: user.id,
     email:
       user.daliEmail ?? user.dartmouthEmail ?? `${user.netId}@dartmouth.edu`,
     firstName: user.firstName,
     lastName: user.lastName,
-    type: authType,
-  };
-}
-
-async function createTokenPair(
-  user: {
-    id: string;
-    daliEmail: string | null;
-    dartmouthEmail: string | null;
-    netId: string | null;
-    firstName: string;
-    lastName: string;
-  },
-  authType: string,
-  family?: string,
-  familyCreatedAt?: Date,
-) {
-  const userInfo = buildUserInfo(user, authType);
-
-  const accessToken = await signAccessToken({
-    sub: user.id,
-    email: userInfo.email,
-    type: authType,
-    firstName: user.firstName,
-    lastName: user.lastName,
-  });
-
-  const rawRefreshToken = generateOpaqueToken();
-
-  await prisma.refreshToken.create({
-    data: {
-      tokenHash: sha256(rawRefreshToken),
-      userId: user.id,
-      family: family ?? generateOpaqueToken(),
-      expiresAt: new Date(Date.now() + REFRESH_TOKEN_TTL_MS),
-      familyCreatedAt: familyCreatedAt ?? new Date(),
-    },
-  });
-
-  return {
-    access_token: accessToken,
-    token_type: "Bearer" as const,
-    expires_in: ACCESS_TOKEN_EXPIRES_IN,
-    refresh_token: rawRefreshToken,
-    userInfo,
+    type: resolvedType,
   };
 }
 
@@ -223,69 +176,10 @@ export async function exchangeAuthorizationCode(params: {
   };
 }
 
-// token issuing and refreshing
-
-export async function issueTokens(userId: string, authType: string) {
-  const user = await prisma.user.findUnique({ where: { id: userId } });
-  if (!user) throw new OAuthError("server_error", "User not found");
-  return createTokenPair(user, authType);
-}
-
-export async function refreshTokens(rawRefreshToken: string) {
-  const tokenHash = sha256(rawRefreshToken);
-  const existing = await prisma.refreshToken.findUnique({
-    where: { tokenHash },
-  });
-
-  if (!existing) throw new OAuthError("invalid_grant", "Invalid refresh token");
-
-  if (existing.revokedAt) {
-    await prisma.refreshToken.updateMany({
-      where: { family: existing.family },
-      data: { revokedAt: new Date() },
-    });
-    throw new OAuthError(
-      "invalid_grant",
-      "Refresh token reuse detected — family revoked",
-    );
-  }
-
-  if (existing.expiresAt < new Date()) {
-    throw new OAuthError("invalid_grant", "Refresh token expired");
-  }
-
-  if (existing.familyCreatedAt.getTime() + SESSION_MAX_AGE_MS < Date.now()) {
-    throw new OAuthError("invalid_grant", "Session expired — please log in again");
-  }
-
-  // revoke old token
-  await prisma.refreshToken.update({
-    where: { id: existing.id },
-    data: { revokedAt: new Date() },
-  });
-
-  const user = await prisma.user.findUnique({
-    where: { id: existing.userId },
-  });
-  if (!user) throw new OAuthError("server_error", "User not found");
-
-  return createTokenPair(user, deriveAuthType(user), existing.family, existing.familyCreatedAt);
-}
-
-// revoke tokens
-
-export async function revokeToken(rawToken: string) {
-  const tokenHash = sha256(rawToken);
-  const existing = await prisma.refreshToken.findUnique({
-    where: { tokenHash },
-  });
-  if (!existing) return;
-
-  await prisma.refreshToken.updateMany({
-    where: { family: existing.family },
-    data: { revokedAt: new Date() },
-  });
-}
+// Token issuing now lives in `lib/session.ts` (`issueSession`). The OAuth
+// provider's `/oauth/token` endpoint calls `issueSession` after
+// `exchangeAuthorizationCode` succeeds. Refresh-token grant has been removed
+// from `/oauth/token` — sessions auto-extend on use. See SESSION_AUTH_PLAN.md.
 
 // google OAuth
 

--- a/dali-api/app/lib/request-meta.ts
+++ b/dali-api/app/lib/request-meta.ts
@@ -1,0 +1,14 @@
+// Extract a client IP from a request. Fly forwards via `Fly-Client-IP`;
+// fall back to the leftmost `X-Forwarded-For` entry. Returns undefined
+// when nothing is available (e.g., direct local connection in tests).
+
+export function getClientIp(request: Request): string | undefined {
+  const fly = request.headers.get("fly-client-ip");
+  if (fly) return fly.trim();
+  const xff = request.headers.get("x-forwarded-for");
+  if (xff) {
+    const first = xff.split(",")[0]?.trim();
+    if (first) return first;
+  }
+  return undefined;
+}

--- a/dali-api/app/lib/session.ts
+++ b/dali-api/app/lib/session.ts
@@ -1,0 +1,138 @@
+import { createHash, randomBytes } from "node:crypto";
+import { prisma } from "~/lib/db";
+
+// 30 days rolling expiry; same value as the absolute cap so a session
+// can be extended for up to 30 days from creation. Matches the prior
+// `RefreshToken.familyCreatedAt + SESSION_MAX_AGE_MS` behavior.
+export const ROLLING_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+export const ABSOLUTE_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+
+export function hashSessionId(raw: string): string {
+  return createHash("sha256").update(raw).digest("base64url");
+}
+
+function generateRawSessionId(): string {
+  return randomBytes(32).toString("base64url");
+}
+
+export interface IssueSessionParams {
+  userId: string;
+  grantId?: string;
+  ttlMs?: number;
+  absoluteTtlMs?: number;
+  userAgent?: string;
+  ip?: string;
+}
+
+export interface IssueSessionResult {
+  rawId: string;
+  expiresAt: Date;
+  absoluteExpiresAt: Date;
+}
+
+export async function issueSession(params: IssueSessionParams): Promise<IssueSessionResult> {
+  const rawId = generateRawSessionId();
+  const ttlMs = params.ttlMs ?? ROLLING_TTL_MS;
+  const absoluteTtlMs = params.absoluteTtlMs ?? ABSOLUTE_TTL_MS;
+  const now = Date.now();
+  const expiresAt = new Date(now + ttlMs);
+  const absoluteExpiresAt = new Date(now + absoluteTtlMs);
+
+  await prisma.session.create({
+    data: {
+      id: hashSessionId(rawId),
+      userId: params.userId,
+      grantId: params.grantId,
+      expiresAt,
+      absoluteExpiresAt,
+      userAgent: params.userAgent,
+      ip: params.ip,
+    },
+  });
+
+  return { rawId, expiresAt, absoluteExpiresAt };
+}
+
+export interface LookupSessionResult {
+  id: string; // hashed id (PK)
+  userId: string;
+  grantId: string | null;
+  expiresAt: Date;
+  absoluteExpiresAt: Date;
+  revokedAt: Date | null;
+  user: {
+    id: string;
+    daliEmail: string | null;
+    dartmouthEmail: string | null;
+    netId: string | null;
+    firstName: string;
+    lastName: string;
+  };
+}
+
+export async function lookupSession(raw: string): Promise<LookupSessionResult | null> {
+  if (!raw) return null;
+  const id = hashSessionId(raw);
+  const session = await prisma.session.findUnique({
+    where: { id },
+    include: {
+      user: {
+        select: {
+          id: true,
+          daliEmail: true,
+          dartmouthEmail: true,
+          netId: true,
+          firstName: true,
+          lastName: true,
+        },
+      },
+    },
+  });
+  if (!session) return null;
+  return session;
+}
+
+// Extends the rolling expiry. Never advances past absoluteExpiresAt.
+// Fire-and-forget from request handlers — a failed roll doesn't break
+// the request that's already authenticated.
+export async function rollSession(hashedId: string, ttlMs = ROLLING_TTL_MS): Promise<void> {
+  const session = await prisma.session.findUnique({
+    where: { id: hashedId },
+    select: { absoluteExpiresAt: true },
+  });
+  if (!session) return;
+
+  const nextExpiry = new Date(Date.now() + ttlMs);
+  const capped =
+    nextExpiry > session.absoluteExpiresAt ? session.absoluteExpiresAt : nextExpiry;
+
+  await prisma.session.update({
+    where: { id: hashedId },
+    data: { lastUsedAt: new Date(), expiresAt: capped },
+  });
+}
+
+export async function revokeSession(rawOrHashed: string, opts: { hashed?: boolean } = {}): Promise<void> {
+  const id = opts.hashed ? rawOrHashed : hashSessionId(rawOrHashed);
+  await prisma.session.updateMany({
+    where: { id, revokedAt: null },
+    data: { revokedAt: new Date() },
+  });
+}
+
+export async function revokeAllForUser(userId: string): Promise<number> {
+  const res = await prisma.session.updateMany({
+    where: { userId, revokedAt: null },
+    data: { revokedAt: new Date() },
+  });
+  return res.count;
+}
+
+// Ships now; takes effect once OAuthGrant lands and grantId is populated.
+export async function revokeAllForGrant(grantId: string): Promise<number> {
+  const res = await prisma.session.updateMany({
+    where: { grantId, revokedAt: null },
+    data: { revokedAt: new Date() },
+  });
+  return res.count;
+}

--- a/dali-api/app/members/routes/members.tsx
+++ b/dali-api/app/members/routes/members.tsx
@@ -1,15 +1,15 @@
 import { redirect } from "react-router";
 import type { Route } from "./+types/members";
-import { requireAuth, withAuth } from "~/lib/auth";
+import { requireAuth } from "~/lib/auth";
 import { ComingSoon } from "~/components/ComingSoon";
 
 export const meta: Route.MetaFunction = () => [{ title: "Members · DALI OS" }];
 
 export async function loader({ request }: Route.LoaderArgs) {
   const auth = await requireAuth(request);
-  if (!auth.ok) return withAuth(auth, redirect("/login"));
-  if (auth.user.type === "applicant") return withAuth(auth, redirect("/portal"));
-  return withAuth(auth, null);
+  if (!auth.ok) return redirect("/login");
+  if (auth.user.type === "applicant") return redirect("/portal");
+  return null;
 }
 
 export default function MembersDirectory() {

--- a/dali-api/app/members/routes/users.$id.ts
+++ b/dali-api/app/members/routes/users.$id.ts
@@ -1,6 +1,6 @@
 import type { Route } from "./+types/users.$id";
 import { prisma } from "~/lib/db";
-import { requireAuth, withAuth } from "~/lib/auth";
+import { requireAuth } from "~/lib/auth";
 import { withCors, handlePreflight } from "~/lib/cors";
 
 
@@ -13,7 +13,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 
   // users can only access their own data
   if (auth.user.sub !== params.id) {
-    return withAuth(auth, withCors(request, Response.json({ error: "Forbidden" }, { status: 403 })));
+    return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
   }
 
   const user = await prisma.user.findUnique({
@@ -21,8 +21,8 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   });
 
   if (!user) {
-    return withAuth(auth, withCors(request, Response.json({ error: "User not found" }, { status: 404 })));
+    return withCors(request, Response.json({ error: "User not found" }, { status: 404 }));
   }
 
-  return withAuth(auth, withCors(request, Response.json(user)));
+  return withCors(request, Response.json(user));
 }

--- a/dali-api/app/partners/routes/partners.tsx
+++ b/dali-api/app/partners/routes/partners.tsx
@@ -1,15 +1,15 @@
 import { redirect } from "react-router";
 import type { Route } from "./+types/partners";
-import { requireAuth, withAuth } from "~/lib/auth";
+import { requireAuth } from "~/lib/auth";
 import { ComingSoon } from "~/components/ComingSoon";
 
 export const meta: Route.MetaFunction = () => [{ title: "Partners · DALI OS" }];
 
 export async function loader({ request }: Route.LoaderArgs) {
   const auth = await requireAuth(request);
-  if (!auth.ok) return withAuth(auth, redirect("/login"));
-  if (auth.user.type === "applicant") return withAuth(auth, redirect("/portal"));
-  return withAuth(auth, null);
+  if (!auth.ok) return redirect("/login");
+  if (auth.user.type === "applicant") return redirect("/portal");
+  return null;
 }
 
 export default function PartnersOrganizations() {

--- a/dali-api/app/projects/routes/projects.list.tsx
+++ b/dali-api/app/projects/routes/projects.list.tsx
@@ -1,15 +1,15 @@
 import { redirect } from "react-router";
 import type { Route } from "./+types/projects.list";
-import { requireAuth, withAuth } from "~/lib/auth";
+import { requireAuth } from "~/lib/auth";
 import { ComingSoon } from "~/components/ComingSoon";
 
 export const meta: Route.MetaFunction = () => [{ title: "Projects · DALI OS" }];
 
 export async function loader({ request }: Route.LoaderArgs) {
   const auth = await requireAuth(request);
-  if (!auth.ok) return withAuth(auth, redirect("/login"));
-  if (auth.user.type === "applicant") return withAuth(auth, redirect("/portal"));
-  return withAuth(auth, null);
+  if (!auth.ok) return redirect("/login");
+  if (auth.user.type === "applicant") return redirect("/portal");
+  return null;
 }
 
 export default function ProjectsList() {

--- a/dali-api/app/projects/routes/projects.staffing.tsx
+++ b/dali-api/app/projects/routes/projects.staffing.tsx
@@ -1,15 +1,15 @@
 import { redirect } from "react-router";
 import type { Route } from "./+types/projects.staffing";
-import { requireAuth, withAuth } from "~/lib/auth";
+import { requireAuth } from "~/lib/auth";
 import { ComingSoon } from "~/components/ComingSoon";
 
 export const meta: Route.MetaFunction = () => [{ title: "Staffing · DALI OS" }];
 
 export async function loader({ request }: Route.LoaderArgs) {
   const auth = await requireAuth(request);
-  if (!auth.ok) return withAuth(auth, redirect("/login"));
-  if (auth.user.type === "applicant") return withAuth(auth, redirect("/portal"));
-  return withAuth(auth, null);
+  if (!auth.ok) return redirect("/login");
+  if (auth.user.type === "applicant") return redirect("/portal");
+  return null;
 }
 
 export default function ProjectsStaffing() {

--- a/dali-api/app/routes/__tests__/api.email.send.test.ts
+++ b/dali-api/app/routes/__tests__/api.email.send.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 
 vi.mock("~/lib/auth", () => ({
   requireAuth: vi.fn(),
-  withAuth: <T,>(_auth: unknown, value: T) => value,
 }));
 vi.mock("~/lib/db");
 vi.mock("~/lib/gmail", () => ({

--- a/dali-api/app/routes/__tests__/api.upload.presign.test.ts
+++ b/dali-api/app/routes/__tests__/api.upload.presign.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 
 vi.mock("~/lib/auth", () => ({
   requireAuth: vi.fn(),
-  withAuth: <T,>(_auth: unknown, value: T) => value,
 }));
 vi.mock("~/lib/s3", () => ({
   getUploadPost: vi.fn(),

--- a/dali-api/app/routes/__tests__/portal.application.withdraw.test.ts
+++ b/dali-api/app/routes/__tests__/portal.application.withdraw.test.ts
@@ -3,7 +3,6 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 vi.mock("~/lib/db");
 vi.mock("~/lib/auth", () => ({
   requireAuth: vi.fn(),
-  withAuth: <T,>(_auth: unknown, value: T) => value,
 }));
 vi.mock("~/hiring/lib/cycles");
 vi.mock("~/lib/s3", () => ({

--- a/dali-api/app/routes/__tests__/portal.apply.test.ts
+++ b/dali-api/app/routes/__tests__/portal.apply.test.ts
@@ -3,7 +3,6 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 vi.mock("~/lib/db");
 vi.mock("~/lib/auth", () => ({
   requireAuth: vi.fn(),
-  withAuth: <T,>(_auth: unknown, value: T) => value,
 }));
 vi.mock("~/hiring/lib/cycles");
 vi.mock("~/hiring/lib/submission-check", () => ({

--- a/dali-api/app/routes/admin.authorize-gmail.callback.ts
+++ b/dali-api/app/routes/admin.authorize-gmail.callback.ts
@@ -2,7 +2,7 @@
 // Receives the Google OAuth callback, exchanges the code for tokens,
 // and stores the refresh token on the applications@dali.dartmouth.edu user row.
 
-import { requireAuth, withAuth } from '~/lib/auth'
+import { requireAuth } from "~/lib/auth";
 import { isHiringLead } from '~/lib/roles'
 import { prisma } from '~/lib/db'
 
@@ -22,11 +22,11 @@ function parseCookies(request: Request): Record<string, string> {
 export async function loader({ request }: { request: Request }) {
   const auth = await requireAuth(request)
   if (!auth.ok) {
-    return withAuth(auth, new Response(null, { status: 302, headers: { Location: '/login' } }))
+    return new Response(null, { status: 302, headers: { Location: '/login' } })
   }
 
   if (!(await isHiringLead(auth.user.sub))) {
-    return withAuth(auth, new Response(null, { status: 302, headers: { Location: '/' } }))
+    return new Response(null, { status: 302, headers: { Location: '/' } })
   }
 
   const url = new URL(request.url)
@@ -41,19 +41,19 @@ export async function loader({ request }: { request: Request }) {
   const clearCookie = `${GMAIL_STATE_COOKIE}=; Path=/admin/authorize-gmail; Max-Age=0; HttpOnly; SameSite=Lax`
 
   if (error || !code || !state) {
-    return withAuth(auth, new Response(null, {
+    return new Response(null, {
           status: 302,
           headers: { 'Set-Cookie': clearCookie, Location: '/hiring/emails?gmail_error=auth_failed' },
-        }))
+        })
   }
 
   // CSRF check
   const cookies = parseCookies(request)
   if (cookies[GMAIL_STATE_COOKIE] !== state) {
-    return withAuth(auth, new Response(null, {
+    return new Response(null, {
           status: 302,
           headers: { 'Set-Cookie': clearCookie, Location: '/hiring/emails?gmail_error=state_mismatch' },
-        }))
+        })
   }
 
   // Exchange code for tokens
@@ -71,20 +71,20 @@ export async function loader({ request }: { request: Request }) {
 
   if (!tokenRes.ok) {
     console.error('Gmail token exchange failed:', await tokenRes.text())
-    return withAuth(auth, new Response(null, {
+    return new Response(null, {
           status: 302,
           headers: { 'Set-Cookie': clearCookie, Location: '/hiring/emails?gmail_error=token_exchange_failed' },
-        }))
+        })
   }
 
   const tokens = await tokenRes.json()
   const refreshToken = tokens.refresh_token as string | undefined
 
   if (!refreshToken) {
-    return withAuth(auth, new Response(null, {
+    return new Response(null, {
           status: 302,
           headers: { 'Set-Cookie': clearCookie, Location: '/hiring/emails?gmail_error=no_refresh_token' },
-        }))
+        })
   }
 
   // Store the refresh token on the applications@ user row (upsert in case it doesn't exist yet)
@@ -109,8 +109,8 @@ export async function loader({ request }: { request: Request }) {
     },
   })
 
-  return withAuth(auth, new Response(null, {
+  return new Response(null, {
       status: 302,
       headers: { 'Set-Cookie': clearCookie, Location: '/hiring/emails?gmail_authorized=1' },
-    }))
+    })
 }

--- a/dali-api/app/routes/admin.authorize-gmail.ts
+++ b/dali-api/app/routes/admin.authorize-gmail.ts
@@ -3,7 +3,7 @@
 // Must be visited while logged in as an admin.
 // After Google redirects back, /admin/authorize-gmail/callback stores the refresh token.
 
-import { requireAuth, withAuth } from '~/lib/auth'
+import { requireAuth } from "~/lib/auth";
 import { isHiringLead } from '~/lib/roles'
 import { randomBytes } from 'node:crypto'
 
@@ -19,11 +19,11 @@ const SCOPES = [
 export async function loader({ request }: { request: Request }) {
   const auth = await requireAuth(request)
   if (!auth.ok) {
-    return withAuth(auth, new Response(null, { status: 302, headers: { Location: '/login' } }))
+    return new Response(null, { status: 302, headers: { Location: '/login' } })
   }
 
   if (!(await isHiringLead(auth.user.sub))) {
-    return withAuth(auth, new Response(null, { status: 302, headers: { Location: '/' } }))
+    return new Response(null, { status: 302, headers: { Location: '/' } })
   }
 
   const apiBase = process.env.API_BASE_URL ?? 'http://localhost:3001'
@@ -43,11 +43,11 @@ export async function loader({ request }: { request: Request }) {
 
   const stateCookie = `${GMAIL_STATE_COOKIE}=${state}; Path=/admin/authorize-gmail; Max-Age=600; HttpOnly; SameSite=Lax`
 
-  return withAuth(auth, new Response(null, {
+  return new Response(null, {
       status: 302,
       headers: {
         'Set-Cookie': stateCookie,
         Location: `https://accounts.google.com/o/oauth2/v2/auth?${params}`,
       },
-    }))
+    })
 }

--- a/dali-api/app/routes/api.check-url.ts
+++ b/dali-api/app/routes/api.check-url.ts
@@ -1,6 +1,6 @@
 import type { Route } from "./+types/api.check-url";
 import { z } from "zod";
-import { requireAuth, withAuth } from "~/lib/auth";
+import { requireAuth } from "~/lib/auth";
 import { checkGitHubUrl, checkFigmaUrl, checkDriveUrl } from "~/hiring/lib/submission-check";
 import { checkRateLimit } from "~/lib/rate-limit";
 import { parseJson } from "~/lib/validate";
@@ -18,10 +18,10 @@ export async function action({ request }: Route.ActionArgs) {
   if (!auth.ok) return auth.response;
 
   const userLimited = checkRateLimit(request, { max: RATE_LIMIT_MAX, windowMs: RATE_LIMIT_WINDOW_MS }, auth.user.sub);
-  if (userLimited) return withAuth(auth, userLimited);
+  if (userLimited) return userLimited;
 
   const body = await parseJson(request, CheckUrlSchema);
-  if (body instanceof Response) return withAuth(auth, body);
+  if (body instanceof Response) return body;
   const { url, type } = body;
 
   const result =
@@ -30,5 +30,5 @@ export async function action({ request }: Route.ActionArgs) {
       : type === "drive_url"
         ? await checkDriveUrl(url)
         : await checkGitHubUrl(url);
-  return withAuth(auth, Response.json(result));
+  return Response.json(result);
 }

--- a/dali-api/app/routes/api.collab.versions.$id.ts
+++ b/dali-api/app/routes/api.collab.versions.$id.ts
@@ -1,7 +1,7 @@
 import type { Route } from "./+types/api.collab.versions.$id";
 import { z } from "zod";
 import { prisma } from "~/lib/db";
-import { requireAuth, withAuth } from "~/lib/auth";
+import { requireAuth } from "~/lib/auth";
 import { authorizeCollabDoc, hydrateAuthors } from "~/lib/collabAuth";
 import { getCollabServer } from "~/collab/server";
 import { restoreVersion } from "~/collab/persistence";
@@ -27,17 +27,17 @@ export async function loader({ request, params }: Route.LoaderArgs) {
       authorIds: true,
     },
   });
-  if (!version) return withAuth(auth, Response.json({ error: "Not found" }, { status: 404 }));
+  if (!version) return Response.json({ error: "Not found" }, { status: 404 });
 
   const allowed = await authorizeCollabDoc(auth.user.sub, version.name);
-  if (!allowed) return withAuth(auth, Response.json({ error: "Forbidden" }, { status: 403 }));
+  if (!allowed) return Response.json({ error: "Forbidden" }, { status: 403 });
 
-  return withAuth(auth, Response.json({
+  return Response.json({
       id: version.id,
       createdAt: version.createdAt,
       plainText: version.plainText,
       authors: await hydrateAuthors(version.authorIds),
-    }));
+    });
 }
 
 // POST /api/collab/versions/{id}  body: { intent: "restore" }
@@ -52,22 +52,22 @@ export async function action({ request, params }: Route.ActionArgs) {
   if (!auth.ok) return auth.response;
 
   const body = await parseJson(request, RestoreSchema);
-  if (body instanceof Response) return withAuth(auth, body);
+  if (body instanceof Response) return body;
 
   const version = await prisma.collabDocumentVersion.findUnique({
     where: { id: params.id },
     select: { id: true, name: true },
   });
-  if (!version) return withAuth(auth, Response.json({ error: "Not found" }, { status: 404 }));
+  if (!version) return Response.json({ error: "Not found" }, { status: 404 });
 
   const allowed = await authorizeCollabDoc(auth.user.sub, version.name);
-  if (!allowed) return withAuth(auth, Response.json({ error: "Forbidden" }, { status: 403 }));
+  if (!allowed) return Response.json({ error: "Forbidden" }, { status: 403 });
 
   const server = getCollabServer();
   if (!server) {
-    return withAuth(auth, Response.json({ error: "Collab server not running" }, { status: 503 }));
+    return Response.json({ error: "Collab server not running" }, { status: 503 });
   }
 
   await restoreVersion(server, version.name, version.id);
-  return withAuth(auth, Response.json({ ok: true }));
+  return Response.json({ ok: true });
 }

--- a/dali-api/app/routes/api.collab.versions.ts
+++ b/dali-api/app/routes/api.collab.versions.ts
@@ -1,6 +1,6 @@
 import type { Route } from "./+types/api.collab.versions";
 import { prisma } from "~/lib/db";
-import { requireAuth, withAuth } from "~/lib/auth";
+import { requireAuth } from "~/lib/auth";
 import { authorizeCollabDoc, hydrateAuthors } from "~/lib/collabAuth";
 
 const PREVIEW_CHARS = 200;
@@ -15,11 +15,11 @@ export async function loader({ request }: Route.LoaderArgs) {
   const url = new URL(request.url);
   const name = url.searchParams.get("name");
   if (!name) {
-    return withAuth(auth, Response.json({ error: "name query param required" }, { status: 400 }));
+    return Response.json({ error: "name query param required" }, { status: 400 });
   }
 
   const allowed = await authorizeCollabDoc(auth.user.sub, name);
-  if (!allowed) return withAuth(auth, Response.json({ error: "Forbidden" }, { status: 403 }));
+  if (!allowed) return Response.json({ error: "Forbidden" }, { status: 403 });
 
   const versions = await prisma.collabDocumentVersion.findMany({
     where: { name },
@@ -33,7 +33,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   const authorList = await hydrateAuthors(Array.from(allAuthorIds));
   const authorsById = new Map(authorList.map((a) => [a.id, a]));
 
-  return withAuth(auth, Response.json(
+  return Response.json(
       versions.map((v) => ({
         id: v.id,
         createdAt: v.createdAt,
@@ -45,5 +45,5 @@ export async function loader({ request }: Route.LoaderArgs) {
           .map((id) => authorsById.get(id))
           .filter(Boolean),
       })),
-    ));
+    );
 }

--- a/dali-api/app/routes/api.email.send.ts
+++ b/dali-api/app/routes/api.email.send.ts
@@ -6,7 +6,7 @@
 //
 // Requires authenticated user.
 
-import { requireAuth, withAuth } from '~/lib/auth'
+import { requireAuth } from "~/lib/auth";
 import { prisma } from '~/lib/db'
 import { sendEmail } from '~/lib/gmail'
 import { logAuditEvent } from '~/lib/audit'
@@ -30,30 +30,30 @@ async function getGmailRefreshToken(): Promise<string> {
 
 export async function action({ request }: { request: Request }) {
   const auth = await requireAuth(request)
-  if (!auth.ok) return withAuth(auth, Response.json({ error: 'Unauthorized' }, { status: 401 }))
+  if (!auth.ok) return Response.json({ error: 'Unauthorized' }, { status: 401 })
 
   const limited = checkRateLimit(request, { max: RATE_LIMIT_MAX, windowMs: RATE_LIMIT_WINDOW_MS }, auth.user.sub)
-  if (limited) return withAuth(auth, limited)
+  if (limited) return limited
 
   let body: Record<string, unknown>
   try {
     body = await request.json()
   } catch {
-    return withAuth(auth, Response.json({ error: 'Invalid JSON body' }, { status: 400 }))
+    return Response.json({ error: 'Invalid JSON body' }, { status: 400 })
   }
 
   const { to, subject, html } = body as { to?: string; subject?: string; html?: string }
 
   if (!to || !subject || !html) {
-    return withAuth(auth, Response.json({ error: 'to, subject, and html are required' }, { status: 400 }))
+    return Response.json({ error: 'to, subject, and html are required' }, { status: 400 })
   }
 
   if (/[\r\n]/.test(to) || /[\r\n]/.test(subject)) {
-    return withAuth(auth, Response.json({ error: 'to and subject must not contain line breaks' }, { status: 400 }))
+    return Response.json({ error: 'to and subject must not contain line breaks' }, { status: 400 })
   }
 
   if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(to)) {
-    return withAuth(auth, Response.json({ error: 'Invalid recipient email' }, { status: 400 }))
+    return Response.json({ error: 'Invalid recipient email' }, { status: 400 })
   }
 
   try {
@@ -65,10 +65,10 @@ export async function action({ request }: { request: Request }) {
       metadata: { to, subject },
       request,
     })
-    return withAuth(auth, Response.json({ ok: true }))
+    return Response.json({ ok: true })
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err)
     console.error('Email send error:', message)
-    return withAuth(auth, Response.json({ error: message }, { status: 500 }))
+    return Response.json({ error: message }, { status: 500 })
   }
 }

--- a/dali-api/app/routes/api.upload.presign.ts
+++ b/dali-api/app/routes/api.upload.presign.ts
@@ -7,7 +7,7 @@
 // signed policy, so a malicious client cannot exceed the size cap.
 // After upload, store the key in the DB and use GET /api/upload/url?key=... to read it.
 
-import { requireAuth, withAuth } from '~/lib/auth'
+import { requireAuth } from "~/lib/auth";
 import { getUploadPost } from '~/lib/s3'
 import {
   MAX_UPLOAD_BYTES,
@@ -60,25 +60,25 @@ function filenameFromKey(key: string): string {
 export async function action({ request }: { request: Request }) {
   try {
     const auth = await requireAuth(request)
-    if (!auth.ok) return withAuth(auth, Response.json({ error: 'Unauthorized' }, { status: 401 }))
+    if (!auth.ok) return Response.json({ error: 'Unauthorized' }, { status: 401 })
 
     const rateLimited = checkRateLimit(
       request,
       { max: RATE_LIMIT_MAX, windowMs: RATE_LIMIT_WINDOW_MS },
       auth.user.sub,
     )
-    if (rateLimited) return withAuth(auth, rateLimited)
+    if (rateLimited) return rateLimited
 
     const { key, contentType, contentLength, accept } = await request.json()
 
     if (!key || typeof key !== 'string') {
-      return withAuth(auth, Response.json({ error: 'key is required' }, { status: 400 }))
+      return Response.json({ error: 'key is required' }, { status: 400 })
     }
     if (!contentType || typeof contentType !== 'string') {
-      return withAuth(auth, Response.json({ error: 'contentType is required' }, { status: 400 }))
+      return Response.json({ error: 'contentType is required' }, { status: 400 })
     }
     if (accept !== undefined && typeof accept !== 'string') {
-      return withAuth(auth, Response.json({ error: 'accept must be a string' }, { status: 400 }))
+      return Response.json({ error: 'accept must be a string' }, { status: 400 })
     }
 
     const fileName = filenameFromKey(key)
@@ -86,27 +86,27 @@ export async function action({ request }: { request: Request }) {
     const lowerType = contentType.toLowerCase()
 
     if (BLOCKED_TYPES.has(lowerType) || (ext && BLOCKED_EXTENSIONS.has(ext))) {
-      return withAuth(auth, Response.json({ error: 'File type not allowed' }, { status: 400 }))
+      return Response.json({ error: 'File type not allowed' }, { status: 400 })
     }
 
     if (accept && !fileMatchesAccept(fileName, contentType, accept)) {
-      return withAuth(auth, Response.json(
+      return Response.json(
               { error: `File type not allowed. Accepted: ${accept}` },
               { status: 400 },
-            ))
+            )
     }
     // Cheap pre-check that returns a clean 413 before signing. The presigned
     // POST policy below also enforces the size cap server-side, so this is
     // only for UX — the client cannot bypass the real limit.
     if (contentLength !== undefined) {
       if (typeof contentLength !== 'number' || !Number.isFinite(contentLength) || contentLength < 0) {
-        return withAuth(auth, Response.json({ error: 'contentLength must be a non-negative number' }, { status: 400 }))
+        return Response.json({ error: 'contentLength must be a non-negative number' }, { status: 400 })
       }
       if (contentLength > MAX_UPLOAD_BYTES) {
-        return withAuth(auth, Response.json(
+        return Response.json(
                   { error: `File too large (max ${MAX_UPLOAD_LABEL})` },
                   { status: 413 },
-                ))
+                )
       }
     }
 
@@ -114,7 +114,7 @@ export async function action({ request }: { request: Request }) {
     const scopedKey = key.startsWith('uploads/') ? key : `uploads/${key}`
 
     const { url, fields } = await getUploadPost(scopedKey, contentType)
-    return withAuth(auth, Response.json({ url, fields, key: scopedKey }))
+    return Response.json({ url, fields, key: scopedKey })
   } catch (err) {
     console.error('Upload presign error:', err)
     return Response.json(

--- a/dali-api/app/routes/api.upload.url.ts
+++ b/dali-api/app/routes/api.upload.url.ts
@@ -1,16 +1,16 @@
 // GET /api/upload/url?key=uploads/projects/abc/poster.png
 // Returns: { url: string } — a presigned S3 read URL valid for 1 hour
 
-import { requireAuth, withAuth } from '~/lib/auth'
+import { requireAuth } from "~/lib/auth";
 import { getDownloadUrl } from '~/lib/s3'
 
 export async function loader({ request }: { request: Request }) {
   const auth = await requireAuth(request)
-  if (!auth.ok) return withAuth(auth, Response.json({ error: 'Unauthorized' }, { status: 401 }))
+  if (!auth.ok) return Response.json({ error: 'Unauthorized' }, { status: 401 })
 
   const key = new URL(request.url).searchParams.get('key')
-  if (!key) return withAuth(auth, Response.json({ error: 'key query param is required' }, { status: 400 }))
+  if (!key) return Response.json({ error: 'key query param is required' }, { status: 400 })
 
   const url = await getDownloadUrl(key)
-  return withAuth(auth, Response.json({ url }))
+  return Response.json({ url })
 }

--- a/dali-api/app/routes/applicant-layout.tsx
+++ b/dali-api/app/routes/applicant-layout.tsx
@@ -1,13 +1,13 @@
 import { Outlet, redirect, useLoaderData, Link } from "react-router";
 import type { Route } from "./+types/applicant-layout";
-import { requireAuth, withAuth } from "~/lib/auth";
+import { requireAuth } from "~/lib/auth";
 import { userInitials } from "~/lib/display";
 import { ApplicantErrorBoundary } from "~/components/ApplicantErrorBoundary";
 
 export async function loader({ request }: Route.LoaderArgs) {
   const auth = await requireAuth(request);
-  if (!auth.ok) return withAuth(auth, redirect("/login"));
-  return withAuth(auth, { user: auth.user });
+  if (!auth.ok) return redirect("/login");
+  return { user: auth.user };
 }
 
 export default function ApplicantLayout() {

--- a/dali-api/app/routes/auth.callback.cas.ts
+++ b/dali-api/app/routes/auth.callback.cas.ts
@@ -1,8 +1,9 @@
 import type { Route } from "./+types/auth.callback.cas";
 import { prisma } from "~/lib/db";
 import { validateCasTicket } from "~/lib/auth";
-import { issueTokens } from "~/lib/oauth";
-import { setTokenCookies } from "~/lib/cookies";
+import { issueSession } from "~/lib/session";
+import { setSessionCookie } from "~/lib/cookies";
+import { getClientIp } from "~/lib/request-meta";
 import { logAuditEvent } from "~/lib/audit";
 
 export async function action() {
@@ -60,8 +61,12 @@ export async function loader({ request }: Route.LoaderArgs) {
     },
   });
 
-  // Issue tokens and set cookies
-  const tokens = await issueTokens(user.id, "dartmouth");
+  // Issue session and set cookie
+  const session = await issueSession({
+    userId: user.id,
+    userAgent: request.headers.get("user-agent") ?? undefined,
+    ip: getClientIp(request),
+  });
   await logAuditEvent({
     action: "login.success",
     userId: user.id,
@@ -73,7 +78,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     request,
   });
   const headers = new Headers();
-  setTokenCookies(headers, tokens.access_token, tokens.refresh_token);
+  setSessionCookie(headers, session.rawId);
   headers.set("Location", "/portal");
 
   return new Response(null, { status: 302, headers });

--- a/dali-api/app/routes/auth.callback.google.ts
+++ b/dali-api/app/routes/auth.callback.google.ts
@@ -1,9 +1,11 @@
 import type { Route } from "./+types/auth.callback.google";
 import { prisma } from "~/lib/db";
-import { exchangeGoogleCode, issueTokens } from "~/lib/oauth";
-import { setTokenCookies } from "~/lib/cookies";
+import { exchangeGoogleCode } from "~/lib/oauth";
+import { issueSession } from "~/lib/session";
+import { setSessionCookie } from "~/lib/cookies";
+import { getClientIp } from "~/lib/request-meta";
 import { logAuditEvent } from "~/lib/audit";
-import { requireAuth, withAuth } from "~/lib/auth";
+import { requireAuth } from "~/lib/auth";
 import { CAL_STATE_PREFIX } from "~/routes/oauth.calendar.google.start";
 import { handleCalendarLinkCallback } from "~/routes/oauth.calendar.google.callback";
 
@@ -37,19 +39,16 @@ export async function loader({ request }: Route.LoaderArgs) {
   if (state?.startsWith(CAL_STATE_PREFIX)) {
     const auth = await requireAuth(request);
     if (!auth.ok) {
-      return withAuth(auth, new Response(null, { status: 302, headers: { Location: "/login" } }));
+      return new Response(null, { status: 302, headers: { Location: "/login" } });
     }
     if (auth.user.type === "applicant") {
-      return withAuth(auth, new Response(null, { status: 302, headers: { Location: "/portal" } }));
+      return new Response(null, { status: 302, headers: { Location: "/portal" } });
     }
     if (googleError || !code) {
-      return withAuth(
-        auth,
-        new Response(null, {
+      return new Response(null, {
           status: 302,
           headers: { Location: "/calendar?calendar_link_error=auth_failed" },
-        }),
-      );
+        });
     }
     const response = await handleCalendarLinkCallback({
       request,
@@ -57,7 +56,7 @@ export async function loader({ request }: Route.LoaderArgs) {
       code,
       state,
     });
-    return withAuth(auth, response);
+    return response;
   }
 
   if (googleError || !code || !state) {
@@ -206,8 +205,12 @@ export async function loader({ request }: Route.LoaderArgs) {
     redirectTo = "/portal";
   }
 
-  // Issue tokens and set cookies
-  const tokens = await issueTokens(user.id, authType);
+  // Issue session and set cookie
+  const session = await issueSession({
+    userId: user.id,
+    userAgent: request.headers.get("user-agent") ?? undefined,
+    ip: getClientIp(request),
+  });
   await logAuditEvent({
     action: "login.success",
     userId: user.id,
@@ -221,7 +224,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   const headers = new Headers();
   headers.append("Set-Cookie", clearStateCookie);
   headers.append("Set-Cookie", clearAccountTypeCookie);
-  setTokenCookies(headers, tokens.access_token, tokens.refresh_token);
+  setSessionCookie(headers, session.rawId);
   headers.set("Location", redirectTo);
 
   return new Response(null, { status: 302, headers });

--- a/dali-api/app/routes/dev-login-as.ts
+++ b/dali-api/app/routes/dev-login-as.ts
@@ -1,12 +1,13 @@
-// DEV-ONLY: log in as any existing user by netId. Sets both __dali_at (api JWT)
-// and __dali_user (web display) cookies via Set-Cookie headers so it overwrites
-// any existing HttpOnly cookies from real OAuth sessions.
+// DEV-ONLY: log in as any existing user by netId or daliEmail. Sets the
+// __dali_sid session cookie via Set-Cookie so it overwrites any existing
+// cookie from a real OAuth session.
 //
 // Usage: GET /dev-login-as?netId=f007al1&redirect=http://localhost:5173/portal
 
 import type { Route } from "./+types/dev-login-as";
-import { signAccessToken } from "~/lib/auth";
 import { isDevLoginEnabled } from "~/lib/dev-login";
+import { issueSession } from "~/lib/session";
+import { setSessionCookie } from "~/lib/cookies";
 import { prisma } from "~/lib/db";
 
 export async function loader({ request }: Route.LoaderArgs) {
@@ -34,13 +35,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   const email = user.daliEmail ?? user.dartmouthEmail ?? "";
   const type = user.daliEmail ? "member" : "applicant";
 
-  const token = await signAccessToken({
-    sub: user.id,
-    email,
-    type,
-    firstName: user.firstName,
-    lastName: user.lastName,
-  });
+  const session = await issueSession({ userId: user.id });
 
   const userPayload = JSON.stringify({
     id: user.id,
@@ -54,11 +49,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     ? redirect
     : type === "member" ? "http://localhost:3001/" : "http://localhost:3001/portal";
   const headers = new Headers({ Location: finalRedirect });
-  // __dali_at: api auth (HttpOnly so JS can't read; server-set overwrites any existing)
-  headers.append(
-    "Set-Cookie",
-    `__dali_at=${token}; Path=/; Max-Age=86400; HttpOnly; SameSite=Lax`,
-  );
+  setSessionCookie(headers, session.rawId);
   // __dali_user: web display (NOT HttpOnly so client JS can read it)
   headers.append(
     "Set-Cookie",

--- a/dali-api/app/routes/dev-login.ts
+++ b/dali-api/app/routes/dev-login.ts
@@ -3,8 +3,9 @@
 // This route should never exist in production.
 
 import type { Route } from "./+types/dev-login";
-import { signAccessToken } from "~/lib/auth";
 import { isDevLoginEnabled } from "~/lib/dev-login";
+import { issueSession } from "~/lib/session";
+import { setSessionCookie } from "~/lib/cookies";
 import { prisma } from "~/lib/db";
 
 export async function loader({ request }: Route.LoaderArgs) {
@@ -141,30 +142,16 @@ export async function loader({ request }: Route.LoaderArgs) {
 }
 
 async function loginAsUser(user: { id: string; daliEmail: string | null; dartmouthEmail: string | null; firstName: string; lastName: string }) {
-  const email = user.daliEmail ?? user.dartmouthEmail ?? "";
   const type = user.daliEmail ? "member" : "applicant";
 
-  const token = await signAccessToken({
-    sub: user.id,
-    email,
-    type,
-    firstName: user.firstName,
-    lastName: user.lastName,
-  });
+  const session = await issueSession({ userId: user.id });
 
-  const cookie = [
-    `__dali_at=${token}`,
-    "Max-Age=86400",
-    "Path=/",
-    "HttpOnly",
-    "SameSite=Lax",
-  ].join("; ");
+  const headers = new Headers();
+  setSessionCookie(headers, session.rawId);
 
   const redirect = type === "member" ? "/" : "/portal";
-  return new Response(null, {
-    status: 302,
-    headers: { "Set-Cookie": cookie, Location: redirect },
-  });
+  headers.set("Location", redirect);
+  return new Response(null, { status: 302, headers });
 }
 
 function renderSection(title: string, cards: string[]): string {

--- a/dali-api/app/routes/home.tsx
+++ b/dali-api/app/routes/home.tsx
@@ -7,14 +7,14 @@ import {
   ChevronLeft,
   ChevronRight,
 } from "lucide-react";
-import { requireAuth, withAuth } from "~/lib/auth";
+import { requireAuth } from "~/lib/auth";
 import type { Route } from "./+types/home";
 
 export async function loader({ request }: Route.LoaderArgs) {
   const auth = await requireAuth(request);
-  if (!auth.ok) return withAuth(auth, redirect("/login"));
-  if (auth.user.type === "applicant") return withAuth(auth, redirect("/portal"));
-  return withAuth(auth, { user: auth.user });
+  if (!auth.ok) return redirect("/login");
+  if (auth.user.type === "applicant") return redirect("/portal");
+  return { user: auth.user };
 }
 
 export default function Home() {

--- a/dali-api/app/routes/layout.tsx
+++ b/dali-api/app/routes/layout.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { Outlet, redirect, useLoaderData, useSearchParams } from 'react-router'
 import { Layout } from '~/components/Layout'
-import { requireAuth, withAuth } from '~/lib/auth'
+import { requireAuth } from "~/lib/auth";
 import { getUserRoles } from '~/lib/roles'
 import { getActiveCycle } from '~/hiring/lib/cycles'
 import { prisma } from '~/lib/db'
@@ -9,8 +9,8 @@ import type { Route } from './+types/layout'
 
 export async function loader({ request }: Route.LoaderArgs) {
   const auth = await requireAuth(request)
-  if (!auth.ok) return withAuth(auth, redirect('/login'))
-  if (auth.user.type === 'applicant') return withAuth(auth, redirect('/portal'))
+  if (!auth.ok) return redirect('/login')
+  if (auth.user.type === 'applicant') return redirect('/portal')
   const { memberId, isHiringLead: hiringLead, isAdmin: admin, isDomainLead: domainLead } = await getUserRoles(auth.user.sub)
 
   let isInterviewer = false
@@ -30,7 +30,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   const fetchDest = request.headers.get('sec-fetch-dest')
   const isEmbedded = fetchDest === 'iframe' || fetchDest === 'frame'
 
-  return withAuth(auth, { user: auth.user, isHiringLead: hiringLead, isAdmin: admin, isDomainLead: domainLead, isInterviewer, isEmbedded })
+  return { user: auth.user, isHiringLead: hiringLead, isAdmin: admin, isDomainLead: domainLead, isInterviewer, isEmbedded }
 }
 
 export default function AppLayoutRoute() {

--- a/dali-api/app/routes/login.tsx
+++ b/dali-api/app/routes/login.tsx
@@ -1,7 +1,7 @@
 import { randomBytes } from "node:crypto";
 import { Form, redirect, useSearchParams } from "react-router";
 import type { Route } from "./+types/login";
-import { requireAuth, withAuth } from "~/lib/auth";
+import { requireAuth } from "~/lib/auth";
 import { checkRateLimit } from "~/lib/rate-limit";
 
 const OAUTH_STATE_COOKIE = "__dali_oauth_state";
@@ -16,10 +16,10 @@ export async function loader({ request }: Route.LoaderArgs) {
   const auth = await requireAuth(request);
   if (auth.ok) {
     // Route based on user type: members go to admin, others to portal
-    if (auth.user.type === "member") return withAuth(auth, redirect("/hiring/reviewer"));
-    return withAuth(auth, redirect("/portal"));
+    if (auth.user.type === "member") return redirect("/hiring/reviewer");
+    return redirect("/portal");
   }
-  return withAuth(auth, {});
+  return {};
 }
 
 export async function action({ request }: Route.ActionArgs) {

--- a/dali-api/app/routes/logout.ts
+++ b/dali-api/app/routes/logout.ts
@@ -1,21 +1,23 @@
 import type { Route } from "./+types/logout";
-import { clearTokenCookies, parseAccessToken } from "~/lib/cookies";
-import { verifyAccessToken } from "~/lib/auth";
+import { clearSessionCookie, parseSessionId } from "~/lib/cookies";
+import { hashSessionId, revokeSession } from "~/lib/session";
+import { prisma } from "~/lib/db";
 import { logAuditEvent } from "~/lib/audit";
 
 export async function loader({ request }: Route.LoaderArgs) {
-  // Best-effort attribution: decode the access token (if any) so we can
-  // record which user logged out. A failed/expired token still emits a
-  // logout event with userId=null.
+  // Best-effort attribution: look up the current session (if any) so we
+  // can record which user logged out. A missing/invalid session still
+  // emits a logout event with userId=null.
   let userId: string | null = null;
-  const token = parseAccessToken(request);
-  if (token) {
-    try {
-      const payload = await verifyAccessToken(token);
-      userId = payload.sub;
-    } catch {
-      userId = null;
-    }
+  const raw = parseSessionId(request);
+  if (raw) {
+    const id = hashSessionId(raw);
+    const session = await prisma.session.findUnique({
+      where: { id },
+      select: { userId: true },
+    });
+    if (session) userId = session.userId;
+    await revokeSession(id, { hashed: true });
   }
   await logAuditEvent({
     action: "logout",
@@ -24,7 +26,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   });
 
   const headers = new Headers();
-  clearTokenCookies(headers);
+  clearSessionCookie(headers);
   headers.set("Location", "/login");
   return new Response(null, { status: 302, headers });
 }

--- a/dali-api/app/routes/oauth.calendar.google.start.ts
+++ b/dali-api/app/routes/oauth.calendar.google.start.ts
@@ -6,7 +6,7 @@
 // to handleCalendarLinkCallback, which writes a UserCalendarLink for the
 // already-authenticated user.
 
-import { requireAuth, withAuth } from "~/lib/auth";
+import { requireAuth } from "~/lib/auth";
 import { randomBytes } from "node:crypto";
 
 export const CAL_STATE_COOKIE = "__dali_cal_oauth_state";
@@ -21,16 +21,16 @@ const SCOPES = [
 export async function loader({ request }: { request: Request }) {
   const auth = await requireAuth(request);
   if (!auth.ok) {
-    return withAuth(auth, new Response(null, { status: 302, headers: { Location: "/login" } }));
+    return new Response(null, { status: 302, headers: { Location: "/login" } });
   }
   if (auth.user.type === "applicant") {
-    return withAuth(auth, new Response(null, { status: 302, headers: { Location: "/portal" } }));
+    return new Response(null, { status: 302, headers: { Location: "/portal" } });
   }
 
   const apiBase = process.env.API_BASE_URL ?? "http://localhost:3001";
   const clientId = process.env.GOOGLE_CLIENT_ID;
   if (!clientId) {
-    return withAuth(auth, new Response("GOOGLE_CLIENT_ID not configured", { status: 500 }));
+    return new Response("GOOGLE_CLIENT_ID not configured", { status: 500 });
   }
 
   const nonce = randomBytes(16).toString("hex");
@@ -50,14 +50,11 @@ export async function loader({ request }: { request: Request }) {
   // Use Path=/ so the cookie is sent on /auth/callback/google too.
   const stateCookie = `${CAL_STATE_COOKIE}=${nonce}; Path=/; Max-Age=600; HttpOnly; SameSite=Lax`;
 
-  return withAuth(
-    auth,
-    new Response(null, {
+  return new Response(null, {
       status: 302,
       headers: {
         "Set-Cookie": stateCookie,
         Location: `https://accounts.google.com/o/oauth2/v2/auth?${params}`,
       },
-    }),
-  );
+    });
 }

--- a/dali-api/app/routes/oauth.revoke.ts
+++ b/dali-api/app/routes/oauth.revoke.ts
@@ -1,7 +1,6 @@
 import type { Route } from "./+types/oauth.revoke";
-import { revokeToken } from "~/lib/oauth";
-
-import { clearTokenCookies, parseRefreshToken } from "~/lib/cookies";
+import { revokeSession } from "~/lib/session";
+import { clearSessionCookie, parseSessionId } from "~/lib/cookies";
 import { withCors, handlePreflight, preflightLoader } from "~/lib/cors";
 import { safeJson } from "~/lib/safe-json";
 
@@ -11,10 +10,9 @@ export async function action({ request }: Route.ActionArgs) {
   const preflight = handlePreflight(request);
   if (preflight) return preflight;
 
-  // read refresh token from cookie first, fall back to body
-  let token: string | undefined = parseRefreshToken(request) ?? undefined;
+  // Cookie or Bearer first, then fall back to body `token`.
+  let token: string | undefined = parseSessionId(request) ?? undefined;
 
-  // don't strictly need this yet but good to have support if we want to support API access later
   if (!token) {
     const contentType = request.headers.get("Content-Type") ?? "";
     if (contentType.includes("application/json")) {
@@ -28,10 +26,10 @@ export async function action({ request }: Route.ActionArgs) {
   }
 
   if (token) {
-    await revokeToken(token);
+    await revokeSession(token);
   }
 
   const res = Response.json({});
-  clearTokenCookies(res.headers);
+  clearSessionCookie(res.headers);
   return withCors(request, res);
 }

--- a/dali-api/app/routes/oauth.token.ts
+++ b/dali-api/app/routes/oauth.token.ts
@@ -1,16 +1,18 @@
 import type { Route } from "./+types/oauth.token";
 import {
   exchangeAuthorizationCode,
-  issueTokens,
-  refreshTokens,
+  buildUserInfo,
   OAuthError,
 } from "~/lib/oauth";
-
-import { setTokenCookies, parseRefreshToken } from "~/lib/cookies";
 import type { UserInfo } from "~/lib/oauth";
+
+import { setSessionCookie } from "~/lib/cookies";
+import { issueSession, ROLLING_TTL_MS } from "~/lib/session";
+import { getClientIp } from "~/lib/request-meta";
 import { withCors, handlePreflight, preflightLoader } from "~/lib/cors";
 import { checkRateLimit } from "~/lib/rate-limit";
 import { safeJson } from "~/lib/safe-json";
+import { prisma } from "~/lib/db";
 
 const RATE_LIMIT_MAX = 200;
 const RATE_LIMIT_WINDOW_MS = 60_000;
@@ -56,21 +58,29 @@ export async function action({ request }: Route.ActionArgs) {
 
       const authType =
         provider === "cas" ? "dartmouth" : (accountType ?? "member");
-      const tokens = await issueTokens(userId, authType);
 
-      return withCors(request, tokenResponse(tokens));
+      const user = await prisma.user.findUnique({ where: { id: userId } });
+      if (!user) throw new OAuthError("server_error", "User not found");
+
+      const session = await issueSession({
+        userId,
+        userAgent: request.headers.get("user-agent") ?? undefined,
+        ip: getClientIp(request),
+        // grantId plumbed through when OAuthGrant lands; for now sessions
+        // issued via the OAuth flow are not yet attributed to a grant row.
+      });
+
+      const userInfo = buildUserInfo(user, authType);
+
+      return withCors(
+        request,
+        tokenResponse(session.rawId, userInfo),
+      );
     }
 
-    if (grantType === "refresh_token") {
-      // read refresh token from cookie first, fall back to body
-      const refreshToken = parseRefreshToken(request) ?? body.refresh_token;
-      if (!refreshToken) {
-        throw new OAuthError("invalid_request", "refresh_token is required");
-      }
-
-      const tokens = await refreshTokens(refreshToken);
-      return withCors(request, tokenResponse(tokens));
-    }
+    // refresh_token grant intentionally removed. Sessions auto-extend on
+    // use (rolling TTL); MCP clients re-run the authorization flow when
+    // the bearer expires. See SESSION_AUTH_PLAN.md.
 
     throw new OAuthError(
       "unsupported_grant_type",
@@ -84,19 +94,14 @@ export async function action({ request }: Route.ActionArgs) {
   }
 }
 
-function tokenResponse(tokens: {
-  access_token: string;
-  token_type: string;
-  expires_in: number;
-  refresh_token: string;
-  userInfo: UserInfo;
-}) {
+function tokenResponse(rawSessionId: string, userInfo: UserInfo) {
+  const expiresIn = Math.floor(ROLLING_TTL_MS / 1000);
   const res = Response.json(
     {
-      access_token: tokens.access_token,
-      token_type: tokens.token_type,
-      expires_in: tokens.expires_in,
-      user: tokens.userInfo,
+      access_token: rawSessionId,
+      token_type: "Bearer",
+      expires_in: expiresIn,
+      user: userInfo,
     },
     {
       headers: {
@@ -106,6 +111,6 @@ function tokenResponse(tokens: {
     },
   );
 
-  setTokenCookies(res.headers, tokens.access_token, tokens.refresh_token);
+  setSessionCookie(res.headers, rawSessionId);
   return res;
 }

--- a/dali-api/app/routes/portal.application.tsx
+++ b/dali-api/app/routes/portal.application.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { redirect, useLoaderData, useFetcher, Link } from "react-router";
 import type { Route } from "./+types/portal.application";
 import { prisma } from "~/lib/db";
-import { requireAuth, withAuth } from "~/lib/auth";
+import { requireAuth } from "~/lib/auth";
 import { getActiveCycle } from "~/hiring/lib/cycles";
 import { presignAnswers } from "~/hiring/lib/presign";
 import type { Question } from "~/types";
@@ -17,7 +17,7 @@ export const meta: Route.MetaFunction = () => [{ title: "My application · DALI 
 
 export async function loader({ request }: Route.LoaderArgs) {
   const auth = await requireAuth(request);
-  if (!auth.ok) return withAuth(auth, redirect("/login"));
+  if (!auth.ok) return redirect("/login");
 
   const active = await getActiveCycle();
   let cycleId: string;
@@ -30,7 +30,7 @@ export async function loader({ request }: Route.LoaderArgs) {
       orderBy: { createdAt: "desc" },
       select: { applicationCycleId: true },
     });
-    if (!recentApp) return withAuth(auth, redirect("/portal"));
+    if (!recentApp) return redirect("/portal");
     cycleId = recentApp.applicationCycleId;
   }
 
@@ -53,7 +53,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   // Need at least one Submitted update to render this page. Withdrawn is allowed
   // (and renders the withdrawn-state view); Draft alone redirects back to /portal.
   const submittedUpdate = application?.statusUpdates.find((u: any) => u.newStatus === "Submitted");
-  if (!application || !submittedUpdate) return withAuth(auth, redirect("/portal"));
+  if (!application || !submittedUpdate) return redirect("/portal");
 
   const latestUpdate = application.statusUpdates[application.statusUpdates.length - 1];
   const isWithdrawn = latestUpdate?.newStatus === "Withdrawn";
@@ -78,14 +78,14 @@ export async function loader({ request }: Route.LoaderArgs) {
     }),
   );
 
-  return withAuth(auth, {
+  return {
       submittedAt: submittedUpdate.createdAt.toISOString(),
       withdrawnAt: withdrawnUpdate?.createdAt.toISOString() ?? null,
       canWithdraw,
       generalQuestions,
       generalAnswers,
       domains,
-    });
+    };
 }
 
 // ─── Action ──────────────────────────────────────────────────────────────────
@@ -98,12 +98,12 @@ export async function action({ request }: Route.ActionArgs) {
   const intent = formData.get("intent");
 
   if (intent !== "withdraw") {
-    return withAuth(auth, Response.json({ error: "Unknown intent" }, { status: 400 }));
+    return Response.json({ error: "Unknown intent" }, { status: 400 });
   }
 
   const active = await getActiveCycle();
   if (!active) {
-    return withAuth(auth, Response.json({ error: "No active cycle" }, { status: 400 }));
+    return Response.json({ error: "No active cycle" }, { status: 400 });
   }
 
   const application = await prisma.application.findFirst({
@@ -112,15 +112,15 @@ export async function action({ request }: Route.ActionArgs) {
   });
 
   if (!application) {
-    return withAuth(auth, Response.json({ error: "No application found" }, { status: 404 }));
+    return Response.json({ error: "No application found" }, { status: 404 });
   }
 
   const latest = application.statusUpdates[0]?.newStatus;
   if (latest !== "Submitted") {
-    return withAuth(auth, Response.json(
+    return Response.json(
           { error: latest === "Withdrawn" ? "Already withdrawn" : "Application is not submitted" },
           { status: 400 },
-        ));
+        );
   }
 
   const cancelledInterviews = await prisma.$transaction(async (tx) => {
@@ -160,7 +160,7 @@ export async function action({ request }: Route.ActionArgs) {
     sendInterviewCancelEmails(id, domainApplicationId).catch(() => {});
   }
 
-  return withAuth(auth, Response.json({ ok: true }));
+  return Response.json({ ok: true });
 }
 
 // ─── Domain section (collapsible) ────────────────────────────────────────────

--- a/dali-api/app/routes/portal.apply.tsx
+++ b/dali-api/app/routes/portal.apply.tsx
@@ -2,7 +2,7 @@ import { useState, useRef, useEffect, useCallback } from "react";
 import { redirect, useLoaderData, useFetcher } from "react-router";
 import type { Route } from "./+types/portal.apply";
 import { prisma } from "~/lib/db";
-import { requireAuth, withAuth } from "~/lib/auth";
+import { requireAuth } from "~/lib/auth";
 import { sendEmail } from "~/lib/gmail";
 import { renderForSlot, notificationSlot } from "~/hiring/lib/email-variables";
 import { getActiveCycle } from "~/hiring/lib/cycles";
@@ -29,11 +29,11 @@ const GMAIL_USER = "applications@dali.dartmouth.edu";
 
 export async function loader({ request }: Route.LoaderArgs) {
   const auth = await requireAuth(request);
-  if (!auth.ok) return withAuth(auth, redirect("/login"));
+  if (!auth.ok) return redirect("/login");
 
   const active = await getActiveCycle();
   if (!active || active.currentStatus !== "Open") {
-    return withAuth(auth, redirect("/portal"));
+    return redirect("/portal");
   }
 
   // Load cycle with its challenge versions and hiring domains
@@ -53,14 +53,14 @@ export async function loader({ request }: Route.LoaderArgs) {
     },
   });
 
-  if (!cycle) return withAuth(auth, redirect("/portal"));
+  if (!cycle) return redirect("/portal");
 
   // General form = ChallengeVersion with domainId: null linked to this cycle
   const generalCvac = cycle.challengeVersions.find(
     cvc => cvc.challengeVersion.domainId === null,
   );
 
-  if (!generalCvac) return withAuth(auth, redirect("/portal"));
+  if (!generalCvac) return redirect("/portal");
 
   const generalChallengeVersionId = generalCvac.challengeVersionId;
   const formQuestions = (generalCvac.challengeVersion.questions as unknown as Question[]) ?? [];
@@ -101,7 +101,7 @@ export async function loader({ request }: Route.LoaderArgs) {
 
   const draftStatus = draft?.statusUpdates[0]?.newStatus ?? null;
 
-  return withAuth(auth, {
+  return {
       cycleId: active.id,
       cycleName: active.name,
       closeDate: active.closeDate ? active.closeDate.toISOString() : null,
@@ -125,7 +125,7 @@ export async function loader({ request }: Route.LoaderArgs) {
             })),
           }
         : null,
-    });
+    };
 }
 
 // ─── Action ──────────────────────────────────────────────────────────────────
@@ -196,7 +196,7 @@ export async function action({ request }: Route.ActionArgs) {
       },
     });
 
-    return withAuth(auth, {
+    return {
           draft: {
             id: application.id,
             answers: application.answers,
@@ -210,7 +210,7 @@ export async function action({ request }: Route.ActionArgs) {
               answers: da.answers,
             })),
           },
-        });
+        };
   }
 
   if (intent === "update-domains") {
@@ -299,7 +299,7 @@ export async function action({ request }: Route.ActionArgs) {
       },
     });
 
-    return withAuth(auth, {
+    return {
           draft: updatedApp ? {
             id: updatedApp.id,
             answers: updatedApp.answers,
@@ -311,7 +311,7 @@ export async function action({ request }: Route.ActionArgs) {
               answers: da.answers,
             })),
           } : null,
-        });
+        };
   }
 
   if (intent === "save-draft") {
@@ -335,7 +335,7 @@ export async function action({ request }: Route.ActionArgs) {
       });
     }
 
-    return withAuth(auth, { saved: true });
+    return { saved: true };
   }
 
   if (intent === "submit") {
@@ -362,7 +362,7 @@ export async function action({ request }: Route.ActionArgs) {
       },
     });
     if (!application) {
-      return withAuth(auth, Response.json({ error: "Application not found" }, { status: 404 }));
+      return Response.json({ error: "Application not found" }, { status: 404 });
     }
     const generalQuestions =
       (application.generalChallengeVersion.questions as unknown as Question[]) ?? [];
@@ -384,7 +384,7 @@ export async function action({ request }: Route.ActionArgs) {
       Object.assign(wordCountErrors, validateWordLimits(questions, da.answers));
     }
     if (Object.keys(wordCountErrors).length > 0) {
-      return withAuth(auth, { wordCountErrors });
+      return { wordCountErrors };
     }
 
     // Required-question validation. Client gates the review modal on this, but
@@ -412,9 +412,9 @@ export async function action({ request }: Route.ActionArgs) {
       }
     }
     if (missingRequired.length > 0) {
-      return withAuth(auth, {
+      return {
         error: `Please answer all required questions before submitting (${missingRequired.length} unanswered).`,
-      });
+      };
     }
 
     // Save final answers
@@ -469,7 +469,7 @@ export async function action({ request }: Route.ActionArgs) {
     }
 
     if (Object.keys(urlWarnings).length > 0) {
-      return withAuth(auth, { urlWarnings });
+      return { urlWarnings };
     }
 
     // Create Submitted status update only on first submission
@@ -525,10 +525,10 @@ export async function action({ request }: Route.ActionArgs) {
 
     // Signal first-time submission so the portal can play a one-shot confetti.
     // Subsequent edit-saves keep the plain redirect so the animation does not replay.
-    return withAuth(auth, redirect(existingSubmitted ? "/portal" : "/portal?just-submitted=1"));
+    return redirect(existingSubmitted ? "/portal" : "/portal?just-submitted=1");
   }
 
-  return withAuth(auth, { error: "Unknown intent" });
+  return { error: "Unknown intent" };
 }
 
 // ─── Domain Colors ──────────────────────────────────────────────────────────

--- a/dali-api/app/routes/portal.tsx
+++ b/dali-api/app/routes/portal.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback } from "react";
 import { redirect, useLoaderData, useRevalidator, useSearchParams, Link } from "react-router";
 import type { Route } from "./+types/portal";
 import { prisma } from "~/lib/db";
-import { requireAuth, withAuth } from "~/lib/auth";
+import { requireAuth } from "~/lib/auth";
 import { getActiveCycle } from "~/hiring/lib/cycles";
 import { sendExtensionNoticeIfDue } from "~/hiring/lib/extension-notice";
 import {
@@ -22,7 +22,7 @@ export const meta: Route.MetaFunction = () => [{ title: "Applicant portal · DAL
 
 export async function loader({ request }: Route.LoaderArgs) {
   const auth = await requireAuth(request);
-  if (!auth.ok) return withAuth(auth, redirect("/login"));
+  if (!auth.ok) return redirect("/login");
 
   const emptyResult = {
     cycleName: null as string | null,
@@ -68,7 +68,7 @@ export async function loader({ request }: Route.LoaderArgs) {
       orderBy: { createdAt: "desc" },
     });
 
-    if (!recentApp) return withAuth(auth, emptyResult);
+    if (!recentApp) return emptyResult;
 
     cycleId = recentApp.applicationCycleId;
     cycleName = recentApp.applicationCycle.name;
@@ -131,7 +131,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     };
   });
 
-  return withAuth(auth, {
+  return {
       cycleName,
       cycleId,
       cycleStatus,
@@ -141,7 +141,7 @@ export async function loader({ request }: Route.LoaderArgs) {
       slotDurationMinutes: config?.slotDurationMinutes ?? 30,
       hasApplication: !!application,
       applicationStatus: appStatus,
-    });
+    };
 }
 
 // ─── Types ───────────────────────────────────────────────────────────────────

--- a/dali-api/package-lock.json
+++ b/dali-api/package-lock.json
@@ -31,7 +31,6 @@
         "ioredis": "^5.10.1",
         "isbot": "^5.1.36",
         "isomorphic-dompurify": "^3.10.0",
-        "jose": "^6.2.2",
         "lucide-react": "^0.544.0",
         "pg": "^8.20.0",
         "react": "^19.2.4",
@@ -7393,15 +7392,6 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
-      }
-    },
-    "node_modules/jose": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
-      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {

--- a/dali-api/package.json
+++ b/dali-api/package.json
@@ -43,7 +43,6 @@
     "ioredis": "^5.10.1",
     "isbot": "^5.1.36",
     "isomorphic-dompurify": "^3.10.0",
-    "jose": "^6.2.2",
     "lucide-react": "^0.544.0",
     "pg": "^8.20.0",
     "react": "^19.2.4",

--- a/dali-api/prisma/migrations/20260513231716_session_auth_refactor/migration.sql
+++ b/dali-api/prisma/migrations/20260513231716_session_auth_refactor/migration.sql
@@ -1,0 +1,39 @@
+-- Session auth refactor: replace JWT access tokens + rotating refresh tokens
+-- with a single opaque session-id model. See SESSION_AUTH_PLAN.md.
+--
+-- Data-losing for RefreshToken — everyone gets logged out once on deploy
+-- and re-logs in. Hard cutover is documented in the plan.
+
+-- DropForeignKey
+ALTER TABLE "RefreshToken" DROP CONSTRAINT IF EXISTS "RefreshToken_userId_fkey";
+
+-- DropTable
+DROP TABLE "RefreshToken";
+
+-- CreateTable
+CREATE TABLE "Session" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "grantId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastUsedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "absoluteExpiresAt" TIMESTAMP(3) NOT NULL,
+    "revokedAt" TIMESTAMP(3),
+    "userAgent" TEXT,
+    "ip" TEXT,
+
+    CONSTRAINT "Session_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Session_userId_revokedAt_idx" ON "Session"("userId", "revokedAt");
+
+-- CreateIndex
+CREATE INDEX "Session_grantId_idx" ON "Session"("grantId");
+
+-- CreateIndex
+CREATE INDEX "Session_expiresAt_idx" ON "Session"("expiresAt");
+
+-- AddForeignKey
+ALTER TABLE "Session" ADD CONSTRAINT "Session_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/dali-api/prisma/schema.prisma
+++ b/dali-api/prisma/schema.prisma
@@ -42,7 +42,7 @@ model User {
   applications                  Application[]
   applicationStatusUpdates      ApplicationStatusUpdate[]
   oauthSessions                 OAuthSession[]
-  refreshTokens                 RefreshToken[]
+  sessions                      Session[]
   rubricVersions                RubricVersion[]
   confidentialitySignatures     ConfidentialityAgreementSignature[]
 
@@ -673,17 +673,40 @@ model OAuthSession {
   user User? @relation(fields: [userId], references: [id], onDelete: Cascade)
 }
 
-model RefreshToken {
-  id              String    @id @default(cuid())
-  tokenHash       String    @unique // sha-256 token hash
-  userId          String
-  family          String // rotation detection
-  expiresAt       DateTime
-  revokedAt       DateTime?
-  createdAt       DateTime  @default(now())
-  familyCreatedAt DateTime  @default(now()) // absolute session cap anchor
+// Single-credential session record backing both browser cookie logins and
+// OAuth-issued (MCP) sessions. See SESSION_AUTH_PLAN.md for design.
+//
+// The PK `id` stores SHA-256(raw) so a DB read leak does not surface live
+// credentials. The raw id is what travels in the __dali_sid cookie or in
+// Authorization: Bearer headers; we never store it.
+model Session {
+  // sha256(raw session id), base64url
+  id                String   @id
+  userId            String
+  // Null for cookie logins. Set for OAuth-issued (MCP) sessions, linking
+  // the session to the OAuthGrant that authorized it. Intentionally a plain
+  // String? with no FK constraint in this PR — the FK lands when OAuthGrant
+  // ships in the MCP foundation track.
+  grantId           String?
+  createdAt         DateTime @default(now())
+  // Bumped on every successful auth lookup. Drives rolling expiry and powers
+  // per-session telemetry.
+  lastUsedAt        DateTime @default(now())
+  // Rolling expiry: extended on use up to absoluteExpiresAt.
+  expiresAt         DateTime
+  // Hard cap: never extended. Equivalent to the legacy familyCreatedAt + 30d.
+  absoluteExpiresAt DateTime
+  // Soft delete. Sessions are never hard-deleted so the audit log stays whole.
+  revokedAt         DateTime?
+  // Populated at issuance for audit / "active sessions" UI.
+  userAgent         String?
+  ip                String?
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId, revokedAt])
+  @@index([grantId])
+  @@index([expiresAt])
 }
 
 // ─── Email Templates ────────────────────────────────────────────────────────

--- a/dali-os-mcp.md
+++ b/dali-os-mcp.md
@@ -1,99 +1,270 @@
 # DALI OS MCP Plan
 
-**Status:** Low priority. Ships post-v0 of the broader expansion plan (see `expansion_plan.md`). One small schema addition (`PersonalAccessToken`) lands with v0; the MCP server itself is its own track.
+**Status:** Quality-of-life integration. Lands after v0 of the broader expansion plan (see `expansion_plan.md`). No schema additions are needed in v0 — the OAuth foundation already exists and the small extensions described here ship with the MCP track itself.
 
 ## Context
 
-DALI OS exposes an **MCP (Model Context Protocol) server** so AI assistants — Claude Desktop, Claude Code, and any other MCP-compatible client — can interact with DALI OS data on a member's behalf.
+DALI OS exposes an **MCP (Model Context Protocol) server** so AI assistants — Claude Desktop, Claude Code, and any other MCP-compatible client — can interact with DALI OS data on a lab member's behalf.
 
-The use case: a lab member is working in Claude and wants to ask "who's on Project Alpha right now?" or "schedule a 30-minute weekly with my Project Alpha team starting next week" without leaving their AI assistant. The MCP server makes DALI OS one of the AI's tools.
+The use case: a member working in Claude wants to ask *"who's on Project Alpha right now?"* or *"schedule a 30-minute weekly with my Project Alpha team starting next week"* without leaving their AI assistant. MCP makes DALI OS one of the AI's tools.
 
-**Why this is low priority:** it's a quality-of-life integration, not a core lab workflow. Members can use the DALI OS UI directly. MCP is leverage on top of an already-working platform — ship after the platform exists.
+**Consumer scope:** lab members only (current members + Core). Not partners, not alumni, not the public. This is the single most important constraint — it collapses most of the OAuth-provider machinery you would otherwise need.
+
+**Why this is post-v0:** members can do everything via the DALI OS UI. MCP is leverage on top of a working platform — ship after the platform exists.
 
 ## Auth model
 
-### v1: Personal Access Tokens (PAT)
+**OAuth 2.1 + PKCE.** No Personal Access Tokens. The existing `lib/oauth.ts` already implements the hard parts (mandatory S256 PKCE, single-use authorization codes, opaque refresh tokens hashed at rest, refresh-token family rotation) — it just needs to be extended from one hardcoded client to a small registry, and to surface a few standard endpoints.
 
-Member generates a long-lived bearer token in Settings, names it ("Claude Desktop on my laptop"), selects scopes, and pastes the token into their MCP client config.
+**Why OAuth over PAT:**
+- A token bound to a registered client, a consent record, and a refresh-token family is materially safer than a bearer secret a member pastes around. Revocation, last-used tracking, and rotation come for free.
+- Standard flow — every MCP client speaks it. PATs would require per-client config docs and copy-paste.
+- The existing implementation is ~80% of the way there. The remaining work is small *because* the consumer is lab-internal — no dynamic client registration, no scope-by-scope consent UI, no confidential clients, no introspection.
 
-**Why PAT and not OAuth:** the existing `lib/oauth.ts` is a single-client first-party auth broker (only `client_id=dali-api` is allowed; only one redirect URI). It is **not** a general-purpose multi-tenant OAuth provider, despite the name. Extending it to support third-party MCP clients (multi-client registry, multi-redirect-URI, scopes, consent screen) is 1–2 weeks of focused work — not justified for a low-priority feature.
+**Why this is small (lab-internal collapses the surface):**
 
-PAT ships in 2–3 days, reuses existing patterns (token hashing matches `RefreshToken.tokenHash`), and is **OAuth-upgradeable** later — the scope vocabulary, audit log conventions, and MCP server endpoints don't change when the auth method swaps.
+| Standard OAuth concern | Required here? |
+|---|---|
+| Dynamic client registration (RFC 7591) | No — handful of known clients, seeded once |
+| Full consent UI with scope grants | No — one-time per-client confirmation as a phishing guard |
+| Confidential vs public clients | No — all MCP clients are native/public; PKCE is the only client auth |
+| Token introspection (RFC 7662) | No — same app issues and consumes the tokens |
+| Authorization server metadata (RFC 8414) | Yes — MCP clients discover endpoints via `.well-known` |
+| Loopback redirect URIs (RFC 8252) | Yes — Claude Desktop/Code use `http://127.0.0.1:<port>/callback` |
 
-### Future: OAuth-based MCP
+### Flow
 
-Eventually — when the existing OAuth provider grows multi-tenant support (its own track, triggered by a second real use case), MCP migrates from PAT to OAuth. PAT stays around for backward compat / power users who prefer it.
+1. Member configures their MCP client with `https://dalios.dartmouth.edu/mcp` as the server URL.
+2. MCP client fetches `/.well-known/oauth-authorization-server`, discovers the authorize/token endpoints.
+3. MCP client opens the member's browser to `/oauth/authorize?client_id=claude-desktop&redirect_uri=http://127.0.0.1:<port>/callback&response_type=code&code_challenge=...&code_challenge_method=S256&state=...&scope=mcp:read mcp:write`.
+4. **Existing-session shortcut:** if the member has a valid dali-os session cookie, skip the Google/CAS bounce. Otherwise log them in normally.
+5. **First-time consent** for this `(user, client)` pair: a single page asking "Authorize Claude Desktop to access your DALI OS account?" with the requested scopes shown. Stores an `OAuthGrant` row on approval. Subsequent authorizations with the same scopes are auto-approved.
+6. Redirect to the loopback URI with `?code=<opaque>&state=...`.
+7. MCP client exchanges the code at `/oauth/token` with its `code_verifier`. Receives an opaque session id as the bearer (30 days rolling, 30 days absolute cap). See `SESSION_AUTH_PLAN.md` for the unified `Session` model that backs both browser cookies and MCP bearers.
+8. MCP client uses `Authorization: Bearer <session_id>` on `/mcp` calls. Sessions auto-extend on use; no `refresh_token` grant — when the rolling TTL lapses, the client re-runs the authorization flow (one redirect if the member still has a dali-os cookie).
+9. Member can revoke the grant from Settings at any time — cascades `revokedAt` to every `Session` row tied to that grant.
 
-The migration path:
-- MCP server's auth middleware (`lib/mcp-auth.ts`) starts with one branch (PAT lookup), gains a second (OAuth bearer token lookup) when OAuth lands
-- Same scope vocabulary
-- Same audit log conventions (token name → client name)
-- Settings UI gains an "Authorized clients" section alongside "Personal access tokens"
+### Extensions needed to `lib/oauth.ts` and `/oauth/*`
 
-No PAT-era data needs migrating; the two coexist.
+These are all small. Sequencing is in the implementation phases section.
+
+| Extension | Current state | What changes |
+|---|---|---|
+| **Client registry** | `VALID_CLIENT_IDS = ["dali-api"]` constant array | New `OAuthClient` Prisma model; seeded with `dali-api`, `claude-desktop`, `claude-code`. `lib/oauth.ts` resolves clients via `getClient(clientId)`. |
+| **Per-client redirect URIs** | `getAllowedRedirectUris()` returns one frontend URL | Resolved from the client record. Loopback rule: for clients flagged `isLoopback`, match scheme + host (`http://127.0.0.1` or `http://localhost`), ignore port. Exact match for everything else. |
+| **Existing-session shortcut on `/oauth/authorize`** | Always bounces through Google/CAS | If the request carries a valid `__dali_sid` cookie, skip straight to consent → code. Only force provider auth when there's no session. |
+| **First-time consent screen** | None — code is generated immediately after provider auth | New route `/oauth/consent`. For first-party (`dali-api`) and previously-granted (user, client, scopes) pairs, skip the screen. For new grants, render it; on approve, insert `OAuthGrant` and continue. |
+| **Scopes** | `scope` param ignored | Plumb through `OAuthSession` → `OAuthGrant` → access token claim. Enforced in MCP route middleware. |
+| **Bearer-token acceptance** | ~~`requireAuth` reads JWT from cookie only~~ Done by the session refactor. `requireAuth` already accepts `Authorization: Bearer <session_id>`; cookie wins if both present. | n/a |
+| **Discovery endpoint** | None | `GET /.well-known/oauth-authorization-server` returns the RFC 8414 JSON document (issuer, authorize/token/revoke URIs, supported grants, supported PKCE methods, supported scopes). Static-ish; can be a single loader. |
+
+Out of scope: dynamic client registration, introspection, confidential clients, OIDC `id_token`, userinfo endpoint. Add later if a concrete need shows up.
+
+## Member onboarding flow
+
+What it actually looks like to connect an MCP client to DALI OS. This section pins the operational requirements that the auth design has to satisfy — specifically loopback redirect URIs, the existing-session shortcut, and the per-client consent record.
+
+### Step 1: Add the server
+
+The only thing a member configures is the server URL.
+
+**Claude Code** (one CLI command, per machine):
+
+```bash
+claude mcp add --transport http dali-os https://dalios.dartmouth.edu/mcp
+```
+
+**Claude Desktop** (edit `~/Library/Application Support/Claude/claude_desktop_config.json`, then restart the app):
+
+```json
+{
+  "mcpServers": {
+    "dali-os": {
+      "url": "https://dalios.dartmouth.edu/mcp"
+    }
+  }
+}
+```
+
+**Other MCP-over-HTTP clients** (Cursor, Zed, custom): same URL. Any compliant client discovers endpoints via `/.well-known/oauth-authorization-server` and handles OAuth + PKCE automatically. Adding a new client type to DALI OS = adding one seeded row to `OAuthClient`.
+
+### Step 2: First tool invocation triggers auth
+
+The member triggers any tool ("list my projects"). Because the client has no token yet, it runs the OAuth flow:
+
+1. Client fetches `/.well-known/oauth-authorization-server`, discovers `/oauth/authorize` and `/oauth/token`.
+2. Client generates a PKCE `code_verifier` + `code_challenge` (S256).
+3. Client spins up a loopback listener on a random local port — e.g., `http://127.0.0.1:54113/callback`. (This is why `OAuthClient.isLoopback` exists: the port is dynamic per session, so the server must match scheme + host and ignore port.)
+4. Client opens the member's default browser to:
+
+   ```
+   https://dalios.dartmouth.edu/oauth/authorize
+     ?client_id=claude-code
+     &response_type=code
+     &redirect_uri=http://127.0.0.1:54113/callback
+     &code_challenge=<challenge>
+     &code_challenge_method=S256
+     &state=<random>
+     &scope=mcp:read+mcp:write
+   ```
+
+In the browser, three sub-cases:
+
+| Member's state | What they see |
+|---|---|
+| Already signed in to DALI OS (cookie session valid) | Skip Google/CAS entirely (existing-session shortcut). Go straight to consent. |
+| Not signed in | Standard `/login` page, pick Google or CAS, then consent. |
+| First time authorizing *this client* | One-time consent screen: *"Authorize Claude Code to access your DALI OS account?"* with the requested scopes listed. Approve once; future re-authorizations for the same `(member, client, scopes)` skip this screen. |
+
+On approval, browser redirects back to `http://127.0.0.1:54113/callback?code=<opaque>&state=<echoed>`. The client's loopback listener catches it, closes itself, and exchanges the code at `/oauth/token` with its `code_verifier`. Receives a session id as the bearer token.
+
+The member's original tool call now completes. Total clicks: typically 1 (consent), occasionally 2 (consent + sign-in if cookie expired).
+
+### Step 3: Steady state
+
+The MCP client stores the session id in its own credentials store (keychain on macOS for Claude Code / Claude Desktop). Every MCP call carries `Authorization: Bearer <session_id>`. The member never sees the token. Sessions auto-extend on use up to the absolute cap (~30 days).
+
+### Idle expiry and re-auth
+
+If the session goes 30 days without use, the next call returns 401. The client re-runs the OAuth flow:
+- Cookie still valid in their browser → one redirect, no clicks. They notice a browser tab opening and closing.
+- Cookie also expired → one Google or CAS click.
+
+Either way, no token to copy-paste. No "rotate your credentials" hygiene to remember.
+
+### Revocation
+
+| Revoke from | What it does | When to use |
+|---|---|---|
+| **DALI OS Settings → Connected apps** | Sets `OAuthGrant.revokedAt`; cascades to every `Session` row under that grant. Within one request cycle, the MCP client starts getting 401s and prompts re-authentication. | Compromised laptop, member offboarding, "I don't use this anymore." Authoritative. |
+| **MCP client side** (`claude mcp remove dali-os` or removing the config entry) | Deletes the client-side credential. Server-side grant + session linger as inactive. | Cleaning up your own machine. **Not** sufficient for a security incident — the session id still works if someone has it. |
+| **DALI OS Settings → "Sign out everywhere"** | One statement revokes every cookie session *and* every OAuth grant for the member. | Suspected account compromise. Nuclear option. |
+
+Members are told in the docs to revoke from DALI OS Settings (not just the client side) when they actually want the credential dead.
+
+### What the member never has to do
+
+- Generate, name, or paste a token.
+- Configure a client_id or client_secret (the client knows its own ID; no secret exists because all MCP clients are public/native).
+- Pick individual scopes (the client requests them; the consent screen shows them; member approves the bundle).
+- Rotate anything (sessions auto-extend; expired sessions trigger a one-click re-auth).
+
+This is the operational payoff for choosing OAuth over PAT: from the member's seat, connecting Claude to DALI OS is *one config line and one consent click*. No long-lived secret in member hands, no copy-paste accidents, no rotation hygiene.
+
+### What needs to exist on the DALI OS side for this to work
+
+- `OAuthClient` rows seeded for each supported client (`claude-code`, `claude-desktop`, anything else added later).
+- Loopback redirect URI matching (`isLoopback: true` clients accept any port on `http://127.0.0.1` / `http://localhost`).
+- Existing-session shortcut on `/oauth/authorize`.
+- First-time consent screen at `/oauth/consent`, idempotent for previously granted `(user, client, scopes)`.
+- `/.well-known/oauth-authorization-server` advertising the endpoints, supported PKCE methods, and supported scopes.
+- Settings → Connected apps UI listing active `OAuthGrant`s with revoke.
+
+All of these are line items in the foundation phase of `Implementation phases` below.
+
+### User-facing docs page
+
+Separately from this plan, a short member-facing docs page at e.g. `https://dalios.dartmouth.edu/help/mcp` should cover:
+
+1. **Claude Code** — the `claude mcp add` command + one-line description of what to expect.
+2. **Claude Desktop** — the config snippet + restart instruction.
+3. **Other clients** — generic "point your MCP-over-HTTP client at `https://dalios.dartmouth.edu/mcp`" with a link to `.well-known` for endpoint discovery.
+4. **Managing connections** — link to Settings → Connected apps.
+
+This docs page is a deliverable of the MCP track (phase 15 in `Implementation phases`), not this plan.
 
 ## Schema
 
-### `PersonalAccessToken`
-
-Lands in v0 (small, low-risk, future-proofs the MCP track).
+### `OAuthClient`
 
 ```prisma
-model PersonalAccessToken {
-  id          String    @id @default(cuid())
-  userId      String
-  // Human label so members can identify which client uses which token.
-  name        String
-  // Stored as SHA-256 hash; raw token is shown to the member exactly once
-  // on creation. Same hashing convention as RefreshToken.tokenHash.
-  tokenHash   String    @unique
-  // Scope vocabulary defined in this doc. Empty array = no access.
-  scopes      String[]
-  createdAt   DateTime  @default(now())
-  lastUsedAt  DateTime?
-  expiresAt   DateTime?  // optional; null = no expiry
-  revokedAt   DateTime?
+model OAuthClient {
+  id            String   @id @default(cuid())
+  // The clientId MCP clients use. Stable, human-readable.
+  clientId      String   @unique
+  // Display name shown on the consent screen and in Settings.
+  name          String
+  redirectUris  String[]
+  // For loopback native clients (Claude Desktop, Claude Code): match scheme +
+  // host on redirectUris, ignore port. RFC 8252.
+  isLoopback    Boolean  @default(false)
+  // First-party clients (dali-api) skip the consent screen.
+  isFirstParty  Boolean  @default(false)
+  // Scopes this client is allowed to request.
+  allowedScopes String[]
+  createdAt     DateTime @default(now())
+}
+```
 
-  user User @relation(fields: [userId], references: [id])
+Seeded entries:
+- `dali-api` — `isFirstParty: true`, redirect `${FRONTEND_URL}/login`, all scopes
+- `claude-desktop` — `isLoopback: true`, redirect `http://127.0.0.1/callback`, `mcp:read mcp:write`
+- `claude-code` — `isLoopback: true`, redirect `http://127.0.0.1/callback`, `mcp:read mcp:write`
 
+### `OAuthGrant`
+
+Represents a member's standing authorization for a specific client. One row per `(user, client)`. Owns N refresh-token families over time.
+
+```prisma
+model OAuthGrant {
+  id           String         @id @default(cuid())
+  userId       String
+  clientId     String          // OAuthClient.clientId
+  // Member-supplied or client-supplied label, shown in Settings.
+  // Defaults to the client's name on first issuance.
+  name         String
+  scopes       String[]
+  createdAt    DateTime       @default(now())
+  lastUsedAt   DateTime?
+  revokedAt    DateTime?
+
+  user     User      @relation(fields: [userId], references: [id])
+  sessions Session[]
+
+  @@unique([userId, clientId])
   @@index([userId, revokedAt])
 }
 ```
 
-**Notes:**
-- `tokenHash` indexed for O(1) lookup at request time
-- `lastUsedAt` updated on every use (best-effort; not transactional with the request)
-- Revoke is soft (sets `revokedAt`), not delete — preserves audit trail
+### `Session` (existing — FK constraint added)
 
-### Reverse relation on `User`
+The unified `Session` model (see `SESSION_AUTH_PLAN.md` and `prisma/schema.prisma`) already has a nullable `grantId String?` column. This migration just wires up the foreign-key constraint to `OAuthGrant.id` and adds the reverse relation. Null `grantId` means the session was issued by cookie login; non-null means it was issued via `/oauth/token` to a registered MCP client.
 
-```prisma
-personalAccessTokens  PersonalAccessToken[]
-```
+Revocation cascades: revoking an `OAuthGrant` runs `session.updateMany({ where: { grantId, revokedAt: null }, data: { revokedAt: new Date() } })`. The `revokeAllForGrant` helper in `lib/session.ts` is already in place — it just becomes load-bearing once `grantId` is populated.
+
+### `OAuthSession` (existing — no schema change)
+
+Already used for the authorize → callback → exchange round-trip. Extend the row with the requested `scopes` (already-present column reusable, or a new array column) so the consent screen and the issued token know what was asked for.
 
 ## Scope vocabulary
 
-Scope strings follow `<area>:<verb>:<resource>` convention. Verbs are `read` or `write`. Areas group related resources.
+**v1 ships with two scopes:**
+- `mcp:read` — every read tool
+- `mcp:write` — every write tool
 
-**Read scopes:**
-- `mcp:read:profile` — own profile + Settings preferences
-- `mcp:read:people` — directory, member profiles, eligibility matrix
-- `mcp:read:projects` — project list, workspace, sprints, tasks, comments, partners (members-of-the-project only)
-- `mcp:read:education` — offerings catalog, own enrollments, session materials
-- `mcp:read:calendar` — own events, free/busy, group memberships
-- `mcp:read:mentorship` — own mentee/mentor list, weekly notes (subject to `isLabMentor` gating)
-- `mcp:read:hiring` — own assigned reviews, applications scoped to own role (subject to per-cycle CA gate)
-- `mcp:read:tasks` — own tasks across projects (subset of `mcp:read:projects` for convenience)
+Two scopes is enough to give members a meaningful kill switch (read-only token for cautious use) without building the full granularity matrix up front.
 
-**Write scopes:**
-- `mcp:write:profile` — edit own profile fields
-- `mcp:write:tasks` — create / update / comment on tasks in projects the user belongs to
-- `mcp:write:calendar` — schedule meetings via the scheduling component, RSVP to events
-- `mcp:write:education` — apply / RSVP to offerings, submit assignments
-- `mcp:write:mentorship` — draft (NOT publish) weekly notes
-- `mcp:write:hiring` — submit review drafts (subject to per-cycle CA gate)
+**Planned granular scopes** (add when a real need shows up — e.g., a member wants to grant read-projects but not read-mentorship):
 
-**Never exposed via MCP** (high-stakes actions that require a human in the loop):
+| Scope | Coverage |
+|---|---|
+| `mcp:read:profile` | own profile + Settings preferences |
+| `mcp:read:people` | directory, member profiles, eligibility matrix |
+| `mcp:read:projects` | project list, workspace, sprints, tasks, comments, partners (project members only) |
+| `mcp:read:education` | offerings catalog, own enrollments, session materials |
+| `mcp:read:calendar` | own events, free/busy, group memberships |
+| `mcp:read:mentorship` | own mentee/mentor list, weekly notes (subject to `isLabMentor` gating) |
+| `mcp:read:hiring` | own assigned reviews, applications scoped to own role (subject to per-cycle CA gate) |
+| `mcp:write:profile` | edit own profile fields |
+| `mcp:write:tasks` | create / update / comment on tasks in projects the user belongs to |
+| `mcp:write:calendar` | schedule meetings, RSVP to events |
+| `mcp:write:education` | apply / RSVP to offerings, submit assignments |
+| `mcp:write:mentorship` | draft (not publish) weekly notes |
+| `mcp:write:hiring` | submit review drafts (subject to per-cycle CA gate) |
+
+When granular scopes ship, `mcp:read` becomes an alias for all `mcp:read:*` and `mcp:write` an alias for all `mcp:write:*`. Existing grants migrate cleanly.
+
+**Never exposed via MCP** (high-stakes actions requiring a human in the loop):
 - Confirming staffing assignments
 - Archiving a project
 - Posting a final mentor evaluation (drafts only)
@@ -102,58 +273,60 @@ Scope strings follow `<area>:<verb>:<resource>` convention. Verbs are `read` or 
 - Admin Console operations
 - Deleting any data
 
-**Default scope set on token creation:** all `mcp:read:*` for the user's tier. Members opt into write scopes deliberately.
-
 ## MCP server architecture
 
 ### Transport
 
-**HTTP MCP** (not stdio). One hosted endpoint at `https://dalios.dartmouth.edu/mcp` (or wherever the dali-api lives). Members configure their MCP client with that URL + their PAT.
+**HTTP MCP** (not stdio). One hosted endpoint at `https://dalios.dartmouth.edu/mcp` (or wherever dali-api lives). Members configure their MCP client with that URL and complete the OAuth flow once.
 
-**Why HTTP, not stdio:**
-- Members don't run dali-api on their laptop; stdio would require a local proxy
-- HTTP works for any MCP client without per-machine setup
-- DALI OS already has Fly hosting; reusing the same app is trivial
+Why HTTP, not stdio:
+- Members don't run dali-api locally; stdio would require a per-laptop proxy.
+- HTTP works for any MCP client with no per-machine setup.
+- Reuses the existing Fly hosting, Prisma client, role helpers, and audit log.
 
 ### Routing
 
 ```
-/mcp                    MCP server endpoint (POST)
-                        Bearer token in Authorization header → resolved to PAT → user
+/.well-known/oauth-authorization-server     OAuth metadata (RFC 8414)
+/oauth/authorize                            existing — extended with consent + session shortcut
+/oauth/token                                existing — extended with scope-aware tokens
+/oauth/revoke                               existing — revokes grant + family
+/oauth/consent                              new — first-time per-client confirmation
+/mcp                                        new — MCP server endpoint (POST)
 ```
 
-Lives in the dali-api app (new route prefix), not a separate Fly service. Reuses the existing Prisma client, role helpers, audit log, etc.
+The MCP server lives in the dali-api app, not a separate Fly service.
 
-### Request flow
+### Request flow on `/mcp`
 
-1. MCP client sends MCP-protocol request with `Authorization: Bearer <pat>`
+1. MCP client sends an MCP-protocol request with `Authorization: Bearer <session_id>`.
 2. `lib/mcp-auth.ts` middleware:
-   - Look up `PersonalAccessToken` by `tokenHash = sha256(pat)`
-   - Reject if not found, revoked, or expired
-   - Update `lastUsedAt` (fire-and-forget)
-   - Attach `{ user, scopes }` to the request context
-3. MCP route handler dispatches by tool name
+   - Calls `lookupSession(raw)` → SHA-256 hash → indexed PK lookup. Rejects if not found, revoked, or expired.
+   - Reads `session.grantId` → resolves the `OAuthGrant` → rejects if revoked.
+   - Updates `OAuthGrant.lastUsedAt` and rolls the session (fire-and-forget).
+   - Attaches `{ user, scopes, grantId, clientName }` to the request context.
+3. The MCP route handler dispatches by tool name.
 4. Each tool handler:
-   - Checks the required scope is in `request.context.scopes` — reject otherwise
-   - Resolves the tier / scope-bound permissions for the user (same `requireTier` / `requireScope` helpers as the rest of the app)
-   - Executes the operation (Prisma query / mutation)
-   - Logs an `AuditLog` entry: `{ action: "mcp.tool_called", actorUserId, metadata: { toolName, tokenName, params (redacted) } }`
-   - Returns the MCP-protocol response
+   - Checks the required scope is present — rejects otherwise.
+   - Resolves role/tier permissions for the user (reuses existing helpers — `requireTier`, scope-bound role checks).
+   - Executes via existing app code (Prisma queries, scheduling component, etc.) — no duplicate business logic.
+   - Logs an `AuditLog` entry: `{ action: "mcp.tool_called", actorUserId, metadata: { toolName, clientName, grantId, params (redacted) } }`.
+   - Returns the MCP-protocol response.
 
-### Tool catalog (rough cut for v1)
+### Tool catalog (v1 cut)
 
-Enumerated here so the team can scope; concrete tool schemas come during implementation.
+For v1, every read tool below requires `mcp:read`; every write tool requires `mcp:write`. When granular scopes ship, the per-tool scope column populates.
 
 **Read tools:**
-| Tool | Scope | Description |
+| Tool | Granular scope (future) | Description |
 |---|---|---|
-| `whoami` | (no scope) | Returns the authenticated user's basic info + tier |
+| `whoami` | (none) | Authenticated user's basic info + tier |
 | `list_my_projects` | `mcp:read:projects` | Current-term projects the user is on |
 | `get_project` | `mcp:read:projects` | Project detail by id (must be a member) |
 | `list_project_members` | `mcp:read:projects` | Roster of a project for a given term |
 | `list_project_sprints` | `mcp:read:projects` | Sprints on a project (with status filters) |
-| `list_project_tasks` | `mcp:read:tasks` | Tasks on a project, optional sprint filter |
-| `get_my_tasks` | `mcp:read:tasks` | Tasks assigned to me across all my projects |
+| `list_project_tasks` | `mcp:read:projects` | Tasks on a project, optional sprint filter |
+| `get_my_tasks` | `mcp:read:projects` | Tasks assigned to me across all my projects |
 | `search_directory` | `mcp:read:people` | Member directory search by name / role / project / domain |
 | `get_member_profile` | `mcp:read:people` | Full profile for a member id |
 | `list_education_offerings` | `mcp:read:education` | Catalog with type / capacity / dates |
@@ -163,8 +336,8 @@ Enumerated here so the team can scope; concrete tool schemas come during impleme
 | `list_my_mentees` | `mcp:read:mentorship` | Mentees the user is currently mentoring |
 | `read_mentor_notes` | `mcp:read:mentorship` | Weekly notes for a mentee (gated by `isLabMentor`) |
 
-**Write tools (require explicit scope opt-in):**
-| Tool | Scope | Description |
+**Write tools:**
+| Tool | Granular scope (future) | Description |
 |---|---|---|
 | `create_task` | `mcp:write:tasks` | Create a task on a project the user belongs to |
 | `update_task_status` | `mcp:write:tasks` | Move a task to a different status |
@@ -175,78 +348,80 @@ Enumerated here so the team can scope; concrete tool schemas come during impleme
 | `draft_mentor_note` | `mcp:write:mentorship` | Create a `MentorNote` row in draft state (member must publish from UI) |
 | `update_my_profile` | `mcp:write:profile` | Edit own profile fields |
 
-**Never exposed:** see "Never exposed via MCP" in the scope section.
-
 ### Tool definitions
 
-Tools are registered with the MCP server as JSON-schema-typed function definitions. Each tool's handler:
-- Validates input against its JSON schema (MCP server does this)
-- Checks scope (middleware-level)
-- Executes via existing app code (Prisma queries, scheduling component, etc.) — no duplicate logic
-- Returns a typed response
+Tools register with the MCP server as JSON-schema-typed function definitions. Each handler:
+- Validates input against its JSON schema (MCP server does this).
+- Checks scope (middleware-level).
+- Executes via existing app code — no duplicate logic.
+- Returns a typed response.
 
-Tool definitions live in `app/mcp/tools/<area>.ts` (one file per area: projects, people, education, calendar, etc.).
+Files live in `app/mcp/tools/<area>.ts` (one file per area: projects, people, education, calendar, etc.).
 
 ## Settings UI
 
-Lives at **Settings > MCP / API Tokens** (a sub-section of the broader Settings page from `expansion_plan.md`).
+Lives at **Settings > Connected apps** (a sub-section of the broader Settings page from `expansion_plan.md`).
 
 **Member view:**
-- List of existing PATs: name, scopes (chips), createdAt, lastUsedAt, revoke button
-- "Generate new token" button → modal:
-  - Name input
-  - Scope checkboxes grouped by area (read scopes default-checked; write scopes opt-in)
-  - Optional expiry (presets: 30 days / 90 days / 1 year / never)
-  - Submit → shows the raw token exactly once with a copy button + warning ("save this now — you won't see it again")
-- Revoke action: confirmation modal → sets `revokedAt`
-
-**Documentation link:** "How to connect Claude to DALI OS" (separate doc — sample MCP config snippets for Claude Desktop and Claude Code).
+- List of active `OAuthGrant`s: client name, scopes (chips), `createdAt`, `lastUsedAt`, **Revoke** button.
+- No "create token" affordance — grants are created exclusively through the OAuth flow initiated by the MCP client. The member doesn't see or handle raw tokens.
+- Revoke action: confirmation modal → sets `OAuthGrant.revokedAt`, calls `revokeAllForGrant` to cascade to every `Session` row tied to that grant.
+- Help link: **"How to connect Claude to DALI OS"** (separate doc with MCP-client config snippets).
 
 ## Implementation phases
 
-### v0 deliverables (lands with the broader v0 migration)
+The OAuth extensions are independently shippable and useful on their own — the existing-session shortcut helps any future third-party client, and Bearer-token acceptance is useful for any non-cookie API call. Order them before the MCP server itself.
 
-- `PersonalAccessToken` Prisma model
-- (Nothing else — actual MCP server is post-v0)
+### Foundation (extends `/oauth/*`)
 
-### MCP track (post-v0, low priority)
+1. **`OAuthClient` model + migration + seed.** Replace the hardcoded `VALID_CLIENT_IDS` array with a DB lookup. No external behavior change.
+2. **Per-client redirect URIs + loopback matching.** `getAllowedRedirectUris` becomes per-client. Loopback rule for `isLoopback` clients.
+3. **Existing-session shortcut on `/oauth/authorize`.** If a valid dali-os session cookie is present, skip the Google/CAS bounce.
+4. **Bearer-token acceptance in `requireAuth`.** Accept `Authorization: Bearer <jwt>` in addition to the existing cookie.
+5. **Scope plumbing.** `scope` param → `OAuthSession.scopes` → access-token claim. Reject scope values not in the client's `allowedScopes`.
+6. **`OAuthGrant` model + consent screen.** `/oauth/consent` route; first-time per-`(user, client, scopes)` confirmation; subsequent flows auto-approve.
+7. **`/.well-known/oauth-authorization-server`.**
+8. **Settings > Connected apps UI.** List + revoke.
 
-1. **`lib/mcp-auth.ts`** — middleware: SHA-256 lookup, scope attach, lastUsedAt update, reject revoked/expired
-2. **`/mcp` route** — MCP server endpoint, dispatches to tools by name
-3. **Read tools first** — implement the read-scope tool catalog above (one PR per area or one big PR, depending on the dev's preference)
-4. **Settings UI for PAT management** — list, create, revoke
-5. **Audit log integration** — every tool call logs
-6. **Write tools** — implement the write-scope tool catalog (separate PR per area)
-7. **Documentation** — "How to connect Claude to DALI OS" with sample config snippets
-8. **Rate limiting** — per-token quotas (reuse existing `lib/rate-limit.ts`)
+### MCP track
 
-Reasonable size: 1–2 weeks for read-only v1; another 1–2 weeks for writes if pursued.
+9. **`lib/mcp-auth.ts`** — middleware: `lookupSession` → resolve grant, check scopes, attach context, fire-and-forget `rollSession`.
+10. **`/mcp` route** — MCP server endpoint, dispatches by tool name.
+11. **Read tools** — implement the read-scope tool catalog (one PR per area or one large PR).
+12. **Audit log integration** — every tool call logs to `AuditLog`.
+13. **Rate limiting** — per-grant quotas (reuse existing `lib/rate-limit.ts`).
+14. **Write tools** — implement the write-scope tool catalog (separate PRs per area).
+15. **Member documentation** — "How to connect Claude to DALI OS" with sample MCP-client config.
+
+Rough sizing: foundation (1–6) is 3–5 focused days. MCP read-only v1 (9–13) is another 1 week. Writes (14) are another 1 week if pursued.
 
 ## Security considerations
 
-- **Tokens are bearer credentials.** Treat as passwords. Never log raw tokens. Show only once at creation.
-- **Tokens grant the user's full effective permissions** (constrained only by the granted scopes). A revoked or compromised token can read everything in scope until revoked.
-- **Audit every tool call.** AI assistants don't always do what users expect; the audit log is the forensics trail.
-- **Rate limit per token** to prevent runaway loops in misbehaving AI clients.
-- **Don't expose mentor notes by default.** Even with `mcp:read:mentorship`, the lab-mentor-collective gate (`isLabMentor`) still applies — non-mentors can't read.
-- **Per-cycle CA gating still applies** to hiring tools — the existing `requireApiSignedOrForbidden` check runs before any hiring data is returned.
-- **Partner / Alumni scope:** out of scope for v1. Only members + Core can generate PATs.
-- **Token rotation:** members should rotate tokens periodically. UI can show "this token hasn't been used in 90 days — consider revoking" hints.
+- **Access tokens are bearer credentials.** Never log them. JWTs are short-lived (15 min) and self-contained; revoking the grant invalidates them as soon as the access token expires (or sooner — the middleware looks up the grant on every request).
+- **Refresh tokens are bearer credentials.** Stored only as SHA-256 hashes. Sliding 7-day expiry, 30-day absolute cap, family-based reuse detection (existing behavior). Revoking a grant cascade-revokes every refresh token in it.
+- **Audit every tool call.** AI assistants don't always do what users expect; the audit log is the forensics trail. Include `clientName` and `grantId` so a misbehaving client is traceable.
+- **Rate limit per grant** to bound runaway-loop damage from a misbehaving AI client.
+- **Lab-mentor-collective gate** (`isLabMentor`) still applies even with `mcp:read:mentorship`. Non-mentors get nothing.
+- **Per-cycle CA gating** still applies to hiring tools — `requireApiSignedOrForbidden` runs before any hiring data is returned.
+- **Loopback URI validation:** for `isLoopback` clients, the redirect URI must match scheme `http`, host `127.0.0.1` or `localhost`, ignoring port — anything else is rejected. No `0.0.0.0`, no public-IP loopback claims.
+- **State + PKCE remain mandatory.** State for CSRF, PKCE for code-interception. Both already enforced.
+- **First-party flag isn't a backdoor.** Only the seeded `dali-api` client gets `isFirstParty: true`; the seed migration is the only path to setting it.
+- **No partners, no alumni, no public.** A `User.tier` check at the start of `/oauth/authorize` rejects anyone outside members + Core when the client is an MCP client.
 
 ## Open questions
 
-1. **Killer use case** — what's the one thing members would most want to do via Claude? Drives which tools to prioritize. Best guess: scheduling. Confirm before the track kicks off.
-2. **Read-only v1 only, or include writes?** Read-only is much safer and shippable in 1–2 weeks. Writes layer on after.
-3. **Lab-internal only, or partners/alumni eventually?** Partners with PATs could ask "what's the status of our project?" via Claude. Alumni tokens probably make less sense. v1 is members + Core only.
-4. **Tool input validation:** rely on MCP's JSON schema, or layer additional Zod schemas? Probably JSON schema is enough.
-5. **Should there be a "DALI assistant" — a curated agent built on top of the MCP server**, hosted by DALI for non-technical members? Future product question. Out of scope for the MCP server itself.
+1. **Killer use case** — drives which tools to prioritize. Best guess: scheduling. Confirm before the track kicks off.
+2. **Read-only v1 only, or include writes?** Read-only is safer and shippable in ~1 week. Writes layer on after.
+3. **Granular scopes timing** — ship v1 with `mcp:read` / `mcp:write` only, or front-load the full `mcp:<area>:<verb>` vocabulary? Default: ship coarse, add granular when a concrete request shows up.
+4. **Loopback port handling for the consent screen.** When the consent screen redirects back, the loopback port is dynamic. Either render the redirect URL server-side (preferred — the port came in on the authorize request) or have the client poll. No issue, just specify the choice during impl.
+5. **Should there be a "DALI assistant"** — a curated agent built on top of the MCP server, hosted by DALI for non-technical members? Future product question. Out of scope for the MCP server itself.
 
 ## Why this lives in its own doc
 
 The MCP feature is genuinely separable from the rest of the expansion plan:
-- Different audience (lab members who use AI assistants — a subset)
-- Different priority (low)
-- Different integration points (auth + a separate server, not feature surfaces)
-- Could ship significantly later without affecting any other track
+- Different audience (members who use AI assistants — a subset).
+- Different priority (post-v0).
+- Different integration points (auth extensions + a separate server, not feature surfaces).
+- Could ship significantly later without affecting any other track.
 
-Cross-references in `expansion_plan.md` should point here when MCP comes up. The `PersonalAccessToken` model is the only schema touchpoint that needs to land in v0.
+Cross-references in `expansion_plan.md` should point here when MCP comes up. No schema changes are required in v0 — every model in this doc lands with the MCP track.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,6 @@ services:
       - ./dali-api/.env
     environment:
       DATABASE_URL: postgresql://dali:dali@db:5432/dali
-      JWT_SECRET: dev-jwt-secret-change-me-in-production!!
       CAS_BASE_URL: https://login.dartmouth.edu/cas
       FRONTEND_URL: http://localhost:5173
       API_BASE_URL: http://localhost:3001


### PR DESCRIPTION
## Summary

Replaces the current JWT access + rotating refresh token scheme with an opaque session id stored in a `Session` table, used uniformly for browser cookies (`__dali_sid`) and `Authorization: Bearer` headers (MCP-ready).

Background and design tradeoffs in [`SESSION_AUTH_PLAN.md`](./SESSION_AUTH_PLAN.md) (added in this PR). Closes #407.

## Why

- JWT statelessness wasn't earning its keep — every protected route already hits the DB for role checks, so the "save a roundtrip on the hot path" argument doesn't apply here.
- Recent bug history (`1757c2a`, `2c01467`) traced back to the silent-refresh complexity (`withAuth` glue + `inFlightRefreshes` dedup).
- The MCP track (`dali-os-mcp.md`) needed Bearer-token API access against the same auth surface. Unifying both onto one `Session` model is simpler than running two parallel systems.

## What changed

| Area | Effect |
|---|---|
| `lib/auth.ts` | 217 → 132 lines. `signAccessToken` / `verifyAccessToken` / `JWT_SECRET` / `inFlightRefreshes` / silent refresh / `withAuth` all gone. `requireAuth` is one indexed `findUnique` and preserves `auth.user.sub` shape. |
| `lib/cookies.ts` | Single `__dali_sid` HttpOnly cookie. Added `parseBearerHeader` + `parseSessionId` (cookie wins over header). |
| `lib/oauth.ts` | 337 → 230 lines. Removed `issueTokens`, `refreshTokens`, `revokeToken`, `createTokenPair`. PKCE / authorize-session surface preserved as foundation for the MCP track. |
| `lib/session.ts` (new) | `issueSession`, `lookupSession`, `rollSession`, `revokeSession`, `revokeAllForUser`, `revokeAllForGrant`. Raw ids never stored — `Session.id` = `sha256(raw)`. |
| Prisma schema | Drops `RefreshToken`, adds `Session` with nullable `grantId String?` (no FK yet — wired when `OAuthGrant` lands with the MCP track). |
| Routes | All three login flows + dev-login + logout + `/oauth/token` + `/oauth/revoke` rewired to the session model. `refresh_token` grant removed from `/oauth/token`. |
| Codemod | 529 `withAuth(auth, X)` calls stripped across 80 files; loaders/actions just return their data. |
| Collab | `collab/auth.ts` rewritten as session-backed verifier (returns legacy `{ sub }` shape); two loaders that pass `collabToken` to the Tiptap editor now use `parseSessionCookie`. |
| Tests | `auth.test.ts`, `cookies.test.ts`, `oauth.test.ts` rewritten. New `session.test.ts` with 15 cases including hash-at-rest assertions. 692 tests passing. |
| Cleanup | `jose` removed from `package.json`. `JWT_SECRET` removed from `docker-compose.yml` and `.env.example`. README + `dali-os-mcp.md` updated. |

## Cutover

**Hard cutover.** The migration drops `RefreshToken` (data-losing). Every active user gets logged out once and re-signs in on next request. Plan recommends scheduling outside hiring-cycle deadline windows and posting a heads-up in `#dali-eng` ~24h ahead — see [`SESSION_AUTH_PLAN.md` § Cutover plan](./SESSION_AUTH_PLAN.md).

## Risks specifically addressed during review

- **Collab/auth.ts** was not in the original plan; caught during implementation. Phase 5.5 added; without it Tiptap docs would stop authenticating mid-deploy.
- **`grantId` ships without an FK** — plain `String?` column until `OAuthGrant` lands in the MCP track. `revokeAllForGrant` is in place but no-ops until then.
- **`Session.id` is the SHA-256 hash** of the raw id (not a separate column) — PK lookup stays indexed, raw never hits the DB, mirrors the `RefreshToken.tokenHash` precedent.
- **`auth.user.sub` preserved** — the 111-file codemod is purely about removing `withAuth` wrappers, not renaming. Regression guarded by a Vitest assertion.

## Commits

| # | Commit | Theme |
|---|---|---|
| 1 | `docs:` | `SESSION_AUTH_PLAN.md`, MCP plan and README updates |
| 2 | `feat(prisma+lib):` | `Session` model + migration, `lib/session.ts`, `lib/request-meta.ts` |
| 3 | `feat(lib):` | Rewrite `auth.ts` + `cookies.ts`; strip token issuance from `oauth.ts` |
| 4 | `refactor:` | Codemod — strip `withAuth()` from 80 files |
| 5 | `feat(routes+collab):` | Wire login/OAuth/logout/collab/linking to sessions |
| 6 | `test:` | Rewrite affected tests; add `session.test.ts` |
| 7 | `chore:` | Drop `jose`, `JWT_SECRET` |

## Test plan

- [x] CI green: `test.yml`, `build-check.yml`, `migration-check.yml`, `codeql.yml`
- [ ] Burn in on dev Neon branch ~24h with no auth-error spikes
- [ ] Manual smoke: Google member login → land on `/hiring/reviewer`
- [ ] Manual smoke: Google partner (`@dartmouth.edu`) login → land on `/portal`
- [ ] Manual smoke: CAS login → land on `/portal`
- [ ] Manual smoke: `/dev-login-as?daliEmail=...` still works
- [ ] Manual smoke: Wait 30+ minutes idle, refresh → still logged in (no "bounced every 15 min" regression)
- [ ] Manual smoke: Logout → next request 302s to `/login`
- [ ] Manual smoke: Revoke a `Session` row in Prisma Studio → next request 302s to `/login`
- [ ] Collab smoke: open a Tiptap document (reviewer application or interviewer interview), presence indicator appears, content persists, two-tab cursor sync works
- [ ] Promote to staging; verify migration drops `RefreshToken` cleanly against prod snapshot
- [ ] Post `#dali-eng` heads-up ~24h before prod cut
- [ ] Promote to prod outside any hiring-cycle close window

🤖 Generated with [Claude Code](https://claude.com/claude-code)