### PR TITLE
v0 Phase 1 — additive schema foundation for parallel feature tracks

### DIFF
--- a/V0_PHASE2_PLAN.md
+++ b/V0_PHASE2_PLAN.md
@@ -1,0 +1,302 @@
+# DALI OS v0 — Phase 2: Destructive Identity Refactor
+
+Runs **after** the 2026-S hire cycle closes (`ApplicationCycleStatus = Completed` in prod). Coordinated with cycle staff. Staging Neon branch restored from prod snapshot and verified before prod rollout.
+
+See `V0_PLAN.md` for the full v0 split and locked decisions. This doc covers Phase 2 only.
+
+## Goal
+
+After Phase 2 lands:
+- `DALIMember` is a thin marker (`{ id, userId @unique NOT NULL, createdAt, updatedAt }`).
+- All universal profile data lives on `User`. `user.firstName`, `user.daliEmail`, etc. — no `user.daliMember.<field>` indirection.
+- 9 hiring tables FK to `User` directly, not `DALIMember`.
+- `User.googleAccessToken / googleRefreshToken / googleTokenExpiresAt` columns are dropped. Gmail send-as moves to `GmailIntegration`. Free-busy uses `UserCalendarLink` exclusively.
+- `MemberRole[]` enum is gone. Roles are derived from `CoreAssignment`, `AdminMembership`, etc.
+- `OAuthAccountType` collapses to `member` only (Q11 / Q14 confirmations).
+- `upsertUserFromGoogle` simplifies to a single `@dali.dartmouth.edu` branch.
+
+## Pre-flight (must be true before merging Phase 2 to dev)
+
+- [ ] Phase 1 migration deployed to dev, staging, and prod (≥1 week of soak)
+- [ ] `feature/v0-phase2-identity-refactor` branched from latest `dev`
+- [ ] Live cycle status = `Completed`. Confirm via `SELECT status, "createdAt" FROM "ApplicationCycle"`.
+- [ ] Cycle staff sign-off that no further reads against pre-rename hiring data are expected
+- [ ] Staging Neon branch reset from a fresh prod snapshot
+
+## Migration sequence — one big PR, four migrations
+
+Phase 2 is a destructive refactor; pgfence will flag it. We split into a sequence so each step is isolated and roll-back-friendly. Each migration is its own SQL file inside the same PR.
+
+### M1 — Backfill staging columns (additive)
+
+```sql
+-- 1a. Add nullable userId columns on the 9 hiring tables that still FK to DALIMember.
+ALTER TABLE "CycleReviewer"                    ADD COLUMN "userId" TEXT;
+ALTER TABLE "CycleInterviewer"                 ADD COLUMN "userId" TEXT;
+ALTER TABLE "DomainLeadAssignment"             ADD COLUMN "userId" TEXT;
+ALTER TABLE "Decision"                         ADD COLUMN "madeByUserId" TEXT;
+ALTER TABLE "ApplicationReview"                ADD COLUMN "submittedByUserId" TEXT;
+ALTER TABLE "DelibsSession"                    ADD COLUMN "openedByUserId" TEXT;
+ALTER TABLE "LegacyEmailTemplate"              ADD COLUMN "createdByUserId" TEXT;
+ALTER TABLE "EmailTemplateVersion"             ADD COLUMN "createdByUserId" TEXT;
+ALTER TABLE "ConfidentialityAgreementVersion"  ADD COLUMN "createdByUserId" TEXT;
+
+-- 1b. Backfill from the existing DALIMember.userId join.
+UPDATE "CycleReviewer"                   SET "userId"            = "DALIMember"."userId" FROM "DALIMember" WHERE "CycleReviewer"."daliMemberId"           = "DALIMember"."id";
+UPDATE "CycleInterviewer"                SET "userId"            = "DALIMember"."userId" FROM "DALIMember" WHERE "CycleInterviewer"."daliMemberId"        = "DALIMember"."id";
+UPDATE "DomainLeadAssignment"            SET "userId"            = "DALIMember"."userId" FROM "DALIMember" WHERE "DomainLeadAssignment"."memberId"         = "DALIMember"."id";
+UPDATE "Decision"                        SET "madeByUserId"      = "DALIMember"."userId" FROM "DALIMember" WHERE "Decision"."madeById"                    = "DALIMember"."id";
+UPDATE "ApplicationReview"               SET "submittedByUserId" = "DALIMember"."userId" FROM "DALIMember" WHERE "ApplicationReview"."submittedById"      = "DALIMember"."id";
+UPDATE "DelibsSession"                   SET "openedByUserId"    = "DALIMember"."userId" FROM "DALIMember" WHERE "DelibsSession"."openedById"             = "DALIMember"."id";
+UPDATE "LegacyEmailTemplate"             SET "createdByUserId"   = "DALIMember"."userId" FROM "DALIMember" WHERE "LegacyEmailTemplate"."createdById"      = "DALIMember"."id";
+UPDATE "EmailTemplateVersion"            SET "createdByUserId"   = "DALIMember"."userId" FROM "DALIMember" WHERE "EmailTemplateVersion"."createdById"     = "DALIMember"."id";
+UPDATE "ConfidentialityAgreementVersion" SET "createdByUserId"   = "DALIMember"."userId" FROM "DALIMember" WHERE "ConfidentialityAgreementVersion"."createdById" = "DALIMember"."id";
+
+-- 1c. Add FK constraints (now valid since backfill is done).
+ALTER TABLE "CycleReviewer"                   ADD CONSTRAINT "CycleReviewer_userId_fkey"                   FOREIGN KEY ("userId")            REFERENCES "User"("id") ON DELETE RESTRICT;
+ALTER TABLE "CycleInterviewer"                ADD CONSTRAINT "CycleInterviewer_userId_fkey"                FOREIGN KEY ("userId")            REFERENCES "User"("id") ON DELETE RESTRICT;
+ALTER TABLE "DomainLeadAssignment"            ADD CONSTRAINT "DomainLeadAssignment_userId_fkey"            FOREIGN KEY ("userId")            REFERENCES "User"("id") ON DELETE RESTRICT;
+ALTER TABLE "Decision"                        ADD CONSTRAINT "Decision_madeByUserId_fkey"                  FOREIGN KEY ("madeByUserId")      REFERENCES "User"("id") ON DELETE RESTRICT;
+ALTER TABLE "ApplicationReview"               ADD CONSTRAINT "ApplicationReview_submittedByUserId_fkey"    FOREIGN KEY ("submittedByUserId") REFERENCES "User"("id") ON DELETE RESTRICT;
+ALTER TABLE "DelibsSession"                   ADD CONSTRAINT "DelibsSession_openedByUserId_fkey"           FOREIGN KEY ("openedByUserId")    REFERENCES "User"("id") ON DELETE RESTRICT;
+ALTER TABLE "LegacyEmailTemplate"             ADD CONSTRAINT "LegacyEmailTemplate_createdByUserId_fkey"    FOREIGN KEY ("createdByUserId")   REFERENCES "User"("id") ON DELETE RESTRICT;
+ALTER TABLE "EmailTemplateVersion"            ADD CONSTRAINT "EmailTemplateVersion_createdByUserId_fkey"   FOREIGN KEY ("createdByUserId")   REFERENCES "User"("id") ON DELETE RESTRICT;
+ALTER TABLE "ConfidentialityAgreementVersion" ADD CONSTRAINT "ConfidentialityAgreementVersion_createdByUserId_fkey" FOREIGN KEY ("createdByUserId") REFERENCES "User"("id") ON DELETE RESTRICT;
+```
+
+Reversibility: dropping columns and constraints. Old columns still active; nothing relies on the new ones yet.
+
+### M2 — Backfill DALIMember orphans → User rows
+
+```sql
+-- 116 orphans (NULL userId, contact-info only). Create matching User rows
+-- using daliEmail/firstName/lastName/did from DALIMember, then link.
+INSERT INTO "User" (id, "createdAt", "updatedAt", "firstName", "lastName", "daliEmail", "netId")
+SELECT
+  m.id,                              -- reuse the DALIMember id as the new User id (safe — Users use cuid; this stays unique)
+  m."createdAt",
+  m."updatedAt",
+  COALESCE(m."firstName", '?'),      -- required column; placeholder for empty rows
+  COALESCE(m."lastName", '?'),
+  m."daliEmail",
+  LOWER(m."did")                     -- did is the same identifier as netId per Kiran's clarification; normalize
+FROM "DALIMember" m
+WHERE m."userId" IS NULL
+  AND m."daliEmail" IS NOT NULL      -- skip totally-empty rows
+ON CONFLICT ("daliEmail") DO NOTHING;
+
+-- Link the now-existent User rows back to their DALIMember rows.
+UPDATE "DALIMember" m
+SET "userId" = u.id
+FROM "User" u
+WHERE m."userId" IS NULL AND m."daliEmail" = u."daliEmail";
+
+-- Surface any remaining orphans (should be 0 after the above).
+-- Run as a check, not a migration step. If non-zero, halt and inspect.
+SELECT COUNT(*) AS still_orphaned FROM "DALIMember" WHERE "userId" IS NULL;
+```
+
+### M3 — Backfill User columns from DALIMember + Gmail integration
+
+```sql
+-- Promote DALIMember.did to User.netId for users who don't have a netId yet.
+UPDATE "User" u
+SET "netId" = LOWER(m."did")
+FROM "DALIMember" m
+WHERE u.id = m."userId"
+  AND u."netId" IS NULL
+  AND m."did" IS NOT NULL;
+
+-- Backfill User.firstName / lastName from DALIMember for users whose User row
+-- has placeholder values (shouldn't be any after Phase 1, but defensive).
+UPDATE "User" u
+SET "firstName" = COALESCE(NULLIF(u."firstName", ''), m."firstName", '?'),
+    "lastName"  = COALESCE(NULLIF(u."lastName",  ''), m."lastName",  '?')
+FROM "DALIMember" m
+WHERE u.id = m."userId"
+  AND (u."firstName" = '?' OR u."lastName" = '?');
+
+-- Backfill MemberRole[] → CoreAssignment / AdminMembership.
+-- Resolve current term once.
+WITH current_term AS (
+  SELECT id FROM "Term"
+  WHERE "startDate" <= NOW() AND "endDate" >= NOW()
+  ORDER BY "sortKey" DESC LIMIT 1
+)
+INSERT INTO "CoreAssignment" (id, "userId", "termId", "leadTitle")
+SELECT
+  gen_random_uuid()::text,
+  m."userId",
+  (SELECT id FROM current_term),
+  'Hiring Lead'
+FROM "DALIMember" m
+WHERE m."userId" IS NOT NULL
+  AND 'HiringLead' = ANY(m."roles")
+  AND NOT EXISTS (
+    SELECT 1 FROM "CoreAssignment" ca
+    WHERE ca."userId" = m."userId"
+      AND ca."termId" = (SELECT id FROM current_term)
+      AND ca."leadTitle" = 'Hiring Lead'
+  );
+
+INSERT INTO "AdminMembership" (id, "userId", "grantedAt")
+SELECT
+  gen_random_uuid()::text,
+  m."userId",
+  NOW()
+FROM "DALIMember" m
+WHERE m."userId" IS NOT NULL
+  AND 'Admin' = ANY(m."roles")
+ON CONFLICT ("userId") DO NOTHING;
+
+-- Backfill DomainLeadAssignment.termId from the current term.
+WITH current_term AS (
+  SELECT id FROM "Term"
+  WHERE "startDate" <= NOW() AND "endDate" >= NOW()
+  ORDER BY "sortKey" DESC LIMIT 1
+)
+UPDATE "DomainLeadAssignment"
+SET "termId" = (SELECT id FROM current_term)
+WHERE "termId" IS NULL;
+
+-- Backfill GmailIntegration from User.google* for users who have a refresh
+-- token (the Gmail send-as admin user(s)).
+INSERT INTO "GmailIntegration" (id, "userId", "sendAsEmail", "oauthTokens", "tokenExpiresAt", "enabled", "linkedAt")
+SELECT
+  gen_random_uuid()::text,
+  u.id,
+  COALESCE(u."daliEmail", u."dartmouthEmail"),
+  -- IMPORTANT: pre-Phase-2, the tokens on User.google* were stored
+  -- plaintext (legacy). The Phase 2 code rewrite of /admin/authorize-gmail
+  -- moves to encrypted-at-rest via lib/calendar-crypto. The first time the
+  -- new code reads this row it should detect the legacy format, encrypt
+  -- in place, and continue. App-level concern; not handled here.
+  'LEGACY:' || u."googleRefreshToken",
+  u."googleTokenExpiresAt",
+  TRUE,
+  NOW()
+FROM "User" u
+WHERE u."googleRefreshToken" IS NOT NULL
+  AND NOT EXISTS (SELECT 1 FROM "GmailIntegration" g WHERE g."userId" = u.id);
+```
+
+### M4 — Drop legacy columns, tighten constraints, rename FK columns
+
+```sql
+-- 4a. Tighten DALIMember.userId.
+ALTER TABLE "DALIMember" ALTER COLUMN "userId" SET NOT NULL;
+
+-- 4b. Drop DALIMember duplicate columns.
+ALTER TABLE "DALIMember"
+  DROP COLUMN "firstName",
+  DROP COLUMN "lastName",
+  DROP COLUMN "daliEmail",
+  DROP COLUMN "dartmouthEmail",
+  DROP COLUMN "did",
+  DROP COLUMN "roles";
+
+-- 4c. Drop the MemberRole enum (no longer referenced).
+DROP TYPE "MemberRole";
+
+-- 4d. Drop legacy hiring FK columns. The new userId columns are in place.
+ALTER TABLE "CycleReviewer"                   DROP CONSTRAINT IF EXISTS "CycleReviewer_daliMemberId_fkey",                   DROP COLUMN "daliMemberId";
+ALTER TABLE "CycleInterviewer"                DROP CONSTRAINT IF EXISTS "CycleInterviewer_daliMemberId_fkey",                DROP COLUMN "daliMemberId";
+ALTER TABLE "DomainLeadAssignment"            DROP CONSTRAINT IF EXISTS "DomainLeadAssignment_memberId_fkey",                DROP COLUMN "memberId";
+ALTER TABLE "Decision"                        DROP CONSTRAINT IF EXISTS "Decision_madeById_fkey",                            DROP COLUMN "madeById";
+ALTER TABLE "ApplicationReview"               DROP CONSTRAINT IF EXISTS "ApplicationReview_submittedById_fkey",              DROP COLUMN "submittedById";
+ALTER TABLE "DelibsSession"                   DROP CONSTRAINT IF EXISTS "DelibsSession_openedById_fkey",                     DROP COLUMN "openedById";
+ALTER TABLE "LegacyEmailTemplate"             DROP CONSTRAINT IF EXISTS "LegacyEmailTemplate_createdById_fkey",              DROP COLUMN "createdById";
+ALTER TABLE "EmailTemplateVersion"            DROP CONSTRAINT IF EXISTS "EmailTemplateVersion_createdById_fkey",             DROP COLUMN "createdById";
+ALTER TABLE "ConfidentialityAgreementVersion" DROP CONSTRAINT IF EXISTS "ConfidentialityAgreementVersion_createdById_fkey", DROP COLUMN "createdById";
+
+-- 4e. Tighten userId columns on hiring tables.
+ALTER TABLE "CycleReviewer"                   ALTER COLUMN "userId"            SET NOT NULL;
+ALTER TABLE "CycleInterviewer"                ALTER COLUMN "userId"            SET NOT NULL;
+ALTER TABLE "DomainLeadAssignment"            ALTER COLUMN "userId"            SET NOT NULL;
+ALTER TABLE "Decision"                        ALTER COLUMN "madeByUserId"      SET NOT NULL;
+ALTER TABLE "DelibsSession"                   ALTER COLUMN "openedByUserId"    SET NOT NULL;
+ALTER TABLE "LegacyEmailTemplate"             ALTER COLUMN "createdByUserId"   SET NOT NULL;
+ALTER TABLE "EmailTemplateVersion"            ALTER COLUMN "createdByUserId"   SET NOT NULL;
+ALTER TABLE "ConfidentialityAgreementVersion" ALTER COLUMN "createdByUserId"   SET NOT NULL;
+-- ApplicationReview.submittedById was nullable (submit/unsubmit); keep
+-- submittedByUserId nullable to match.
+
+-- 4f. Tighten DomainLeadAssignment.termId.
+ALTER TABLE "DomainLeadAssignment" ALTER COLUMN "termId" SET NOT NULL;
+
+-- 4g. Recreate unique constraints with new column names.
+ALTER TABLE "CycleReviewer"        DROP CONSTRAINT IF EXISTS "CycleReviewer_daliMemberId_applicationCycleId_domainId_key";
+ALTER TABLE "CycleReviewer"        ADD CONSTRAINT "CycleReviewer_userId_applicationCycleId_domainId_key" UNIQUE ("userId", "applicationCycleId", "domainId");
+ALTER TABLE "CycleInterviewer"     DROP CONSTRAINT IF EXISTS "CycleInterviewer_daliMemberId_applicationCycleId_domainId_key";
+ALTER TABLE "CycleInterviewer"     ADD CONSTRAINT "CycleInterviewer_userId_applicationCycleId_domainId_key" UNIQUE ("userId", "applicationCycleId", "domainId");
+ALTER TABLE "DomainLeadAssignment" DROP CONSTRAINT IF EXISTS "DomainLeadAssignment_memberId_domainId_key";
+ALTER TABLE "DomainLeadAssignment" ADD CONSTRAINT "DomainLeadAssignment_userId_domainId_termId_key" UNIQUE ("userId", "domainId", "termId");
+ALTER TABLE "ApplicationReview"    DROP CONSTRAINT IF EXISTS "ApplicationReview_cycleReviewerId_domainApplicationId_key";
+-- (Recreate unchanged — only column references changed.)
+ALTER TABLE "ApplicationReview"    ADD CONSTRAINT "ApplicationReview_cycleReviewerId_domainApplicationId_key" UNIQUE ("cycleReviewerId", "domainApplicationId");
+
+-- 4h. Drop User.google* columns.
+ALTER TABLE "User"
+  DROP COLUMN "googleAccessToken",
+  DROP COLUMN "googleRefreshToken",
+  DROP COLUMN "googleTokenExpiresAt";
+
+-- 4i. Tighten Domain.code, Domain.displayName.
+ALTER TABLE "Domain" ALTER COLUMN "code"        SET NOT NULL;
+ALTER TABLE "Domain" ALTER COLUMN "displayName" SET NOT NULL;
+-- Domain.name retained (legacy display fallback in lib/display.ts).
+-- Drop in a follow-up if/when display.ts is rewritten.
+```
+
+## Code changes shipping in the same PR
+
+The schema-level rename is mechanical, but the code that reads/writes via Prisma needs updates. Touch list (file-by-file targets, not exhaustive):
+
+- `prisma/schema.prisma` — relations on hiring models flip from `DALIMember` to `User`; drop `roles` field; collapse `OAuthAccountType`.
+- `app/lib/auth/` — directory split (per Q6); `requireAuth`, `validateCasTicket` move to `cookie-login.ts`.
+- `app/lib/auth/oauth-provider.ts` — `upsertUserFromGoogle` collapses to member branch only; `OAuthAccountType` references removed.
+- `app/lib/auth/linking.ts` — add CAS→Google merge (per Q9 / Cl-4).
+- `app/lib/roles.ts` — rewritten per `V0_PLAN.md` §"Identity model". `MemberRole` references gone.
+- `app/lib/collabAuth.ts` — `daliMemberId` reads switch to `userId`.
+- `app/lib/google-calendar.ts` — delete `fetchBusyFromLegacyUserTokens`. Caller falls back to empty.
+- `app/lib/gmail.ts` (existing) and `lib/email.ts` — read from `GmailIntegration`.
+- `app/routes/admin.authorize-gmail.callback.ts` — write to `GmailIntegration`.
+- `app/routes/api.email.send.ts`, `hiring/lib/interview-emails.ts`, `hiring/lib/extension-notice.ts`, `hiring/routes/email-templates.tsx`, `hiring/routes/api.decisions.$id.release.ts`, `routes/portal.apply.tsx` — read `GmailIntegration` instead of `User.googleRefreshToken`.
+- ~30 hiring routes — replace `prisma.dALIMember.findFirst({ where: { userId } })` patterns with direct User reads. Per a grep at start of this work: see `app/admin-console/routes/api.members.$memberId.roles.ts`, all `/hiring/routes/api.*` files.
+- `app/admin-console/routes/admin-console.members.tsx`, `admin-console.domains.tsx` — `DALIMember.roles` editor removed; replace with `CoreAssignment` / `AdminMembership` UIs (or stub until Admin CRUD track ships).
+- `app/types.ts:193,200` — drop `daliMemberId` fields.
+- Tests — fixtures referencing `daliMemberId` / `DALIMember.firstName` updated.
+
+## Verification checklist
+
+### Staging dry-run
+
+- [ ] Reset staging Neon from prod snapshot
+- [ ] `npx prisma migrate deploy` applies M1–M4 cleanly
+- [ ] Run smoke tests on staging:
+  - [ ] CAS login → User row resolved
+  - [ ] Google login → DALIMember row resolved
+  - [ ] Domain Lead applications page lists all current-domain applications
+  - [ ] Reviewer can submit a review (writes to `ApplicationReview.submittedByUserId`)
+  - [ ] Interview can be scheduled / completed (Decision write path)
+  - [ ] Delibs session opens (DelibsSession.openedByUserId)
+  - [ ] Gmail send-as still sends (reads `GmailIntegration`)
+  - [ ] Free-busy returns events for users with `UserCalendarLink` (legacy fallback removed; users without link return empty — confirm 0 admin users are affected)
+- [ ] `SELECT COUNT(*) FROM "DALIMember" WHERE "userId" IS NULL` returns 0
+- [ ] `SELECT COUNT(*) FROM "DomainLeadAssignment" WHERE "termId" IS NULL` returns 0
+- [ ] `SELECT COUNT(*) FROM "CycleReviewer" WHERE "userId" IS NULL` returns 0 (and same for all 9 renamed tables)
+
+### Production rollout
+
+- [ ] Sign-off from cycle staff that 2026-S data is no longer being mutated
+- [ ] Database backup taken via Neon point-in-time recovery snapshot (`Neon → Branches → New from prod`)
+- [ ] Maintenance window scheduled (~30 min) for migration + smoke tests
+- [ ] Deploy to prod via the standard Fly.io release command flow
+- [ ] Post-deploy: re-run staging smoke checklist against prod
+- [ ] Rollback plan: revert the Fly release; Neon snapshot can be restored within minutes if catastrophic
+
+## Rollback notes
+
+M1 (column adds) and M2 (orphan migration) are reversible — drop new columns and User rows respectively. M3 (backfills) is reversible by deleting CoreAssignment/AdminMembership rows created from backfill. M4 (drops) is **not** reversible without restoring from snapshot. The Neon snapshot taken pre-deploy is the rollback path for M4 failures.
+
+If M4 fails partway, the migration is left in an inconsistent state. Do NOT attempt to hand-patch — restore from snapshot and re-run from scratch on staging to identify the failure.

