### PR TITLE
Always enforce Google domain + drop account-type cookie + OAuthSession enums (issues E, H)

### DIFF
--- a/dali-api/app/lib/oauth.ts
+++ b/dali-api/app/lib/oauth.ts
@@ -1,6 +1,7 @@
 import { createHash, randomBytes } from "node:crypto";
 import { OAuth2Client } from "google-auth-library";
 import { prisma } from "~/lib/db";
+import type { OAuthProvider, OAuthAccountType } from "~/generated/prisma/enums";
 
 // types
 
@@ -97,8 +98,8 @@ export async function createOAuthSession(params: {
   codeChallengeMethod: string;
   redirectUri: string;
   state: string;
-  provider: string;
-  accountType?: string;
+  provider: OAuthProvider;
+  accountType?: OAuthAccountType;
 }) {
   return prisma.oAuthSession.create({
     data: {

--- a/dali-api/app/routes/__tests__/login.test.ts
+++ b/dali-api/app/routes/__tests__/login.test.ts
@@ -11,7 +11,6 @@ import { action } from "~/routes/login";
 function makeRequest(ip = "1.2.3.4") {
   const form = new URLSearchParams({
     provider: "google",
-    accountType: "member",
   });
   return new Request("http://localhost/login", {
     method: "POST",

--- a/dali-api/app/routes/auth.callback.google.ts
+++ b/dali-api/app/routes/auth.callback.google.ts
@@ -10,7 +10,6 @@ import { CAL_STATE_PREFIX } from "~/routes/oauth.calendar.google.start";
 import { handleCalendarLinkCallback } from "~/routes/oauth.calendar.google.callback";
 
 const OAUTH_STATE_COOKIE = "__dali_oauth_state";
-const ACCOUNT_TYPE_COOKIE = "__dali_account_type";
 
 function parseCookies(request: Request): Record<string, string> {
   const header = request.headers.get("Cookie") ?? "";
@@ -110,13 +109,15 @@ export async function loader({ request }: Route.LoaderArgs) {
     });
   }
 
-  // Determine account type from the cookie set during the login action
-  const accountType = cookies[ACCOUNT_TYPE_COOKIE] ?? "";
-  const clearAccountTypeCookie = `${ACCOUNT_TYPE_COOKIE}=; Path=/; Max-Age=0; HttpOnly; SameSite=Lax`;
-  const isMemberLogin = accountType === "member";
-
-  // For member login, enforce DALI domain
-  if (isMemberLogin && !googleUser.email.endsWith("@dali.dartmouth.edu")) {
+  // The only /login button that uses this callback is the Member button, so
+  // @dali.dartmouth.edu is the only valid outcome. Enforce unconditionally —
+  // we no longer rely on the __dali_account_type cookie (which could be
+  // stripped) to gate the check. Dartmouth-student and partner branches that
+  // used to live inline below are gone for the same reason: unreachable from
+  // any production route. They live on (for now) in the OAuth-provider
+  // callback `/oauth/callback/google`, which gates on a different signal
+  // (`OAuthSession.accountType`).
+  if (!googleUser.email.endsWith("@dali.dartmouth.edu")) {
     await logAuditEvent({
       action: "login.failure",
       metadata: {
@@ -126,15 +127,21 @@ export async function loader({ request }: Route.LoaderArgs) {
       },
       request,
     });
-    const headers = new Headers();
-    headers.append("Set-Cookie", clearStateCookie);
-    headers.append("Set-Cookie", clearAccountTypeCookie);
-    headers.set("Location", "/login?error=access_denied");
-    return new Response(null, { status: 302, headers });
+    return new Response(null, {
+      status: 302,
+      headers: {
+        "Set-Cookie": clearStateCookie,
+        Location: "/login?error=access_denied",
+      },
+    });
   }
 
-  const { user, authType } = await upsertUserFromGoogle(googleUser);
-  const redirectTo = authType === "member" ? "/hiring/reviewer" : "/portal";
+  // Always-enforce above means we only reach this with an @dali.dartmouth.edu
+  // email, so the helper's member branch fires and creates a DALIMember if
+  // missing. Dartmouth-student and partner branches in the helper are
+  // unreachable through this route — they live on for the OAuth-provider
+  // callback `/oauth/callback/google` which gates on a different signal.
+  const { user } = await upsertUserFromGoogle(googleUser);
 
   // Issue session and set cookie
   const session = await issueSession({
@@ -147,16 +154,15 @@ export async function loader({ request }: Route.LoaderArgs) {
     userId: user.id,
     metadata: {
       provider: "google",
-      authType,
+      authType: "member",
       email: googleUser.email,
     },
     request,
   });
   const headers = new Headers();
   headers.append("Set-Cookie", clearStateCookie);
-  headers.append("Set-Cookie", clearAccountTypeCookie);
   setSessionCookie(headers, session.rawId);
-  headers.set("Location", redirectTo);
+  headers.set("Location", "/hiring/reviewer");
 
   return new Response(null, { status: 302, headers });
 }

--- a/dali-api/app/routes/login.tsx
+++ b/dali-api/app/routes/login.tsx
@@ -5,7 +5,6 @@ import { requireAuth } from "~/lib/auth";
 import { checkRateLimit } from "~/lib/rate-limit";
 
 const OAUTH_STATE_COOKIE = "__dali_oauth_state";
-const ACCOUNT_TYPE_COOKIE = "__dali_account_type";
 
 const RATE_LIMIT_MAX = 5;
 const RATE_LIMIT_WINDOW_MS = 60_000;
@@ -31,24 +30,12 @@ export async function action({ request }: Route.ActionArgs) {
 
   const formData = await request.formData();
   const provider = formData.get("provider") as string;
-  const accountType = formData.get("accountType") as string | null;
 
   const state = randomBytes(32).toString("base64url");
   const apiBase = process.env.API_BASE_URL ?? "http://localhost:3001";
   const casBase = process.env.CAS_BASE_URL ?? "https://login.dartmouth.edu/cas";
 
   const headers = new Headers();
-
-  // Store account type so callback knows where to redirect
-  const accountTypeCookie = [
-    `${ACCOUNT_TYPE_COOKIE}=${accountType ?? ""}`,
-    "Path=/",
-    "Max-Age=600",
-    "HttpOnly",
-    "SameSite=Lax",
-    ...(process.env.NODE_ENV === "production" ? ["Secure"] : []),
-  ].join("; ");
-  headers.append("Set-Cookie", accountTypeCookie);
 
   if (provider === "cas") {
     // Dartmouth CAS login — redirect to CAS with service URL pointing to our callback
@@ -69,7 +56,7 @@ export async function action({ request }: Route.ActionArgs) {
     return new Response(null, { status: 302, headers });
   }
 
-  // Google OAuth — redirect to Google with optional hd restriction
+  // Google OAuth — redirect to Google with @dali.dartmouth.edu hd hint
   const stateCookie = [
     `${OAUTH_STATE_COOKIE}=${state}`,
     "Path=/auth/callback/google",
@@ -80,18 +67,19 @@ export async function action({ request }: Route.ActionArgs) {
   ].join("; ");
   headers.append("Set-Cookie", stateCookie);
 
+  // The Member button is the only button that posts provider=google, so we
+  // always want the @dali.dartmouth.edu hd nudge on Google's account picker.
+  // Enforcement of the domain still happens server-side in
+  // /auth/callback/google; `hd` is purely a UX hint and not a security
+  // boundary.
   const googleParams = new URLSearchParams({
     client_id: process.env.GOOGLE_CLIENT_ID!,
     redirect_uri: `${apiBase}/auth/callback/google`,
     response_type: "code",
     scope: "openid email profile",
     state,
+    hd: "dali.dartmouth.edu",
   });
-
-  // Restrict to DALI domain for member login
-  if (accountType === "member") {
-    googleParams.set("hd", "dali.dartmouth.edu");
-  }
 
   headers.set(
     "Location",
@@ -164,7 +152,6 @@ export default function Login() {
             {/* DALI Member */}
             <Form method="post">
               <input type="hidden" name="provider" value="google" />
-              <input type="hidden" name="accountType" value="member" />
               <button
                 type="submit"
                 className="w-full flex items-center gap-4 p-5 rounded-2xl border-2 border-transparent bg-[#E8F4FA] dark:bg-secondary hover:border-accent-coral transition group text-left"
@@ -211,7 +198,6 @@ export default function Login() {
             {/* Applicant */}
             <Form method="post">
               <input type="hidden" name="provider" value="cas" />
-              <input type="hidden" name="accountType" value="dartmouth" />
               <button
                 type="submit"
                 className="w-full flex items-center gap-4 p-5 rounded-2xl border-2 border-transparent bg-[#E8F4FA] dark:bg-secondary hover:border-accent-coral transition group text-left"

--- a/dali-api/app/routes/oauth.authorize.ts
+++ b/dali-api/app/routes/oauth.authorize.ts
@@ -6,6 +6,13 @@ import {
   OAuthError,
 } from "~/lib/oauth";
 import { checkRateLimit } from "~/lib/rate-limit";
+import type { OAuthAccountType } from "~/generated/prisma/enums";
+
+const VALID_ACCOUNT_TYPES: ReadonlyArray<OAuthAccountType> = [
+  "member",
+  "dartmouth",
+  "partner",
+];
 
 const RATE_LIMIT_MAX = 10;
 const RATE_LIMIT_WINDOW_MS = 60_000;
@@ -70,10 +77,19 @@ export async function loader({ request }: Route.LoaderArgs) {
       "code_challenge with method S256 is required",
     );
   }
-  if (!provider || !["google", "cas"].includes(provider)) {
+  if (provider !== "google" && provider !== "cas") {
     return errorRedirect(
       "invalid_request",
       "provider must be 'google' or 'cas'",
+    );
+  }
+  if (
+    accountType !== null &&
+    !VALID_ACCOUNT_TYPES.includes(accountType as OAuthAccountType)
+  ) {
+    return errorRedirect(
+      "invalid_request",
+      "account_type must be 'member', 'dartmouth', or 'partner'",
     );
   }
 
@@ -83,7 +99,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     redirectUri,
     state,
     provider,
-    accountType: accountType ?? undefined,
+    accountType: (accountType as OAuthAccountType | null) ?? undefined,
   });
 
   const apiBase = process.env.API_BASE_URL ?? "http://localhost:5173";

--- a/dali-api/prisma/migrations/20260514024500_oauth_session_enums/migration.sql
+++ b/dali-api/prisma/migrations/20260514024500_oauth_session_enums/migration.sql
@@ -1,0 +1,17 @@
+-- Tighten OAuthSession.provider and OAuthSession.accountType from free-form
+-- text to Prisma enums. All current values ("google", "cas" for provider;
+-- "member", "dartmouth", "partner", or NULL for accountType) match the new
+-- enum labels, so the USING cast is a 1:1 relabel — no data conversion.
+
+-- CreateEnum
+CREATE TYPE "OAuthProvider" AS ENUM ('google', 'cas');
+
+-- CreateEnum
+CREATE TYPE "OAuthAccountType" AS ENUM ('member', 'dartmouth', 'partner');
+
+-- AlterTable
+ALTER TABLE "OAuthSession"
+  ALTER COLUMN "provider" TYPE "OAuthProvider"
+    USING ("provider"::text::"OAuthProvider"),
+  ALTER COLUMN "accountType" TYPE "OAuthAccountType"
+    USING ("accountType"::text::"OAuthAccountType");

--- a/dali-api/prisma/schema.prisma
+++ b/dali-api/prisma/schema.prisma
@@ -646,6 +646,17 @@ model CollabDocumentVersion {
 
 // ─── OAuth & Sessions ────────────────────────────────────────────────────────
 
+enum OAuthProvider {
+  google
+  cas
+}
+
+enum OAuthAccountType {
+  member
+  dartmouth
+  partner
+}
+
 model OAuthSession {
   id String @id @default(cuid())
 
@@ -656,8 +667,11 @@ model OAuthSession {
   // oAuth params preserved across IDP redirect
   redirectUri String
   state       String
-  provider    String // "google" | "cas"
-  accountType String? // "member" | "partner" (Google only)
+  provider    OAuthProvider
+  // Optional. Set when the OAuthClient row pins a single accountType
+  // (e.g. MCP clients require "member"). Null = any accountType is OK
+  // for this session, decided by the callback's domain branch.
+  accountType OAuthAccountType?
 
   // set after IDP authenticates user
   userId            String?


### PR DESCRIPTION
Closes / addresses Known auth-surface issues **E** and **H** in `dali-os-mcp.md`.

## Summary

**Issue E - always-enforce `@dali.dartmouth.edu` on `/auth/callback/google`.**
The domain check was previously gated on the `__dali_account_type=member`
cookie. If the cookie was missing or stripped, the check fell open and the
route's email-domain branches silently provisioned a Dartmouth-student or
partner User for someone who had clicked the Member button. The Member
button is the only `/login` path that uses this callback, so
`@dali.dartmouth.edu` is the only valid outcome. The check is now
unconditional, the `__dali_account_type` cookie is gone (the action no
longer sets it; the callback no longer reads or clears it), and the
now-unreachable dartmouth/partner branches in `/auth/callback/google` have
been removed. The OAuth-provider `/oauth/callback/google` still handles
those branches but gates on `OAuthSession.accountType`, which is
server-stored.

**Issue H - add Prisma enums for `OAuthSession`.** `provider` and
`accountType` were free-form strings, validated by route logic only.
Convert them to Prisma enums:

```prisma
enum OAuthProvider     { google, cas }
enum OAuthAccountType  { member, dartmouth, partner }
```

The migration is a 1:1 USING text->enum relabel (all existing rows already
match the new labels). `createOAuthSession` is now typed against the
enums, and `/oauth/authorize` validates `account_type` query values up
front rather than letting a bad value fail at INSERT.

## User-visible behavior change

The Member-button login flow used to silently log a user in as a
Dartmouth student or partner if the `__dali_account_type` cookie was
absent. After this change, any non-`@dali.dartmouth.edu` email at
`/auth/callback/google` returns to `/login?error=access_denied` with the
existing "Only @dali.dartmouth.edu accounts are allowed" message. The
Applicant (CAS) flow is unchanged. The Google `hd=dali.dartmouth.edu`
hint on Google's account picker is still set (it's a UX nudge, not a
security boundary).

## Test plan

- [ ] CI green (unit, e2e, migration-check, build-check, codeql)
- [ ] Manual smoke: Member-button login with `@dali.dartmouth.edu` -> success
- [ ] Manual smoke: Member-button login with a `@dartmouth.edu` student account -> `access_denied`
- [ ] Manual smoke: Applicant CAS login still works
- [ ] Migration runs cleanly on the staging Neon branch via the standard deploy path

## Concurrent PR notice

PR `claude/cleanup-calendar-link-route` (calendar-link split, issue F)
is running concurrently and touches a different section of
`auth.callback.google.ts` (the `cal:` state dispatch at lines ~37-61, untouched here).
Mergeable in either order; second-in gets a small rebase.