### PR TITLE
Fix Google Calendar write scope + improve partial-failure UX

### DIFF
--- a/dali-api/app/calendar/routes/calendar.tsx
+++ b/dali-api/app/calendar/routes/calendar.tsx
@@ -1757,11 +1757,33 @@ function CreateScheduledMeetingForm({
 
         <div className="flex items-center justify-between pt-1">
           <div className="text-sm">
-            {status?.ok === true && (
+            {status?.ok === true && !status.gcalError && (
               <span className="text-green-700">
                 Meeting created. Notified {status.count} participant{status.count === 1 ? "" : "s"}.
-                {status.gcalError ? ` (Google Calendar push failed: ${status.gcalError})` : ""}
               </span>
+            )}
+            {status?.ok === true && status.gcalError && (
+              <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-amber-900">
+                <div className="font-medium">
+                  Meeting created, but the Google Calendar invite didn't go out.
+                </div>
+                <div className="text-xs mt-0.5">
+                  Notified {status.count} participant{status.count === 1 ? "" : "s"} in-app.{" "}
+                  {/insufficient.*scope|insufficientPermissions|invalid_grant|unauthorized/i.test(
+                    status.gcalError,
+                  ) ? (
+                    <>
+                      Your linked Google account is missing calendar-write permission.{" "}
+                      <a href="/oauth/calendar/google/start" className="underline font-medium">
+                        Reconnect Google Calendar
+                      </a>{" "}
+                      to send invites.
+                    </>
+                  ) : (
+                    <>Details: {status.gcalError}</>
+                  )}
+                </div>
+              </div>
             )}
             {status?.ok === false && <span className="text-red-700">{status.error}</span>}
           </div>

--- a/dali-api/app/routes/oauth.calendar.google.start.ts
+++ b/dali-api/app/routes/oauth.calendar.google.start.ts
@@ -12,7 +12,9 @@ export const CAL_STATE_COOKIE = "__dali_cal_oauth_state";
 const SCOPES = [
   "openid",
   "email",
-  "https://www.googleapis.com/auth/calendar.readonly",
+  // Full calendar scope: needed for events.insert / events.patch when pushing
+  // scheduled meetings and RSVP updates, plus calendarList + freebusy reads.
+  "https://www.googleapis.com/auth/calendar",
 ].join(" ");
 
 export async function loader({ request }: { request: Request }) {


### PR DESCRIPTION
## Summary
- `/oauth/calendar/google/start` only requested `calendar.readonly`, so `events.insert` / `events.patch` (RSVP) calls failed with `403 insufficientPermissions`. Switched to the full `https://www.googleapis.com/auth/calendar` scope to match the gmail-authorization flow.
- When the meeting was created but Google push failed, the toast rendered as green success with the error appended in parens — misleading. It now renders an amber warning card distinguishing the in-app success from the calendar failure.
- If the error matches a known scope/auth-revoked pattern (`insufficientPermissions`, `invalid_grant`, etc.) the card includes a **Reconnect Google Calendar** link to `/oauth/calendar/google/start`.

## Migration note
Existing users who linked their calendar before this PR still have a refresh token with the old read-only scope. They must reconnect via `/oauth/calendar/google/start` to grant write access. The new UX surfaces this prompt automatically the first time they try to send an invite.

## Test plan
- [ ] Unlink + relink a Google Calendar; verify consent screen now requests calendar read/write
- [ ] Create a scheduled meeting → Google invite lands in attendees' inboxes
- [ ] With a stale read-only refresh token, create a meeting → see amber warning + Reconnect link, click link, complete reconsent, retry succeeds
- [ ] Pure success path still renders green
- [ ] Hard failure (`ok: false`) still renders red

🤖 Generated with [Claude Code](https://claude.com/claude-code)