--- a/V0_PLAN.md
+++ b/V0_PLAN.md
@@ -1,0 +1,190 @@
+# DALI OS v0 Foundation Plan
+
+Coordinated migration that unlocks parallel post-v0 track work. Authored after a Q&A pass on `expansion_plan.md` + `dali-os-mcp.md`. This doc captures the locked decisions; the source-of-truth for the schema is `dali-api/prisma/schema.prisma`.
+
+## Constraint: a hiring cycle is live in production
+
+The 2026-S hire cycle is `Open` / `UnderReview` while this lands. Migrations must be **additive only** during the cycle. Destructive changes (column drops, FK renames, NOT NULL tightening) are deferred to Phase 2 and run after the cycle closes — or coordinated with cycle staff on staging first.
+
+## Two-phase split
+
+| Phase | Scope | Live-cycle safe? | When |
+|---|---|---|---|
+| **1** | Add new tables. Add nullable columns. Backfill where data already exists. Seed Domain code/displayName, Term, JobCodeLookup, PageTemplate, MentorNoteTemplate. | Yes — purely additive | Now |
+| **2** | Drop `User.googleAccessToken/RefreshToken/TokenExpiresAt`. Drop `DALIMember.firstName/lastName/daliEmail/dartmouthEmail/did/roles[]`. Rename hiring FKs `memberId/daliMemberId → userId` (9 tables). Tighten `NOT NULL`. Drop `MemberRole` enum. | No — modifies hot-path columns | After 2026-S cycle closes |
+
+Feature tracks can start building against Phase 1 models the moment Phase 1 lands. They only depend on the **new** tables; the destructive parts of Phase 2 don't block them.
+
+## Locked decisions (from Kiran's Q&A pass)
+
+### Identity model
+
+- **DALIMember** stays as a thin marker after Phase 2: `{ id, userId @unique (NOT NULL), createdAt, updatedAt }`. Membership semantic = "row exists." Auto-created on any `@dali.dartmouth.edu` Google sign-in (per MCP decision D-1).
+- **`netId` = `did`**. They're the same Dartmouth identifier (case-normalized via lowercase). Keep `User.netId` column. Drop `DALIMember.did` in Phase 2; data backfills into `User.netId`.
+- **All universal profile fields live on `User`**, accessed as `user.<field>`. No `user.daliMember.firstName` indirection.
+- **PartnerUser.userId @unique → User**. Single Session model, shared middleware. PartnerUser carries org-scoped metadata (partnerOrgId, displayRole) and partner-only flags.
+- **116 orphan DALIMember rows** (NULL userId, contact-info only) get migrated to User rows + linked DALIMember rows during Phase 2. After Phase 2 there are no orphans.
+
+### User column changes
+
+**Added in Phase 1 (all nullable):**
+`classYear`, `graduatedAt`, `pronouns`, `photoUrl`, `bioDocId`, `major`, `hometown`, `linkedinUrl`, `githubUrl`, `personalSite`, `personalEmail`.
+`timeZone` already exists.
+
+**Dropped in Phase 2:** `googleAccessToken`, `googleRefreshToken`, `googleTokenExpiresAt`. Gmail send-as moves to new `GmailIntegration` model (added Phase 1). The legacy free-busy fallback in `lib/google-calendar.ts:fetchBusyFromLegacyUserTokens` is deleted in Phase 2 — it's only reachable for users with no `UserCalendarLink` AND Gmail-authorize tokens populated (today: ~1 admin account).
+
+### Auth / OAuth separation
+
+- `/auth/*` = website cookie sessions only. `/auth/callback/{google,cas}` issues `__dali_sid`.
+- `/oauth/*` = MCP only. `/oauth/{authorize,callback/*,token,revoke,consent}` issues opaque session ids (also stored in `__dali_sid` after exchange).
+- `/integrations/*` = token grants for external API access (calendar, gmail).
+- New file split (Phase 1):
+  - `lib/auth/cookie-login.ts` (was `lib/auth.ts`)
+  - `lib/auth/oauth-provider.ts` (was `lib/oauth.ts`)
+  - `lib/auth/session.ts` (unchanged)
+  - `lib/auth/provisioning.ts` (was `lib/user-provisioning.ts`)
+  - `lib/auth/linking.ts` (unchanged + adds CAS→Google merge)
+- `OAuthClient`, `OAuthGrant`, `OneTimeToken` (magic-link) models added in Phase 1. No `dali-api` client seed — table stays empty until MCP foundation track seeds `claude-desktop` / `claude-code` rows.
+- `upsertUserFromGoogle` collapses to **member-only** in Phase 2 (the `@dartmouth.edu` and partner branches are dead code post-Q14/Q11 confirmations). Partners auth through magic-link (Phase 1 has the model; Partner portal track builds the UI).
+
+### Hiring FK renames (Phase 2)
+
+Full sweep. Nine tables rename `memberId` / `daliMemberId` → `userId` and point at User:
+
+- `DomainLeadAssignment.memberId` → `userId` (also adds `termId` Phase 1 nullable, Phase 2 NOT NULL with backfill to current term)
+- `CycleReviewer.daliMemberId` → `userId`
+- `CycleInterviewer.daliMemberId` → `userId`
+- `Decision.madeById` → `userId`
+- `ApplicationReview.submittedById` → `userId`
+- `DelibsSession.openedById` → `userId`
+- `LegacyEmailTemplate.createdById` → `userId`
+- `EmailTemplateVersion.createdById` → `userId`
+- `ConfidentialityAgreementVersion.createdById` → `userId`
+
+`lib/roles.ts` gets rewritten same PR: `MemberRole[]` enum gone, helpers replaced per expansion_plan §"v0 Deliverables → §3."
+
+### Tier resolution
+
+```
+tier(userId, term?) =
+  has AdminMembership                    → Admin
+  has CoreAssignment(term)               → Core (still Member-access)
+  has DALIMember row:
+    if setupComplete(userId) is false    → MemberPendingSetup
+    else                                  → Member
+  has PartnerUser row                     → Partner
+  has any past assignments, no current:
+    if before classYear graduation       → "on leave" (treat as Member tier with reduced surface)
+    else                                  → Alumni
+  has netId, no DALIMember, no PartnerUser → Student
+  default                                  → Unknown (treated as logged-out)
+```
+
+`setupComplete(userId)`: `UserCalendarLink` row exists AND `classYear`, `pronouns`, `photoUrl` non-null. Derived, not stored.
+
+`currentTerm()`: resolves now() against `Term.startDate/endDate`. Between terms → returns upcoming term (so a member doesn't briefly become Alumni).
+
+### Notification reconciliation with PR #517
+
+PR #517 (`sp/notifications`) is currently open and introduces a `Notification` model + `MeetingRsvp` enum + `ScheduledMeeting.organizerCalendarLinkId`. The expansion plan calls for `NotificationEvent` / `NotificationPreference`.
+
+**Decision (pending Kiran's nod):** merge PR #517 first; v0 adopts its `Notification` as the canonical name, adds `NotificationPreference` alongside. If PR #517 doesn't land before this branch, v0 ships `NotificationEvent` and PR #517 rebases.
+
+### Other locked answers
+
+- `InstructorAssignment` unique → `[userId, offeringId, termId]` (a member instructing the same offering across two terms gets two rows).
+- `MentorshipPair` unique loosened to allow multi-mentor: drop the unique entirely, keep `@@index([menteeUserId, projectId, termId])`.
+- `Level <= DomainEligibility.level` check stays app-level (no DB constraint).
+- `Project.firstTermId` NOT NULL on creation. New rows always set it.
+- CAS→Google merge added to `lib/auth/linking.ts`: when an `@dali.dartmouth.edu` Google sign-in finds no daliEmail match but the chained CAS step returns a netId that matches an existing User, merge the User rows instead of creating a new one.
+
+## Phase 1 deliverables (this branch)
+
+1. **Schema additions** in `dali-api/prisma/schema.prisma`:
+   - All ~40 new models from expansion_plan + MCP plan.
+   - `User`: new nullable profile columns.
+   - `Domain`: add `code String?`, `displayName String?`, `isInternProgram Boolean @default(false)`, `active Boolean @default(true)`. Existing `name` retained for transition; Phase 2 enforces NOT NULL on code/displayName and drops `name`.
+   - `Application`: add `applicationType ApplicationType @default(Standard)`.
+   - `DomainLeadAssignment`: add `termId String?` (nullable).
+   - `Session.grantId`: add FK constraint to `OAuthGrant.id`.
+   - `OAuthAccountType` enum: leave intact in Phase 1; Phase 2 collapses to `member`-only.
+
+2. **Migration**: `npx prisma migrate dev --name v0_phase1_additive`. Single SQL file, no destructive operations. pgfence should be green.
+
+3. **Seed**:
+   - Local dev (`prisma/seed.ts`): the 3 existing domains get `code` + `displayName` populated. No change in dev test flow.
+   - Production reference data (`prisma/seeds/v0-reference.ts`): run via `npm run db:seed:v0-reference` after `prisma migrate deploy`. Seeds the 17 domains from expansion_plan §"Initial Domain seed" (idempotent), 12 Term rows (26W–28F), `PageTemplate` rows (Empty, Project Brief, Sprint Retro, Sprint Goals, Meeting Notes, Decision Log, Onboarding Doc), and a default `MentorNoteTemplate`. `JobCodeLookup` is intentionally NOT seeded here — it needs real Dartmouth payroll mappings managed via Admin Console.
+
+4. **No code changes** that depend on the new tables in Phase 1. `lib/auth/*` split + provisioning collapse happen in Phase 2.
+
+5. **`emitEvent` producer stub** in `lib/notifications.ts` so feature tracks can emit from day 1. Delivery is its own track.
+
+## Phase 2 deliverables (separate branch, after live cycle)
+
+1. Backfill scripts:
+   - Migrate `DALIMember` orphan rows → User + DALIMember pairs.
+   - Backfill `DomainLeadAssignment.termId` to current term.
+   - Backfill `MemberRole[]` → `CoreAssignment` (HiringLead) + `AdminMembership` (Admin) rows.
+   - Backfill `DALIMember.did` → `User.netId` (case-normalize).
+   - Backfill hiring-FK `userId` columns from `DALIMember.userId`.
+   - Backfill `GmailIntegration` from `User.google*` for the 1–2 admin accounts.
+   - Backfill `Domain.code` / `Domain.displayName` for any pre-Phase-1 rows missing them.
+
+2. Drop columns:
+   - `User.googleAccessToken`, `googleRefreshToken`, `googleTokenExpiresAt`
+   - `DALIMember.firstName`, `lastName`, `daliEmail`, `dartmouthEmail`, `did`, `roles[]`
+   - Old FK columns (`daliMemberId`, `memberId`, `madeById`, etc.) — keep new `userId` column.
+
+3. Tighten constraints:
+   - `DALIMember.userId` NOT NULL
+   - `DomainLeadAssignment.termId` NOT NULL
+   - `Domain.code`, `Domain.displayName` NOT NULL
+   - Hiring FKs `userId` NOT NULL
+
+4. Code refactor:
+   - `lib/roles.ts` rewritten.
+   - `lib/auth/*` file split.
+   - `upsertUserFromGoogle` collapsed to member-only branch.
+   - All `prisma.dALIMember.findFirst({ where: { userId } })` calls in ~30 hiring routes replaced with direct User reads.
+   - `MemberRole` enum dropped.
+   - `OAuthAccountType` enum collapsed to `member`-only.
+   - Legacy `fetchBusyFromLegacyUserTokens` deleted.
+   - Gmail send-as code (interview-emails.ts, extension-notice.ts, etc.) reads `GmailIntegration` instead of `User.google*`.
+
+5. Drop legacy:
+   - `MemberRole` enum.
+   - Test fixtures referencing `daliMemberId`.
+
+## Deploy sequencing
+
+| Step | Branch | Target | Notes |
+|---|---|---|---|
+| 1 | `v0-phase1-additive` | `dev` then `staging` then `prod` | Additive only. Live cycle unaffected. |
+| 2 | (feature tracks fork from here) | various | Parallel work. Build against new models. |
+| 3 | `v0-phase2-identity-refactor` | dev/staging first; **wait for cycle close** before prod | Destructive. Run backfills on staging; verify hiring routes still work end-to-end against the cycle data clone. |
+
+## Staging verification checklist (Phase 1)
+
+Run **before** merging Phase 1 to dev:
+
+- [ ] `npx prisma migrate dev` applies cleanly on a fresh DB
+- [ ] `npm run typecheck` green
+- [ ] `npm test` green (Vitest)
+- [ ] `npm run test:e2e` green (Playwright)
+- [ ] `migration-check.yml` (pgfence) green on the PR
+- [ ] Manual: dev seed runs; new tables empty as expected; existing data untouched
+- [ ] Manual: hiring routes still work against seeded cycle (no schema-driven regressions)
+
+## Staging verification checklist (Phase 2)
+
+Pre-merge gate (after cycle close):
+
+- [ ] Phase 1 already in prod
+- [ ] 2026-S cycle status = `Completed`
+- [ ] Staging Neon branch restored from prod snapshot
+- [ ] Backfill scripts dry-run on staging — counts match expectations
+- [ ] Apply Phase 2 migration on staging — `prisma migrate deploy` succeeds
+- [ ] Run hiring route smoke tests on staging against migrated data
+- [ ] Run new track integration tests
+- [ ] Sign-off from cycle staff that hiring data isn't needed in old shape
+- [ ] Roll forward to prod

--- a/dali-api/package.json
+++ b/dali-api/package.json
@@ -15,7 +15,8 @@
     "db:reset": "PRISMA_USER_CONSENT_FOR_DANGEROUS_AI_ACTION=yes prisma migrate reset --force && prisma db seed",
     "db:reset:local": "PRISMA_USER_CONSENT_FOR_DANGEROUS_AI_ACTION=yes DATABASE_URL=postgresql://dali:dali@localhost:5432/dali prisma migrate reset --force && DATABASE_URL=postgresql://dali:dali@localhost:5432/dali prisma db seed",
     "db:fetch:members": "tsx --env-file .env prisma/fetch-members.ts",
-    "db:seed:members": "tsx prisma/seed-members.ts"
+    "db:seed:members": "tsx prisma/seed-members.ts",
+    "db:seed:v0-reference": "tsx --env-file .env prisma/seeds/v0-reference.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1030.0",

--- a/dali-api/prisma/migrations/20260514040346_v0_phase1_additive/migration.sql
+++ b/dali-api/prisma/migrations/20260514040346_v0_phase1_additive/migration.sql
@@ -1,0 +1,1040 @@
+-- CreateEnum
+CREATE TYPE "ApplicationType" AS ENUM ('Standard', 'Intern', 'InternToFull', 'Transfer');
+
+-- CreateEnum
+CREATE TYPE "Season" AS ENUM ('W', 'S', 'X', 'F');
+
+-- CreateEnum
+CREATE TYPE "Level" AS ENUM ('P1', 'P2', 'P3');
+
+-- CreateEnum
+CREATE TYPE "AssignmentType" AS ENUM ('Project', 'Core', 'Instructor', 'DomainLead', 'Admin');
+
+-- CreateEnum
+CREATE TYPE "ProjectStatus" AS ENUM ('Active', 'Paused', 'Archived');
+
+-- CreateEnum
+CREATE TYPE "EpicStatus" AS ENUM ('Open', 'InProgress', 'Done', 'Cancelled');
+
+-- CreateEnum
+CREATE TYPE "SprintStatus" AS ENUM ('Planned', 'Active', 'Closed');
+
+-- CreateEnum
+CREATE TYPE "TaskStatus" AS ENUM ('Todo', 'InProgress', 'InReview', 'Done', 'Cancelled');
+
+-- CreateEnum
+CREATE TYPE "Priority" AS ENUM ('Low', 'Normal', 'High', 'Urgent');
+
+-- CreateEnum
+CREATE TYPE "OfferingType" AS ENUM ('Miniseries', 'Workshop');
+
+-- CreateEnum
+CREATE TYPE "OfferingStatus" AS ENUM ('Draft', 'Published', 'Archived');
+
+-- CreateEnum
+CREATE TYPE "EduApplicationStatus" AS ENUM ('Submitted', 'Approved', 'Rejected', 'Waitlisted', 'Withdrawn');
+
+-- CreateEnum
+CREATE TYPE "AttendanceStatus" AS ENUM ('Present', 'Absent', 'Excused');
+
+-- CreateEnum
+CREATE TYPE "SubmissionType" AS ENUM ('Text', 'File', 'Mixed');
+
+-- CreateEnum
+CREATE TYPE "StaffingStatus" AS ENUM ('Draft', 'OpenToCoreFirst', 'OpenToMembers', 'Assigning', 'Closed');
+
+-- CreateEnum
+CREATE TYPE "EssentialityLevel" AS ENUM ('Critical', 'Important', 'NiceToHave', 'NotNeeded');
+
+-- CreateEnum
+CREATE TYPE "StaffingAssignmentStatus" AS ENUM ('Proposed', 'Confirmed', 'Declined');
+
+-- CreateEnum
+CREATE TYPE "WorkspaceType" AS ENUM ('Lab', 'Project', 'EducationOffering');
+
+-- CreateEnum
+CREATE TYPE "PageKind" AS ENUM ('FreeForm', 'Structured');
+
+-- CreateEnum
+CREATE TYPE "DigestFreq" AS ENUM ('Instant', 'Daily', 'Weekly', 'Off');
+
+-- CreateEnum
+CREATE TYPE "PartnerAuthProvider" AS ENUM ('MagicLink', 'Google');
+
+-- CreateEnum
+CREATE TYPE "TokenPurpose" AS ENUM ('PartnerMagicLink', 'AlumniEmailLink', 'EmailVerification');
+
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "bioDocId" TEXT,
+ADD COLUMN     "classYear" INTEGER,
+ADD COLUMN     "githubUrl" TEXT,
+ADD COLUMN     "graduatedAt" TIMESTAMP(3),
+ADD COLUMN     "hometown" TEXT,
+ADD COLUMN     "linkedinUrl" TEXT,
+ADD COLUMN     "major" TEXT,
+ADD COLUMN     "personalEmail" TEXT,
+ADD COLUMN     "personalSite" TEXT,
+ADD COLUMN     "photoUrl" TEXT,
+ADD COLUMN     "pronouns" TEXT;
+
+-- AlterTable
+ALTER TABLE "Application" ADD COLUMN     "applicationType" "ApplicationType" NOT NULL DEFAULT 'Standard';
+
+-- AlterTable
+ALTER TABLE "Domain" ADD COLUMN     "active" BOOLEAN NOT NULL DEFAULT true,
+ADD COLUMN     "code" TEXT,
+ADD COLUMN     "displayName" TEXT,
+ADD COLUMN     "isInternProgram" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "DomainLeadAssignment" ADD COLUMN     "termId" TEXT;
+
+-- CreateTable
+CREATE TABLE "Term" (
+    "id" TEXT NOT NULL,
+    "code" TEXT NOT NULL,
+    "year" INTEGER NOT NULL,
+    "season" "Season" NOT NULL,
+    "sortKey" INTEGER NOT NULL,
+    "startDate" TIMESTAMP(3) NOT NULL,
+    "endDate" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Term_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "DomainEligibility" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "domainId" TEXT NOT NULL,
+    "level" "Level" NOT NULL,
+    "promotedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "promotedBy" TEXT,
+
+    CONSTRAINT "DomainEligibility_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ProjectAssignment" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "termId" TEXT NOT NULL,
+    "domainId" TEXT NOT NULL,
+    "level" "Level" NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ProjectAssignment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "MentorshipPair" (
+    "id" TEXT NOT NULL,
+    "menteeUserId" TEXT NOT NULL,
+    "mentorUserId" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "termId" TEXT NOT NULL,
+    "domainId" TEXT NOT NULL,
+
+    CONSTRAINT "MentorshipPair_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "CoreAssignment" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "termId" TEXT NOT NULL,
+    "leadTitle" TEXT,
+
+    CONSTRAINT "CoreAssignment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "InstructorAssignment" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "offeringId" TEXT NOT NULL,
+    "termId" TEXT NOT NULL,
+
+    CONSTRAINT "InstructorAssignment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "AdminMembership" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "grantedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "grantedBy" TEXT,
+
+    CONSTRAINT "AdminMembership_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "JobCodeLookup" (
+    "id" TEXT NOT NULL,
+    "assignmentType" "AssignmentType" NOT NULL,
+    "level" "Level",
+    "domainId" TEXT,
+    "jobCode" TEXT NOT NULL,
+    "payRateUsdHour" DECIMAL(65,30),
+    "notes" TEXT,
+
+    CONSTRAINT "JobCodeLookup_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Project" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "calendarEmail" TEXT,
+    "firstTermId" TEXT,
+    "status" "ProjectStatus" NOT NULL DEFAULT 'Active',
+    "overviewPageId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Project_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ProjectTermStatus" (
+    "id" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "termId" TEXT NOT NULL,
+    "isContinuing" BOOLEAN NOT NULL,
+    "setBy" TEXT,
+    "setAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ProjectTermStatus_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ProjectRoleRequest" (
+    "id" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "termId" TEXT NOT NULL,
+    "domainId" TEXT NOT NULL,
+    "level" "Level" NOT NULL,
+    "slots" INTEGER NOT NULL,
+    "notesDocId" TEXT,
+
+    CONSTRAINT "ProjectRoleRequest_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Epic" (
+    "id" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "descriptionDocId" TEXT,
+    "status" "EpicStatus" NOT NULL DEFAULT 'Open',
+    "targetTermId" TEXT,
+    "position" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Epic_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Sprint" (
+    "id" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "startsAt" TIMESTAMP(3) NOT NULL,
+    "endsAt" TIMESTAMP(3) NOT NULL,
+    "goalDocId" TEXT,
+    "status" "SprintStatus" NOT NULL DEFAULT 'Planned',
+
+    CONSTRAINT "Sprint_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Task" (
+    "id" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "sprintId" TEXT,
+    "epicId" TEXT,
+    "title" TEXT NOT NULL,
+    "descriptionDocId" TEXT,
+    "status" "TaskStatus" NOT NULL DEFAULT 'Todo',
+    "priority" "Priority" NOT NULL DEFAULT 'Normal',
+    "position" INTEGER NOT NULL DEFAULT 0,
+    "checklist" JSONB,
+    "createdById" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Task_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "TaskAssignee" (
+    "taskId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+
+    CONSTRAINT "TaskAssignee_pkey" PRIMARY KEY ("taskId","userId")
+);
+
+-- CreateTable
+CREATE TABLE "TaskComment" (
+    "id" TEXT NOT NULL,
+    "taskId" TEXT NOT NULL,
+    "authorId" TEXT NOT NULL,
+    "body" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "TaskComment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "EducationOffering" (
+    "id" TEXT NOT NULL,
+    "type" "OfferingType" NOT NULL,
+    "title" TEXT NOT NULL,
+    "descriptionDocId" TEXT,
+    "capacity" INTEGER NOT NULL,
+    "registrationOpensAt" TIMESTAMP(3) NOT NULL,
+    "registrationClosesAt" TIMESTAMP(3) NOT NULL,
+    "startsAt" TIMESTAMP(3) NOT NULL,
+    "endsAt" TIMESTAMP(3) NOT NULL,
+    "status" "OfferingStatus" NOT NULL DEFAULT 'Draft',
+    "requiresReview" BOOLEAN NOT NULL,
+    "calendarEmail" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "EducationOffering_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "EducationSession" (
+    "id" TEXT NOT NULL,
+    "offeringId" TEXT NOT NULL,
+    "sequence" INTEGER NOT NULL,
+    "datetime" TIMESTAMP(3) NOT NULL,
+    "location" TEXT,
+    "materialsDocId" TEXT,
+    "recordingUrl" TEXT,
+
+    CONSTRAINT "EducationSession_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "EducationApplication" (
+    "id" TEXT NOT NULL,
+    "applicantUserId" TEXT NOT NULL,
+    "offeringId" TEXT NOT NULL,
+    "status" "EduApplicationStatus" NOT NULL,
+    "submittedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "reviewedAt" TIMESTAMP(3),
+    "reviewedBy" TEXT,
+
+    CONSTRAINT "EducationApplication_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "EducationApplicationQuestion" (
+    "id" TEXT NOT NULL,
+    "offeringId" TEXT NOT NULL,
+    "prompt" TEXT NOT NULL,
+    "position" INTEGER NOT NULL,
+    "required" BOOLEAN NOT NULL DEFAULT true,
+
+    CONSTRAINT "EducationApplicationQuestion_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "EducationApplicationAnswer" (
+    "id" TEXT NOT NULL,
+    "applicationId" TEXT NOT NULL,
+    "questionId" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+
+    CONSTRAINT "EducationApplicationAnswer_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "EducationAttendance" (
+    "id" TEXT NOT NULL,
+    "applicationId" TEXT NOT NULL,
+    "sessionId" TEXT NOT NULL,
+    "status" "AttendanceStatus" NOT NULL,
+
+    CONSTRAINT "EducationAttendance_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "EducationAssignment" (
+    "id" TEXT NOT NULL,
+    "offeringId" TEXT,
+    "sessionId" TEXT,
+    "title" TEXT NOT NULL,
+    "instructionsDocId" TEXT,
+    "dueAt" TIMESTAMP(3),
+    "submissionType" "SubmissionType" NOT NULL,
+
+    CONSTRAINT "EducationAssignment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "EducationSubmission" (
+    "id" TEXT NOT NULL,
+    "assignmentId" TEXT NOT NULL,
+    "studentId" TEXT NOT NULL,
+    "contentDocId" TEXT,
+    "files" JSONB,
+    "submittedAt" TIMESTAMP(3),
+    "gradedAt" TIMESTAMP(3),
+    "feedbackDocId" TEXT,
+    "educationApplicationId" TEXT,
+
+    CONSTRAINT "EducationSubmission_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "EducationAnnouncement" (
+    "id" TEXT NOT NULL,
+    "offeringId" TEXT NOT NULL,
+    "authorId" TEXT NOT NULL,
+    "body" TEXT NOT NULL,
+    "sentAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "EducationAnnouncement_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "StaffingCycle" (
+    "id" TEXT NOT NULL,
+    "termId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "opensAt" TIMESTAMP(3) NOT NULL,
+    "closesAt" TIMESTAMP(3) NOT NULL,
+    "maxPreferencesPerMember" INTEGER NOT NULL DEFAULT 3,
+    "status" "StaffingStatus" NOT NULL DEFAULT 'Draft',
+
+    CONSTRAINT "StaffingCycle_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "StaffingPreference" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "staffingCycleId" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "domainId" TEXT NOT NULL,
+    "level" "Level" NOT NULL,
+    "preferenceRank" INTEGER NOT NULL,
+    "notes" TEXT,
+
+    CONSTRAINT "StaffingPreference_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "EssentialityForm" (
+    "id" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "staffingCycleId" TEXT NOT NULL,
+    "pmUserId" TEXT NOT NULL,
+    "submittedAt" TIMESTAMP(3),
+
+    CONSTRAINT "EssentialityForm_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "EssentialityRating" (
+    "id" TEXT NOT NULL,
+    "essentialityFormId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "rating" "EssentialityLevel" NOT NULL,
+    "notes" TEXT,
+
+    CONSTRAINT "EssentialityRating_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "StaffingAssignment" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "staffingCycleId" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "termId" TEXT NOT NULL,
+    "domainId" TEXT NOT NULL,
+    "level" "Level" NOT NULL,
+    "status" "StaffingAssignmentStatus" NOT NULL DEFAULT 'Proposed',
+    "assignedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "assignedById" TEXT,
+
+    CONSTRAINT "StaffingAssignment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Page" (
+    "id" TEXT NOT NULL,
+    "workspaceType" "WorkspaceType" NOT NULL,
+    "workspaceId" TEXT,
+    "parentPageId" TEXT,
+    "title" TEXT NOT NULL,
+    "kind" "PageKind" NOT NULL DEFAULT 'FreeForm',
+    "contentDocId" TEXT,
+    "position" INTEGER NOT NULL DEFAULT 0,
+    "iconEmoji" TEXT,
+    "coverImageUrl" TEXT,
+    "lastEditedById" TEXT,
+    "archivedAt" TIMESTAMP(3),
+    "createdById" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Page_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "PageTemplate" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "workspaceTypes" "WorkspaceType"[],
+    "contentDocId" TEXT NOT NULL,
+    "iconEmoji" TEXT,
+    "isDefault" BOOLEAN NOT NULL DEFAULT false,
+    "createdBy" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "PageTemplate_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "MentorNote" (
+    "id" TEXT NOT NULL,
+    "mentorId" TEXT NOT NULL,
+    "menteeId" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "termId" TEXT NOT NULL,
+    "domainId" TEXT NOT NULL,
+    "weekOf" TIMESTAMP(3) NOT NULL,
+    "contentDocId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "MentorNote_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "MentorNoteTemplate" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "contentDocId" TEXT NOT NULL,
+    "isDefault" BOOLEAN NOT NULL DEFAULT false,
+    "lastUpdatedBy" TEXT,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "MentorNoteTemplate_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "NotificationEvent" (
+    "id" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "recipientId" TEXT NOT NULL,
+    "payload" JSONB NOT NULL,
+    "readAt" TIMESTAMP(3),
+    "inAppDelivered" BOOLEAN NOT NULL DEFAULT false,
+    "emailDelivered" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "NotificationEvent_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "NotificationPreference" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "eventType" TEXT NOT NULL,
+    "inApp" BOOLEAN NOT NULL DEFAULT true,
+    "email" BOOLEAN NOT NULL DEFAULT true,
+    "digestFrequency" "DigestFreq" NOT NULL DEFAULT 'Instant',
+
+    CONSTRAINT "NotificationPreference_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "PartnerOrg" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "logoUrl" TEXT,
+    "website" TEXT,
+    "primaryContactId" TEXT,
+    "isIndividual" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "PartnerOrg_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "PartnerUser" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "partnerOrgId" TEXT NOT NULL,
+    "displayRole" TEXT,
+    "authProvider" "PartnerAuthProvider" NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "PartnerUser_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ProjectPartner" (
+    "id" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "partnerOrgId" TEXT NOT NULL,
+    "startedAt" TIMESTAMP(3),
+    "endedAt" TIMESTAMP(3),
+
+    CONSTRAINT "ProjectPartner_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "OAuthClient" (
+    "id" TEXT NOT NULL,
+    "clientId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "redirectUris" TEXT[],
+    "isLoopback" BOOLEAN NOT NULL DEFAULT false,
+    "isFirstParty" BOOLEAN NOT NULL DEFAULT false,
+    "allowedScopes" TEXT[],
+    "allowedProviders" TEXT[],
+    "requiredAccountType" TEXT,
+    "requireMembership" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "OAuthClient_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "OAuthGrant" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "clientId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "scopes" TEXT[],
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastUsedAt" TIMESTAMP(3),
+    "revokedAt" TIMESTAMP(3),
+
+    CONSTRAINT "OAuthGrant_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "OneTimeToken" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "tokenHash" TEXT NOT NULL,
+    "purpose" "TokenPurpose" NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "usedAt" TIMESTAMP(3),
+    "metadata" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "OneTimeToken_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "GmailIntegration" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "sendAsEmail" TEXT NOT NULL,
+    "oauthTokens" TEXT NOT NULL,
+    "tokenExpiresAt" TIMESTAMP(3),
+    "enabled" BOOLEAN NOT NULL DEFAULT true,
+    "lastUsedAt" TIMESTAMP(3),
+    "syncError" TEXT,
+    "linkedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "GmailIntegration_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Term_code_key" ON "Term"("code");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Term_sortKey_key" ON "Term"("sortKey");
+
+-- CreateIndex
+CREATE INDEX "Term_sortKey_idx" ON "Term"("sortKey");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "DomainEligibility_userId_domainId_key" ON "DomainEligibility"("userId", "domainId");
+
+-- CreateIndex
+CREATE INDEX "ProjectAssignment_userId_termId_idx" ON "ProjectAssignment"("userId", "termId");
+
+-- CreateIndex
+CREATE INDEX "ProjectAssignment_projectId_termId_idx" ON "ProjectAssignment"("projectId", "termId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ProjectAssignment_userId_projectId_termId_domainId_key" ON "ProjectAssignment"("userId", "projectId", "termId", "domainId");
+
+-- CreateIndex
+CREATE INDEX "MentorshipPair_menteeUserId_projectId_termId_idx" ON "MentorshipPair"("menteeUserId", "projectId", "termId");
+
+-- CreateIndex
+CREATE INDEX "MentorshipPair_mentorUserId_termId_idx" ON "MentorshipPair"("mentorUserId", "termId");
+
+-- CreateIndex
+CREATE INDEX "CoreAssignment_userId_termId_idx" ON "CoreAssignment"("userId", "termId");
+
+-- CreateIndex
+CREATE INDEX "CoreAssignment_termId_leadTitle_idx" ON "CoreAssignment"("termId", "leadTitle");
+
+-- CreateIndex
+CREATE INDEX "InstructorAssignment_offeringId_termId_idx" ON "InstructorAssignment"("offeringId", "termId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "InstructorAssignment_userId_offeringId_termId_key" ON "InstructorAssignment"("userId", "offeringId", "termId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AdminMembership_userId_key" ON "AdminMembership"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Project_overviewPageId_key" ON "Project"("overviewPageId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ProjectTermStatus_projectId_termId_key" ON "ProjectTermStatus"("projectId", "termId");
+
+-- CreateIndex
+CREATE INDEX "ProjectRoleRequest_projectId_termId_idx" ON "ProjectRoleRequest"("projectId", "termId");
+
+-- CreateIndex
+CREATE INDEX "Sprint_projectId_status_idx" ON "Sprint"("projectId", "status");
+
+-- CreateIndex
+CREATE INDEX "Task_projectId_sprintId_idx" ON "Task"("projectId", "sprintId");
+
+-- CreateIndex
+CREATE INDEX "TaskComment_taskId_createdAt_idx" ON "TaskComment"("taskId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "EducationSession_offeringId_sequence_idx" ON "EducationSession"("offeringId", "sequence");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "EducationApplication_applicantUserId_offeringId_key" ON "EducationApplication"("applicantUserId", "offeringId");
+
+-- CreateIndex
+CREATE INDEX "EducationApplicationQuestion_offeringId_position_idx" ON "EducationApplicationQuestion"("offeringId", "position");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "EducationApplicationAnswer_applicationId_questionId_key" ON "EducationApplicationAnswer"("applicationId", "questionId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "EducationAttendance_applicationId_sessionId_key" ON "EducationAttendance"("applicationId", "sessionId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "EducationSubmission_assignmentId_studentId_key" ON "EducationSubmission"("assignmentId", "studentId");
+
+-- CreateIndex
+CREATE INDEX "EducationAnnouncement_offeringId_sentAt_idx" ON "EducationAnnouncement"("offeringId", "sentAt");
+
+-- CreateIndex
+CREATE INDEX "StaffingPreference_staffingCycleId_userId_idx" ON "StaffingPreference"("staffingCycleId", "userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "StaffingPreference_userId_staffingCycleId_projectId_domainI_key" ON "StaffingPreference"("userId", "staffingCycleId", "projectId", "domainId", "level");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "EssentialityForm_projectId_staffingCycleId_key" ON "EssentialityForm"("projectId", "staffingCycleId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "EssentialityRating_essentialityFormId_userId_key" ON "EssentialityRating"("essentialityFormId", "userId");
+
+-- CreateIndex
+CREATE INDEX "StaffingAssignment_userId_termId_idx" ON "StaffingAssignment"("userId", "termId");
+
+-- CreateIndex
+CREATE INDEX "StaffingAssignment_projectId_termId_idx" ON "StaffingAssignment"("projectId", "termId");
+
+-- CreateIndex
+CREATE INDEX "Page_workspaceType_workspaceId_parentPageId_idx" ON "Page"("workspaceType", "workspaceId", "parentPageId");
+
+-- CreateIndex
+CREATE INDEX "Page_archivedAt_idx" ON "Page"("archivedAt");
+
+-- CreateIndex
+CREATE INDEX "MentorNote_menteeId_termId_idx" ON "MentorNote"("menteeId", "termId");
+
+-- CreateIndex
+CREATE INDEX "MentorNote_mentorId_termId_idx" ON "MentorNote"("mentorId", "termId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "MentorNote_mentorId_menteeId_projectId_termId_domainId_week_key" ON "MentorNote"("mentorId", "menteeId", "projectId", "termId", "domainId", "weekOf");
+
+-- CreateIndex
+CREATE INDEX "NotificationEvent_recipientId_readAt_idx" ON "NotificationEvent"("recipientId", "readAt");
+
+-- CreateIndex
+CREATE INDEX "NotificationEvent_recipientId_createdAt_idx" ON "NotificationEvent"("recipientId", "createdAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "NotificationPreference_userId_eventType_key" ON "NotificationPreference"("userId", "eventType");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PartnerUser_userId_key" ON "PartnerUser"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ProjectPartner_projectId_partnerOrgId_key" ON "ProjectPartner"("projectId", "partnerOrgId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "OAuthClient_clientId_key" ON "OAuthClient"("clientId");
+
+-- CreateIndex
+CREATE INDEX "OAuthGrant_userId_revokedAt_idx" ON "OAuthGrant"("userId", "revokedAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "OAuthGrant_userId_clientId_key" ON "OAuthGrant"("userId", "clientId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "OneTimeToken_tokenHash_key" ON "OneTimeToken"("tokenHash");
+
+-- CreateIndex
+CREATE INDEX "OneTimeToken_userId_purpose_idx" ON "OneTimeToken"("userId", "purpose");
+
+-- CreateIndex
+CREATE INDEX "OneTimeToken_expiresAt_idx" ON "OneTimeToken"("expiresAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "GmailIntegration_userId_key" ON "GmailIntegration"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_personalEmail_key" ON "User"("personalEmail");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Domain_code_key" ON "Domain"("code");
+
+-- CreateIndex
+CREATE INDEX "DomainLeadAssignment_termId_idx" ON "DomainLeadAssignment"("termId");
+
+-- AddForeignKey
+ALTER TABLE "Session" ADD CONSTRAINT "Session_grantId_fkey" FOREIGN KEY ("grantId") REFERENCES "OAuthGrant"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DomainLeadAssignment" ADD CONSTRAINT "DomainLeadAssignment_termId_fkey" FOREIGN KEY ("termId") REFERENCES "Term"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DomainEligibility" ADD CONSTRAINT "DomainEligibility_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DomainEligibility" ADD CONSTRAINT "DomainEligibility_domainId_fkey" FOREIGN KEY ("domainId") REFERENCES "Domain"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ProjectAssignment" ADD CONSTRAINT "ProjectAssignment_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ProjectAssignment" ADD CONSTRAINT "ProjectAssignment_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ProjectAssignment" ADD CONSTRAINT "ProjectAssignment_termId_fkey" FOREIGN KEY ("termId") REFERENCES "Term"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ProjectAssignment" ADD CONSTRAINT "ProjectAssignment_domainId_fkey" FOREIGN KEY ("domainId") REFERENCES "Domain"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MentorshipPair" ADD CONSTRAINT "MentorshipPair_menteeUserId_fkey" FOREIGN KEY ("menteeUserId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MentorshipPair" ADD CONSTRAINT "MentorshipPair_mentorUserId_fkey" FOREIGN KEY ("mentorUserId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MentorshipPair" ADD CONSTRAINT "MentorshipPair_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MentorshipPair" ADD CONSTRAINT "MentorshipPair_termId_fkey" FOREIGN KEY ("termId") REFERENCES "Term"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MentorshipPair" ADD CONSTRAINT "MentorshipPair_domainId_fkey" FOREIGN KEY ("domainId") REFERENCES "Domain"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CoreAssignment" ADD CONSTRAINT "CoreAssignment_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "CoreAssignment" ADD CONSTRAINT "CoreAssignment_termId_fkey" FOREIGN KEY ("termId") REFERENCES "Term"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "InstructorAssignment" ADD CONSTRAINT "InstructorAssignment_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "InstructorAssignment" ADD CONSTRAINT "InstructorAssignment_offeringId_fkey" FOREIGN KEY ("offeringId") REFERENCES "EducationOffering"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "InstructorAssignment" ADD CONSTRAINT "InstructorAssignment_termId_fkey" FOREIGN KEY ("termId") REFERENCES "Term"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AdminMembership" ADD CONSTRAINT "AdminMembership_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Project" ADD CONSTRAINT "Project_firstTermId_fkey" FOREIGN KEY ("firstTermId") REFERENCES "Term"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Project" ADD CONSTRAINT "Project_overviewPageId_fkey" FOREIGN KEY ("overviewPageId") REFERENCES "Page"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ProjectTermStatus" ADD CONSTRAINT "ProjectTermStatus_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ProjectTermStatus" ADD CONSTRAINT "ProjectTermStatus_termId_fkey" FOREIGN KEY ("termId") REFERENCES "Term"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ProjectRoleRequest" ADD CONSTRAINT "ProjectRoleRequest_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ProjectRoleRequest" ADD CONSTRAINT "ProjectRoleRequest_termId_fkey" FOREIGN KEY ("termId") REFERENCES "Term"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ProjectRoleRequest" ADD CONSTRAINT "ProjectRoleRequest_domainId_fkey" FOREIGN KEY ("domainId") REFERENCES "Domain"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Epic" ADD CONSTRAINT "Epic_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Sprint" ADD CONSTRAINT "Sprint_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Task" ADD CONSTRAINT "Task_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Task" ADD CONSTRAINT "Task_sprintId_fkey" FOREIGN KEY ("sprintId") REFERENCES "Sprint"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Task" ADD CONSTRAINT "Task_epicId_fkey" FOREIGN KEY ("epicId") REFERENCES "Epic"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Task" ADD CONSTRAINT "Task_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TaskAssignee" ADD CONSTRAINT "TaskAssignee_taskId_fkey" FOREIGN KEY ("taskId") REFERENCES "Task"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TaskAssignee" ADD CONSTRAINT "TaskAssignee_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TaskComment" ADD CONSTRAINT "TaskComment_taskId_fkey" FOREIGN KEY ("taskId") REFERENCES "Task"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TaskComment" ADD CONSTRAINT "TaskComment_authorId_fkey" FOREIGN KEY ("authorId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "EducationSession" ADD CONSTRAINT "EducationSession_offeringId_fkey" FOREIGN KEY ("offeringId") REFERENCES "EducationOffering"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "EducationApplication" ADD CONSTRAINT "EducationApplication_applicantUserId_fkey" FOREIGN KEY ("applicantUserId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "EducationApplication" ADD CONSTRAINT "EducationApplication_offeringId_fkey" FOREIGN KEY ("offeringId") REFERENCES "EducationOffering"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "EducationApplicationQuestion" ADD CONSTRAINT "EducationApplicationQuestion_offeringId_fkey" FOREIGN KEY ("offeringId") REFERENCES "EducationOffering"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "EducationApplicationAnswer" ADD CONSTRAINT "EducationApplicationAnswer_applicationId_fkey" FOREIGN KEY ("applicationId") REFERENCES "EducationApplication"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "EducationApplicationAnswer" ADD CONSTRAINT "EducationApplicationAnswer_questionId_fkey" FOREIGN KEY ("questionId") REFERENCES "EducationApplicationQuestion"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "EducationAttendance" ADD CONSTRAINT "EducationAttendance_applicationId_fkey" FOREIGN KEY ("applicationId") REFERENCES "EducationApplication"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "EducationAttendance" ADD CONSTRAINT "EducationAttendance_sessionId_fkey" FOREIGN KEY ("sessionId") REFERENCES "EducationSession"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "EducationAssignment" ADD CONSTRAINT "EducationAssignment_offeringId_fkey" FOREIGN KEY ("offeringId") REFERENCES "EducationOffering"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "EducationAssignment" ADD CONSTRAINT "EducationAssignment_sessionId_fkey" FOREIGN KEY ("sessionId") REFERENCES "EducationSession"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "EducationSubmission" ADD CONSTRAINT "EducationSubmission_assignmentId_fkey" FOREIGN KEY ("assignmentId") REFERENCES "EducationAssignment"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "EducationSubmission" ADD CONSTRAINT "EducationSubmission_studentId_fkey" FOREIGN KEY ("studentId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "EducationSubmission" ADD CONSTRAINT "EducationSubmission_educationApplicationId_fkey" FOREIGN KEY ("educationApplicationId") REFERENCES "EducationApplication"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "EducationAnnouncement" ADD CONSTRAINT "EducationAnnouncement_offeringId_fkey" FOREIGN KEY ("offeringId") REFERENCES "EducationOffering"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "EducationAnnouncement" ADD CONSTRAINT "EducationAnnouncement_authorId_fkey" FOREIGN KEY ("authorId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "StaffingCycle" ADD CONSTRAINT "StaffingCycle_termId_fkey" FOREIGN KEY ("termId") REFERENCES "Term"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "StaffingPreference" ADD CONSTRAINT "StaffingPreference_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "StaffingPreference" ADD CONSTRAINT "StaffingPreference_staffingCycleId_fkey" FOREIGN KEY ("staffingCycleId") REFERENCES "StaffingCycle"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "EssentialityForm" ADD CONSTRAINT "EssentialityForm_staffingCycleId_fkey" FOREIGN KEY ("staffingCycleId") REFERENCES "StaffingCycle"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "EssentialityForm" ADD CONSTRAINT "EssentialityForm_pmUserId_fkey" FOREIGN KEY ("pmUserId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "EssentialityRating" ADD CONSTRAINT "EssentialityRating_essentialityFormId_fkey" FOREIGN KEY ("essentialityFormId") REFERENCES "EssentialityForm"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "EssentialityRating" ADD CONSTRAINT "EssentialityRating_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "StaffingAssignment" ADD CONSTRAINT "StaffingAssignment_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "StaffingAssignment" ADD CONSTRAINT "StaffingAssignment_staffingCycleId_fkey" FOREIGN KEY ("staffingCycleId") REFERENCES "StaffingCycle"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "StaffingAssignment" ADD CONSTRAINT "StaffingAssignment_termId_fkey" FOREIGN KEY ("termId") REFERENCES "Term"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Page" ADD CONSTRAINT "Page_parentPageId_fkey" FOREIGN KEY ("parentPageId") REFERENCES "Page"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Page" ADD CONSTRAINT "Page_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Page" ADD CONSTRAINT "Page_lastEditedById_fkey" FOREIGN KEY ("lastEditedById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MentorNote" ADD CONSTRAINT "MentorNote_mentorId_fkey" FOREIGN KEY ("mentorId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MentorNote" ADD CONSTRAINT "MentorNote_menteeId_fkey" FOREIGN KEY ("menteeId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "NotificationEvent" ADD CONSTRAINT "NotificationEvent_recipientId_fkey" FOREIGN KEY ("recipientId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "NotificationPreference" ADD CONSTRAINT "NotificationPreference_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PartnerUser" ADD CONSTRAINT "PartnerUser_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PartnerUser" ADD CONSTRAINT "PartnerUser_partnerOrgId_fkey" FOREIGN KEY ("partnerOrgId") REFERENCES "PartnerOrg"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ProjectPartner" ADD CONSTRAINT "ProjectPartner_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ProjectPartner" ADD CONSTRAINT "ProjectPartner_partnerOrgId_fkey" FOREIGN KEY ("partnerOrgId") REFERENCES "PartnerOrg"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "OAuthGrant" ADD CONSTRAINT "OAuthGrant_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "OAuthGrant" ADD CONSTRAINT "OAuthGrant_clientId_fkey" FOREIGN KEY ("clientId") REFERENCES "OAuthClient"("clientId") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "OneTimeToken" ADD CONSTRAINT "OneTimeToken_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "GmailIntegration" ADD CONSTRAINT "GmailIntegration_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+

--- a/dali-api/prisma/schema.prisma
+++ b/dali-api/prisma/schema.prisma
@@ -1153,6 +1153,47 @@ enum MeetingStatus {
   Cancelled
 }
 
+// In-app notification delivered to a single user. Fan-out at write time:
+// sending to a group resolves to N rows (one per recipient).
+model Notification {
+  id              String           @id @default(cuid())
+  recipientUserId String
+  recipient       User             @relation("NotificationRecipient", fields: [recipientUserId], references: [id])
+  createdByUserId String?
+  createdBy       User?            @relation("NotificationAuthor", fields: [createdByUserId], references: [id])
+  kind            NotificationKind @default(General)
+  title           String
+  body            String?
+  link            String?
+  // Origin group for bulk sends. Not an FK so groups can be deleted independently.
+  sourceGroupId   String?
+  readAt          DateTime?
+  createdAt       DateTime         @default(now())
+
+  // Set on MeetingInvite notifications so the bell can render Accept/Decline
+  // buttons and the RSVP endpoint can locate the underlying meeting.
+  scheduledMeetingId String?
+  scheduledMeeting   ScheduledMeeting? @relation(fields: [scheduledMeetingId], references: [id], onDelete: SetNull)
+  rsvp               MeetingRsvp?
+  rsvpAt             DateTime?
+
+  @@index([recipientUserId, readAt])
+  @@index([recipientUserId, createdAt])
+}
+
+enum NotificationKind {
+  General
+  MeetingInvite
+  MeetingReminder
+  SystemAnnouncement
+}
+
+enum MeetingRsvp {
+  Accepted
+  Declined
+  Tentative
+}
+
 model GroupDefinition {
   id              String    @id @default(cuid())
   name            String

--- a/dali-api/prisma/schema.prisma
+++ b/dali-api/prisma/schema.prisma
@@ -18,17 +18,26 @@ model User {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  // all nullable, but at least one of these must be non-null
-  netId          String? @unique // Dartmouth SSO
-  daliEmail      String? @unique // DALI Google
-  dartmouthEmail String? @unique // Dartmouth Google OAuth
+  // ─── Identity (≥1 must be non-null for an auth path to land) ──────────────
+  // netId is the canonical Dartmouth identifier (same value as the historical
+  // "did" Dartmouth ID; case-normalized to lowercase here). CAS callbacks
+  // write to this column. DALIMember.did is dropped in Phase 2 after a
+  // backfill into User.netId.
+  netId          String? @unique // Dartmouth NetID / DID
+  daliEmail      String? @unique // @dali.dartmouth.edu Google
+  dartmouthEmail String? @unique // @dartmouth.edu Google
+  // Personal (non-Dartmouth) email. Used by alumni post-grad after
+  // @dali.dartmouth.edu revocation and as the magic-link target for partners.
+  personalEmail  String? @unique
 
-  // profile
+  // ─── Names — single source of truth ───────────────────────────────────────
   firstName String
   lastName  String
 
-  // Google API tokens (for calendar integration etc.) — populated when user
-  // signs in via Google with appropriate scopes
+  // ─── Google API tokens (Phase 1: retained for transition) ─────────────────
+  // Read by /admin/authorize-gmail (Gmail send-as) and the legacy free-busy
+  // fallback in lib/google-calendar.ts:fetchBusyFromLegacyUserTokens. Both
+  // move to GmailIntegration in Phase 2; these columns are then dropped.
   googleAccessToken    String?
   googleRefreshToken   String?
   googleTokenExpiresAt DateTime?
@@ -36,6 +45,23 @@ model User {
   // IANA zone, e.g. "America/New_York". Used by calendar/scheduling.
   timeZone String?
 
+  // ─── Profile fields (Phase 1 additions; all nullable) ─────────────────────
+  // Dartmouth class year (e.g., 2026). Solves the "took a term off"
+  // ambiguity. Used for alumni derivation + display.
+  classYear    Int?
+  // Optional explicit graduation override for off-cycle graduations.
+  graduatedAt  DateTime?
+  pronouns     String?
+  photoUrl     String?
+  // Bio stored as a collab doc reference for rich formatting + @mentions.
+  bioDocId     String?
+  major        String?
+  hometown     String?
+  linkedinUrl  String?
+  githubUrl    String?
+  personalSite String?
+
+  // ─── Relations: existing ──────────────────────────────────────────────────
   daliMember                    DALIMember?
   applicationCycleStatusUpdates ApplicationCycleStatusUpdate[]
   challengeVersions             ChallengeVersion[]
@@ -52,6 +78,53 @@ model User {
   availabilitySettings UserAvailabilitySettings?
   workingHoursDays     WorkingHoursDay[]
   manualBlocks         ManualBlock[]
+
+  // ─── Phase 1: foundational role-model back-relations ──────────────────────
+  domainEligibilities     DomainEligibility[]
+  projectAssignments      ProjectAssignment[]
+  coreAssignments         CoreAssignment[]
+  instructorAssignments   InstructorAssignment[]
+  adminMembership         AdminMembership?
+  mentorshipPairsAsMentee MentorshipPair[]       @relation("MenteePairs")
+  mentorshipPairsAsMentor MentorshipPair[]       @relation("MentorPairs")
+
+  // ─── Phase 1: project workspace back-relations ────────────────────────────
+  createdTasks  Task[]         @relation("TaskCreatedBy")
+  taskAssignees TaskAssignee[]
+  taskComments  TaskComment[]
+
+  // ─── Phase 1: staffing back-relations ─────────────────────────────────────
+  staffingPreferences   StaffingPreference[]
+  essentialityFormsAsPm EssentialityForm[]   @relation("EssentialityFormPm")
+  essentialityRatings   EssentialityRating[]
+  staffingAssignments   StaffingAssignment[]
+
+  // ─── Phase 1: education back-relations ────────────────────────────────────
+  educationApplications  EducationApplication[]  @relation("EducationApplicant")
+  educationSubmissions   EducationSubmission[]   @relation("EducationSubmissionStudent")
+  educationAnnouncements EducationAnnouncement[] @relation("EducationAnnouncementAuthor")
+
+  // ─── Phase 1: mentorship back-relations ───────────────────────────────────
+  mentorNotesAsMentor MentorNote[] @relation("MentorNoteMentor")
+  mentorNotesAsMentee MentorNote[] @relation("MentorNoteMentee")
+
+  // ─── Phase 1: page-tree back-relations ────────────────────────────────────
+  createdPages    Page[] @relation("PageCreatedBy")
+  lastEditedPages Page[] @relation("PageLastEditedBy")
+
+  // ─── Phase 1: notification back-relations ─────────────────────────────────
+  notificationEvents      NotificationEvent[]
+  notificationPreferences NotificationPreference[]
+
+  // ─── Phase 1: partner back-relation (single per User) ─────────────────────
+  partnerUser PartnerUser?
+
+  // ─── Phase 1: OAuth / magic-link back-relations ───────────────────────────
+  oauthGrants   OAuthGrant[]
+  oneTimeTokens OneTimeToken[]
+
+  // ─── Phase 1: Gmail integration (single per User) ─────────────────────────
+  gmailIntegration GmailIntegration?
 }
 
 // A DALI lab member. userId is optional because a member may be known (e.g. via daliEmail)
@@ -72,15 +145,15 @@ model DALIMember {
 
   roles MemberRole[] @default([])
 
-  cycleReviewers        CycleReviewer[]
-  cycleInterviewers     CycleInterviewer[]
-  decisions             Decision[]
-  applicationReviews    ApplicationReview[]    @relation("SubmittedBy")
-  delibSessions         DelibsSession[]
-  legacyEmailTemplates  LegacyEmailTemplate[]
-  emailTemplateVersions EmailTemplateVersion[]
+  cycleReviewers                   CycleReviewer[]
+  cycleInterviewers                CycleInterviewer[]
+  decisions                        Decision[]
+  applicationReviews               ApplicationReview[]               @relation("SubmittedBy")
+  delibSessions                    DelibsSession[]
+  legacyEmailTemplates             LegacyEmailTemplate[]
+  emailTemplateVersions            EmailTemplateVersion[]
   confidentialityAgreementVersions ConfidentialityAgreementVersion[]
-  domainLeadAssignments DomainLeadAssignment[]
+  domainLeadAssignments            DomainLeadAssignment[]
 }
 
 model ApplicationCycle {
@@ -115,16 +188,16 @@ model ApplicationCycle {
   domains           DomainApplicationCycle[]
   challengeVersions ChallengeVersionApplicationCycle[]
 
-  interviewConfig   InterviewConfig?
-  cycleReviewers    CycleReviewer[]
-  cycleInterviewers CycleInterviewer[]
-  interviews        Interview[]
-  delibsSessions    DelibsSession[]
-  decisionEmails    CycleDecisionEmail[]
+  interviewConfig    InterviewConfig?
+  cycleReviewers     CycleReviewer[]
+  cycleInterviewers  CycleInterviewer[]
+  interviews         Interview[]
+  delibsSessions     DelibsSession[]
+  decisionEmails     CycleDecisionEmail[]
   notificationEmails CycleNotificationEmail[]
   notificationSends  CycleNotificationSend[]
 
-  confidentialityBinding   CycleConfidentialityAgreement?
+  confidentialityBinding    CycleConfidentialityAgreement?
   confidentialitySignatures ConfidentialityAgreementSignature[]
 }
 
@@ -165,11 +238,24 @@ model Application {
   generalChallengeVersionId String
   generalChallengeVersion   ChallengeVersion @relation("ApplicationGeneralChallenge", fields: [generalChallengeVersionId], references: [id])
 
+  // Phase 1: distinguishes the application's purpose. Standard = regular DALI
+  // hire cycle (only value used today). Intern = shorter form for intern
+  // programs (ERAS, EEJUST, WISP). InternToFull = current intern applying
+  // for regular hire. Transfer = informal internal domain transfer.
+  applicationType ApplicationType @default(Standard)
+
   statusUpdates      ApplicationStatusUpdate[]
   domainApplications DomainApplication[]
   notificationSends  CycleNotificationSend[]
 
   @@unique([userId, applicationCycleId])
+}
+
+enum ApplicationType {
+  Standard
+  Intern
+  InternToFull
+  Transfer
 }
 
 // Domain is not stored directly — it is derivable via challengeVersion.domain.
@@ -212,7 +298,21 @@ model Domain {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
+  // Legacy display name. Retained through Phase 1; Phase 2 enforces NOT NULL
+  // on the new `code` + `displayName` columns and drops this.
   name String
+
+  // ─── Phase 1 additions (all nullable; backfilled in seed) ─────────────────
+  // Stable code referenced from app code (e.g. "Fullstack", "UIUX", "ERAS").
+  code            String? @unique
+  // Human-friendly display label (e.g. "Fullstack Dev").
+  displayName     String?
+  // Intern programs (ERAS, EEJUST, WISP) are domains with this set true.
+  // After the intern term, members apply normally and get a fresh
+  // DomainEligibility in their actual hire domain.
+  isInternProgram Boolean @default(false)
+  // Toggle visibility from Admin Console without code changes.
+  active          Boolean @default(true)
 
   challengeVersions     ChallengeVersion[]
   applicationCycles     DomainApplicationCycle[]
@@ -220,6 +320,12 @@ model Domain {
   cycleReviewers        CycleReviewer[]
   cycleInterviewers     CycleInterviewer[]
   delibsSessions        DelibsSession[]
+
+  // ─── Phase 1 back-relations ───────────────────────────────────────────────
+  eligibilities       DomainEligibility[]
+  projectAssignments  ProjectAssignment[]
+  mentorshipPairs     MentorshipPair[]
+  projectRoleRequests ProjectRoleRequest[]
 }
 
 // Immutable snapshot of a challenge. Never update rows in this table —
@@ -315,7 +421,7 @@ model InterviewConfig {
   interviewEndDate   DateTime
 
   rescheduleNoticeHours Int @default(12) // minimum hours before interview to allow reschedule
-  cancelNoticeHours     Int @default(0)  // minimum hours before interview to allow cancel (0 = up until start)
+  cancelNoticeHours     Int @default(0) // minimum hours before interview to allow cancel (0 = up until start)
 
   timezone String @default("America/New_York")
 }
@@ -402,7 +508,7 @@ model Interview {
 
   startTime DateTime
   endTime   DateTime
-  status    InterviewStatus @default(Scheduled)
+  status    InterviewStatus   @default(Scheduled)
   location  InterviewLocation @default(Online)
 
   zoomMeetingId String?
@@ -695,17 +801,17 @@ model OAuthSession {
 // Authorization: Bearer headers; we never store it.
 model Session {
   // sha256(raw session id), base64url
-  id                String   @id
+  id                String    @id
   userId            String
   // Null for cookie logins. Set for OAuth-issued (MCP) sessions, linking
   // the session to the OAuthGrant that authorized it. Intentionally a plain
   // String? with no FK constraint in this PR — the FK lands when OAuthGrant
   // ships in the MCP foundation track.
   grantId           String?
-  createdAt         DateTime @default(now())
+  createdAt         DateTime  @default(now())
   // Bumped on every successful auth lookup. Drives rolling expiry and powers
   // per-session telemetry.
-  lastUsedAt        DateTime @default(now())
+  lastUsedAt        DateTime  @default(now())
   // Rolling expiry: extended on use up to absoluteExpiresAt.
   expiresAt         DateTime
   // Hard cap: never extended. Equivalent to the legacy familyCreatedAt + 30d.
@@ -716,7 +822,8 @@ model Session {
   userAgent         String?
   ip                String?
 
-  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user  User        @relation(fields: [userId], references: [id], onDelete: Cascade)
+  grant OAuthGrant? @relation(fields: [grantId], references: [id])
 
   @@index([userId, revokedAt])
   @@index([grantId])
@@ -925,8 +1032,8 @@ model CycleConfidentialityAgreement {
 // Per-user-per-cycle signature. Pinned to the version that was active when
 // the user signed — re-binding the cycle to a new version forces re-signing.
 model ConfidentialityAgreementSignature {
-  id        String   @id @default(cuid())
-  signedAt  DateTime @default(now())
+  id       String   @id @default(cuid())
+  signedAt DateTime @default(now())
 
   userId             String
   user               User             @relation(fields: [userId], references: [id], onDelete: Cascade)
@@ -949,11 +1056,18 @@ model DomainLeadAssignment {
   memberId String
   domainId String
 
+  // Phase 1: termId nullable. Phase 2 backfills existing rows to the current
+  // term then enforces NOT NULL. Phase 2 also renames memberId → userId
+  // (pointing at User instead of DALIMember).
+  termId String?
+
   member DALIMember @relation(fields: [memberId], references: [id])
   domain Domain     @relation(fields: [domainId], references: [id])
+  term   Term?      @relation(fields: [termId], references: [id])
 
   @@unique([memberId, domainId])
   @@index([domainId])
+  @@index([termId])
 }
 
 // ─── Calendar / Scheduling ───────────────────────────────────────────────────
@@ -987,16 +1101,16 @@ enum CalProvider {
 }
 
 model ScheduledMeeting {
-  id                 String        @id @default(cuid())
-  organizerId        String
-  organizer          User          @relation(fields: [organizerId], references: [id])
-  title              String
-  descriptionDocId   String?
-  durationMinutes    Int
+  id               String  @id @default(cuid())
+  organizerId      String
+  organizer        User    @relation(fields: [organizerId], references: [id])
+  title            String
+  descriptionDocId String?
+  durationMinutes  Int
 
-  scopeType          ScopeType
+  scopeType ScopeType
   // Untyped at DB layer — dispatched in app code by scopeType.
-  scopeId            String?
+  scopeId   String?
 
   participantUserIds String[]
   selectedAt         DateTime?
@@ -1004,7 +1118,7 @@ model ScheduledMeeting {
   status             MeetingStatus @default(Searching)
 
   // RFC 5545 RRULE for recurring meetings.
-  recurrenceRule     String?
+  recurrenceRule String?
 
   // Resolved at create-time from scopeType/scopeId.
   ownerCalendarEmail String
@@ -1046,14 +1160,14 @@ enum GroupType {
 }
 
 model MeetingException {
-  id                  String   @id @default(cuid())
+  id                  String    @id @default(cuid())
   scheduledMeetingId  String
   // The original occurrence start time being overridden.
   originalStart       DateTime
   overrideStart       DateTime?
   overrideDurationMin Int?
   overrideTitle       String?
-  cancelled           Boolean  @default(false)
+  cancelled           Boolean   @default(false)
 
   meeting ScheduledMeeting @relation(fields: [scheduledMeetingId], references: [id])
 
@@ -1078,9 +1192,9 @@ model UserAvailabilitySettings {
 model WorkingHoursDay {
   id          String       @id @default(cuid())
   userId      String
-  dayOfWeek   Int          // 0=Sunday .. 6=Saturday
+  dayOfWeek   Int // 0=Sunday .. 6=Saturday
   enabled     Boolean      @default(true)
-  startMinute Int          @default(540)  // 9:00
+  startMinute Int          @default(540) // 9:00
   endMinute   Int          @default(1020) // 17:00
   location    WorkLocation @default(InPerson)
 
@@ -1097,21 +1211,1069 @@ enum WorkLocation {
 
 // User-defined busy blocks, optionally recurring (RFC 5545 RRULE).
 model ManualBlock {
-  id              String   @id @default(cuid())
+  id              String    @id @default(cuid())
   userId          String
   title           String
   startTime       DateTime
   endTime         DateTime
-  allDay          Boolean  @default(false)
+  allDay          Boolean   @default(false)
   // Nullable: a one-off block has no rule. When set, startTime/endTime define
   // the first occurrence; subsequent ones are expanded by rrule.
   recurrenceRule  String?
   // Optional cached UNTIL for query bounds; not authoritative.
   recurrenceUntil DateTime?
-  createdAt       DateTime @default(now())
+  createdAt       DateTime  @default(now())
 
   user User @relation(fields: [userId], references: [id])
 
   @@index([userId, startTime])
 }
 
+// ═══ V0 Phase 1 ═════════════════════════════════════════════════════════════
+//
+// The models below land in `v0-phase1-additive`. They are purely additive
+// (new tables; no column drops, no FK renames). Together they implement the
+// foundational role model + new feature surfaces from `expansion_plan.md`
+// and the auth-side foundation from `dali-os-mcp.md`. Phase 2 (destructive
+// refactor) runs separately after the live 2026-S cycle closes.
+//
+// See V0_PLAN.md for the locked decisions, deploy sequencing, and the
+// Phase 2 column-drop / FK-rename plan.
+
+// ─── Term ────────────────────────────────────────────────────────────────────
+
+model Term {
+  id        String   @id @default(cuid())
+  code      String   @unique // "26S", "27F", etc.
+  year      Int
+  season    Season
+  // sortKey enables chronological sort. Alphabetical sort of `code` breaks
+  // because within a year the seasons go W → S → X → F, not alphabetic.
+  sortKey   Int      @unique // year * 10 + (W=1, S=2, X=3, F=4)
+  startDate DateTime
+  endDate   DateTime
+
+  projectAssignments    ProjectAssignment[]
+  mentorshipPairs       MentorshipPair[]
+  domainLeadAssignments DomainLeadAssignment[]
+  coreAssignments       CoreAssignment[]
+  instructorAssignments InstructorAssignment[]
+  staffingCycles        StaffingCycle[]
+  projectTermStatuses   ProjectTermStatus[]
+  projectRoleRequests   ProjectRoleRequest[]
+  staffingAssignments   StaffingAssignment[]
+  projectsAsFirstTerm   Project[]              @relation("ProjectFirstTerm")
+
+  @@index([sortKey])
+}
+
+enum Season {
+  W // Winter
+  S // Spring
+  X // Summer
+  F // Fall
+}
+
+// ─── Foundational role model ─────────────────────────────────────────────────
+
+// Tracks qualifications, independent of active assignments. A member can hold
+// P3 eligibility in Graphics and Animation but be currently working only as
+// Animation P3 — the Graphics P3 eligibility persists.
+model DomainEligibility {
+  id         String   @id @default(cuid())
+  userId     String
+  domainId   String
+  // Eligibility is monotonic in v1: only goes up (no demotions). To preserve
+  // a simple one-row-per-(user,domain) shape, we update `level` in place and
+  // store the most recent promotion metadata here.
+  level      Level
+  promotedAt DateTime @default(now())
+  // Free-form: the userId of a Domain Lead / Core member / Admin who
+  // promoted them. Not an FK so audit history survives user deletion.
+  promotedBy String?
+
+  user   User   @relation(fields: [userId], references: [id])
+  domain Domain @relation(fields: [domainId], references: [id])
+
+  @@unique([userId, domainId])
+}
+
+enum Level {
+  P1 // Learner
+  P2 // Doer
+  P3 // Mentor
+}
+
+// Active project work for a term. Drawn from the member's DomainEligibility
+// rows. App-level constraint: assignment.level <= eligibility.level for
+// (userId, domainId).
+model ProjectAssignment {
+  id        String @id @default(cuid())
+  userId    String
+  projectId String
+  termId    String
+  domainId  String
+  level     Level
+
+  createdAt DateTime @default(now())
+
+  user    User    @relation(fields: [userId], references: [id])
+  project Project @relation(fields: [projectId], references: [id])
+  term    Term    @relation(fields: [termId], references: [id])
+  domain  Domain  @relation(fields: [domainId], references: [id])
+
+  // Multiple rows per (user, term) is normal: a member can be on multiple
+  // projects, and even multiple domains within the same project for
+  // cross-training. The unique below prevents only literal duplicates.
+  @@unique([userId, projectId, termId, domainId])
+  @@index([userId, termId])
+  @@index([projectId, termId])
+}
+
+// Domain-scoped mentorship within a project's context. The mentor is NOT
+// required to have a ProjectAssignment for that project — Domain Leads and
+// PM Mentors mentor across the lab without project membership.
+//
+// Per Cl-clarification Q22 (loosened): no unique on (mentee, project, term,
+// domain); we allow multiple mentors per mentee in the same scope (rare but
+// supported, e.g. a Domain Lead + project P3 co-mentorship).
+model MentorshipPair {
+  id           String @id @default(cuid())
+  menteeUserId String
+  mentorUserId String
+  projectId    String
+  termId       String
+  domainId     String
+
+  mentee  User    @relation("MenteePairs", fields: [menteeUserId], references: [id])
+  mentor  User    @relation("MentorPairs", fields: [mentorUserId], references: [id])
+  project Project @relation(fields: [projectId], references: [id])
+  term    Term    @relation(fields: [termId], references: [id])
+  domain  Domain  @relation(fields: [domainId], references: [id])
+
+  @@index([menteeUserId, projectId, termId])
+  @@index([mentorUserId, termId])
+}
+
+// Year-long elected lead position. `leadTitle` is display-only — Core has
+// broad access to everything; the title affords UI surfacing but does not
+// gate permissions.
+model CoreAssignment {
+  id        String  @id @default(cuid())
+  userId    String
+  termId    String
+  leadTitle String?
+
+  user User @relation(fields: [userId], references: [id])
+  term Term @relation(fields: [termId], references: [id])
+
+  // No (userId, termId) unique — a member can hold multiple Core titles in
+  // the same term. App-level validates "no duplicate (user, term, leadTitle)".
+  @@index([userId, termId])
+  @@index([termId, leadTitle])
+}
+
+// Authority to teach a specific education offering in a specific term.
+// Per Cl-clarification Q21: term scopes the uniqueness so a member can
+// instruct the same offering across multiple terms.
+model InstructorAssignment {
+  id         String @id @default(cuid())
+  userId     String
+  offeringId String
+  termId     String
+
+  user     User              @relation(fields: [userId], references: [id])
+  offering EducationOffering @relation(fields: [offeringId], references: [id])
+  term     Term              @relation(fields: [termId], references: [id])
+
+  @@unique([userId, offeringId, termId])
+  @@index([offeringId, termId])
+}
+
+// Permanent (until revoked). Maps to the lab's full-time staff. Admin is a
+// superset of Core. CSV "Staff" entries map directly here.
+model AdminMembership {
+  id        String   @id @default(cuid())
+  userId    String   @unique
+  grantedAt DateTime @default(now())
+  // Free-form: the userId of the actor who granted Admin. Not an FK so audit
+  // history survives user deletion.
+  grantedBy String?
+
+  user User @relation(fields: [userId], references: [id])
+}
+
+// Each (assignmentType × level × domain) maps to a Dartmouth payroll job
+// code. DALI OS does NOT track hours, but it surfaces job codes for payroll
+// mapping/export. Derived at query time, not stored on assignment rows.
+model JobCodeLookup {
+  id             String         @id @default(cuid())
+  // Nullable level/domain act as wildcards in the lookup.
+  assignmentType AssignmentType
+  level          Level?
+  domainId       String?
+  jobCode        String
+  payRateUsdHour Decimal?
+  notes          String?
+}
+
+enum AssignmentType {
+  Project
+  Core
+  Instructor
+  DomainLead
+  Admin
+}
+
+// ─── Project workspace ───────────────────────────────────────────────────────
+
+model Project {
+  id            String        @id @default(cuid())
+  name          String
+  // Project-owned Google Workspace identity (e.g.,
+  // "projectalpha@dali.dartmouth.edu"). Calendar events for this project
+  // are owned by this identity, not the organizer's personal calendar.
+  calendarEmail String?
+  // Term the project was first activated. Phase 1: nullable to allow
+  // creation in a transaction before the Term row may exist; in steady
+  // state all new Projects set this. Phase 2 enforces NOT NULL after
+  // backfilling any legacy rows.
+  firstTermId   String?
+  status        ProjectStatus @default(Active)
+
+  // Auto-created on Project creation: a top-level FreeForm Page in the
+  // Project workspace, seeded from the "Project Brief" PageTemplate. The
+  // workspace's Overview tab renders this page's contentDoc with a
+  // structured project header above. Nullable to allow Project creation in
+  // a transaction before the Page row exists; populated immediately after.
+  overviewPageId String? @unique
+
+  firstTerm    Term? @relation("ProjectFirstTerm", fields: [firstTermId], references: [id])
+  overviewPage Page? @relation("ProjectOverview", fields: [overviewPageId], references: [id])
+
+  partners        ProjectPartner[]
+  termStatuses    ProjectTermStatus[]
+  assignments     ProjectAssignment[]
+  roleRequests    ProjectRoleRequest[]
+  mentorshipPairs MentorshipPair[]
+  sprints         Sprint[]
+  epics           Epic[]
+  tasks           Task[]
+
+  createdAt DateTime @default(now())
+}
+
+enum ProjectStatus {
+  Active
+  Paused
+  Archived
+}
+
+// Continuing-or-not flag per project per term. Both PM and Partner Relations
+// Lead can write to this.
+model ProjectTermStatus {
+  id           String   @id @default(cuid())
+  projectId    String
+  termId       String
+  isContinuing Boolean
+  // Free-form actor userId.
+  setBy        String?
+  setAt        DateTime @default(now())
+
+  project Project @relation(fields: [projectId], references: [id])
+  term    Term    @relation(fields: [termId], references: [id])
+
+  @@unique([projectId, termId])
+}
+
+// Per-project per-term role requirements. Defines the slots staffing needs
+// to fill — a project might need 2 P1 Fullstack, 1 P3 Fullstack Mentor,
+// 1 P1 UIUX, etc.
+model ProjectRoleRequest {
+  id         String  @id @default(cuid())
+  projectId  String
+  termId     String
+  domainId   String
+  level      Level
+  slots      Int
+  // Optional collab doc explaining what this role entails on this project.
+  notesDocId String?
+
+  project Project @relation(fields: [projectId], references: [id])
+  term    Term    @relation(fields: [termId], references: [id])
+  domain  Domain  @relation(fields: [domainId], references: [id])
+
+  @@index([projectId, termId])
+}
+
+model Epic {
+  id               String     @id @default(cuid())
+  projectId        String
+  title            String
+  // Description as collab doc — Notion-style rich content.
+  descriptionDocId String?
+  status           EpicStatus @default(Open)
+  // Optional target term for cross-term epics that span multiple sprints.
+  targetTermId     String?
+  position         Int        @default(0)
+
+  project Project @relation(fields: [projectId], references: [id])
+  tasks   Task[]
+
+  createdAt DateTime @default(now())
+}
+
+enum EpicStatus {
+  Open
+  InProgress
+  Done
+  Cancelled
+}
+
+model Sprint {
+  id        String       @id @default(cuid())
+  projectId String
+  name      String
+  startsAt  DateTime
+  endsAt    DateTime
+  // Sprint goal as collab doc. Retros live as collab pages in the project's
+  // page tree.
+  goalDocId String?
+  status    SprintStatus @default(Planned)
+
+  project Project @relation(fields: [projectId], references: [id])
+  tasks   Task[]
+
+  @@index([projectId, status])
+}
+
+enum SprintStatus {
+  Planned
+  Active
+  Closed
+}
+
+model Task {
+  id        String  @id @default(cuid())
+  projectId String
+  // Null sprintId = backlog.
+  sprintId  String?
+  // Optional epic linkage for cross-sprint grouping.
+  epicId    String?
+
+  title            String
+  descriptionDocId String?
+  status           TaskStatus @default(Todo)
+  priority         Priority   @default(Normal)
+  position         Int        @default(0)
+
+  // Subtasks: simple checklist field rather than hierarchical Task→Task
+  // children (Linear/Notion style).
+  // JSON shape: [{ "text": "...", "done": false }]
+  checklist Json?
+
+  project   Project        @relation(fields: [projectId], references: [id])
+  sprint    Sprint?        @relation(fields: [sprintId], references: [id])
+  epic      Epic?          @relation(fields: [epicId], references: [id])
+  assignees TaskAssignee[]
+  comments  TaskComment[]
+
+  createdById String
+  createdBy   User     @relation("TaskCreatedBy", fields: [createdById], references: [id])
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  @@index([projectId, sprintId])
+}
+
+enum TaskStatus {
+  Todo
+  InProgress
+  InReview
+  Done
+  Cancelled
+}
+
+enum Priority {
+  Low
+  Normal
+  High
+  Urgent
+}
+
+// Multi-assignee per task (solo or multi both supported).
+model TaskAssignee {
+  taskId String
+  userId String
+
+  task Task @relation(fields: [taskId], references: [id])
+  user User @relation(fields: [userId], references: [id])
+
+  @@id([taskId, userId])
+}
+
+model TaskComment {
+  id        String   @id @default(cuid())
+  taskId    String
+  authorId  String
+  // Plain text or markdown — small comments, not collab doc.
+  body      String
+  createdAt DateTime @default(now())
+
+  task   Task @relation(fields: [taskId], references: [id])
+  author User @relation(fields: [authorId], references: [id])
+
+  @@index([taskId, createdAt])
+}
+
+// ─── Education ───────────────────────────────────────────────────────────────
+
+model EducationOffering {
+  id                   String         @id @default(cuid())
+  type                 OfferingType
+  title                String
+  descriptionDocId     String?
+  capacity             Int
+  registrationOpensAt  DateTime
+  registrationClosesAt DateTime
+  startsAt             DateTime
+  endsAt               DateTime
+  status               OfferingStatus @default(Draft)
+  // True for typical miniseries (instructor-reviewed), false for typical
+  // workshops (auto-approve up to capacity, waitlist after). Configurable
+  // per-offering — workshops can opt into review without a schema change.
+  requiresReview       Boolean
+  // Optional per-offering Google Workspace identity. Falls back to a shared
+  // education identity if not set.
+  calendarEmail        String?
+
+  instructors          InstructorAssignment[]
+  sessions             EducationSession[]
+  applications         EducationApplication[]
+  applicationQuestions EducationApplicationQuestion[]
+  assignments          EducationAssignment[]
+  announcements        EducationAnnouncement[]
+
+  createdAt DateTime @default(now())
+}
+
+enum OfferingType {
+  Miniseries
+  Workshop
+}
+
+enum OfferingStatus {
+  Draft
+  Published
+  Archived
+}
+
+model EducationSession {
+  id             String   @id @default(cuid())
+  offeringId     String
+  sequence       Int
+  datetime       DateTime
+  location       String?
+  // Materials as collab doc — slides, notes, pre-reads.
+  materialsDocId String?
+  recordingUrl   String?
+
+  offering    EducationOffering     @relation(fields: [offeringId], references: [id])
+  attendances EducationAttendance[]
+  assignments EducationAssignment[]
+
+  @@index([offeringId, sequence])
+}
+
+// Per Q14b: any User can apply (members can apply to offerings too). Field
+// name preserves the "applicant" framing without restricting to students.
+model EducationApplication {
+  id              String               @id @default(cuid())
+  applicantUserId String
+  offeringId      String
+  status          EduApplicationStatus
+  submittedAt     DateTime             @default(now())
+  reviewedAt      DateTime?
+  // Free-form: the userId of the reviewer who approved/rejected.
+  reviewedBy      String?
+
+  applicant   User                         @relation("EducationApplicant", fields: [applicantUserId], references: [id])
+  offering    EducationOffering            @relation(fields: [offeringId], references: [id])
+  answers     EducationApplicationAnswer[]
+  attendances EducationAttendance[]
+  submissions EducationSubmission[]
+
+  // One application per (applicant, offering). Withdrawal transitions
+  // status, doesn't insert a second row.
+  @@unique([applicantUserId, offeringId])
+}
+
+enum EduApplicationStatus {
+  Submitted
+  Approved
+  Rejected
+  Waitlisted
+  Withdrawn
+}
+
+model EducationApplicationQuestion {
+  id         String  @id @default(cuid())
+  offeringId String
+  prompt     String
+  position   Int
+  required   Boolean @default(true)
+
+  offering EducationOffering            @relation(fields: [offeringId], references: [id])
+  answers  EducationApplicationAnswer[]
+
+  @@index([offeringId, position])
+}
+
+model EducationApplicationAnswer {
+  id            String @id @default(cuid())
+  applicationId String
+  questionId    String
+  content       String
+
+  application EducationApplication         @relation(fields: [applicationId], references: [id])
+  question    EducationApplicationQuestion @relation(fields: [questionId], references: [id])
+
+  @@unique([applicationId, questionId])
+}
+
+model EducationAttendance {
+  id            String           @id @default(cuid())
+  applicationId String
+  sessionId     String
+  status        AttendanceStatus
+
+  application EducationApplication @relation(fields: [applicationId], references: [id])
+  session     EducationSession     @relation(fields: [sessionId], references: [id])
+
+  @@unique([applicationId, sessionId])
+}
+
+enum AttendanceStatus {
+  Present
+  Absent
+  Excused
+}
+
+model EducationAssignment {
+  id                String         @id @default(cuid())
+  // Exactly one of offeringId/sessionId should be set. App-level enforced.
+  offeringId        String?
+  sessionId         String?
+  title             String
+  instructionsDocId String?
+  dueAt             DateTime?
+  submissionType    SubmissionType
+
+  offering    EducationOffering?    @relation(fields: [offeringId], references: [id])
+  session     EducationSession?     @relation(fields: [sessionId], references: [id])
+  submissions EducationSubmission[]
+}
+
+enum SubmissionType {
+  Text
+  File
+  Mixed
+}
+
+model EducationSubmission {
+  id            String    @id @default(cuid())
+  assignmentId  String
+  studentId     String
+  // Submission body as collab doc + optional file attachments (S3 URLs JSON).
+  contentDocId  String?
+  files         Json?
+  submittedAt   DateTime?
+  gradedAt      DateTime?
+  // Feedback as collab doc — instructor can leave rich feedback.
+  feedbackDocId String?
+
+  assignment             EducationAssignment   @relation(fields: [assignmentId], references: [id])
+  student                User                  @relation("EducationSubmissionStudent", fields: [studentId], references: [id])
+  educationApplication   EducationApplication? @relation(fields: [educationApplicationId], references: [id])
+  educationApplicationId String?
+
+  @@unique([assignmentId, studentId])
+}
+
+// Broadcast from instructor to all approved enrollees. On create, emits a
+// NotificationEvent (type="education.announcement_posted") for each
+// recipient via lib/notifications.ts:emitEvent.
+model EducationAnnouncement {
+  id         String   @id @default(cuid())
+  offeringId String
+  authorId   String
+  body       String
+  sentAt     DateTime @default(now())
+
+  offering EducationOffering @relation(fields: [offeringId], references: [id])
+  author   User              @relation("EducationAnnouncementAuthor", fields: [authorId], references: [id])
+
+  @@index([offeringId, sentAt])
+}
+
+// ─── Staffing ────────────────────────────────────────────────────────────────
+
+model StaffingCycle {
+  id                      String         @id @default(cuid())
+  termId                  String
+  name                    String
+  opensAt                 DateTime
+  closesAt                DateTime
+  // Member preference limit (UI-configurable per cycle, default 3).
+  maxPreferencesPerMember Int            @default(3)
+  status                  StaffingStatus @default(Draft)
+
+  term              Term                 @relation(fields: [termId], references: [id])
+  preferences       StaffingPreference[]
+  essentialityForms EssentialityForm[]
+  assignments       StaffingAssignment[]
+}
+
+enum StaffingStatus {
+  Draft
+  OpenToCoreFirst
+  OpenToMembers
+  Assigning
+  Closed
+}
+
+model StaffingPreference {
+  id              String  @id @default(cuid())
+  userId          String
+  staffingCycleId String
+  projectId       String
+  domainId        String
+  level           Level
+  // 1-based ranking among the member's preferences (1 = top choice).
+  preferenceRank  Int
+  notes           String?
+
+  user          User          @relation(fields: [userId], references: [id])
+  staffingCycle StaffingCycle @relation(fields: [staffingCycleId], references: [id])
+
+  // Prevents duplicate preferences for the same (user, project, domain,
+  // level) combination. Members revise prefs by updating the existing row.
+  @@unique([userId, staffingCycleId, projectId, domainId, level])
+  @@index([staffingCycleId, userId])
+}
+
+model EssentialityForm {
+  id              String    @id @default(cuid())
+  projectId       String
+  staffingCycleId String
+  // PM only — not project mentors. App-level check: pmUserId must have an
+  // active ProjectAssignment with domain=PM on this project.
+  pmUserId        String
+  submittedAt     DateTime?
+
+  staffingCycle StaffingCycle        @relation(fields: [staffingCycleId], references: [id])
+  pmUser        User                 @relation("EssentialityFormPm", fields: [pmUserId], references: [id])
+  ratings       EssentialityRating[]
+
+  @@unique([projectId, staffingCycleId])
+}
+
+model EssentialityRating {
+  id                 String            @id @default(cuid())
+  essentialityFormId String
+  userId             String
+  rating             EssentialityLevel
+  notes              String?
+
+  form EssentialityForm @relation(fields: [essentialityFormId], references: [id])
+  user User             @relation(fields: [userId], references: [id])
+
+  @@unique([essentialityFormId, userId])
+}
+
+enum EssentialityLevel {
+  Critical
+  Important
+  NiceToHave
+  NotNeeded
+}
+
+// Output of the staffing assignment process. On Confirm, promoted to a
+// canonical ProjectAssignment row; this row retains the proposal/audit
+// trail and can be referenced for future analysis.
+model StaffingAssignment {
+  id              String                   @id @default(cuid())
+  userId          String
+  staffingCycleId String
+  projectId       String
+  termId          String
+  domainId        String
+  level           Level
+  status          StaffingAssignmentStatus @default(Proposed)
+  assignedAt      DateTime                 @default(now())
+  // Free-form actor userId.
+  assignedById    String?
+
+  user          User          @relation(fields: [userId], references: [id])
+  staffingCycle StaffingCycle @relation(fields: [staffingCycleId], references: [id])
+  term          Term          @relation(fields: [termId], references: [id])
+
+  @@index([userId, termId])
+  @@index([projectId, termId])
+}
+
+// Distinct from the existing AssignmentStatus enum (which scopes
+// InterviewAssignment with Active/Declined/Replaced).
+enum StaffingAssignmentStatus {
+  Proposed
+  Confirmed
+  Declined
+}
+
+// ─── Page tree ───────────────────────────────────────────────────────────────
+
+model Page {
+  id            String        @id @default(cuid())
+  workspaceType WorkspaceType
+  // Null for Lab workspace. Otherwise references the Project or
+  // EducationOffering id. The FK is loose (no Prisma relation enforced at
+  // the DB layer for the polymorphic scope id); the explicit project /
+  // offering back-relations below cover the cases we look up by.
+  workspaceId   String?
+  // Null for top-level pages. App-level constraint: parentPageId's parent
+  // must itself be null (enforces the 2-level cap from the plan).
+  parentPageId  String?
+  title         String
+  kind          PageKind      @default(FreeForm)
+  // Collab doc reference for FreeForm pages. Null for Structured pages
+  // (which render from their underlying schema entities).
+  contentDocId  String?
+  position      Int           @default(0)
+
+  // Notion-style page metadata.
+  iconEmoji     String?
+  coverImageUrl String?
+
+  // Distinct from createdById; updated on every edit. Used in breadcrumb
+  // tooltips, page lists, and mention previews.
+  lastEditedById String?
+
+  // Soft delete. Archived pages are filtered out of the tree by default
+  // and surface only in the workspace's Archive view.
+  archivedAt DateTime?
+
+  parent   Page?  @relation("PageTree", fields: [parentPageId], references: [id])
+  children Page[] @relation("PageTree")
+
+  // Reverse of Project.overviewPageId. The polymorphic `workspaceId` column
+  // above is intentionally NOT declared as a Prisma relation — workspaceType
+  // dispatches to the right table at the app layer (see expansion_plan
+  // §"Page Tree"). Two FK constraints on one column would conflict at the
+  // DB level.
+  projectAsOverview Project? @relation("ProjectOverview")
+
+  createdById  String
+  createdBy    User     @relation("PageCreatedBy", fields: [createdById], references: [id])
+  lastEditedBy User?    @relation("PageLastEditedBy", fields: [lastEditedById], references: [id])
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  @@index([workspaceType, workspaceId, parentPageId])
+  @@index([archivedAt])
+}
+
+enum WorkspaceType {
+  Lab
+  Project
+  EducationOffering
+}
+
+enum PageKind {
+  FreeForm
+  Structured
+}
+
+model PageTemplate {
+  id             String          @id @default(cuid())
+  name           String
+  description    String?
+  // Which workspace types this template is offered for. Empty array =
+  // available everywhere.
+  workspaceTypes WorkspaceType[]
+  // Template body. On Page create from this template, the new page's
+  // contentDoc is initialized from a clone of this doc.
+  contentDocId   String
+  iconEmoji      String?
+  isDefault      Boolean         @default(false)
+  // Free-form creator userId.
+  createdBy      String?
+  createdAt      DateTime        @default(now())
+}
+
+// ─── Mentorship ──────────────────────────────────────────────────────────────
+
+model MentorNote {
+  id           String   @id @default(cuid())
+  mentorId     String
+  menteeId     String
+  projectId    String
+  termId       String
+  domainId     String
+  // Start-of-week date (Monday) the note covers. App enforces one row
+  // per (mentor, mentee, project, term, domain, week).
+  weekOf       DateTime
+  // Note body as collab doc — template seeded on create.
+  contentDocId String
+
+  mentor User @relation("MentorNoteMentor", fields: [mentorId], references: [id])
+  mentee User @relation("MentorNoteMentee", fields: [menteeId], references: [id])
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([mentorId, menteeId, projectId, termId, domainId, weekOf])
+  @@index([menteeId, termId])
+  @@index([mentorId, termId])
+}
+
+model MentorNoteTemplate {
+  id            String   @id @default(cuid())
+  name          String
+  // Template body as collab doc; new MentorNote contentDocs are seeded
+  // from this on create.
+  contentDocId  String
+  isDefault     Boolean  @default(false)
+  // Free-form last-updated userId.
+  lastUpdatedBy String?
+  updatedAt     DateTime @updatedAt
+}
+
+// ─── Notifications ───────────────────────────────────────────────────────────
+//
+// Phase 1 ships `NotificationEvent` (event-log shape from the expansion plan)
+// plus `NotificationPreference`. PR #517 (`sp/notifications`) is currently
+// open with a separate `Notification` model (interactive in-app inbox with
+// rsvp affordances). The two coexist temporarily; a reconciliation PR after
+// PR #517 merges either folds NotificationEvent into Notification or keeps
+// them as distinct concerns (event log vs in-app inbox).
+
+model NotificationEvent {
+  id             String    @id @default(cuid())
+  // Typed event identifier, e.g., "interview_scheduled", "sprint_due",
+  // "miniseries_session_reminder", "mentor_eval_requested",
+  // "staffing_assignment_published".
+  type           String
+  recipientId    String
+  // Event-specific payload (links, names, IDs). Structured per type.
+  payload        Json
+  readAt         DateTime?
+  inAppDelivered Boolean   @default(false)
+  emailDelivered Boolean   @default(false)
+  createdAt      DateTime  @default(now())
+
+  recipient User @relation(fields: [recipientId], references: [id])
+
+  @@index([recipientId, readAt])
+  @@index([recipientId, createdAt])
+}
+
+model NotificationPreference {
+  id              String     @id @default(cuid())
+  userId          String
+  // Matches NotificationEvent.type, or "*" for the user's global default.
+  eventType       String
+  inApp           Boolean    @default(true)
+  email           Boolean    @default(true)
+  digestFrequency DigestFreq @default(Instant)
+
+  user User @relation(fields: [userId], references: [id])
+
+  @@unique([userId, eventType])
+}
+
+enum DigestFreq {
+  Instant
+  Daily
+  Weekly
+  Off
+}
+
+// ─── Partner portal ──────────────────────────────────────────────────────────
+
+model PartnerOrg {
+  id               String  @id @default(cuid())
+  name             String
+  logoUrl          String?
+  website          String?
+  // Optional designated primary contact (FK to PartnerUser within this org).
+  // Free-form: a PartnerUser.id. Not enforced as a Prisma relation to avoid
+  // a circular FK; app-level keeps this valid.
+  primaryContactId String?
+  // True for solo-individual partners (e.g., a Dartmouth professor funding
+  // a one-off project, no real organization). Single-user org to avoid a
+  // second code path.
+  isIndividual     Boolean @default(false)
+
+  users    PartnerUser[]
+  projects ProjectPartner[]
+
+  createdAt DateTime @default(now())
+}
+
+// Per Cl-3: PartnerUser.userId @unique → User. Single Session model and
+// auth surface; partner-only metadata (org membership, displayRole) lives
+// here. Tier resolver returns Partner when this row exists for the User.
+model PartnerUser {
+  id           String              @id @default(cuid())
+  userId       String              @unique
+  partnerOrgId String
+  // Free-text display role, e.g. "VP Engineering", "Technical PM".
+  // Not a permission — visibility derives entirely from org membership.
+  displayRole  String?
+  authProvider PartnerAuthProvider
+
+  user       User       @relation(fields: [userId], references: [id])
+  partnerOrg PartnerOrg @relation(fields: [partnerOrgId], references: [id])
+
+  createdAt DateTime @default(now())
+}
+
+enum PartnerAuthProvider {
+  MagicLink
+  Google
+}
+
+// Many-to-many: projects can have multiple partners, and partners can fund
+// multiple projects.
+model ProjectPartner {
+  id           String    @id @default(cuid())
+  projectId    String
+  partnerOrgId String
+  startedAt    DateTime?
+  endedAt      DateTime?
+
+  project    Project    @relation(fields: [projectId], references: [id])
+  partnerOrg PartnerOrg @relation(fields: [partnerOrgId], references: [id])
+
+  @@unique([projectId, partnerOrgId])
+}
+
+// ─── OAuth provider (MCP) ────────────────────────────────────────────────────
+//
+// Empty in Phase 1. The MCP foundation track seeds claude-desktop /
+// claude-code rows. No `dali-api` seed — per Q7 the OAuth provider surface
+// is MCP-only.
+
+model OAuthClient {
+  id            String   @id @default(cuid())
+  // The clientId MCP clients use. Stable, human-readable.
+  clientId      String   @unique
+  // Display name shown on the consent screen and in Settings.
+  name          String
+  redirectUris  String[]
+  // For loopback native clients (Claude Desktop, Claude Code): match scheme
+  // + host on redirectUris, ignore port. RFC 8252.
+  isLoopback    Boolean  @default(false)
+  // First-party clients skip the consent screen. No client gets this in v0
+  // (per Q27); reserved for future use.
+  isFirstParty  Boolean  @default(false)
+  // Scopes this client is allowed to request.
+  allowedScopes String[]
+
+  // ─── Hard auth constraints ────────────────────────────────────────────────
+  // Identity providers this client may use. MCP clients are ["google"].
+  // /oauth/authorize rejects `provider` values not in this list.
+  allowedProviders    String[]
+  // Required accountType for this client. MCP clients: "member" — bars
+  // Dartmouth-student and partner accounts. Null = any.
+  requiredAccountType String?
+  // If true, /oauth/callback/google verifies a DALIMember row exists for
+  // the authenticated user. MCP clients: true.
+  requireMembership   Boolean  @default(false)
+
+  grants OAuthGrant[]
+
+  createdAt DateTime @default(now())
+}
+
+// Represents a member's standing authorization for a specific client. One
+// row per (user, client). Owns N Session rows over time (one per
+// re-authorization after rolling expiry).
+model OAuthGrant {
+  id         String    @id @default(cuid())
+  userId     String
+  clientId   String // OAuthClient.clientId
+  // Member-supplied or client-supplied label, shown in Settings.
+  // Defaults to the client's name on first issuance.
+  name       String
+  scopes     String[]
+  createdAt  DateTime  @default(now())
+  lastUsedAt DateTime?
+  revokedAt  DateTime?
+
+  user     User        @relation(fields: [userId], references: [id])
+  client   OAuthClient @relation(fields: [clientId], references: [clientId])
+  sessions Session[]
+
+  @@unique([userId, clientId])
+  @@index([userId, revokedAt])
+}
+
+// ─── Magic-link (partner + alumni personal-email auth) ───────────────────────
+
+// Single-use tokens for magic-link sign-in. Used by Partner portal (primary
+// auth) and alumni post-grad (personal-email fallback after dali.dartmouth
+// .edu revocation). The raw token is SHA-256 hashed at rest; the email
+// contains the raw value. Tokens are single-use: `usedAt` set on consumption.
+model OneTimeToken {
+  id        String       @id @default(cuid())
+  userId    String
+  // sha256(raw token), base64url. Looked up by hash.
+  tokenHash String       @unique
+  purpose   TokenPurpose
+  expiresAt DateTime
+  usedAt    DateTime?
+  // Optional context: e.g. the email that was sent the link, the redirect
+  // target after verification.
+  metadata  Json?
+  createdAt DateTime     @default(now())
+
+  user User @relation(fields: [userId], references: [id])
+
+  @@index([userId, purpose])
+  @@index([expiresAt])
+}
+
+enum TokenPurpose {
+  PartnerMagicLink
+  AlumniEmailLink
+  EmailVerification
+}
+
+// ─── Gmail integration (send-as) ─────────────────────────────────────────────
+//
+// New home for the Gmail send-as credential that today lives on the
+// User.googleAccessToken/RefreshToken/TokenExpiresAt columns. Phase 1 adds
+// this table; Phase 2 backfills from User.google* for the 1–2 admin
+// accounts that use Gmail send-as, then drops the User columns.
+
+model GmailIntegration {
+  id             String    @id @default(cuid())
+  userId         String    @unique
+  // The Gmail account email being sent-as.
+  sendAsEmail    String
+  // Encrypted at rest (same AES-256-GCM helper used by UserCalendarLink).
+  oauthTokens    String
+  // Cached expiration of the access token portion of `oauthTokens`. Drives
+  // proactive refresh ahead of expiry.
+  tokenExpiresAt DateTime?
+  // Soft-disable so the admin UI can revoke without deleting.
+  enabled        Boolean   @default(true)
+  // Last successful Gmail API call against this integration. Drives the
+  // "Gmail connected" indicator on hiring email-templates UI.
+  lastUsedAt     DateTime?
+  syncError      String?
+  linkedAt       DateTime  @default(now())
+
+  user User @relation(fields: [userId], references: [id])
+}

--- a/dali-api/prisma/seed.ts
+++ b/dali-api/prisma/seed.ts
@@ -29,21 +29,39 @@ async function main() {
   });
 
   // ── Domains ────────────────────────────────────────────────────────────────
+  // Phase 1 adds `code` + `displayName` to Domain. Local seeds populate them
+  // so a fresh dev DB has consistent values; prod backfill is handled by the
+  // v0 reference-data script (prisma/data/v0-reference-seed.ts).
   const [designDomain, engDomain, pmDomain] = await Promise.all([
     prisma.domain.upsert({
       where: { id: "domain-design" },
-      update: {},
-      create: { id: "domain-design", name: "Design" },
+      update: { code: "UIUX", displayName: "UI/UX Design" },
+      create: {
+        id: "domain-design",
+        name: "Design",
+        code: "UIUX",
+        displayName: "UI/UX Design",
+      },
     }),
     prisma.domain.upsert({
       where: { id: "domain-eng" },
-      update: {},
-      create: { id: "domain-eng", name: "Engineering" },
+      update: { code: "Fullstack", displayName: "Fullstack Dev" },
+      create: {
+        id: "domain-eng",
+        name: "Engineering",
+        code: "Fullstack",
+        displayName: "Fullstack Dev",
+      },
     }),
     prisma.domain.upsert({
       where: { id: "domain-pm" },
-      update: {},
-      create: { id: "domain-pm", name: "Product" },
+      update: { code: "PM", displayName: "Product Management" },
+      create: {
+        id: "domain-pm",
+        name: "Product",
+        code: "PM",
+        displayName: "Product Management",
+      },
     }),
   ]);
 

--- a/dali-api/prisma/seeds/v0-reference.ts
+++ b/dali-api/prisma/seeds/v0-reference.ts
@@ -1,0 +1,182 @@
+/**
+ * v0 reference-data seeder. Run AFTER `npx prisma migrate deploy` has applied
+ * the `20260514040346_v0_phase1_additive` migration. Idempotent — re-runs are
+ * safe (uses upserts and skips rows already present).
+ *
+ *   npm run db:seed:v0-reference        (production / staging / dev)
+ *
+ * What this seeds:
+ *   - 17 Domain rows (with code, displayName, isInternProgram). Backfills
+ *     code/displayName on existing Domain rows where missing.
+ *   - Term rows: 26W..28F (an 8-quarter window).
+ *   - 7 PageTemplate rows (Empty, Project Brief, Sprint Retro, Sprint Goals,
+ *     Meeting Notes, Decision Log, Onboarding Doc) — empty contentDoc; the
+ *     Page Tree UX track replaces the contentDoc bodies when it ships.
+ *   - 1 MentorNoteTemplate row (default) — empty contentDoc; mentorship track
+ *     replaces.
+ *
+ * NOT seeded (out of scope for v0 reference data):
+ *   - JobCodeLookup — needs real Dartmouth payroll mapping; the Admin Console
+ *     payroll-codes UI (admin CRUD track) is the entry point.
+ *   - Domain-specific OAuthClient rows — MCP foundation track seeds these.
+ *   - StaffingCycle / Project / EducationOffering — operational data created
+ *     via UI by Core members.
+ */
+
+import { PrismaClient } from "../../app/generated/prisma/client.js";
+import { PrismaPg } from "@prisma/adapter-pg";
+
+// Lives outside prisma/data/ because prisma/data/ is gitignored (PII).
+
+const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL! });
+const prisma = new PrismaClient({ adapter });
+
+type DomainSeed = {
+  code: string;
+  displayName: string;
+  isInternProgram: boolean;
+};
+
+const DOMAINS: DomainSeed[] = [
+  { code: "Fullstack", displayName: "Fullstack Dev", isInternProgram: false },
+  { code: "UIUX", displayName: "UI/UX Design", isInternProgram: false },
+  { code: "ARVR", displayName: "AR/VR Dev", isInternProgram: false },
+  { code: "Data", displayName: "Data Dev", isInternProgram: false },
+  { code: "Engineering", displayName: "Engineering", isInternProgram: false },
+  { code: "ThreeDModeling", displayName: "3D Modeling", isInternProgram: false },
+  { code: "Animation", displayName: "Animation", isInternProgram: false },
+  { code: "Graphics", displayName: "Graphics", isInternProgram: false },
+  { code: "Writing", displayName: "Writing", isInternProgram: false },
+  { code: "Videography", displayName: "Videography", isInternProgram: false },
+  { code: "Photography", displayName: "Photography", isInternProgram: false },
+  { code: "Production", displayName: "Production", isInternProgram: false },
+  { code: "PM", displayName: "Product Management", isInternProgram: false },
+  { code: "DigitalArts", displayName: "Digital Arts Design", isInternProgram: false },
+  { code: "ERAS", displayName: "ERAS Intern", isInternProgram: true },
+  { code: "EEJUST", displayName: "EE Just Intern", isInternProgram: true },
+  { code: "WISP", displayName: "WISP Intern", isInternProgram: true },
+];
+
+type Season = "W" | "S" | "X" | "F";
+const SEASONS: { code: Season; sortIndex: 1 | 2 | 3 | 4 }[] = [
+  { code: "W", sortIndex: 1 },
+  { code: "S", sortIndex: 2 },
+  { code: "X", sortIndex: 3 },
+  { code: "F", sortIndex: 4 },
+];
+
+// Approximate Dartmouth quarter windows. Dates are illustrative; Admin
+// Console > Terms can edit any of these post-seed if real boundaries shift.
+function quarterDates(year: number, season: Season): { start: Date; end: Date } {
+  switch (season) {
+    case "W": return { start: new Date(`${year}-01-04`), end: new Date(`${year}-03-13`) };
+    case "S": return { start: new Date(`${year}-03-28`), end: new Date(`${year}-06-05`) };
+    case "X": return { start: new Date(`${year}-06-22`), end: new Date(`${year}-08-29`) };
+    case "F": return { start: new Date(`${year}-09-12`), end: new Date(`${year}-11-23`) };
+  }
+}
+
+async function seedDomains() {
+  for (const d of DOMAINS) {
+    await prisma.domain.upsert({
+      where: { code: d.code },
+      // If the row already exists, update only the new Phase 1 fields.
+      // Legacy `name` is left alone (Phase 2 drops it).
+      update: {
+        displayName: d.displayName,
+        isInternProgram: d.isInternProgram,
+        active: true,
+      },
+      create: {
+        name: d.displayName,
+        code: d.code,
+        displayName: d.displayName,
+        isInternProgram: d.isInternProgram,
+        active: true,
+      },
+    });
+  }
+  console.log(`✓ Seeded ${DOMAINS.length} domains.`);
+}
+
+async function seedTerms() {
+  // 26W .. 28F (12 quarters).
+  let count = 0;
+  for (const year of [2026, 2027, 2028]) {
+    for (const s of SEASONS) {
+      const code = `${year % 100}${s.code}`;
+      const { start, end } = quarterDates(year, s.code);
+      const sortKey = year * 10 + s.sortIndex;
+      await prisma.term.upsert({
+        where: { code },
+        update: { sortKey, startDate: start, endDate: end, season: s.code, year },
+        create: { code, year, season: s.code, sortKey, startDate: start, endDate: end },
+      });
+      count++;
+    }
+  }
+  console.log(`✓ Seeded ${count} terms.`);
+}
+
+async function seedPageTemplates() {
+  // Stub collab doc id per template. The Page Tree UX track replaces these
+  // with real CollabDocument rows whose bodies encode the template content.
+  const TEMPLATES = [
+    { name: "Empty", iconEmoji: "📄", isDefault: true },
+    { name: "Project Brief", iconEmoji: "📋", isDefault: false },
+    { name: "Sprint Retro", iconEmoji: "🔁", isDefault: false },
+    { name: "Sprint Goals", iconEmoji: "🎯", isDefault: false },
+    { name: "Meeting Notes", iconEmoji: "📝", isDefault: false },
+    { name: "Decision Log", iconEmoji: "✅", isDefault: false },
+    { name: "Onboarding Doc", iconEmoji: "🚀", isDefault: false },
+  ] as const;
+
+  for (const t of TEMPLATES) {
+    const existing = await prisma.pageTemplate.findFirst({ where: { name: t.name } });
+    if (existing) continue;
+    await prisma.pageTemplate.create({
+      data: {
+        name: t.name,
+        contentDocId: `page-template:${t.name.toLowerCase().replace(/\s+/g, "-")}`,
+        iconEmoji: t.iconEmoji,
+        isDefault: t.isDefault,
+        workspaceTypes: [],
+      },
+    });
+  }
+  console.log(`✓ Seeded ${TEMPLATES.length} page templates (existing rows untouched).`);
+}
+
+async function seedMentorNoteTemplate() {
+  const existing = await prisma.mentorNoteTemplate.findFirst({ where: { isDefault: true } });
+  if (existing) {
+    console.log(`✓ Mentor-note default template already present (id=${existing.id}).`);
+    return;
+  }
+  await prisma.mentorNoteTemplate.create({
+    data: {
+      name: "Weekly Mentor Note (default)",
+      contentDocId: "mentor-note-template:default",
+      isDefault: true,
+    },
+  });
+  console.log(`✓ Seeded default mentor-note template.`);
+}
+
+async function main() {
+  console.log("Running v0 reference-data seed against", process.env.DATABASE_URL?.split("@")[1]?.split("/")[0] ?? "(unknown DB)");
+  await seedDomains();
+  await seedTerms();
+  await seedPageTemplates();
+  await seedMentorNoteTemplate();
+  console.log("Done.");
+}
+
+main()
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
Lands the full Phase-1 schema additions called out in V0_PLAN.md: ~40 new models (Term/Project/Education/Staffing/Page/Mentorship/ Notification/Partner/OAuth/OneTimeToken/GmailIntegration) plus additive nullable columns on User, Domain, Application, and DomainLeadAssignment, and the Session.grantId FK constraint to the new OAuthGrant table.

Migration is purely additive (43 CREATE TABLE, 0 DROP) — safe to roll forward while the 2026-S hire cycle is live. Destructive identity refactor (DALIMember slim-down, User.google* drop, 9 hiring FK renames, MemberRole[] removal) is scoped to Phase 2 per V0_PHASE2_PLAN.md and waits for cycle close.

Includes prisma/seeds/v0-reference.ts (idempotent prod reference seed for Domain catalog, Terms, PageTemplate, MentorNoteTemplate). Local prisma/seed.ts updated minimally so a fresh dev DB has Domain.code/displayName on the 3 existing rows.

Schema validates clean; all 703 unit tests pass.