### PR TITLE
v0 Phase 2 — destructive identity refactor (DALIMember slim-down + hiring FK renames)

### DIFF
--- a/dali-api/app/admin-console/__tests__/api.domains.create.test.ts
+++ b/dali-api/app/admin-console/__tests__/api.domains.create.test.ts
@@ -48,7 +48,9 @@ describe("POST /api/domains — name validation", () => {
       context: {},
     } as any);
     expect(res.status).toBe(201);
-    expect(mockPrisma.domain.create).toHaveBeenCalledWith({ data: { name: "Design" } });
+    expect(mockPrisma.domain.create).toHaveBeenCalledWith({
+      data: { name: "Design", code: "Design", displayName: "Design" },
+    });
   });
 
   it("rejects an empty name", async () => {

--- a/dali-api/app/admin-console/__tests__/api.members.roles.test.ts
+++ b/dali-api/app/admin-console/__tests__/api.members.roles.test.ts
@@ -13,34 +13,67 @@ vi.mock("~/lib/cors", () => ({
 
 import { prisma } from "~/lib/db";
 import { requireAuth } from "~/lib/auth";
-import { isAdmin } from "~/lib/roles";
+import { isAdmin, currentTerm } from "~/lib/roles";
 import { action } from "~/admin-console/routes/api.members.$memberId.roles";
 
 const ADMIN_ID = "admin-1";
-const MEMBER_ID = "member-1";
+const USER_ID = "user-1";
+const TERM_ID = "term-1";
+
+// Phase 2: the endpoint translates legacy role labels ("Admin", "HiringLead")
+// into AdminMembership / CoreAssignment writes. `memberId` in the route param
+// is now the User.id.
 
 const mockPrisma = prisma as unknown as {
-  dALIMember: {
+  adminMembership: {
     findUnique: ReturnType<typeof vi.fn>;
-    update: ReturnType<typeof vi.fn>;
+    upsert: ReturnType<typeof vi.fn>;
+    deleteMany: ReturnType<typeof vi.fn>;
   };
+  coreAssignment: {
+    findFirst: ReturnType<typeof vi.fn>;
+    create: ReturnType<typeof vi.fn>;
+    deleteMany: ReturnType<typeof vi.fn>;
+  };
+  user: {
+    findUnique: ReturnType<typeof vi.fn>;
+  };
+  $transaction: ReturnType<typeof vi.fn>;
 };
 
 beforeEach(() => {
   vi.clearAllMocks();
-  (mockPrisma as any).dALIMember = {
-    findUnique: vi.fn().mockResolvedValue({ roles: [] }),
-    update: vi.fn().mockResolvedValue({ id: MEMBER_ID, roles: ["Admin"] }),
+  (mockPrisma as any).adminMembership = {
+    findUnique: vi.fn().mockResolvedValue(null),
+    upsert: vi.fn(),
+    deleteMany: vi.fn(),
   };
+  (mockPrisma as any).coreAssignment = {
+    findFirst: vi.fn().mockResolvedValue(null),
+    create: vi.fn(),
+    deleteMany: vi.fn(),
+  };
+  (mockPrisma as any).user = {
+    findUnique: vi.fn().mockResolvedValue({
+      id: USER_ID,
+      firstName: "Ada",
+      lastName: "Lovelace",
+      daliEmail: "ada@dali.dartmouth.edu",
+      adminMembership: { id: "a1" },
+      coreAssignments: [],
+    }),
+  };
+  (mockPrisma as any).$transaction = vi.fn(async (cb: (tx: unknown) => Promise<unknown>) => cb(mockPrisma));
   vi.mocked(requireAuth).mockResolvedValue({
     ok: true,
     user: { sub: ADMIN_ID, email: "a@x.com", type: "user" },
   } as any);
   vi.mocked(isAdmin).mockResolvedValue(true);
+  vi.mocked(currentTerm).mockResolvedValue({ id: TERM_ID } as any);
 });
 
 function makeRequest(body: unknown) {
-  return new Request(`http://localhost/api/members/${MEMBER_ID}/roles`, {
+  return new Request(`http://localhost/api/members/${USER_ID}/roles`, {
     method: "PATCH",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
@@ -48,45 +81,45 @@ function makeRequest(body: unknown) {
 }
 
 describe("PATCH /api/members/:memberId/roles — schema validation", () => {
-  it("accepts a valid roles array", async () => {
+  it("accepts a valid roles array (Admin)", async () => {
     const res = await action({
       request: makeRequest({ roles: ["Admin"] }),
-      params: { memberId: MEMBER_ID },
+      params: { memberId: USER_ID },
       context: {},
     } as any);
     expect(res.status).toBe(200);
-    expect(mockPrisma.dALIMember.update).toHaveBeenCalledWith(
-      expect.objectContaining({ data: { roles: ["Admin"] } }),
+    expect(mockPrisma.adminMembership.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { userId: USER_ID } }),
     );
   });
 
   it("rejects when roles is not an array", async () => {
     const res = await action({
       request: makeRequest({ roles: "Admin" }),
-      params: { memberId: MEMBER_ID },
+      params: { memberId: USER_ID },
       context: {},
     } as any);
     expect(res.status).toBe(400);
-    expect(mockPrisma.dALIMember.update).not.toHaveBeenCalled();
+    expect(mockPrisma.adminMembership.upsert).not.toHaveBeenCalled();
   });
 
   it("rejects unknown role values", async () => {
     const res = await action({
       request: makeRequest({ roles: ["SuperAdmin"] }),
-      params: { memberId: MEMBER_ID },
+      params: { memberId: USER_ID },
       context: {},
     } as any);
     expect(res.status).toBe(400);
-    expect(mockPrisma.dALIMember.update).not.toHaveBeenCalled();
+    expect(mockPrisma.adminMembership.upsert).not.toHaveBeenCalled();
   });
 
   it("rejects oversized roles arrays", async () => {
     const res = await action({
       request: makeRequest({ roles: Array(50).fill("Admin") }),
-      params: { memberId: MEMBER_ID },
+      params: { memberId: USER_ID },
       context: {},
     } as any);
     expect(res.status).toBe(400);
-    expect(mockPrisma.dALIMember.update).not.toHaveBeenCalled();
+    expect(mockPrisma.adminMembership.upsert).not.toHaveBeenCalled();
   });
 });

--- a/dali-api/app/admin-console/components/admin-console-shared.tsx
+++ b/dali-api/app/admin-console/components/admin-console-shared.tsx
@@ -3,38 +3,49 @@ import { createPortal } from "react-dom";
 import { useFetcher } from "react-router";
 import { Shield, ChevronDown, X, Check } from "lucide-react";
 
+// Phase 2 reshape: Member is rooted at User. Role flags derive from typed
+// assignment tables (AdminMembership, CoreAssignment, DomainLeadAssignment)
+// rather than the dropped DALIMember.roles[] enum.
+
 export interface DomainRow {
   id: string;
   name: string;
 }
 
-export interface DomainLeadAssignment {
+export interface DomainLeadAssignmentForMember {
   id: string;
   domain: DomainRow;
 }
 
 export interface Member {
+  // User.id — the canonical actor id used by all admin-console actions.
   id: string;
-  firstName: string | null;
-  lastName: string | null;
+  firstName: string;
+  lastName: string;
   daliEmail: string | null;
-  roles: string[];
-  user: { id: string; firstName: string; lastName: string } | null;
-  domainLeadAssignments: DomainLeadAssignment[];
+  // Presence indicates a lab member (vs a Dartmouth student or partner).
+  isLabMember: boolean;
+  // Presence = Admin (AdminMembership row exists).
+  isAdmin: boolean;
+  // Presence = Core in the current term (any CoreAssignment with current term).
+  // We surface this as the "Hiring Lead"-equivalent toggle (Core has hiring
+  // lead-equivalent access per V0_PLAN.md).
+  isCore: boolean;
+  domainLeadAssignments: DomainLeadAssignmentForMember[];
 }
 
-export interface DomainLeadAssignmentWithMember {
+export interface DomainLeadAssignmentWithUser {
   id: string;
-  member: {
+  user: {
     id: string;
-    firstName: string | null;
-    lastName: string | null;
+    firstName: string;
+    lastName: string;
     daliEmail: string | null;
   };
 }
 
 export interface DomainWithCounts extends DomainRow {
-  domainLeadAssignments: DomainLeadAssignmentWithMember[];
+  domainLeadAssignments: DomainLeadAssignmentWithUser[];
   _count: {
     challengeVersions: number;
     applicationCycles: number;
@@ -45,7 +56,7 @@ export interface DomainWithCounts extends DomainRow {
   };
 }
 
-export function memberLabel(member: { firstName: string | null; lastName: string | null; daliEmail: string | null }) {
+export function memberLabel(member: { firstName: string; lastName: string; daliEmail: string | null }) {
   const name = `${member.firstName ?? ""} ${member.lastName ?? ""}`.trim();
   return name || member.daliEmail || "Unnamed member";
 }
@@ -67,12 +78,12 @@ export function RemoveDomainLeadButton({ assignmentId }: { assignmentId: string 
   );
 }
 
-function AddDomainLeadButton({ memberId, domain, onAdded }: { memberId: string; domain: DomainRow; onAdded: () => void }) {
+function AddDomainLeadButton({ userId, domain, onAdded }: { userId: string; domain: DomainRow; onAdded: () => void }) {
   const fetcher = useFetcher();
   return (
     <fetcher.Form method="post" onSubmit={onAdded}>
       <input type="hidden" name="intent" value="add-domain-lead" />
-      <input type="hidden" name="memberId" value={memberId} />
+      <input type="hidden" name="userId" value={userId} />
       <input type="hidden" name="domainId" value={domain.id} />
       <button type="submit" className="w-full text-left px-4 py-2 text-sm text-foreground/80 hover:bg-muted/50">
         {domain.name}
@@ -149,7 +160,7 @@ export function DomainLeadPicker({
                     {available.map((domain) => (
                       <AddDomainLeadButton
                         key={domain.id}
-                        memberId={member.id}
+                        userId={member.id}
                         domain={domain}
                         onAdded={() => setOpen(false)}
                       />
@@ -170,12 +181,12 @@ export function AdminToggle({ member }: { member: Member }) {
   const submittedValue = fetcher.formData?.get("value");
   const isAdminMember = submittedValue != null
     ? submittedValue === "true"
-    : member.roles.includes("Admin");
+    : member.isAdmin;
 
   return (
     <fetcher.Form method="post">
       <input type="hidden" name="intent" value="set-admin" />
-      <input type="hidden" name="memberId" value={member.id} />
+      <input type="hidden" name="userId" value={member.id} />
       <input type="hidden" name="value" value={String(!isAdminMember)} />
       <button
         type="submit"
@@ -197,12 +208,12 @@ export function HiringLeadToggle({ member }: { member: Member }) {
   const submittedValue = fetcher.formData?.get("value");
   const isHiringLead = submittedValue != null
     ? submittedValue === "true"
-    : member.roles.includes("HiringLead");
+    : member.isCore;
 
   return (
     <fetcher.Form method="post">
       <input type="hidden" name="intent" value="set-hiring-lead" />
-      <input type="hidden" name="memberId" value={member.id} />
+      <input type="hidden" name="userId" value={member.id} />
       <input type="hidden" name="value" value={String(!isHiringLead)} />
       <button
         type="submit"

--- a/dali-api/app/admin-console/routes/admin-console.domains.tsx
+++ b/dali-api/app/admin-console/routes/admin-console.domains.tsx
@@ -3,7 +3,7 @@ import { redirect, useLoaderData, useFetcher } from "react-router";
 import type { Route } from "./+types/admin-console.domains";
 import { prisma } from "~/lib/db";
 import { requireAuth } from "~/lib/auth";
-import { isAdmin } from "~/lib/roles";
+import { isAdmin, currentTerm } from "~/lib/roles";
 import { describeDomainUsage } from "./api.domains.$domainId";
 import { ChevronDown, Trash2, Plus } from "lucide-react";
 import {
@@ -15,30 +15,36 @@ import {
 
 export const meta: Route.MetaFunction = () => [{ title: "Domains · Admin console · DALI OS" }];
 
+// Phase 2 rewrite: domain-lead assignments now key off User.id (not
+// DALIMember.id) and require a termId. Lead picker lists Users with a
+// DALIMember row (lab members).
+
 export async function loader({ request }: Route.LoaderArgs) {
   const auth = await requireAuth(request);
   if (!auth.ok) return redirect("/login");
   const admin = await isAdmin(auth.user.sub);
   if (!admin) return redirect("/admin-console/members");
 
-  const [members, domains] = await Promise.all([
-    prisma.dALIMember.findMany({
+  const [users, domains] = await Promise.all([
+    prisma.user.findMany({
+      where: { daliMember: { isNot: null } },
       include: {
-        user: { select: { id: true, firstName: true, lastName: true } },
-        domainLeadAssignments: { include: { domain: true } },
+        adminMembership: { select: { id: true } },
+        coreAssignments: { select: { termId: true, leadTitle: true } },
+        domainLeadAssignmentsAsUser: { include: { domain: true } },
       },
       orderBy: [{ lastName: "asc" }, { firstName: "asc" }],
     }),
     prisma.domain.findMany({
-      orderBy: { name: "asc" },
+      orderBy: { displayName: "asc" },
       include: {
         domainLeadAssignments: {
           include: {
-            member: {
+            user: {
               select: { id: true, firstName: true, lastName: true, daliEmail: true },
             },
           },
-          orderBy: [{ member: { lastName: "asc" } }, { member: { firstName: "asc" } }],
+          orderBy: [{ user: { lastName: "asc" } }, { user: { firstName: "asc" } }],
         },
         _count: {
           select: {
@@ -54,7 +60,36 @@ export async function loader({ request }: Route.LoaderArgs) {
     }),
   ]);
 
-  return { members, domains };
+  const members: Member[] = users.map((u) => ({
+    id: u.id,
+    firstName: u.firstName,
+    lastName: u.lastName,
+    daliEmail: u.daliEmail,
+    isLabMember: true,
+    isAdmin: u.adminMembership !== null,
+    isCore: u.coreAssignments.length > 0,
+    domainLeadAssignments: u.domainLeadAssignmentsAsUser.map((a) => ({
+      id: a.id,
+      domain: { id: a.domain.id, name: a.domain.displayName },
+    })),
+  }));
+
+  const domainsForView: DomainWithCounts[] = domains.map((d) => ({
+    id: d.id,
+    name: d.displayName,
+    domainLeadAssignments: d.domainLeadAssignments.map((a) => ({
+      id: a.id,
+      user: {
+        id: a.user.id,
+        firstName: a.user.firstName,
+        lastName: a.user.lastName,
+        daliEmail: a.user.daliEmail,
+      },
+    })),
+    _count: d._count,
+  }));
+
+  return { members, domains: domainsForView };
 }
 
 export async function action({ request }: Route.ActionArgs) {
@@ -69,7 +104,13 @@ export async function action({ request }: Route.ActionArgs) {
   if (intent === "create-domain") {
     const name = String(formData.get("name") ?? "").trim();
     if (!name) return Response.json({ error: "Name is required" }, { status: 400 });
-    await prisma.domain.create({ data: { name } });
+    // Phase 2: code + displayName required. Derive code from the name by
+    // stripping non-alnum (admin can rename later). displayName mirrors
+    // name on create; both editable post-create.
+    const code = name.replace(/[^A-Za-z0-9]/g, "") || "Domain";
+    await prisma.domain.create({
+      data: { name, code, displayName: name },
+    });
     return null;
   }
 
@@ -105,17 +146,30 @@ export async function action({ request }: Route.ActionArgs) {
     }
     if (result.kind === "in-use") {
       return Response.json(
-              { error: `Cannot delete: domain is in use by ${result.blocking.join(", ")}.` },
-              { status: 409 },
-            );
+        { error: `Cannot delete: domain is in use by ${result.blocking.join(", ")}.` },
+        { status: 409 },
+      );
     }
     return null;
   }
 
   if (intent === "add-domain-lead") {
-    const memberId = formData.get("memberId") as string;
+    const userId = formData.get("userId") as string;
     const domainId = formData.get("domainId") as string;
-    await prisma.domainLeadAssignment.create({ data: { memberId, domainId } });
+    const term = await currentTerm();
+    if (!term) {
+      return Response.json(
+        { error: "No current Term — run npm run db:seed:v0-reference" },
+        { status: 500 },
+      );
+    }
+    await prisma.domainLeadAssignment.upsert({
+      where: {
+        userId_domainId_termId: { userId, domainId, termId: term.id },
+      },
+      update: {},
+      create: { userId, domainId, termId: term.id },
+    });
     return null;
   }
 
@@ -133,7 +187,7 @@ function AddDomainLeadForMemberButton({ domainId, member, onAdded }: { domainId:
   return (
     <fetcher.Form method="post" onSubmit={onAdded}>
       <input type="hidden" name="intent" value="add-domain-lead" />
-      <input type="hidden" name="memberId" value={member.id} />
+      <input type="hidden" name="userId" value={member.id} />
       <input type="hidden" name="domainId" value={domainId} />
       <button type="submit" className="w-full text-left px-4 py-2 text-sm text-foreground/80 hover:bg-muted/50">
         {memberLabel(member)}
@@ -145,8 +199,8 @@ function AddDomainLeadForMemberButton({ domainId, member, onAdded }: { domainId:
 function DomainLeadsForDomain({ domain, members }: { domain: DomainWithCounts; members: Member[] }) {
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
-  const assignedMemberIds = new Set(domain.domainLeadAssignments.map((a) => a.member.id));
-  const available = members.filter((m) => !assignedMemberIds.has(m.id));
+  const assignedUserIds = new Set(domain.domainLeadAssignments.map((a) => a.user.id));
+  const available = members.filter((m) => !assignedUserIds.has(m.id));
   const q = search.trim().toLowerCase();
   const filtered = q
     ? available.filter((m) => memberLabel(m).toLowerCase().includes(q) || (m.daliEmail ?? "").toLowerCase().includes(q))
@@ -163,7 +217,7 @@ function DomainLeadsForDomain({ domain, members }: { domain: DomainWithCounts; m
           key={assignment.id}
           className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-800"
         >
-          {memberLabel(assignment.member)}
+          {memberLabel(assignment.user)}
           <RemoveDomainLeadButton assignmentId={assignment.id} />
         </span>
       ))}

--- a/dali-api/app/admin-console/routes/admin-console.members.tsx
+++ b/dali-api/app/admin-console/routes/admin-console.members.tsx
@@ -3,15 +3,22 @@ import { redirect, useLoaderData } from "react-router";
 import type { Route } from "./+types/admin-console.members";
 import { prisma } from "~/lib/db";
 import { requireAuth } from "~/lib/auth";
-import { isAdmin } from "~/lib/roles";
+import { isAdmin, currentTerm } from "~/lib/roles";
 import { Users, Check } from "lucide-react";
 import {
   AdminToggle,
   DomainLeadPicker,
   HiringLeadToggle,
+  type Member,
 } from "~/admin-console/components/admin-console-shared";
 
 export const meta: Route.MetaFunction = () => [{ title: "Members · Admin console · DALI OS" }];
+
+// Phase 2 rewrite: role state lives in AdminMembership / CoreAssignment /
+// DomainLeadAssignment instead of DALIMember.roles[]. The admin page now
+// lists Users (filtered to those with a DALIMember row, i.e. lab members)
+// and presents per-user toggles backed by row insert/delete on the three
+// assignment tables.
 
 export async function loader({ request }: Route.LoaderArgs) {
   const auth = await requireAuth(request);
@@ -19,21 +26,45 @@ export async function loader({ request }: Route.LoaderArgs) {
   const admin = await isAdmin(auth.user.sub);
   if (!admin) return redirect("/");
 
-  const [members, domains] = await Promise.all([
-    prisma.dALIMember.findMany({
+  const [users, domains, term] = await Promise.all([
+    prisma.user.findMany({
+      where: { daliMember: { isNot: null } },
       include: {
-        user: { select: { id: true, firstName: true, lastName: true } },
-        domainLeadAssignments: { include: { domain: true } },
+        daliMember: { select: { id: true } },
+        adminMembership: { select: { id: true } },
+        coreAssignments: { select: { id: true, termId: true, leadTitle: true } },
+        domainLeadAssignmentsAsUser: { include: { domain: true } },
       },
       orderBy: [{ lastName: "asc" }, { firstName: "asc" }],
     }),
     prisma.domain.findMany({
-      orderBy: { name: "asc" },
-      select: { id: true, name: true },
+      where: { active: true },
+      orderBy: { displayName: "asc" },
+      select: { id: true, name: true, displayName: true },
     }),
+    currentTerm(),
   ]);
 
-  return { members, domains };
+  const members: Member[] = users.map((u) => ({
+    id: u.id,
+    firstName: u.firstName,
+    lastName: u.lastName,
+    daliEmail: u.daliEmail,
+    isLabMember: u.daliMember !== null,
+    isAdmin: u.adminMembership !== null,
+    isCore:
+      term !== null &&
+      u.coreAssignments.some((a) => a.termId === term.id),
+    domainLeadAssignments: u.domainLeadAssignmentsAsUser.map((a) => ({
+      id: a.id,
+      domain: { id: a.domain.id, name: a.domain.displayName },
+    })),
+  }));
+
+  return {
+    members,
+    domains: domains.map((d) => ({ id: d.id, name: d.displayName })),
+  };
 }
 
 export async function action({ request }: Route.ActionArgs) {
@@ -47,37 +78,66 @@ export async function action({ request }: Route.ActionArgs) {
   const intent = formData.get("intent") as string;
 
   if (intent === "set-admin") {
-    const memberId = formData.get("memberId") as string;
+    const userId = formData.get("userId") as string;
     const value = formData.get("value") === "true";
-    const member = await prisma.dALIMember.findUniqueOrThrow({
-      where: { id: memberId },
-      select: { roles: true },
-    });
-    const roles = value
-      ? [...new Set([...member.roles, "Admin" as const])]
-      : member.roles.filter((r) => r !== "Admin");
-    await prisma.dALIMember.update({ where: { id: memberId }, data: { roles } });
+    if (value) {
+      await prisma.adminMembership.upsert({
+        where: { userId },
+        update: {},
+        create: { userId, grantedBy: auth.user.sub },
+      });
+    } else {
+      await prisma.adminMembership.deleteMany({ where: { userId } });
+    }
     return null;
   }
 
   if (intent === "set-hiring-lead") {
-    const memberId = formData.get("memberId") as string;
+    const userId = formData.get("userId") as string;
     const value = formData.get("value") === "true";
-    const member = await prisma.dALIMember.findUniqueOrThrow({
-      where: { id: memberId },
-      select: { roles: true },
-    });
-    const roles = value
-      ? [...new Set([...member.roles, "HiringLead" as const])]
-      : member.roles.filter((r) => r !== "HiringLead");
-    await prisma.dALIMember.update({ where: { id: memberId }, data: { roles } });
+    const term = await currentTerm();
+    if (!term) {
+      return Response.json(
+        { error: "No current Term — run npm run db:seed:v0-reference" },
+        { status: 500 },
+      );
+    }
+    if (value) {
+      // App-level "no duplicate (user, term, leadTitle)" check.
+      const existing = await prisma.coreAssignment.findFirst({
+        where: { userId, termId: term.id, leadTitle: "Hiring Lead" },
+        select: { id: true },
+      });
+      if (!existing) {
+        await prisma.coreAssignment.create({
+          data: { userId, termId: term.id, leadTitle: "Hiring Lead" },
+        });
+      }
+    } else {
+      await prisma.coreAssignment.deleteMany({
+        where: { userId, termId: term.id, leadTitle: "Hiring Lead" },
+      });
+    }
     return null;
   }
 
   if (intent === "add-domain-lead") {
-    const memberId = formData.get("memberId") as string;
+    const userId = formData.get("userId") as string;
     const domainId = formData.get("domainId") as string;
-    await prisma.domainLeadAssignment.create({ data: { memberId, domainId } });
+    const term = await currentTerm();
+    if (!term) {
+      return Response.json(
+        { error: "No current Term — run npm run db:seed:v0-reference" },
+        { status: 500 },
+      );
+    }
+    await prisma.domainLeadAssignment.upsert({
+      where: {
+        userId_domainId_termId: { userId, domainId, termId: term.id },
+      },
+      update: {},
+      create: { userId, domainId, termId: term.id },
+    });
     return null;
   }
 
@@ -98,12 +158,12 @@ export default function AdminConsoleMembers() {
   const [roleFilter, setRoleFilter] = useState<RoleFilter>("all");
 
   const filtered = members.filter((m) => {
-    const name = `${m.firstName ?? ""} ${m.lastName ?? ""}`.toLowerCase();
+    const name = `${m.firstName} ${m.lastName}`.toLowerCase();
     const email = (m.daliEmail ?? "").toLowerCase();
     const q = search.toLowerCase();
     if (q && !name.includes(q) && !email.includes(q)) return false;
-    if (roleFilter === "admin" && !m.roles.includes("Admin")) return false;
-    if (roleFilter === "hiringLead" && !m.roles.includes("HiringLead")) return false;
+    if (roleFilter === "admin" && !m.isAdmin) return false;
+    if (roleFilter === "hiringLead" && !m.isCore) return false;
     return true;
   });
 
@@ -152,7 +212,7 @@ export default function AdminConsoleMembers() {
             <tr className="border-b border-border bg-muted/50">
               <th className="text-left px-4 py-3 font-medium text-muted-foreground">Name</th>
               <th className="text-left px-4 py-3 font-medium text-muted-foreground">DALI Email</th>
-              <th className="text-left px-4 py-3 font-medium text-muted-foreground">Linked User</th>
+              <th className="text-left px-4 py-3 font-medium text-muted-foreground">Lab Member</th>
               <th className="text-left px-4 py-3 font-medium text-muted-foreground">Admin</th>
               <th className="text-left px-4 py-3 font-medium text-muted-foreground">Hiring Lead</th>
               <th className="text-left px-4 py-3 font-medium text-muted-foreground">Domain Lead</th>
@@ -173,13 +233,12 @@ export default function AdminConsoleMembers() {
                 </td>
                 <td className="px-4 py-3 text-muted-foreground">{member.daliEmail ?? "—"}</td>
                 <td className="px-4 py-3">
-                  {member.user ? (
+                  {member.isLabMember ? (
                     <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">
-                      <Check className="w-3 h-3" />
-                      {member.user.firstName} {member.user.lastName}
+                      <Check className="w-3 h-3" /> Yes
                     </span>
                   ) : (
-                    <span className="text-xs text-muted-foreground/70">No account</span>
+                    <span className="text-xs text-muted-foreground/70">No</span>
                   )}
                 </td>
                 <td className="px-4 py-3">

--- a/dali-api/app/admin-console/routes/api.domains.$domainId.leads.ts
+++ b/dali-api/app/admin-console/routes/api.domains.$domainId.leads.ts
@@ -2,12 +2,16 @@ import type { Route } from "./+types/api.domains.$domainId.leads";
 import { z } from "zod";
 import { prisma } from "~/lib/db";
 import { requireAuth } from "~/lib/auth";
-import { isAdmin } from "~/lib/roles";
+import { isAdmin, currentTerm } from "~/lib/roles";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { parseJson } from "~/lib/validate";
 
+// Phase 2: domain-lead body uses `userId` (not `memberId`). The User must
+// exist and (per the admin UI convention) be a lab member, though we only
+// enforce the FK at the DB layer.
+
 const AddLeadSchema = z.object({
-  memberId: z.string().min(1).max(100),
+  userId: z.string().min(1).max(100),
 });
 
 const RemoveLeadSchema = z.object({
@@ -24,7 +28,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 
   const leads = await prisma.domainLeadAssignment.findMany({
     where: { domainId: params.domainId },
-    include: { member: { include: { user: true } }, domain: true },
+    include: { user: true, domain: true, term: true },
   });
 
   return withCors(request, Response.json(leads));
@@ -41,11 +45,22 @@ export async function action({ request, params }: Route.ActionArgs) {
   if (request.method === "POST") {
     const postBody = await parseJson(request, AddLeadSchema);
     if (postBody instanceof Response) return withCors(request, postBody);
-    const { memberId } = postBody;
+    const { userId } = postBody;
+
+    const term = await currentTerm();
+    if (!term) {
+      return withCors(
+        request,
+        Response.json(
+          { error: "No current Term — run npm run db:seed:v0-reference" },
+          { status: 500 },
+        ),
+      );
+    }
 
     const assignment = await prisma.domainLeadAssignment.create({
-      data: { memberId, domainId: params.domainId! },
-      include: { member: { include: { user: true } }, domain: true },
+      data: { userId, domainId: params.domainId!, termId: term.id },
+      include: { user: true, domain: true, term: true },
     });
     return withCors(request, Response.json(assignment, { status: 201 }));
   }

--- a/dali-api/app/admin-console/routes/api.domains.ts
+++ b/dali-api/app/admin-console/routes/api.domains.ts
@@ -26,10 +26,10 @@ export async function loader({ request }: Route.LoaderArgs) {
     return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
 
   const domains = await prisma.domain.findMany({
-    orderBy: { name: "asc" },
+    orderBy: { displayName: "asc" },
     include: {
       domainLeadAssignments: {
-        include: { member: { include: { user: true } } },
+        include: { user: true },
       },
       _count: {
         select: {
@@ -63,6 +63,11 @@ export async function action({ request }: Route.ActionArgs) {
   if (body instanceof Response) return withCors(request, body);
   const { name } = body;
 
-  const domain = await prisma.domain.create({ data: { name } });
+  // Phase 2: code + displayName required. Derive code from name (admin can
+  // rename later via Admin Console > Domains).
+  const code = name.replace(/[^A-Za-z0-9]/g, "") || "Domain";
+  const domain = await prisma.domain.create({
+    data: { name, code, displayName: name },
+  });
   return withCors(request, Response.json(domain, { status: 201 }));
 }

--- a/dali-api/app/admin-console/routes/api.members.$memberId.roles.ts
+++ b/dali-api/app/admin-console/routes/api.members.$memberId.roles.ts
@@ -2,12 +2,19 @@ import type { Route } from "./+types/api.members.$memberId.roles";
 import { z } from "zod";
 import { prisma } from "~/lib/db";
 import { requireAuth } from "~/lib/auth";
-import { isAdmin } from "~/lib/roles";
+import { isAdmin, currentTerm } from "~/lib/roles";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { parseJson } from "~/lib/validate";
 import { logAuditEvent } from "~/lib/audit";
 
+// Phase 2: PATCH body is a desired-set of legacy role labels. We translate:
+//   - "Admin"      → AdminMembership row (created/deleted)
+//   - "HiringLead" → CoreAssignment row with leadTitle="Hiring Lead" for the
+//                    current term (created/deleted)
+// `memberId` in the route param is now the User.id (renamed semantically).
+
 const MEMBER_ROLES = ["Admin", "HiringLead"] as const;
+type LegacyRole = (typeof MEMBER_ROLES)[number];
 
 const RolesPatchSchema = z.object({
   roles: z.array(z.enum(MEMBER_ROLES)).max(MEMBER_ROLES.length),
@@ -28,29 +35,88 @@ export async function action({ request, params }: Route.ActionArgs) {
   const body = await parseJson(request, RolesPatchSchema);
   if (body instanceof Response) return withCors(request, body);
   const { roles } = body;
+  const userId = params.memberId!;
 
-  const before = await prisma.dALIMember.findUnique({
-    where: { id: params.memberId },
-    select: { roles: true },
-  });
+  const term = await currentTerm();
+  if (!term) {
+    return withCors(
+      request,
+      Response.json(
+        { error: "No current Term — run npm run db:seed:v0-reference" },
+        { status: 500 },
+      ),
+    );
+  }
 
-  const member = await prisma.dALIMember.update({
-    where: { id: params.memberId },
-    data: { roles },
-    include: { user: { select: { id: true, firstName: true, lastName: true } } },
+  // Before-snapshot for audit.
+  const [adminBefore, coreBefore] = await Promise.all([
+    prisma.adminMembership.findUnique({
+      where: { userId },
+      select: { id: true },
+    }),
+    prisma.coreAssignment.findFirst({
+      where: { userId, termId: term.id, leadTitle: "Hiring Lead" },
+      select: { id: true },
+    }),
+  ]);
+  const before: LegacyRole[] = [
+    ...(adminBefore ? (["Admin"] as const) : []),
+    ...(coreBefore ? (["HiringLead"] as const) : []),
+  ];
+
+  const wantAdmin = roles.includes("Admin");
+  const wantHiringLead = roles.includes("HiringLead");
+
+  await prisma.$transaction(async (tx) => {
+    if (wantAdmin) {
+      await tx.adminMembership.upsert({
+        where: { userId },
+        update: {},
+        create: { userId, grantedBy: auth.user.sub },
+      });
+    } else {
+      await tx.adminMembership.deleteMany({ where: { userId } });
+    }
+
+    if (wantHiringLead) {
+      const exists = await tx.coreAssignment.findFirst({
+        where: { userId, termId: term.id, leadTitle: "Hiring Lead" },
+        select: { id: true },
+      });
+      if (!exists) {
+        await tx.coreAssignment.create({
+          data: { userId, termId: term.id, leadTitle: "Hiring Lead" },
+        });
+      }
+    } else {
+      await tx.coreAssignment.deleteMany({
+        where: { userId, termId: term.id, leadTitle: "Hiring Lead" },
+      });
+    }
   });
 
   await logAuditEvent({
     action: "role.change",
     userId: auth.user.sub,
-    targetId: params.memberId,
-    metadata: {
-      before: before?.roles ?? [],
-      after: roles,
-      targetMemberId: params.memberId,
-    },
+    targetId: userId,
+    metadata: { before, after: roles, targetUserId: userId },
     request,
   });
 
-  return withCors(request, Response.json(member));
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: {
+      id: true,
+      firstName: true,
+      lastName: true,
+      daliEmail: true,
+      adminMembership: { select: { id: true } },
+      coreAssignments: {
+        where: { termId: term.id },
+        select: { leadTitle: true },
+      },
+    },
+  });
+
+  return withCors(request, Response.json(user));
 }

--- a/dali-api/app/admin-console/routes/api.members.ts
+++ b/dali-api/app/admin-console/routes/api.members.ts
@@ -4,26 +4,57 @@ import { requireAuth } from "~/lib/auth";
 import { isAdmin, isHiringLead, isDomainLead } from "~/lib/roles";
 import { withCors, handlePreflight } from "~/lib/cors";
 
+// Phase 2: returns lab members rooted at User. Role shape derives from
+// AdminMembership / CoreAssignment / DomainLeadAssignment rows.
+
 export async function loader({ request }: Route.LoaderArgs) {
   const preflight = handlePreflight(request);
   if (preflight) return preflight;
 
   const auth = await requireAuth(request);
   if (!auth.ok) return withCors(request, auth.response);
-  const [admin, hiringLead, domainLead] = await Promise.all([isAdmin(auth.user.sub), isHiringLead(auth.user.sub), isDomainLead(auth.user.sub)]);
+  const [admin, hiringLead, domainLead] = await Promise.all([
+    isAdmin(auth.user.sub),
+    isHiringLead(auth.user.sub),
+    isDomainLead(auth.user.sub),
+  ]);
   if (!admin && !hiringLead && !domainLead) return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
 
-  const members = await prisma.dALIMember.findMany({
-    orderBy: { createdAt: "asc" },
+  const users = await prisma.user.findMany({
+    where: { daliMember: { isNot: null } },
+    orderBy: [{ lastName: "asc" }, { firstName: "asc" }],
     select: {
       id: true,
-      daliEmail: true,
       firstName: true,
       lastName: true,
-      roles: true,
-      domainLeadAssignments: { select: { id: true, domain: { select: { id: true, name: true } } } },
+      daliEmail: true,
+      adminMembership: { select: { id: true } },
+      coreAssignments: { select: { id: true, termId: true, leadTitle: true } },
+      domainLeadAssignmentsAsUser: {
+        select: {
+          id: true,
+          termId: true,
+          domain: { select: { id: true, displayName: true } },
+        },
+      },
     },
   });
+
+  const members = users.map((u) => ({
+    id: u.id,
+    firstName: u.firstName,
+    lastName: u.lastName,
+    daliEmail: u.daliEmail,
+    isAdmin: u.adminMembership !== null,
+    isCore: u.coreAssignments.length > 0,
+    coreTitles: u.coreAssignments
+      .map((a) => a.leadTitle)
+      .filter((t): t is string => !!t),
+    domainLeadAssignments: u.domainLeadAssignmentsAsUser.map((a) => ({
+      id: a.id,
+      domain: { id: a.domain.id, name: a.domain.displayName },
+    })),
+  }));
 
   return withCors(request, Response.json(members));
 }

--- a/dali-api/app/calendar/routes/calendar.tsx
+++ b/dali-api/app/calendar/routes/calendar.tsx
@@ -1757,11 +1757,33 @@ function CreateScheduledMeetingForm({
 
         <div className="flex items-center justify-between pt-1">
           <div className="text-sm">
-            {status?.ok === true && (
+            {status?.ok === true && !status.gcalError && (
               <span className="text-green-700">
                 Meeting created. Notified {status.count} participant{status.count === 1 ? "" : "s"}.
-                {status.gcalError ? ` (Google Calendar push failed: ${status.gcalError})` : ""}
               </span>
+            )}
+            {status?.ok === true && status.gcalError && (
+              <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-amber-900">
+                <div className="font-medium">
+                  Meeting created, but the Google Calendar invite didn't go out.
+                </div>
+                <div className="text-xs mt-0.5">
+                  Notified {status.count} participant{status.count === 1 ? "" : "s"} in-app.{" "}
+                  {/insufficient.*scope|insufficientPermissions|invalid_grant|unauthorized/i.test(
+                    status.gcalError,
+                  ) ? (
+                    <>
+                      Your linked Google account is missing calendar-write permission.{" "}
+                      <a href="/oauth/calendar/google/start" className="underline font-medium">
+                        Reconnect Google Calendar
+                      </a>{" "}
+                      to send invites.
+                    </>
+                  ) : (
+                    <>Details: {status.gcalError}</>
+                  )}
+                </div>
+              </div>
             )}
             {status?.ok === false && <span className="text-red-700">{status.error}</span>}
           </div>

--- a/dali-api/app/collab/persistence.ts
+++ b/dali-api/app/collab/persistence.ts
@@ -49,7 +49,7 @@ async function seedContent(name: string): Promise<string | null> {
         where: { interviewId: id },
         include: {
           noteVersions: { orderBy: { createdAt: "desc" }, take: 1 },
-          cycleInterviewer: { include: { daliMember: true } },
+          cycleInterviewer: { include: { user: true } },
         },
       });
       const parts: string[] = [];
@@ -58,8 +58,8 @@ async function seedContent(name: string): Promise<string | null> {
         if (latest?.content) {
           const name =
             [
-              a.cycleInterviewer.daliMember.firstName,
-              a.cycleInterviewer.daliMember.lastName,
+              a.cycleInterviewer.user.firstName,
+              a.cycleInterviewer.user.lastName,
             ]
               .filter(Boolean)
               .join(" ") || "Interviewer";

--- a/dali-api/app/hiring/components/delibs/ApplicantContextModal.tsx
+++ b/dali-api/app/hiring/components/delibs/ApplicantContextModal.tsx
@@ -201,7 +201,7 @@ function ReviewsSection({ reviews, criteria }: { reviews: any[]; criteria: any[]
       ) : (
         <div className="divide-y divide-gray-100">
           {reviews.map((review) => {
-            const reviewer = review.cycleReviewer?.daliMember;
+            const reviewer = review.cycleReviewer?.user;
             const name = reviewer ? `${reviewer.firstName} ${reviewer.lastName}` : "Unknown";
             const isSubmitted = !!review.submittedAt;
             const scores = (review.scores ?? {}) as Record<string, number>;

--- a/dali-api/app/hiring/lib/__tests__/api.decisions.lineage.test.ts
+++ b/dali-api/app/hiring/lib/__tests__/api.decisions.lineage.test.ts
@@ -17,7 +17,8 @@ import { action as delibsAction } from "~/hiring/routes/api.delibs.$id";
 import { loader as decisionsLoader } from "~/hiring/routes/api.domain-applications.$id.decisions";
 
 const mockPrisma = prisma as unknown as {
-  dALIMember: { findFirst: ReturnType<typeof vi.fn> };
+  dALIMember: { findUnique: ReturnType<typeof vi.fn> };
+  gmailIntegration: { findFirst: ReturnType<typeof vi.fn> };
   decision: {
     findUnique: ReturnType<typeof vi.fn>;
     create: ReturnType<typeof vi.fn>;
@@ -40,7 +41,8 @@ const FINAL_ID = "dec-final";
 
 beforeEach(() => {
   vi.clearAllMocks();
-  (mockPrisma as any).dALIMember = { findFirst: vi.fn() };
+  (mockPrisma as any).dALIMember = { findUnique: vi.fn() };
+  (mockPrisma as any).gmailIntegration = { findFirst: vi.fn() };
   (mockPrisma as any).decision = { findUnique: vi.fn(), create: vi.fn(), findMany: vi.fn() };
   (mockPrisma as any).domainApplication = { findUnique: vi.fn() };
   (mockPrisma as any).cycleDecisionEmail = { findUnique: vi.fn() };
@@ -49,7 +51,7 @@ beforeEach(() => {
   (mockPrisma as any).$transaction = vi.fn(async (fn: any) => fn(mockPrisma));
   vi.mocked(sendEmail).mockResolvedValue(undefined as any);
   vi.mocked(requireAuth).mockResolvedValue({ ok: true, user: { sub: USER_ID } } as any);
-  mockPrisma.dALIMember.findFirst.mockResolvedValue({ id: MEMBER_ID, userId: USER_ID });
+  mockPrisma.dALIMember.findUnique.mockResolvedValue({ id: MEMBER_ID, userId: USER_ID });
 });
 
 describe("Decision lineage (parentDecisionId)", () => {
@@ -98,6 +100,7 @@ describe("Decision lineage (parentDecisionId)", () => {
     mockPrisma.cycleDecisionEmail.findUnique.mockResolvedValue({
       emailTemplateVersion: { id: "etv-1", subject: "s", body: "b" },
     });
+    mockPrisma.gmailIntegration.findFirst.mockResolvedValue(null);
 
     const req = new Request("http://localhost/api/decisions/dec-final/release", { method: "POST" });
     const res = await releaseAction({ request: req, params: { id: FINAL_ID }, context: {} } as any);

--- a/dali-api/app/hiring/lib/__tests__/api.decisions.lineage.test.ts
+++ b/dali-api/app/hiring/lib/__tests__/api.decisions.lineage.test.ts
@@ -76,7 +76,10 @@ describe("Decision lineage (parentDecisionId)", () => {
     const arg = mockPrisma.decision.create.mock.calls[0][0];
     expect(arg.data.stage).toBe("Final");
     expect(arg.data.parentDecisionId).toBe(DRAFT_ID);
-    expect(arg.data.madeById).toBe(MEMBER_ID);
+    // Phase 2: Decision.madeById points at User.id (auth.user.sub) instead of
+    // DALIMember.id. The test mock's `member` is the DALIMember row; the
+    // actual stored value is the authenticated user.
+    expect(arg.data.madeById).toBe(USER_ID);
   });
 
   it("release: links the new Released record to its Final predecessor", async () => {

--- a/dali-api/app/hiring/lib/__tests__/api.decisions.release.test.ts
+++ b/dali-api/app/hiring/lib/__tests__/api.decisions.release.test.ts
@@ -14,7 +14,7 @@ import { sendEmail } from "~/lib/gmail";
 import { action } from "~/hiring/routes/api.decisions.$id.release";
 
 const mockPrisma = prisma as unknown as {
-  dALIMember: { findFirst: ReturnType<typeof vi.fn> };
+  dALIMember: { findUnique: ReturnType<typeof vi.fn> };
   decision: {
     findUnique: ReturnType<typeof vi.fn>;
     create: ReturnType<typeof vi.fn>;
@@ -22,6 +22,7 @@ const mockPrisma = prisma as unknown as {
   domainApplication: { findUnique: ReturnType<typeof vi.fn> };
   cycleDecisionEmail: { findUnique: ReturnType<typeof vi.fn> };
   user: { findUnique: ReturnType<typeof vi.fn> };
+  gmailIntegration: { findFirst: ReturnType<typeof vi.fn> };
 };
 
 const USER_ID = "user-hl";
@@ -32,7 +33,7 @@ const CYCLE_ID = "cycle-1";
 function setupAuth() {
   vi.mocked(requireAuth).mockResolvedValue({ ok: true, user: { sub: USER_ID } } as any);
   vi.mocked(isHiringLead).mockResolvedValue(true);
-  mockPrisma.dALIMember.findFirst.mockResolvedValue({ id: MEMBER_ID, userId: USER_ID });
+  mockPrisma.dALIMember.findUnique.mockResolvedValue({ id: MEMBER_ID, userId: USER_ID });
 }
 
 function setupFinalDecision(type: "Rejected" | "InvitedToInterview" | "Accepted" | "Waitlisted" = "Accepted") {
@@ -65,16 +66,17 @@ function setupApplicantContext(opts: { domainName?: string | null } = {}) {
       },
     },
   });
-  mockPrisma.user.findUnique.mockResolvedValue({ googleRefreshToken: "gmail-rt" });
+  mockPrisma.gmailIntegration.findFirst.mockResolvedValue({ oauthTokens: "gmail-rt" });
 }
 
 beforeEach(() => {
   vi.clearAllMocks();
-  (mockPrisma as any).dALIMember = { findFirst: vi.fn() };
+  (mockPrisma as any).dALIMember = { findUnique: vi.fn() };
   (mockPrisma as any).decision = { findUnique: vi.fn(), create: vi.fn() };
   (mockPrisma as any).domainApplication = { findUnique: vi.fn() };
   (mockPrisma as any).cycleDecisionEmail = { findUnique: vi.fn() };
   (mockPrisma as any).user = { findUnique: vi.fn() };
+  (mockPrisma as any).gmailIntegration = { findFirst: vi.fn() };
   vi.mocked(sendEmail).mockResolvedValue(undefined as any);
 });
 
@@ -220,7 +222,7 @@ describe("POST /api/hiring/decisions/:id/release", () => {
         },
       },
     });
-    mockPrisma.user.findUnique.mockResolvedValue({ googleRefreshToken: "gmail-rt" });
+    mockPrisma.gmailIntegration.findFirst.mockResolvedValue({ oauthTokens: "gmail-rt" });
     mockPrisma.cycleDecisionEmail.findUnique.mockResolvedValue({
       applicationCycleId: CYCLE_ID,
       decisionType: "InvitedToInterview",

--- a/dali-api/app/hiring/lib/__tests__/api.delibs.close.test.ts
+++ b/dali-api/app/hiring/lib/__tests__/api.delibs.close.test.ts
@@ -21,7 +21,7 @@ const mockTx: any = {
 };
 
 const mockPrisma = prisma as unknown as {
-  dALIMember: { findFirst: ReturnType<typeof vi.fn> };
+  dALIMember: { findUnique: ReturnType<typeof vi.fn> };
   delibsSession: {
     findUnique: ReturnType<typeof vi.fn>;
     update: ReturnType<typeof vi.fn>;
@@ -35,14 +35,14 @@ beforeEach(() => {
   mockTx.decision.create = vi.fn().mockResolvedValue({});
   mockTx.delibsSession.update = vi.fn().mockResolvedValue({});
 
-  (mockPrisma as any).dALIMember = { findFirst: vi.fn() };
+  (mockPrisma as any).dALIMember = { findUnique: vi.fn() };
   (mockPrisma as any).delibsSession = { findUnique: vi.fn(), update: vi.fn() };
   (mockPrisma as any).$transaction = vi.fn(async (cb: any) => cb(mockTx));
 
   vi.mocked(requireAuth).mockResolvedValue({ ok: true, user: { sub: USER_ID } } as any);
   vi.mocked(isHiringLead).mockResolvedValue(true);
   vi.mocked(isDomainLead).mockResolvedValue(false);
-  mockPrisma.dALIMember.findFirst.mockResolvedValue({ id: MEMBER_ID, userId: USER_ID });
+  mockPrisma.dALIMember.findUnique.mockResolvedValue({ id: MEMBER_ID, userId: USER_ID });
 });
 
 function makeCloseRequest() {

--- a/dali-api/app/hiring/lib/__tests__/scheduling.test.ts
+++ b/dali-api/app/hiring/lib/__tests__/scheduling.test.ts
@@ -52,7 +52,7 @@ describe("isInterviewerFree", () => {
   it("returns true when availability covers slot and no conflicts", () => {
     const reviewer = {
       cycleInterviewerId: "r1",
-      daliMemberId: "m1",
+      userId: "m1",
       domainId: "d1",
       availability: [
         { startTime: new Date("2026-04-15T13:00:00Z"), endTime: new Date("2026-04-15T17:00:00Z") },
@@ -65,7 +65,7 @@ describe("isInterviewerFree", () => {
   it("returns false when no availability block covers the slot", () => {
     const reviewer = {
       cycleInterviewerId: "r1",
-      daliMemberId: "m1",
+      userId: "m1",
       domainId: "d1",
       availability: [
         { startTime: new Date("2026-04-15T15:00:00Z"), endTime: new Date("2026-04-15T17:00:00Z") },
@@ -78,7 +78,7 @@ describe("isInterviewerFree", () => {
   it("returns false when availability only partially covers the slot", () => {
     const reviewer = {
       cycleInterviewerId: "r1",
-      daliMemberId: "m1",
+      userId: "m1",
       domainId: "d1",
       availability: [
         { startTime: new Date("2026-04-15T14:00:00Z"), endTime: new Date("2026-04-15T14:20:00Z") },
@@ -91,7 +91,7 @@ describe("isInterviewerFree", () => {
   it("returns false when a booked interval overlaps the slot", () => {
     const reviewer = {
       cycleInterviewerId: "r1",
-      daliMemberId: "m1",
+      userId: "m1",
       domainId: "d1",
       availability: [
         { startTime: new Date("2026-04-15T13:00:00Z"), endTime: new Date("2026-04-15T17:00:00Z") },
@@ -106,7 +106,7 @@ describe("isInterviewerFree", () => {
   it("returns true when booked interval ends exactly at slot start (no overlap)", () => {
     const reviewer = {
       cycleInterviewerId: "r1",
-      daliMemberId: "m1",
+      userId: "m1",
       domainId: "d1",
       availability: [
         { startTime: new Date("2026-04-15T13:00:00Z"), endTime: new Date("2026-04-15T17:00:00Z") },
@@ -121,7 +121,7 @@ describe("isInterviewerFree", () => {
   it("returns true when booked interval starts exactly at slot end (no overlap)", () => {
     const reviewer = {
       cycleInterviewerId: "r1",
-      daliMemberId: "m1",
+      userId: "m1",
       domainId: "d1",
       availability: [
         { startTime: new Date("2026-04-15T13:00:00Z"), endTime: new Date("2026-04-15T17:00:00Z") },
@@ -136,7 +136,7 @@ describe("isInterviewerFree", () => {
   it("returns false with empty availability", () => {
     const reviewer = {
       cycleInterviewerId: "r1",
-      daliMemberId: "m1",
+      userId: "m1",
       domainId: "d1",
       availability: [],
       bookedIntervals: [],
@@ -248,7 +248,7 @@ describe("computeAvailableSlots", () => {
     mockPrisma.cycleInterviewer.findMany.mockResolvedValue([
       {
         id: "r1",
-        daliMemberId: "m1",
+        userId: "m1",
         domainId: "domain1",
         availabilityBlocks: [
           { startTime: new Date("2030-04-15T00:00:00Z"), endTime: new Date("2030-04-15T23:59:59Z") },
@@ -257,7 +257,7 @@ describe("computeAvailableSlots", () => {
       },
       {
         id: "r2",
-        daliMemberId: "m2",
+        userId: "m2",
         domainId: "domain-other",
         availabilityBlocks: [
           { startTime: new Date("2030-04-15T00:00:00Z"), endTime: new Date("2030-04-15T23:59:59Z") },
@@ -291,7 +291,7 @@ describe("computeAvailableSlots", () => {
     mockPrisma.cycleInterviewer.findMany.mockResolvedValue([
       {
         id: "r1",
-        daliMemberId: "m1",
+        userId: "m1",
         domainId: "domain1",
         availabilityBlocks: [
           { startTime: new Date("2030-04-15T00:00:00Z"), endTime: new Date("2030-04-15T23:59:59Z") },
@@ -323,7 +323,7 @@ describe("computeAvailableSlots", () => {
     mockPrisma.cycleInterviewer.findMany.mockResolvedValue([
       {
         id: "r-mira-eng",
-        daliMemberId: "mira",
+        userId: "mira",
         domainId: "domain1",
         availabilityBlocks: [
           { startTime: new Date("2030-04-15T00:00:00Z"), endTime: new Date("2030-04-15T23:59:59Z") },
@@ -339,7 +339,7 @@ describe("computeAvailableSlots", () => {
       },
       {
         id: "r-mira-design",
-        daliMemberId: "mira", // same member
+        userId: "mira", // same member
         domainId: "domain-other",
         availabilityBlocks: [
           { startTime: new Date("2030-04-15T00:00:00Z"), endTime: new Date("2030-04-15T23:59:59Z") },
@@ -348,7 +348,7 @@ describe("computeAvailableSlots", () => {
       },
       {
         id: "r-bob",
-        daliMemberId: "bob",
+        userId: "bob",
         domainId: "domain1",
         availabilityBlocks: [
           { startTime: new Date("2030-04-15T00:00:00Z"), endTime: new Date("2030-04-15T23:59:59Z") },
@@ -392,7 +392,7 @@ describe("computeAvailableSlots", () => {
     mockPrisma.cycleInterviewer.findMany.mockResolvedValue([
       {
         id: "r-mira-eng",
-        daliMemberId: "mira",
+        userId: "mira",
         domainId: "domain1",
         availabilityBlocks: [
           { startTime: new Date("2030-04-15T00:00:00Z"), endTime: new Date("2030-04-15T23:59:59Z") },
@@ -401,7 +401,7 @@ describe("computeAvailableSlots", () => {
       },
       {
         id: "r-mira-design",
-        daliMemberId: "mira",
+        userId: "mira",
         domainId: "domain-other",
         availabilityBlocks: [
           { startTime: new Date("2030-04-15T00:00:00Z"), endTime: new Date("2030-04-15T23:59:59Z") },
@@ -431,7 +431,7 @@ describe("computeAvailableSlots", () => {
     mockPrisma.cycleInterviewer.findMany.mockResolvedValue([
       {
         id: "r-bob",
-        daliMemberId: "bob",
+        userId: "bob",
         domainId: "domain1",
         availabilityBlocks: [
           { startTime: new Date("2030-04-15T00:00:00Z"), endTime: new Date("2030-04-15T23:59:59Z") },
@@ -440,7 +440,7 @@ describe("computeAvailableSlots", () => {
       },
       {
         id: "r-mira-eng",
-        daliMemberId: "mira",
+        userId: "mira",
         domainId: "domain1",
         availabilityBlocks: [
           { startTime: new Date("2030-04-15T00:00:00Z"), endTime: new Date("2030-04-15T23:59:59Z") },
@@ -449,7 +449,7 @@ describe("computeAvailableSlots", () => {
       },
       {
         id: "r-mira-design",
-        daliMemberId: "mira",
+        userId: "mira",
         domainId: "domain-other",
         availabilityBlocks: [
           { startTime: new Date("2030-04-15T00:00:00Z"), endTime: new Date("2030-04-15T23:59:59Z") },
@@ -485,7 +485,7 @@ describe("assignInterviewers", () => {
       const fullInterviewers = [
         {
           id: "r1",
-          daliMemberId: "m1",
+          userId: "m1",
           domainId: "domain1",
           availabilityBlocks: [
             { startTime: new Date("2026-04-13T13:00:00Z"), endTime: new Date("2026-04-13T17:00:00Z") },
@@ -496,7 +496,7 @@ describe("assignInterviewers", () => {
         },
         {
           id: "r1-busy",
-          daliMemberId: "m-busy",
+          userId: "m-busy",
           domainId: "domain1",
           availabilityBlocks: [
             { startTime: new Date("2026-04-13T13:00:00Z"), endTime: new Date("2026-04-13T17:00:00Z") },
@@ -509,7 +509,7 @@ describe("assignInterviewers", () => {
         },
         {
           id: "r2",
-          daliMemberId: "m2",
+          userId: "m2",
           domainId: "domain-other",
           availabilityBlocks: [
             { startTime: new Date("2026-04-13T13:00:00Z"), endTime: new Date("2026-04-13T17:00:00Z") },
@@ -583,7 +583,7 @@ describe("assignInterviewers", () => {
     const onlyCrossDomain = [
       {
         id: "r2",
-        daliMemberId: "m2",
+        userId: "m2",
         domainId: "domain-other",
         availabilityBlocks: [
           { startTime: new Date("2026-04-13T13:00:00Z"), endTime: new Date("2026-04-13T17:00:00Z") },
@@ -617,12 +617,12 @@ describe("assignInterviewers", () => {
     // Mira is the only in-domain candidate (domain1) and also appears under a
     // Design row (domain-other). Without Fix A, the scheduler would pick
     // Mira-eng as in-domain AND Mira-design as cross-domain. Fix A rejects
-    // this by excluding Mira's daliMemberId from the cross-domain pool —
+    // this by excluding Mira's userId from the cross-domain pool —
     // and since she's the only cross-domain option, the booking must fail.
     const twoMiraRows = [
       {
         id: "r-mira-eng",
-        daliMemberId: "mira",
+        userId: "mira",
         domainId: "domain1",
         availabilityBlocks: [
           { startTime: new Date("2026-04-13T13:00:00Z"), endTime: new Date("2026-04-13T17:00:00Z") },
@@ -631,7 +631,7 @@ describe("assignInterviewers", () => {
       },
       {
         id: "r-mira-design",
-        daliMemberId: "mira",
+        userId: "mira",
         domainId: "domain-other",
         availabilityBlocks: [
           { startTime: new Date("2026-04-13T13:00:00Z"), endTime: new Date("2026-04-13T17:00:00Z") },
@@ -678,7 +678,7 @@ describe("assignInterviewers", () => {
     const interviewers = [
       {
         id: "r-mira-eng",
-        daliMemberId: "mira",
+        userId: "mira",
         domainId: "domain1",
         availabilityBlocks: [
           { startTime: new Date("2026-04-13T13:00:00Z"), endTime: new Date("2026-04-13T17:00:00Z") },
@@ -691,7 +691,7 @@ describe("assignInterviewers", () => {
       },
       {
         id: "r-bob",
-        daliMemberId: "bob",
+        userId: "bob",
         domainId: "domain1",
         availabilityBlocks: [
           { startTime: new Date("2026-04-13T13:00:00Z"), endTime: new Date("2026-04-13T17:00:00Z") },
@@ -702,7 +702,7 @@ describe("assignInterviewers", () => {
       },
       {
         id: "r-cross",
-        daliMemberId: "pat",
+        userId: "pat",
         domainId: "domain-other",
         availabilityBlocks: [
           { startTime: new Date("2026-04-13T13:00:00Z"), endTime: new Date("2026-04-13T17:00:00Z") },
@@ -744,7 +744,7 @@ describe("assignInterviewers", () => {
     const interviewers = [
       {
         id: "r1",
-        daliMemberId: "m1",
+        userId: "m1",
         domainId: "domain1",
         availabilityBlocks: [
           { startTime: new Date("2026-04-13T13:00:00Z"), endTime: new Date("2026-04-13T17:00:00Z") },
@@ -753,7 +753,7 @@ describe("assignInterviewers", () => {
       },
       {
         id: "r2",
-        daliMemberId: "m2",
+        userId: "m2",
         domainId: "domain-other",
         availabilityBlocks: [
           { startTime: new Date("2026-04-13T13:00:00Z"), endTime: new Date("2026-04-13T17:00:00Z") },
@@ -805,7 +805,7 @@ describe("assignInterviewers", () => {
     const interviewers = [
       {
         id: "r1",
-        daliMemberId: "m1",
+        userId: "m1",
         domainId: "domain1",
         availabilityBlocks: [
           { startTime: new Date("2026-04-13T13:00:00Z"), endTime: new Date("2026-04-13T17:00:00Z") },
@@ -814,7 +814,7 @@ describe("assignInterviewers", () => {
       },
       {
         id: "r2",
-        daliMemberId: "m2",
+        userId: "m2",
         domainId: "domain-other",
         availabilityBlocks: [
           { startTime: new Date("2026-04-13T13:00:00Z"), endTime: new Date("2026-04-13T17:00:00Z") },
@@ -865,7 +865,7 @@ describe("reassignInterviewer", () => {
           findUnique: vi.fn().mockResolvedValue({
             id: "a1",
             role: "InDomain",
-            cycleInterviewer: { id: "r1", daliMemberId: "m1", domainId: "domain1" },
+            cycleInterviewer: { id: "r1", userId: "m1", domainId: "domain1" },
             interview: {
               id: "int1",
               applicationCycleId: "cycle1",
@@ -881,8 +881,8 @@ describe("reassignInterviewer", () => {
             },
           }),
           findMany: vi.fn().mockResolvedValue([
-            { cycleInterviewer: { daliMemberId: "m1" } },
-            { cycleInterviewer: { daliMemberId: "m3" } },
+            { cycleInterviewer: { userId: "m1" } },
+            { cycleInterviewer: { userId: "m3" } },
           ]),
           update: vi.fn().mockResolvedValue({}),
           create: vi.fn().mockResolvedValue({ cycleInterviewerId: "r2" }),
@@ -894,7 +894,7 @@ describe("reassignInterviewer", () => {
           findMany: vi.fn().mockResolvedValue([
             {
               id: "r2",
-              daliMemberId: "m2",
+              userId: "m2",
               domainId: "domain1",
               availabilityBlocks: [
                 { startTime: new Date("2026-04-13T13:00:00Z"), endTime: new Date("2026-04-13T17:00:00Z") },
@@ -927,7 +927,7 @@ describe("reassignInterviewer", () => {
           findUnique: vi.fn().mockResolvedValue({
             id: "a1",
             role: "CrossDomain",
-            cycleInterviewer: { id: "r-mira-design", daliMemberId: "mira", domainId: "domain-other" },
+            cycleInterviewer: { id: "r-mira-design", userId: "mira", domainId: "domain-other" },
             interview: {
               id: "int1",
               applicationCycleId: "cycle1",
@@ -939,7 +939,7 @@ describe("reassignInterviewer", () => {
             },
           }),
           findMany: vi.fn().mockResolvedValue([
-            { cycleInterviewer: { daliMemberId: "mira" } },
+            { cycleInterviewer: { userId: "mira" } },
           ]),
           update: vi.fn().mockResolvedValue({}),
           create: vi.fn().mockResolvedValue({}),
@@ -952,7 +952,7 @@ describe("reassignInterviewer", () => {
             // Mira's Eng row — same human, excluded by existingMemberIds.
             {
               id: "r-mira-eng",
-              daliMemberId: "mira",
+              userId: "mira",
               domainId: "domain1",
               availabilityBlocks: [
                 { startTime: new Date("2026-04-13T13:00:00Z"), endTime: new Date("2026-04-13T17:00:00Z") },
@@ -978,7 +978,7 @@ describe("reassignInterviewer", () => {
           findUnique: vi.fn().mockResolvedValue({
             id: "a1",
             role: "InDomain",
-            cycleInterviewer: { id: "r1", daliMemberId: "m1", domainId: "domain1" },
+            cycleInterviewer: { id: "r1", userId: "m1", domainId: "domain1" },
             interview: {
               id: "int1",
               applicationCycleId: "cycle1",
@@ -990,7 +990,7 @@ describe("reassignInterviewer", () => {
             },
           }),
           findMany: vi.fn().mockResolvedValue([
-            { cycleInterviewer: { daliMemberId: "m1" } },
+            { cycleInterviewer: { userId: "m1" } },
           ]),
           update: vi.fn().mockResolvedValue({}),
           create: vi.fn().mockResolvedValue({}),

--- a/dali-api/app/hiring/lib/cycles.ts
+++ b/dali-api/app/hiring/lib/cycles.ts
@@ -100,7 +100,7 @@ export function cycleStatusToStage(status: string): CycleStage {
  */
 export async function inferUnderReviewStage(
   cycleId: string,
-  memberId: string,
+  userId: string,
   reviewerIds: string[],
 ): Promise<CycleStage> {
   const invitedDecisions = await prisma.decision.count({
@@ -140,7 +140,7 @@ export async function inferUnderReviewStage(
   if (completedInterviews > 0) return 'finalDelibs';
 
   const myInterviewerRecords = await prisma.cycleInterviewer.findMany({
-    where: { userId: memberId, applicationCycleId: cycleId },
+    where: { userId, applicationCycleId: cycleId },
     select: { id: true },
   });
 

--- a/dali-api/app/hiring/lib/cycles.ts
+++ b/dali-api/app/hiring/lib/cycles.ts
@@ -140,7 +140,7 @@ export async function inferUnderReviewStage(
   if (completedInterviews > 0) return 'finalDelibs';
 
   const myInterviewerRecords = await prisma.cycleInterviewer.findMany({
-    where: { daliMemberId: memberId, applicationCycleId: cycleId },
+    where: { userId: memberId, applicationCycleId: cycleId },
     select: { id: true },
   });
 

--- a/dali-api/app/hiring/lib/extension-notice.ts
+++ b/dali-api/app/hiring/lib/extension-notice.ts
@@ -16,10 +16,9 @@
 
 import { prisma } from "~/lib/db";
 import { sendEmail } from "~/lib/gmail";
+import { getApplicationsGmailRefreshToken } from "~/lib/gmail-integration";
 import { renderForSlot, notificationSlot } from "./email-variables";
 import { logAuditEvent } from "~/lib/audit";
-
-const GMAIL_USER = "applications@dali.dartmouth.edu";
 
 function formatCloseInstant(d: Date): string {
   return `${d.toLocaleString("en-US", {
@@ -34,11 +33,7 @@ function formatCloseInstant(d: Date): string {
 }
 
 async function getGmailRefreshToken(): Promise<string | null> {
-  const gmailUser = await prisma.user.findUnique({
-    where: { daliEmail: GMAIL_USER },
-    select: { googleRefreshToken: true },
-  });
-  return gmailUser?.googleRefreshToken ?? null;
+  return getApplicationsGmailRefreshToken();
 }
 
 interface DraftRecipient {

--- a/dali-api/app/hiring/lib/interview-emails.ts
+++ b/dali-api/app/hiring/lib/interview-emails.ts
@@ -6,10 +6,9 @@ import type { NotificationType } from "~/generated/prisma/enums";
 import { prisma } from "~/lib/db";
 import { sendEmail } from "~/lib/gmail";
 import { type InterpolationVars } from "~/lib/email";
+import { getApplicationsGmailRefreshToken } from "~/lib/gmail-integration";
 import { renderForSlot, notificationSlot } from "./email-variables";
 import { buildInviteIcs, buildCancelIcs } from "./interview-ics";
-
-const GMAIL_USER = "applications@dali.dartmouth.edu";
 
 function formatLocation(location: string, meetingUrl?: string | null): string {
   if (location === "PodAppa") return "Pod Appa, DALI Lab";
@@ -29,11 +28,7 @@ function formatTime(d: Date): string {
 }
 
 async function getGmailRefreshToken(): Promise<string | null> {
-  const gmailUser = await prisma.user.findUnique({
-    where: { daliEmail: GMAIL_USER },
-    select: { googleRefreshToken: true },
-  });
-  return gmailUser?.googleRefreshToken ?? null;
+  return getApplicationsGmailRefreshToken();
 }
 
 interface Recipient {
@@ -64,20 +59,16 @@ async function getInterviewerRecipients(interviewId: string): Promise<Recipient[
     where: { interviewId, status: "Active" },
     include: {
       cycleInterviewer: {
-        include: {
-          daliMember: {
-            include: { user: { select: { firstName: true, daliEmail: true } } },
-          },
-        },
+        include: { user: { select: { firstName: true, daliEmail: true } } },
       },
     },
   });
 
   return assignments
     .map((a) => {
-      const member = a.cycleInterviewer.daliMember;
-      const email = member.user?.daliEmail ?? null;
-      const firstName = member.user?.firstName ?? member.firstName ?? "Interviewer";
+      const user = a.cycleInterviewer.user;
+      const email = user?.daliEmail ?? null;
+      const firstName = user?.firstName ?? "Interviewer";
       if (!email) return null;
       return { email, firstName };
     })
@@ -288,16 +279,16 @@ export async function sendReassignmentEmails(
     // Cancel ICS to removed interviewer
     const removedCI = await prisma.cycleInterviewer.findUnique({
       where: { id: removedCycleInterviewerId },
-      include: { daliMember: { include: { user: { select: { firstName: true, daliEmail: true } } } } },
+      include: { user: { select: { firstName: true, daliEmail: true } } },
     });
-    if (removedCI?.daliMember.user?.daliEmail) {
+    if (removedCI?.user.daliEmail) {
       const cancelIcs = buildCancelIcs({
         interviewId: interview.id,
         summary: `DALI Interview — ${domainName}`,
         startTime: interview.startTime,
         endTime: interview.endTime,
       });
-      const firstName = removedCI.daliMember.user.firstName ?? "Interviewer";
+      const firstName = removedCI.user.firstName ?? "Interviewer";
       const rendered = await renderFromBinding(
         interview.applicationCycleId,
         "InterviewCancelledInterviewer",
@@ -306,7 +297,7 @@ export async function sendReassignmentEmails(
       if (rendered) {
         sends.push(sendEmail({
           refreshToken,
-          to: removedCI.daliMember.user.daliEmail,
+          to: removedCI.user.daliEmail,
           subject: rendered.subject,
           html: rendered.html,
           ics: cancelIcs,
@@ -317,9 +308,9 @@ export async function sendReassignmentEmails(
     // Invite ICS to new interviewer
     const newCI = await prisma.cycleInterviewer.findUnique({
       where: { id: newCycleInterviewerId },
-      include: { daliMember: { include: { user: { select: { firstName: true, daliEmail: true } } } } },
+      include: { user: { select: { firstName: true, daliEmail: true } } },
     });
-    if (newCI?.daliMember.user?.daliEmail) {
+    if (newCI?.user.daliEmail) {
       const inviteIcs = buildInviteIcs({
         interviewId: interview.id,
         summary: `DALI Interview — ${domainName}`,
@@ -328,7 +319,7 @@ export async function sendReassignmentEmails(
         location: formatLocation(interview.location, interview.zoomJoinUrl),
         meetingUrl: interview.zoomJoinUrl,
       });
-      const firstName = newCI.daliMember.user.firstName ?? "Interviewer";
+      const firstName = newCI.user.firstName ?? "Interviewer";
       const rendered = await renderFromBinding(
         interview.applicationCycleId,
         "InterviewInviteMentor",
@@ -337,7 +328,7 @@ export async function sendReassignmentEmails(
       if (rendered) {
         sends.push(sendEmail({
           refreshToken,
-          to: newCI.daliMember.user.daliEmail,
+          to: newCI.user.daliEmail,
           subject: rendered.subject,
           html: rendered.html,
           ics: inviteIcs,

--- a/dali-api/app/hiring/lib/scheduling.ts
+++ b/dali-api/app/hiring/lib/scheduling.ts
@@ -10,7 +10,7 @@ interface AvailableSlot {
 
 interface InterviewerFreeCheck {
   cycleInterviewerId: string;
-  daliMemberId: string;
+  userId: string;
   domainId: string;
   availability: { startTime: Date; endTime: Date }[];
   bookedIntervals: { start: Date; end: Date }[]; // aggregated across ALL rows for this member; includes buffer
@@ -30,7 +30,7 @@ const ACTIVE_ASSIGNMENT_WITH_ACTIVE_INTERVIEW = {
 // applicationCycleId, and interviewAssignments were filtered to Active.
 function buildMemberAggregations(
   interviewers: Array<{
-    daliMemberId: string;
+    userId: string;
     interviewAssignments: Array<{ interview: { startTime: Date; endTime: Date } }>;
   }>,
   bufferMinutes: number,
@@ -43,12 +43,12 @@ function buildMemberAggregations(
       end: new Date(a.interview.endTime.getTime() + bufferMinutes * 60_000),
     }));
     memberIntervals.set(
-      r.daliMemberId,
-      (memberIntervals.get(r.daliMemberId) ?? []).concat(intervals),
+      r.userId,
+      (memberIntervals.get(r.userId) ?? []).concat(intervals),
     );
     memberActiveCount.set(
-      r.daliMemberId,
-      (memberActiveCount.get(r.daliMemberId) ?? 0) + r.interviewAssignments.length,
+      r.userId,
+      (memberActiveCount.get(r.userId) ?? 0) + r.interviewAssignments.length,
     );
   }
   return { memberIntervals, memberActiveCount };
@@ -93,13 +93,13 @@ export async function computeAvailableSlots(
   // Build free-check data per interviewer
   const interviewerChecks: InterviewerFreeCheck[] = interviewers.map((r) => ({
     cycleInterviewerId: r.id,
-    daliMemberId: r.daliMemberId,
+    userId: r.userId,
     domainId: r.domainId,
     availability: r.availabilityBlocks.map((b) => ({
       startTime: b.startTime,
       endTime: b.endTime,
     })),
-    bookedIntervals: memberIntervals.get(r.daliMemberId) ?? [],
+    bookedIntervals: memberIntervals.get(r.userId) ?? [],
   }));
 
   // For in-person mode, load existing pod bookings so we can filter out
@@ -141,9 +141,9 @@ export async function computeAvailableSlots(
     for (const r of interviewerChecks) {
       if (!isInterviewerFree(r, slotStart, slotEnd)) continue;
       if (applicantDomainIds.includes(r.domainId)) {
-        inDomainFreeMembers.add(r.daliMemberId);
+        inDomainFreeMembers.add(r.userId);
       } else {
-        crossDomainFreeMembers.add(r.daliMemberId);
+        crossDomainFreeMembers.add(r.userId);
       }
     }
 
@@ -253,14 +253,14 @@ async function assignInterviewersWithTx(
 
   const checks: (InterviewerFreeCheck & { activeCount: number })[] = interviewers.map((r) => ({
     cycleInterviewerId: r.id,
-    daliMemberId: r.daliMemberId,
+    userId: r.userId,
     domainId: r.domainId,
     availability: r.availabilityBlocks.map((b) => ({
       startTime: b.startTime,
       endTime: b.endTime,
     })),
-    bookedIntervals: memberIntervals.get(r.daliMemberId) ?? [],
-    activeCount: memberActiveCount.get(r.daliMemberId) ?? 0,
+    bookedIntervals: memberIntervals.get(r.userId) ?? [],
+    activeCount: memberActiveCount.get(r.userId) ?? 0,
   }));
 
   // Find least-scheduled free in-domain interviewer
@@ -282,7 +282,7 @@ async function assignInterviewersWithTx(
     .filter(
       (r) =>
         !applicantDomainIds.includes(r.domainId) &&
-        r.daliMemberId !== inDomainPick.daliMemberId &&
+        r.userId !== inDomainPick.userId &&
         isInterviewerFree(r, slotStart, slotEnd),
     )
     .sort((a, b) => a.activeCount - b.activeCount);
@@ -400,10 +400,10 @@ export async function reassignInterviewer(
     // different row.
     const existingAssignments = await tx.interviewAssignment.findMany({
       where: { interviewId: interview.id, status: "Active" },
-      include: { cycleInterviewer: { select: { daliMemberId: true } } },
+      include: { cycleInterviewer: { select: { userId: true } } },
     });
     const existingMemberIds = new Set(
-      existingAssignments.map((a) => a.cycleInterviewer.daliMemberId),
+      existingAssignments.map((a) => a.cycleInterviewer.userId),
     );
 
     // Load every CycleInterviewer in the cycle so we can build member-level
@@ -424,7 +424,7 @@ export async function reassignInterviewer(
     );
 
     const candidates = allInterviewers.filter((r) => {
-      if (existingMemberIds.has(r.daliMemberId)) return false;
+      if (existingMemberIds.has(r.userId)) return false;
       if (role === "InDomain") return r.domainId === applicantDomainId;
       return r.domainId !== applicantDomainId;
     });
@@ -433,20 +433,20 @@ export async function reassignInterviewer(
       .filter((r) => {
         const check: InterviewerFreeCheck = {
           cycleInterviewerId: r.id,
-          daliMemberId: r.daliMemberId,
+          userId: r.userId,
           domainId: r.domainId,
           availability: r.availabilityBlocks.map((b) => ({
             startTime: b.startTime,
             endTime: b.endTime,
           })),
-          bookedIntervals: memberIntervals.get(r.daliMemberId) ?? [],
+          bookedIntervals: memberIntervals.get(r.userId) ?? [],
         };
         return isInterviewerFree(check, interview.startTime, interview.endTime);
       })
       .sort(
         (a, b) =>
-          (memberActiveCount.get(a.daliMemberId) ?? 0) -
-          (memberActiveCount.get(b.daliMemberId) ?? 0),
+          (memberActiveCount.get(a.userId) ?? 0) -
+          (memberActiveCount.get(b.userId) ?? 0),
       );
 
     if (freeAndSorted.length === 0) {

--- a/dali-api/app/hiring/routes/__tests__/analytics.test.ts
+++ b/dali-api/app/hiring/routes/__tests__/analytics.test.ts
@@ -26,7 +26,7 @@ beforeEach(() => {
     user: { sub: HIRING_LEAD_ID, email: "lead@x.com", type: "user" },
   } as any);
   vi.mocked(getUserRoles).mockResolvedValue({
-    memberId: null,
+    isLabMember: false,
     isHiringLead: true,
     isAdmin: false,
     isDomainLead: false,

--- a/dali-api/app/hiring/routes/__tests__/api.cycles.my-availability.test.ts
+++ b/dali-api/app/hiring/routes/__tests__/api.cycles.my-availability.test.ts
@@ -17,7 +17,7 @@ const USER_ID = "user-1";
 const CYCLE_ID = "cycle-1";
 
 const mockPrisma = prisma as unknown as {
-  dALIMember: { findFirst: ReturnType<typeof vi.fn> };
+  dALIMember: { findUnique: ReturnType<typeof vi.fn> };
   cycleInterviewer: { findMany: ReturnType<typeof vi.fn> };
   interviewerAvailability: {
     findMany: ReturnType<typeof vi.fn>;
@@ -30,8 +30,7 @@ const mockPrisma = prisma as unknown as {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  (mockPrisma as any).dALIMember = {
-    findFirst: vi.fn().mockResolvedValue({ id: "m1" }),
+  (mockPrisma as any).dALIMember = { findUnique: vi.fn().mockResolvedValue({ id: "m1" }),
   };
   (mockPrisma as any).cycleInterviewer = {
     findMany: vi.fn().mockResolvedValue([{ id: "ci-1" }]),

--- a/dali-api/app/hiring/routes/__tests__/api.domain-applications.$id.reviews.test.ts
+++ b/dali-api/app/hiring/routes/__tests__/api.domain-applications.$id.reviews.test.ts
@@ -16,7 +16,7 @@ const mockPrisma = prisma as unknown as {
   applicationCycle: { findUniqueOrThrow: ReturnType<typeof vi.fn> };
   domainApplicationCycle: { findUnique: ReturnType<typeof vi.fn> };
   applicationReview: { create: ReturnType<typeof vi.fn> };
-  dALIMember: { findFirst: ReturnType<typeof vi.fn> };
+  domainLeadAssignment: { findFirst: ReturnType<typeof vi.fn> };
 };
 
 const USER_ID = "user-1";
@@ -56,7 +56,7 @@ beforeEach(() => {
   (mockPrisma as any).applicationReview = {
     create: vi.fn().mockImplementation(({ data }: any) => Promise.resolve({ id: "rev-1", ...data })),
   };
-  (mockPrisma as any).dALIMember = {
+  (mockPrisma as any).domainLeadAssignment = {
     findFirst: vi.fn().mockResolvedValue(null),
   };
   vi.mocked(requireAuth).mockResolvedValue({
@@ -117,11 +117,11 @@ describe("POST /api/hiring/domain-applications/:id/reviews", () => {
     expect(mockPrisma.applicationReview.create).toHaveBeenCalledWith({
       data: { domainApplicationId: DA_ID, cycleReviewerId: CYCLE_REVIEWER_ID },
     });
-    expect(mockPrisma.dALIMember.findFirst).not.toHaveBeenCalled();
+    expect(mockPrisma.domainLeadAssignment.findFirst).not.toHaveBeenCalled();
   });
 
   it("allows a domain lead for the matching domain (201)", async () => {
-    mockPrisma.dALIMember.findFirst.mockResolvedValue({ id: "member-1" });
+    mockPrisma.domainLeadAssignment.findFirst.mockResolvedValue({ id: "member-1" });
 
     const res = await action({
       request: makeRequest(),
@@ -130,11 +130,8 @@ describe("POST /api/hiring/domain-applications/:id/reviews", () => {
     } as any);
 
     expect(res.status).toBe(201);
-    expect(mockPrisma.dALIMember.findFirst).toHaveBeenCalledWith({
-      where: {
-        userId: USER_ID,
-        domainLeadAssignments: { some: { domainId: DOMAIN_ID } },
-      },
+    expect(mockPrisma.domainLeadAssignment.findFirst).toHaveBeenCalledWith({
+      where: { userId: USER_ID, domainId: DOMAIN_ID },
       select: { id: true },
     });
     expect(mockPrisma.applicationReview.create).toHaveBeenCalled();
@@ -147,8 +144,8 @@ describe("POST /api/hiring/domain-applications/:id/reviews", () => {
       application: { applicationCycleId: CYCLE_ID },
       challengeVersion: { domainId: OTHER_DOMAIN_ID },
     });
-    // dALIMember.findFirst is scoped to OTHER_DOMAIN_ID — user has no assignment there.
-    mockPrisma.dALIMember.findFirst.mockResolvedValue(null);
+    // domainLeadAssignment.findFirst is scoped to OTHER_DOMAIN_ID — no row.
+    mockPrisma.domainLeadAssignment.findFirst.mockResolvedValue(null);
 
     const res = await action({
       request: makeRequest(),
@@ -157,18 +154,15 @@ describe("POST /api/hiring/domain-applications/:id/reviews", () => {
     } as any);
 
     expect(res.status).toBe(403);
-    expect(mockPrisma.dALIMember.findFirst).toHaveBeenCalledWith({
-      where: {
-        userId: USER_ID,
-        domainLeadAssignments: { some: { domainId: OTHER_DOMAIN_ID } },
-      },
+    expect(mockPrisma.domainLeadAssignment.findFirst).toHaveBeenCalledWith({
+      where: { userId: USER_ID, domainId: OTHER_DOMAIN_ID },
       select: { id: true },
     });
     expect(mockPrisma.applicationReview.create).not.toHaveBeenCalled();
   });
 
   it("rejects a non-lead, non-hiring-lead member (403)", async () => {
-    mockPrisma.dALIMember.findFirst.mockResolvedValue(null);
+    mockPrisma.domainLeadAssignment.findFirst.mockResolvedValue(null);
 
     const res = await action({
       request: makeRequest(),

--- a/dali-api/app/hiring/routes/__tests__/api.reviews.$id.test.ts
+++ b/dali-api/app/hiring/routes/__tests__/api.reviews.$id.test.ts
@@ -18,7 +18,7 @@ const mockPrisma = prisma as unknown as {
     delete: ReturnType<typeof vi.fn>;
   };
   dALIMember: {
-    findFirst: ReturnType<typeof vi.fn>;
+    findUnique: ReturnType<typeof vi.fn>;
   };
 };
 
@@ -40,13 +40,12 @@ beforeEach(() => {
     findUnique: vi.fn().mockResolvedValue({
       id: REVIEW_ID,
       submittedAt: null,
-      cycleReviewer: { daliMemberId: MEMBER_ID },
+      cycleReviewer: { userId: USER_ID },
     }),
     update: vi.fn().mockImplementation(({ data }: any) => Promise.resolve({ id: REVIEW_ID, ...data })),
     delete: vi.fn(),
   };
-  (mockPrisma as any).dALIMember = {
-    findFirst: vi.fn().mockResolvedValue({ id: MEMBER_ID, userId: USER_ID }),
+  (mockPrisma as any).dALIMember = { findUnique: vi.fn().mockResolvedValue({ id: MEMBER_ID, userId: USER_ID }),
   };
   vi.mocked(requireAuth).mockResolvedValue({
     ok: true,
@@ -213,7 +212,7 @@ describe("PATCH /api/hiring/reviews/:id", () => {
     mockPrisma.applicationReview.findUnique.mockResolvedValueOnce({
       id: REVIEW_ID,
       submittedAt: new Date(),
-      cycleReviewer: { daliMemberId: MEMBER_ID },
+      cycleReviewer: { userId: USER_ID },
     });
     const res = await action({
       request: makeRequest({ feedback: "later edit" }),

--- a/dali-api/app/hiring/routes/__tests__/reviewer.loader.test.ts
+++ b/dali-api/app/hiring/routes/__tests__/reviewer.loader.test.ts
@@ -41,8 +41,7 @@ beforeEach(() => {
     currentStatus: "UnderReview",
   } as any);
 
-  mockPrisma.dALIMember = {
-    findFirst: vi.fn().mockResolvedValue({ id: MEMBER_ID, userId: USER_ID }),
+  mockPrisma.dALIMember = { findUnique: vi.fn().mockResolvedValue({ id: MEMBER_ID, userId: USER_ID }),
   };
   mockPrisma.cycleReviewer = {
     findMany: vi

--- a/dali-api/app/hiring/routes/analytics.tsx
+++ b/dali-api/app/hiring/routes/analytics.tsx
@@ -173,7 +173,7 @@ export async function loader({ request }: Route.LoaderArgs) {
           id: true,
           cycleReviewer: {
             select: {
-              daliMember: { select: { firstName: true, lastName: true } },
+              user: { select: { firstName: true, lastName: true } },
             },
           },
         },
@@ -187,7 +187,7 @@ export async function loader({ request }: Route.LoaderArgs) {
             select: {
               cycleInterviewer: {
                 select: {
-                  daliMember: { select: { firstName: true, lastName: true } },
+                  user: { select: { firstName: true, lastName: true } },
                 },
               },
             },
@@ -219,14 +219,14 @@ export async function loader({ request }: Route.LoaderArgs) {
 
     const reviewerNames = Array.from(
       new Set(
-        (da as any).reviews.map((r: any) => fullName(r.cycleReviewer.daliMember)),
+        (da as any).reviews.map((r: any) => fullName(r.cycleReviewer.user)),
       ),
     ) as string[];
 
     const interviewerNames = Array.from(
       new Set(
         ((da as any).interviews as any[]).flatMap((iv) =>
-          iv.assignments.map((a: any) => fullName(a.cycleInterviewer.daliMember)),
+          iv.assignments.map((a: any) => fullName(a.cycleInterviewer.user)),
         ),
       ),
     ) as string[];

--- a/dali-api/app/hiring/routes/api.cycles.$cycleId.delibs.ts
+++ b/dali-api/app/hiring/routes/api.cycles.$cycleId.delibs.ts
@@ -46,7 +46,7 @@ export async function action({ request, params }: Route.ActionArgs) {
   const gate = await requireApiSignedOrForbidden(auth.user.sub, params.cycleId!);
   if (gate) return gate;
 
-  const member = await prisma.dALIMember.findFirst({
+  const member = await prisma.dALIMember.findUnique({
     where: { userId: auth.user.sub },
   });
   if (!member) {

--- a/dali-api/app/hiring/routes/api.cycles.$cycleId.delibs.ts
+++ b/dali-api/app/hiring/routes/api.cycles.$cycleId.delibs.ts
@@ -71,7 +71,7 @@ export async function action({ request, params }: Route.ActionArgs) {
       applicationCycleId: params.cycleId,
       type,
       status: "Active",
-      openedById: member.id,
+      openedById: auth.user.sub,
     },
     update: {
       status: "Active",

--- a/dali-api/app/hiring/routes/api.cycles.$cycleId.interviewers.ts
+++ b/dali-api/app/hiring/routes/api.cycles.$cycleId.interviewers.ts
@@ -6,7 +6,7 @@ import { isHiringLead, isDomainLead, hasCycleAccess } from "~/lib/roles";
 import { parseJson } from "~/lib/validate";
 
 const CreateInterviewerSchema = z.object({
-  daliMemberId: z.string().min(1).max(100),
+  userId: z.string().min(1).max(100),
   domainId: z.string().min(1).max(100),
 });
 
@@ -24,7 +24,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   const interviewers = await prisma.cycleInterviewer.findMany({
     where: { applicationCycleId: params.cycleId },
     include: {
-      daliMember: { select: { firstName: true, lastName: true, daliEmail: true } },
+      user: { select: { firstName: true, lastName: true, daliEmail: true } },
       domain: { select: { id: true, name: true } },
     },
     orderBy: { createdAt: "asc" },
@@ -46,11 +46,11 @@ export async function action({ request, params }: Route.ActionArgs) {
   if (request.method === "POST") {
     const body = await parseJson(request, CreateInterviewerSchema);
     if (body instanceof Response) return body;
-    const { daliMemberId, domainId } = body;
+    const { userId, domainId } = body;
 
     const interviewer = await prisma.cycleInterviewer.create({
       data: {
-        daliMemberId,
+        userId,
         applicationCycleId: params.cycleId,
         domainId,
       },

--- a/dali-api/app/hiring/routes/api.cycles.$cycleId.interviews.ts
+++ b/dali-api/app/hiring/routes/api.cycles.$cycleId.interviews.ts
@@ -35,7 +35,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
         include: {
           cycleInterviewer: {
             include: {
-              daliMember: true,
+              user: true,
               domain: true,
             },
           },

--- a/dali-api/app/hiring/routes/api.cycles.$cycleId.my-availability.ts
+++ b/dali-api/app/hiring/routes/api.cycles.$cycleId.my-availability.ts
@@ -51,10 +51,10 @@ function interviewWindowUtcBounds(config: {
 // cycle. A member who serves multiple domains has multiple rows; availability
 // is a per-human concept, so writes fan out across every row.
 async function findCycleInterviewers(userId: string, cycleId: string) {
-  const member = await prisma.dALIMember.findFirst({ where: { userId } });
+  const member = await prisma.dALIMember.findUnique({ where: { userId } });
   if (!member) return [];
   return prisma.cycleInterviewer.findMany({
-    where: { daliMemberId: member.id, applicationCycleId: cycleId },
+    where: { userId: member.id, applicationCycleId: cycleId },
     select: { id: true },
   });
 }

--- a/dali-api/app/hiring/routes/api.cycles.$cycleId.my-availability.ts
+++ b/dali-api/app/hiring/routes/api.cycles.$cycleId.my-availability.ts
@@ -54,7 +54,7 @@ async function findCycleInterviewers(userId: string, cycleId: string) {
   const member = await prisma.dALIMember.findUnique({ where: { userId } });
   if (!member) return [];
   return prisma.cycleInterviewer.findMany({
-    where: { userId: member.id, applicationCycleId: cycleId },
+    where: { userId, applicationCycleId: cycleId },
     select: { id: true },
   });
 }

--- a/dali-api/app/hiring/routes/api.cycles.$cycleId.my-interviews.$interviewId.decline.ts
+++ b/dali-api/app/hiring/routes/api.cycles.$cycleId.my-interviews.$interviewId.decline.ts
@@ -28,7 +28,7 @@ export async function action({ request, params }: Route.ActionArgs) {
   // per domain), so look up ALL of their rows and find any active assignment
   // on this interview under any of them.
   const interviewerRows = await prisma.cycleInterviewer.findMany({
-    where: { userId: member.id, applicationCycleId: params.cycleId },
+    where: { userId: auth.user.sub, applicationCycleId: params.cycleId },
     select: { id: true },
   });
   if (interviewerRows.length === 0) {

--- a/dali-api/app/hiring/routes/api.cycles.$cycleId.my-interviews.$interviewId.decline.ts
+++ b/dali-api/app/hiring/routes/api.cycles.$cycleId.my-interviews.$interviewId.decline.ts
@@ -19,7 +19,7 @@ export async function action({ request, params }: Route.ActionArgs) {
   const gate = await requireApiSignedOrForbidden(auth.user.sub, params.cycleId!);
   if (gate) return withCors(request, gate);
 
-  const member = await prisma.dALIMember.findFirst({ where: { userId: auth.user.sub } });
+  const member = await prisma.dALIMember.findUnique({ where: { userId: auth.user.sub } });
   if (!member) {
     return withCors(request, Response.json({ error: "Not a DALI member" }, { status: 403 }));
   }
@@ -28,7 +28,7 @@ export async function action({ request, params }: Route.ActionArgs) {
   // per domain), so look up ALL of their rows and find any active assignment
   // on this interview under any of them.
   const interviewerRows = await prisma.cycleInterviewer.findMany({
-    where: { daliMemberId: member.id, applicationCycleId: params.cycleId },
+    where: { userId: member.id, applicationCycleId: params.cycleId },
     select: { id: true },
   });
   if (interviewerRows.length === 0) {

--- a/dali-api/app/hiring/routes/api.cycles.$cycleId.my-interviews.$interviewId.notes.ts
+++ b/dali-api/app/hiring/routes/api.cycles.$cycleId.my-interviews.$interviewId.notes.ts
@@ -11,11 +11,11 @@ const NoteVersionSchema = z.object({
 });
 
 async function getAssignment(userId: string, cycleId: string, interviewId: string) {
-  const member = await prisma.dALIMember.findFirst({ where: { userId } });
+  const member = await prisma.dALIMember.findUnique({ where: { userId } });
   if (!member) return null;
 
   const interviewer = await prisma.cycleInterviewer.findFirst({
-    where: { daliMemberId: member.id, applicationCycleId: cycleId },
+    where: { userId: member.id, applicationCycleId: cycleId },
   });
   if (!interviewer) return null;
 

--- a/dali-api/app/hiring/routes/api.cycles.$cycleId.my-interviews.$interviewId.notes.ts
+++ b/dali-api/app/hiring/routes/api.cycles.$cycleId.my-interviews.$interviewId.notes.ts
@@ -15,7 +15,7 @@ async function getAssignment(userId: string, cycleId: string, interviewId: strin
   if (!member) return null;
 
   const interviewer = await prisma.cycleInterviewer.findFirst({
-    where: { userId: member.id, applicationCycleId: cycleId },
+    where: { userId, applicationCycleId: cycleId },
   });
   if (!interviewer) return null;
 

--- a/dali-api/app/hiring/routes/api.cycles.$cycleId.my-interviews.ts
+++ b/dali-api/app/hiring/routes/api.cycles.$cycleId.my-interviews.ts
@@ -11,11 +11,11 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   const auth = await requireAuth(request);
   if (!auth.ok) return withCors(request, auth.response);
 
-  const member = await prisma.dALIMember.findFirst({ where: { userId: auth.user.sub } });
+  const member = await prisma.dALIMember.findUnique({ where: { userId: auth.user.sub } });
   if (!member) return withCors(request, Response.json([]));
 
   const interviewer = await prisma.cycleInterviewer.findFirst({
-    where: { daliMemberId: member.id, applicationCycleId: params.cycleId },
+    where: { userId: member.id, applicationCycleId: params.cycleId },
   });
   if (!interviewer) return withCors(request, Response.json([]));
 
@@ -42,7 +42,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
             include: {
               cycleInterviewer: {
                 include: {
-                  daliMember: true,
+                  user: true,
                   domain: true,
                 },
               },

--- a/dali-api/app/hiring/routes/api.cycles.$cycleId.my-interviews.ts
+++ b/dali-api/app/hiring/routes/api.cycles.$cycleId.my-interviews.ts
@@ -15,7 +15,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   if (!member) return withCors(request, Response.json([]));
 
   const interviewer = await prisma.cycleInterviewer.findFirst({
-    where: { userId: member.id, applicationCycleId: params.cycleId },
+    where: { userId: auth.user.sub, applicationCycleId: params.cycleId },
   });
   if (!interviewer) return withCors(request, Response.json([]));
 

--- a/dali-api/app/hiring/routes/api.cycles.$cycleId.reviewers.$reviewerId.ts
+++ b/dali-api/app/hiring/routes/api.cycles.$cycleId.reviewers.$reviewerId.ts
@@ -27,7 +27,7 @@ export async function action({ request, params }: Route.ActionArgs) {
         domainId: body.domainId,
       },
       include: {
-        daliMember: { include: { user: true } },
+        user: true,
         domain: true,
       },
     });

--- a/dali-api/app/hiring/routes/api.cycles.$cycleId.reviewers.ts
+++ b/dali-api/app/hiring/routes/api.cycles.$cycleId.reviewers.ts
@@ -7,7 +7,7 @@ import { withCors, handlePreflight } from "~/lib/cors";
 import { parseJson } from "~/lib/validate";
 
 const CreateReviewerSchema = z.object({
-  daliMemberId: z.string().min(1).max(100),
+  userId: z.string().min(1).max(100),
   domainId: z.string().min(1).max(100),
 });
 
@@ -24,7 +24,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   const reviewers = await prisma.cycleReviewer.findMany({
     where: { applicationCycleId: params.cycleId },
     include: {
-      daliMember: { include: { user: true } },
+      user: true,
       domain: true,
     },
   });
@@ -46,7 +46,7 @@ export async function action({ request, params }: Route.ActionArgs) {
 
   const body = await parseJson(request, CreateReviewerSchema);
   if (body instanceof Response) return withCors(request, body);
-  const { daliMemberId, domainId } = body;
+  const { userId, domainId } = body;
 
   // Ensure domain is linked to cycle
   await prisma.domainApplicationCycle.upsert({
@@ -57,12 +57,12 @@ export async function action({ request, params }: Route.ActionArgs) {
 
   const reviewer = await prisma.cycleReviewer.create({
     data: {
-      daliMemberId,
+      userId,
       applicationCycleId: params.cycleId,
       domainId,
     },
     include: {
-      daliMember: { include: { user: true } },
+      user: true,
       domain: true,
     },
   });

--- a/dali-api/app/hiring/routes/api.decisions.$id.finalize.ts
+++ b/dali-api/app/hiring/routes/api.decisions.$id.finalize.ts
@@ -19,7 +19,7 @@ export async function action({ request, params }: Route.ActionArgs) {
     return Response.json({ error: "Forbidden" }, { status: 403 });
   }
 
-  const member = await prisma.dALIMember.findFirst({ where: { userId: auth.user.sub } });
+  const member = await prisma.dALIMember.findUnique({ where: { userId: auth.user.sub } });
   if (!member) {
     return Response.json({ error: "Not a DALI member" }, { status: 403 });
   }

--- a/dali-api/app/hiring/routes/api.decisions.$id.finalize.ts
+++ b/dali-api/app/hiring/routes/api.decisions.$id.finalize.ts
@@ -46,7 +46,7 @@ export async function action({ request, params }: Route.ActionArgs) {
       domainApplicationId: decision.domainApplicationId,
       type: decision.type,
       stage: "Final",
-      madeById: member.id,
+      madeById: auth.user.sub,
       notes: decision.notes,
       waitlistRank: decision.waitlistRank,
       parentDecisionId: decision.id,

--- a/dali-api/app/hiring/routes/api.decisions.$id.release.ts
+++ b/dali-api/app/hiring/routes/api.decisions.$id.release.ts
@@ -98,7 +98,7 @@ export async function action({ request, params }: Route.ActionArgs) {
       domainApplicationId: decision.domainApplicationId,
       type: decision.type,
       stage: "Released",
-      madeById: member.id,
+      madeById: auth.user.sub,
       notes: decision.notes,
       waitlistRank: decision.waitlistRank,
       parentDecisionId: decision.id,

--- a/dali-api/app/hiring/routes/api.decisions.$id.release.ts
+++ b/dali-api/app/hiring/routes/api.decisions.$id.release.ts
@@ -3,11 +3,10 @@ import { prisma } from "~/lib/db";
 import { requireAuth } from "~/lib/auth";
 import { isHiringLead } from "~/lib/roles";
 import { sendEmail } from "~/lib/gmail";
+import { getApplicationsGmailRefreshToken } from "~/lib/gmail-integration";
 import { renderForSlot, decisionSlot } from "~/hiring/lib/email-variables";
 import { logAuditEvent } from "~/lib/audit";
 import { requireApiSignedOrForbidden } from "~/hiring/lib/confidentiality";
-
-const GMAIL_USER = "applications@dali.dartmouth.edu";
 
 export async function action({ request, params }: Route.ActionArgs) {
   const auth = await requireAuth(request);
@@ -24,7 +23,7 @@ export async function action({ request, params }: Route.ActionArgs) {
         );
   }
 
-  const member = await prisma.dALIMember.findFirst({
+  const member = await prisma.dALIMember.findUnique({
     where: { userId: auth.user.sub },
   });
   if (!member) {
@@ -116,12 +115,9 @@ export async function action({ request, params }: Route.ActionArgs) {
     const domainName = domainApp.challengeVersion.domain?.name ?? "";
 
     if (email && user) {
-      const gmailUser = await prisma.user.findUnique({
-        where: { daliEmail: GMAIL_USER },
-        select: { googleRefreshToken: true },
-      });
+      const refreshToken = await getApplicationsGmailRefreshToken();
 
-      if (gmailUser?.googleRefreshToken) {
+      if (refreshToken) {
         const { subject, html } = renderForSlot(
           decisionSlot(decision.type),
           binding.emailTemplateVersion,
@@ -132,7 +128,7 @@ export async function action({ request, params }: Route.ActionArgs) {
         );
 
         await sendEmail({
-          refreshToken: gmailUser.googleRefreshToken,
+          refreshToken,
           to: email,
           subject,
           html,

--- a/dali-api/app/hiring/routes/api.delibs.$id.ts
+++ b/dali-api/app/hiring/routes/api.delibs.$id.ts
@@ -110,7 +110,7 @@ export async function action({ request, params }: Route.ActionArgs) {
               domainApplicationId: d.domainApplicationId,
               type: d.type as any,
               stage: "Draft",
-              madeById: member.id,
+              madeById: auth.user.sub,
               waitlistRank: d.waitlistRank,
             },
           });

--- a/dali-api/app/hiring/routes/api.delibs.$id.ts
+++ b/dali-api/app/hiring/routes/api.delibs.$id.ts
@@ -63,7 +63,7 @@ export async function action({ request, params }: Route.ActionArgs) {
     const { intent } = body;
 
     if (intent === "close") {
-      const member = await prisma.dALIMember.findFirst({
+      const member = await prisma.dALIMember.findUnique({
         where: { userId: auth.user.sub },
       });
       if (!member) {

--- a/dali-api/app/hiring/routes/api.domain-applications.$id.decisions.ts
+++ b/dali-api/app/hiring/routes/api.domain-applications.$id.decisions.ts
@@ -68,7 +68,7 @@ export async function action({ request, params }: Route.ActionArgs) {
   );
   if (gate) return gate;
 
-  const member = await prisma.dALIMember.findFirst({
+  const member = await prisma.dALIMember.findUnique({
     where: { userId: auth.user.sub },
   });
   if (!member) {

--- a/dali-api/app/hiring/routes/api.domain-applications.$id.decisions.ts
+++ b/dali-api/app/hiring/routes/api.domain-applications.$id.decisions.ts
@@ -95,7 +95,7 @@ export async function action({ request, params }: Route.ActionArgs) {
       domainApplicationId: params.id,
       type,
       stage,
-      madeById: member.id,
+      madeById: auth.user.sub,
       notes: notes ?? null,
       waitlistRank: waitlistRank ?? null,
     },

--- a/dali-api/app/hiring/routes/api.domain-applications.$id.full-context.ts
+++ b/dali-api/app/hiring/routes/api.domain-applications.$id.full-context.ts
@@ -29,7 +29,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
         include: {
           cycleReviewer: {
             include: {
-              daliMember: { select: { firstName: true, lastName: true } },
+              user: { select: { firstName: true, lastName: true } },
             },
           },
         },

--- a/dali-api/app/hiring/routes/api.domain-applications.$id.reviews.ts
+++ b/dali-api/app/hiring/routes/api.domain-applications.$id.reviews.ts
@@ -33,7 +33,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     include: {
       cycleReviewer: {
         include: {
-          daliMember: { select: { firstName: true, lastName: true, daliEmail: true } },
+          user: { select: { firstName: true, lastName: true, daliEmail: true } },
         },
       },
     },
@@ -84,14 +84,11 @@ export async function action({ request, params }: Route.ActionArgs) {
   if (gate) return gate;
 
   if (!(await isHiringLead(auth.user.sub))) {
-    const domainLeadForThisDomain = await prisma.dALIMember.findFirst({
-      where: {
-        userId: auth.user.sub,
-        domainLeadAssignments: { some: { domainId } },
-      },
+    const domainLead = await prisma.domainLeadAssignment.findFirst({
+      where: { userId: auth.user.sub, domainId },
       select: { id: true },
     });
-    if (!domainLeadForThisDomain) {
+    if (!domainLead) {
       return Response.json({ error: "Forbidden" }, { status: 403 });
     }
   }

--- a/dali-api/app/hiring/routes/api.interview-assignments.$id.notes.ts
+++ b/dali-api/app/hiring/routes/api.interview-assignments.$id.notes.ts
@@ -49,7 +49,7 @@ export async function action({ request, params }: Route.ActionArgs) {
     where: { id: params.id },
     include: {
       cycleInterviewer: {
-        include: { daliMember: true },
+        include: { user: true },
       },
       interview: { select: { applicationCycleId: true } },
     },
@@ -59,7 +59,7 @@ export async function action({ request, params }: Route.ActionArgs) {
     return Response.json({ error: "Assignment not found" }, { status: 404 });
   }
 
-  if (assignment.cycleInterviewer.daliMember.userId !== auth.user.sub) {
+  if (assignment.cycleInterviewer.userId !== auth.user.sub) {
     return Response.json({ error: "Not your assignment" }, { status: 403 });
   }
 

--- a/dali-api/app/hiring/routes/api.interviews.$id.complete.ts
+++ b/dali-api/app/hiring/routes/api.interviews.$id.complete.ts
@@ -31,7 +31,7 @@ export async function action({ request, params }: Route.ActionArgs) {
     where: {
       interviewId: params.id,
       status: "Active",
-      cycleInterviewer: { userId: member.id },
+      cycleInterviewer: { userId: auth.user.sub },
     },
   });
   if (!assignment) {

--- a/dali-api/app/hiring/routes/api.interviews.$id.complete.ts
+++ b/dali-api/app/hiring/routes/api.interviews.$id.complete.ts
@@ -21,7 +21,7 @@ export async function action({ request, params }: Route.ActionArgs) {
     return Response.json({ error: "Method not allowed" }, { status: 405 });
   }
 
-  const member = await prisma.dALIMember.findFirst({ where: { userId: auth.user.sub } });
+  const member = await prisma.dALIMember.findUnique({ where: { userId: auth.user.sub } });
   if (!member) {
     return Response.json({ error: "Not a DALI member" }, { status: 403 });
   }
@@ -31,7 +31,7 @@ export async function action({ request, params }: Route.ActionArgs) {
     where: {
       interviewId: params.id,
       status: "Active",
-      cycleInterviewer: { daliMemberId: member.id },
+      cycleInterviewer: { userId: member.id },
     },
   });
   if (!assignment) {

--- a/dali-api/app/hiring/routes/api.interviews.$id.reassign.ts
+++ b/dali-api/app/hiring/routes/api.interviews.$id.reassign.ts
@@ -49,7 +49,7 @@ export async function action({ request, params }: Route.ActionArgs) {
   // across domains).
   const newCI = await prisma.cycleInterviewer.findUnique({
     where: { id: newCycleInterviewerId },
-    select: { daliMemberId: true },
+    select: { userId: true },
   });
   if (!newCI) {
     return Response.json({ error: "Interviewer not found" }, { status: 404 });
@@ -69,7 +69,7 @@ export async function action({ request, params }: Route.ActionArgs) {
       const conflict = await tx.interviewAssignment.findFirst({
         where: {
           status: "Active",
-          cycleInterviewer: { daliMemberId: newCI.daliMemberId },
+          cycleInterviewer: { userId: newCI.userId },
           interview: {
             id: { not: interview.id },
             status: "Scheduled",

--- a/dali-api/app/hiring/routes/api.reviews.$id.submit.ts
+++ b/dali-api/app/hiring/routes/api.reviews.$id.submit.ts
@@ -12,7 +12,7 @@ export async function action({ request, params }: Route.ActionArgs) {
     return Response.json({ error: "Method not allowed" }, { status: 405 });
   }
 
-  const member = await prisma.dALIMember.findFirst({
+  const member = await prisma.dALIMember.findUnique({
     where: { userId: auth.user.sub },
   });
   if (!member) {
@@ -36,7 +36,7 @@ export async function action({ request, params }: Route.ActionArgs) {
   );
   if (gate) return gate;
 
-  const isOwner = review.cycleReviewer.daliMemberId === member.id;
+  const isOwner = review.cycleReviewer.userId === auth.user.sub;
   const isLead = await isDomainLead(auth.user.sub);
   const isHL = await isHiringLead(auth.user.sub);
   if (!isOwner && !isLead && !isHL) {
@@ -47,7 +47,7 @@ export async function action({ request, params }: Route.ActionArgs) {
     where: { id: params.id },
     data: {
       submittedAt: new Date(),
-      submittedById: member.id,
+      submittedById: auth.user.sub,
     },
   });
 

--- a/dali-api/app/hiring/routes/api.reviews.$id.ts
+++ b/dali-api/app/hiring/routes/api.reviews.$id.ts
@@ -167,8 +167,7 @@ export async function action({ request, params }: Route.ActionArgs) {
       return Response.json({ error: "Cannot edit a submitted review. Unsubmit first." }, { status: 409 });
     }
 
-    const member = await prisma.dALIMember.findFirst({ where: { userId: auth.user.sub } });
-    const isOwner = member && review.cycleReviewer.daliMemberId === member.id;
+    const isOwner = review.cycleReviewer.userId === auth.user.sub;
     const isLead = await isDomainLead(auth.user.sub);
     const isHL = await isHiringLead(auth.user.sub);
     if (!isOwner && !isLead && !isHL) {

--- a/dali-api/app/hiring/routes/api.reviews.$id.unsubmit.ts
+++ b/dali-api/app/hiring/routes/api.reviews.$id.unsubmit.ts
@@ -29,8 +29,7 @@ export async function action({ request, params }: Route.ActionArgs) {
   );
   if (gate) return gate;
 
-  const member = await prisma.dALIMember.findFirst({ where: { userId: auth.user.sub } });
-  const isOwner = member && review.cycleReviewer.daliMemberId === member.id;
+  const isOwner = review.cycleReviewer.userId === auth.user.sub;
   const isLead = await isDomainLead(auth.user.sub);
   const isHL = await isHiringLead(auth.user.sub);
   if (!isOwner && !isLead && !isHL) {

--- a/dali-api/app/hiring/routes/confidentiality-agreements.$id.tsx
+++ b/dali-api/app/hiring/routes/confidentiality-agreements.$id.tsx
@@ -44,7 +44,7 @@ export async function action({ request, params }: Route.ActionArgs) {
   ]);
   if (!hiringLead && !domainLead && !admin) return redirect("/");
 
-  const member = await prisma.dALIMember.findFirst({
+  const member = await prisma.dALIMember.findUnique({
     where: { userId: auth.user.sub },
   });
   if (!member) return redirect("/login");

--- a/dali-api/app/hiring/routes/confidentiality-agreements.$id.tsx
+++ b/dali-api/app/hiring/routes/confidentiality-agreements.$id.tsx
@@ -72,7 +72,7 @@ export async function action({ request, params }: Route.ActionArgs) {
         agreementId: params.id,
         versionNumber,
         body: body as any,
-        createdById: member.id,
+        createdById: auth.user.sub,
       },
     });
 

--- a/dali-api/app/hiring/routes/domain-lead.application.$id.tsx
+++ b/dali-api/app/hiring/routes/domain-lead.application.$id.tsx
@@ -57,16 +57,16 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   const auth = await requireAuth(request);
   if (!auth.ok) return redirect("/login");
 
-  const member = await prisma.dALIMember.findFirst({
+  const domainLeadAssignments = await prisma.domainLeadAssignment.findMany({
     where: { userId: auth.user.sub },
-    include: { domainLeadAssignments: true },
+    select: { domainId: true },
   });
 
-  if (!member || member.domainLeadAssignments.length === 0) {
+  if (domainLeadAssignments.length === 0) {
     return redirect("/hiring/reviewer");
   }
 
-  const leadDomainIds = member.domainLeadAssignments.map((a) => a.domainId);
+  const leadDomainIds = domainLeadAssignments.map((a) => a.domainId);
 
   const da = await prisma.domainApplication.findUnique({
     where: { id: params.id },
@@ -86,7 +86,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
       reviews: {
         include: {
           cycleReviewer: {
-            include: { daliMember: { select: { firstName: true, lastName: true } } },
+            include: { user: { select: { firstName: true, lastName: true } } },
           },
         },
         orderBy: { createdAt: "asc" },
@@ -104,7 +104,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
             where: { status: "Active" },
             include: {
               cycleInterviewer: {
-                include: { daliMember: { select: { firstName: true, lastName: true } } },
+                include: { user: { select: { firstName: true, lastName: true } } },
               },
             },
           },
@@ -302,7 +302,7 @@ export default function DomainLeadApplicationView() {
                 {interview.assignments?.length > 0 && (
                   <div className="text-xs text-muted-foreground pt-1">
                     Interviewers: {interview.assignments.map((a: any) => {
-                      const m = a.cycleInterviewer?.daliMember;
+                      const m = a.cycleInterviewer?.user;
                       return m ? `${m.firstName} ${m.lastName}` : "?";
                     }).join(", ")}
                   </div>
@@ -342,7 +342,7 @@ export default function DomainLeadApplicationView() {
 
 function ReviewCard({ review, criteria }: { review: any; criteria: any[] }) {
   const [expanded, setExpanded] = useState(false);
-  const reviewer = review.cycleReviewer?.daliMember;
+  const reviewer = review.cycleReviewer?.user;
   const name = reviewer ? `${reviewer.firstName} ${reviewer.lastName}` : "Unknown";
   const isSubmitted = !!review.submittedAt;
   const scores = (review.scores ?? {}) as Record<string, number>;

--- a/dali-api/app/hiring/routes/domain-lead.delibs.$id.tsx
+++ b/dali-api/app/hiring/routes/domain-lead.delibs.$id.tsx
@@ -71,7 +71,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
         include: {
           cycleReviewer: {
             include: {
-              daliMember: {
+              user: {
                 select: { firstName: true, lastName: true, daliEmail: true },
               },
             },

--- a/dali-api/app/hiring/routes/domain-lead.tsx
+++ b/dali-api/app/hiring/routes/domain-lead.tsx
@@ -51,18 +51,14 @@ export async function loader({ request }: Route.LoaderArgs) {
   const auth = await requireAuth(request);
   if (!auth.ok) return { domainData: [] };
 
-  const member = await prisma.dALIMember.findFirst({
-    where: { userId: auth.user.sub },
-  });
-
-  if (!member) {
-    return { domainData: [] };
-  }
-
   const assignments = await prisma.domainLeadAssignment.findMany({
-    where: { memberId: member.id },
+    where: { userId: auth.user.sub },
     include: { domain: true },
   });
+
+  if (assignments.length === 0) {
+    return { domainData: [] };
+  }
 
   const domainData = await Promise.all(
     assignments.map(async (assignment) => {
@@ -95,7 +91,7 @@ export async function loader({ request }: Route.LoaderArgs) {
                   reviews: {
                     include: {
                       cycleReviewer: {
-                        include: { daliMember: { select: { firstName: true, lastName: true, daliEmail: true } } },
+                        include: { user: { select: { firstName: true, lastName: true, daliEmail: true } } },
                       },
                     },
                   },
@@ -199,7 +195,7 @@ export async function loader({ request }: Route.LoaderArgs) {
                 where: { status: "Active" },
                 include: {
                   cycleInterviewer: {
-                    include: { daliMember: true, domain: true },
+                    include: { user: true, domain: true },
                   },
                 },
               },
@@ -212,7 +208,7 @@ export async function loader({ request }: Route.LoaderArgs) {
       const reviewers = cycle
         ? await prisma.cycleReviewer.findMany({
             where: { applicationCycleId: cycle.id, domainId: assignment.domainId },
-            include: { daliMember: { include: { user: true } }, domain: true },
+            include: { user: true, domain: true },
           })
         : [];
 
@@ -283,7 +279,7 @@ export async function loader({ request }: Route.LoaderArgs) {
       const cycleReviewersForDomain = cycle
         ? await prisma.cycleReviewer.findMany({
             where: { applicationCycleId: cycle.id, domainId: assignment.domainId },
-            include: { daliMember: { select: { id: true, firstName: true, lastName: true, daliEmail: true } } },
+            include: { user: { select: { id: true, firstName: true, lastName: true, daliEmail: true } } },
           })
         : [];
 
@@ -301,7 +297,7 @@ export async function loader({ request }: Route.LoaderArgs) {
         ? await prisma.cycleInterviewer.findMany({
             where: { applicationCycleId: cycle.id, domainId: assignment.domainId },
             include: {
-              daliMember: { select: { id: true, firstName: true, lastName: true, daliEmail: true } },
+              user: { select: { id: true, firstName: true, lastName: true, daliEmail: true } },
               availabilityBlocks: { select: { startTime: true, endTime: true } },
             },
           })
@@ -943,7 +939,7 @@ export default function DomainLeadDashboard() {
                                     const start = new Date(interview.startTime);
                                     const end = new Date(interview.endTime);
                                     const formatAssignment = (a: any) => {
-                                      const m = a.cycleInterviewer.daliMember;
+                                      const m = a.cycleInterviewer.user;
                                       return m.firstName && m.lastName
                                         ? `${m.firstName} ${m.lastName}`
                                         : m.daliEmail ?? '?';
@@ -994,7 +990,7 @@ export default function DomainLeadDashboard() {
                                   const start = new Date(interview.startTime);
                                   const end = new Date(interview.endTime);
                                   const formatAssignment = (a: any) => {
-                                    const m = a.cycleInterviewer.daliMember;
+                                    const m = a.cycleInterviewer.user;
                                     return m.firstName && m.lastName
                                       ? `${m.firstName} ${m.lastName}`
                                       : m.daliEmail ?? '?';
@@ -1360,7 +1356,7 @@ function ReviewerSection({ cycleId, domainId, initialReviewers }: {
     const res = await fetch(`/api/hiring/cycles/${cycleId}/reviewers`, {
       method: 'POST', credentials: 'include',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ daliMemberId: selectedMemberId, domainId, isLead: false }),
+      body: JSON.stringify({ userId: selectedMemberId, domainId, isLead: false }),
     });
     if (res.ok) {
       const reviewer = await res.json();
@@ -1388,13 +1384,13 @@ function ReviewerSection({ cycleId, domainId, initialReviewers }: {
   }
 
   const pendingName = pendingRemove
-    ? (pendingRemove.daliMember?.firstName && pendingRemove.daliMember?.lastName
-        ? `${pendingRemove.daliMember.firstName} ${pendingRemove.daliMember.lastName}`
-        : pendingRemove.daliMember?.daliEmail ?? "this reviewer")
+    ? (pendingRemove.user?.firstName && pendingRemove.user?.lastName
+        ? `${pendingRemove.user.firstName} ${pendingRemove.user.lastName}`
+        : pendingRemove.user?.daliEmail ?? "this reviewer")
     : "";
 
   // Filter out members already assigned as reviewers for this domain
-  const existingMemberIds = new Set(reviewers.map((r: any) => r.daliMemberId));
+  const existingMemberIds = new Set(reviewers.map((r: any) => r.userId));
   const availableMembers = members.filter(m => !existingMemberIds.has(m.id));
 
   return (
@@ -1432,7 +1428,7 @@ function ReviewerSection({ cycleId, domainId, initialReviewers }: {
             {reviewers.map((r: any) => (
               <div key={r.id} className="flex items-center justify-between py-2">
                 <span className="text-sm font-medium text-foreground">
-                  {r.daliMember?.firstName && r.daliMember?.lastName ? `${r.daliMember.firstName} ${r.daliMember.lastName}` : r.daliMember?.daliEmail ?? r.daliMemberId}
+                  {r.user?.firstName && r.user?.lastName ? `${r.user.firstName} ${r.user.lastName}` : r.user?.daliEmail ?? r.userId}
                 </span>
                 <button
                   onClick={() => setPendingRemove(r)}
@@ -1559,12 +1555,12 @@ function InterviewerSection({ cycleId, domainId, initialInterviewers }: {
     const res = await fetch(`/api/hiring/cycles/${cycleId}/interviewers`, {
       method: "POST", credentials: "include",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ daliMemberId: selectedMemberId, domainId }),
+      body: JSON.stringify({ userId: selectedMemberId, domainId }),
     });
     if (res.ok) {
       const interviewer = await res.json();
       const member = members.find((m: any) => m.id === selectedMemberId);
-      setInterviewers(prev => [...prev, { ...interviewer, daliMember: member, availabilityHours: 0 }]);
+      setInterviewers(prev => [...prev, { ...interviewer, user: member, availabilityHours: 0 }]);
       setSelectedMemberId("");
     }
   }
@@ -1589,12 +1585,12 @@ function InterviewerSection({ cycleId, domainId, initialInterviewers }: {
     }
   }
 
-  const existingMemberIds = new Set(interviewers.map((i: any) => i.daliMemberId));
+  const existingMemberIds = new Set(interviewers.map((i: any) => i.userId));
   const availableMembers = members.filter(m => !existingMemberIds.has(m.id));
   const pendingName = pendingRemove
-    ? (pendingRemove.daliMember?.firstName && pendingRemove.daliMember?.lastName
-        ? `${pendingRemove.daliMember.firstName} ${pendingRemove.daliMember.lastName}`
-        : pendingRemove.daliMember?.daliEmail ?? "this interviewer")
+    ? (pendingRemove.user?.firstName && pendingRemove.user?.lastName
+        ? `${pendingRemove.user.firstName} ${pendingRemove.user.lastName}`
+        : pendingRemove.user?.daliEmail ?? "this interviewer")
     : "";
 
   return (
@@ -1630,10 +1626,10 @@ function InterviewerSection({ cycleId, domainId, initialInterviewers }: {
         {interviewers.length > 0 ? (
           <div className="divide-y divide-gray-100">
             {interviewers.map((i: any) => {
-              const m = i.daliMember;
+              const m = i.user;
               const name = m?.firstName && m?.lastName
                 ? `${m.firstName} ${m.lastName}`
-                : m?.daliEmail ?? i.daliMemberId;
+                : m?.daliEmail ?? i.userId;
               const hours = i.availabilityHours ?? 0;
               const hasAvailability = hours > 0;
               const hoursLabel =
@@ -2186,7 +2182,7 @@ function ApplicationsTable({ apps, draftDecisions, cycleReviewersForDomain, cycl
             >
               <option value="">Assign reviewer…</option>
               {cycleReviewersForDomain.map((cr: any) => {
-                const m = cr.daliMember;
+                const m = cr.user;
                 const label = m?.firstName && m?.lastName
                   ? `${m.firstName} ${m.lastName}`
                   : m?.daliEmail ?? cr.id;
@@ -2534,7 +2530,7 @@ function ReviewerAssignmentCell({ domainApplicationId, reviews, cycleReviewers, 
   return (
     <div className={cellClass}>
       {localReviews.map((r: any) => {
-        const m = r.cycleReviewer?.daliMember;
+        const m = r.cycleReviewer?.user;
         const name = m?.firstName && m?.lastName
           ? `${m.firstName} ${m.lastName[0]}.`
           : m?.daliEmail ?? "?";
@@ -2610,7 +2606,7 @@ function ReviewerAssignmentCell({ domainApplicationId, reviews, cycleReviewers, 
           >
             <option value="">Select...</option>
             {available.map((cr: any) => {
-              const m = cr.daliMember;
+              const m = cr.user;
               const label = m?.firstName && m?.lastName
                 ? `${m.firstName} ${m.lastName}`
                 : m?.daliEmail ?? cr.id;
@@ -2655,7 +2651,7 @@ function ReviewerAssignmentCell({ domainApplicationId, reviews, cycleReviewers, 
           <p>
             <strong>
               {(() => {
-                const m = pendingRemoveReview?.cycleReviewer?.daliMember;
+                const m = pendingRemoveReview?.cycleReviewer?.user;
                 if (!m) return "This reviewer";
                 return m.firstName && m.lastName ? `${m.firstName} ${m.lastName}` : (m.daliEmail ?? "This reviewer");
               })()}
@@ -2681,7 +2677,7 @@ function ReviewModal({ review, rubricCriteria, onClose }: {
   rubricCriteria: any[];
   onClose: () => void;
 }) {
-  const m = review.cycleReviewer?.daliMember;
+  const m = review.cycleReviewer?.user;
   const reviewerName = m?.firstName && m?.lastName
     ? `${m.firstName} ${m.lastName}`
     : m?.daliEmail ?? "Reviewer";

--- a/dali-api/app/hiring/routes/email-templates.$id.tsx
+++ b/dali-api/app/hiring/routes/email-templates.$id.tsx
@@ -33,7 +33,7 @@ export async function action({ request, params }: Route.ActionArgs) {
   if (!auth.ok) return redirect('/login')
   if (!(await isHiringLead(auth.user.sub))) return redirect('/')
 
-  const member = await prisma.dALIMember.findFirst({
+  const member = await prisma.dALIMember.findUnique({
     where: { userId: auth.user.sub },
   })
   if (!member) return redirect('/login')

--- a/dali-api/app/hiring/routes/email-templates.$id.tsx
+++ b/dali-api/app/hiring/routes/email-templates.$id.tsx
@@ -58,7 +58,7 @@ export async function action({ request, params }: Route.ActionArgs) {
         versionNumber,
         subject,
         body,
-        createdById: member.id,
+        createdById: auth.user.sub,
       },
     })
 

--- a/dali-api/app/hiring/routes/email-templates.tsx
+++ b/dali-api/app/hiring/routes/email-templates.tsx
@@ -3,6 +3,7 @@ import type { Route } from './+types/email-templates'
 import { prisma } from '~/lib/db'
 import { requireAuth } from "~/lib/auth";
 import { isHiringLead } from '~/lib/roles'
+import { isApplicationsGmailConnected } from "~/lib/gmail-integration";
 import EmailTemplatesList from '~/hiring/components/EmailTemplates'
 
 export const meta: Route.MetaFunction = () => [{ title: 'Email templates · DALI OS' }]
@@ -12,7 +13,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   if (!auth.ok) return redirect('/login')
   if (!(await isHiringLead(auth.user.sub))) return redirect('/')
 
-  const [templates, gmailUser] = await Promise.all([
+  const [templates, gmailConnected] = await Promise.all([
     prisma.emailTemplate.findMany({
       include: {
         versions: {
@@ -22,12 +23,9 @@ export async function loader({ request }: Route.LoaderArgs) {
       },
       orderBy: { createdAt: 'desc' },
     }),
-    prisma.user.findUnique({
-      where: { daliEmail: 'applications@dali.dartmouth.edu' },
-      select: { googleRefreshToken: true },
-    }),
+    isApplicationsGmailConnected(),
   ])
-  return { templates, gmailConnected: !!gmailUser?.googleRefreshToken }
+  return { templates, gmailConnected }
 }
 
 export async function action({ request }: Route.ActionArgs) {

--- a/dali-api/app/hiring/routes/interviewer.interview.$interviewId.tsx
+++ b/dali-api/app/hiring/routes/interviewer.interview.$interviewId.tsx
@@ -51,10 +51,11 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   const auth = await requireAuth(request)
   if (!auth.ok) throw redirect('/login')
 
-  const member = await prisma.dALIMember.findFirst({
-    where: { userId: auth.user.sub },
+  const member = await prisma.user.findUnique({
+    where: { id: auth.user.sub },
+    select: { id: true, firstName: true, lastName: true, daliMember: { select: { id: true } } },
   })
-  if (!member) throw redirect('/hiring/interviewer')
+  if (!member?.daliMember) throw redirect('/hiring/interviewer')
 
   const interview = await prisma.interview.findUnique({
     where: { id: params.interviewId },
@@ -62,7 +63,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
       assignments: {
         include: {
           cycleInterviewer: {
-            include: { daliMember: true },
+            include: { user: true },
           },
         },
       },
@@ -79,7 +80,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
             where: { submittedAt: { not: null } },
             orderBy: { submittedAt: 'asc' },
             include: {
-              cycleReviewer: { include: { daliMember: true } },
+              cycleReviewer: { include: { user: true } },
             },
           },
         },
@@ -90,7 +91,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   if (!interview) throw redirect('/hiring/interviewer')
 
   const myAssignment = interview.assignments.find(
-    (a: any) => a.cycleInterviewer.daliMemberId === member.id,
+    (a: any) => a.cycleInterviewer.userId === auth.user.sub,
   )
 
   if (!myAssignment) throw redirect('/hiring/interviewer')
@@ -480,7 +481,7 @@ export default function InterviewDetailPage() {
             ) : (
               <div className="space-y-6">
                 {submittedReviews.map((review: any) => {
-                  const m = review.cycleReviewer?.daliMember
+                  const m = review.cycleReviewer?.user
                   const reviewerName =
                     m?.firstName && m?.lastName
                       ? `${m.firstName} ${m.lastName}`

--- a/dali-api/app/hiring/routes/interviewer.tsx
+++ b/dali-api/app/hiring/routes/interviewer.tsx
@@ -39,7 +39,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     confidentialityRequired: null as null | "no_agreement" | "unsigned",
   }
 
-  const member = await prisma.dALIMember.findFirst({
+  const member = await prisma.dALIMember.findUnique({
     where: { userId: auth.user.sub },
   })
   if (!member) return empty
@@ -50,7 +50,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   // Find CycleInterviewer records for this member in the active cycle
   const cycleInterviewers = await prisma.cycleInterviewer.findMany({
     where: {
-      daliMemberId: member.id,
+      userId: member.id,
       applicationCycleId: active.id,
     },
     include: {

--- a/dali-api/app/hiring/routes/interviewer.tsx
+++ b/dali-api/app/hiring/routes/interviewer.tsx
@@ -50,7 +50,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   // Find CycleInterviewer records for this member in the active cycle
   const cycleInterviewers = await prisma.cycleInterviewer.findMany({
     where: {
-      userId: member.id,
+      userId: auth.user.sub,
       applicationCycleId: active.id,
     },
     include: {

--- a/dali-api/app/hiring/routes/lead.cycle.$id.tsx
+++ b/dali-api/app/hiring/routes/lead.cycle.$id.tsx
@@ -43,12 +43,12 @@ interface InterviewConfig {
 
 interface CycleReviewer {
   id: string
-  daliMember: {
+  user: { 
     id: string
     firstName: string | null
     lastName: string | null
     daliEmail: string | null
-  }
+   }
   domain: { id: string; name: string }
 }
 
@@ -68,7 +68,7 @@ interface InterviewRow {
     role: string
     status: string
     cycleInterviewer: {
-      daliMember: { firstName: string | null; lastName: string | null; daliEmail: string | null }
+      user: {  firstName: string | null; lastName: string | null; daliEmail: string | null  }
       domain: { name: string }
     }
   }[]
@@ -1044,7 +1044,7 @@ export default function HiringLeadCycleDetails() {
       method: 'POST',
       credentials: 'include',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ daliMemberId: newMemberId, domainId: newDomainId }),
+      body: JSON.stringify({ userId: newMemberId, domainId: newDomainId }),
     })
     if (res.ok) {
       const reviewer = await res.json()
@@ -1071,7 +1071,7 @@ export default function HiringLeadCycleDetails() {
       method: 'POST',
       credentials: 'include',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ daliMemberId: newInterviewerMemberId, domainId: newInterviewerDomainId }),
+      body: JSON.stringify({ userId: newInterviewerMemberId, domainId: newInterviewerDomainId }),
     })
     if (res.ok) {
       // POST returns the bare cycleInterviewer row without daliMember/domain
@@ -1560,8 +1560,8 @@ export default function HiringLeadCycleDetails() {
               </thead>
               <tbody className="divide-y divide-border">
                 {reviewers.map(r => {
-                  const m = r.daliMember
-                  const name = m?.firstName && m?.lastName ? `${m.firstName} ${m.lastName}` : m?.daliEmail ?? r.daliMember.id
+                  const m = r.user
+                  const name = m?.firstName && m?.lastName ? `${m.firstName} ${m.lastName}` : m?.daliEmail ?? r.user.id
                   return (
                   <tr key={r.id} className="hover:bg-muted/50 transition">
                     <td className="px-4 py-3 font-medium text-foreground">{name}</td>
@@ -1582,8 +1582,8 @@ export default function HiringLeadCycleDetails() {
             </div>
             <ul className="sm:hidden divide-y divide-border">
               {reviewers.map(r => {
-                const m = r.daliMember
-                const name = m?.firstName && m?.lastName ? `${m.firstName} ${m.lastName}` : m?.daliEmail ?? r.daliMember.id
+                const m = r.user
+                const name = m?.firstName && m?.lastName ? `${m.firstName} ${m.lastName}` : m?.daliEmail ?? r.user.id
                 return (
                 <li key={r.id} className="px-4 py-3 flex items-start justify-between gap-3">
                   <div className="min-w-0">
@@ -1665,8 +1665,8 @@ export default function HiringLeadCycleDetails() {
               </thead>
               <tbody className="divide-y divide-border">
                 {interviewers.map((i: any) => {
-                  const m = i.daliMember
-                  const name = m?.firstName && m?.lastName ? `${m.firstName} ${m.lastName}` : m?.daliEmail ?? i.daliMemberId
+                  const m = i.user
+                  const name = m?.firstName && m?.lastName ? `${m.firstName} ${m.lastName}` : m?.daliEmail ?? i.userId
                   return (
                     <tr key={i.id} className="hover:bg-muted/50 transition">
                       <td className="px-4 py-3 font-medium text-foreground">{name}</td>
@@ -1687,8 +1687,8 @@ export default function HiringLeadCycleDetails() {
             </div>
             <ul className="sm:hidden divide-y divide-border">
               {interviewers.map((i: any) => {
-                const m = i.daliMember
-                const name = m?.firstName && m?.lastName ? `${m.firstName} ${m.lastName}` : m?.daliEmail ?? i.daliMemberId
+                const m = i.user
+                const name = m?.firstName && m?.lastName ? `${m.firstName} ${m.lastName}` : m?.daliEmail ?? i.userId
                 return (
                   <li key={i.id} className="px-4 py-3 flex items-start justify-between gap-3">
                     <div className="min-w-0">
@@ -1834,7 +1834,7 @@ export default function HiringLeadCycleDetails() {
                         {interview.assignments
                           .filter((a: any) => a.status === 'Active')
                           .map((a: any) => {
-                            const m = a.cycleInterviewer.daliMember
+                            const m = a.cycleInterviewer.user
                             const name = m.firstName && m.lastName
                               ? `${m.firstName} ${m.lastName}`
                               : m.daliEmail ?? '?'
@@ -1864,7 +1864,7 @@ export default function HiringLeadCycleDetails() {
                                         : i.domain?.name !== domainName)
                                       .filter((i: any) => i.id !== a.cycleInterviewerId)
                                       .map((i: any) => {
-                                        const im = i.daliMember
+                                        const im = i.user
                                         const iName = im?.firstName && im?.lastName ? `${im.firstName} ${im.lastName}` : im?.daliEmail ?? i.id
                                         return <option key={i.id} value={i.id}>{iName}</option>
                                       })}
@@ -1987,7 +1987,7 @@ export default function HiringLeadCycleDetails() {
                         {interview.assignments
                           .filter((a: any) => a.status === 'Active')
                           .map((a: any) => {
-                            const m = a.cycleInterviewer.daliMember
+                            const m = a.cycleInterviewer.user
                             const name = m.firstName && m.lastName
                               ? `${m.firstName} ${m.lastName}`
                               : m.daliEmail ?? '?'
@@ -2017,7 +2017,7 @@ export default function HiringLeadCycleDetails() {
                                         : i.domain?.name !== domainName)
                                       .filter((i: any) => i.id !== a.cycleInterviewerId)
                                       .map((i: any) => {
-                                        const im = i.daliMember
+                                        const im = i.user
                                         const iName = im?.firstName && im?.lastName ? `${im.firstName} ${im.lastName}` : im?.daliEmail ?? i.id
                                         return <option key={i.id} value={i.id}>{iName}</option>
                                       })}

--- a/dali-api/app/hiring/routes/reviewer.application.$id.tsx
+++ b/dali-api/app/hiring/routes/reviewer.application.$id.tsx
@@ -61,7 +61,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   const cycleReviewers = await prisma.cycleReviewer.findMany({
     where: {
       applicationCycleId: applicationBase.applicationCycleId,
-      daliMember: { userId: auth.user.sub },
+      userId: auth.user.sub,
     },
     select: { id: true, domainId: true },
   })
@@ -84,7 +84,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     prisma.applicationReview.findFirst({
       where: {
         domainApplication: { applicationId: params.id },
-        cycleReviewer: { daliMember: { userId: auth.user.sub } },
+        cycleReviewer: { userId: auth.user.sub },
       },
     }),
   ])
@@ -167,7 +167,7 @@ export async function action({ request, params }: Route.ActionArgs) {
     const existing = await prisma.applicationReview.findFirst({
       where: {
         domainApplication: { applicationId: params.id },
-        cycleReviewer: { daliMember: { userId: auth.user.sub } },
+        cycleReviewer: { userId: auth.user.sub },
       },
     })
 

--- a/dali-api/app/hiring/routes/reviewer.tsx
+++ b/dali-api/app/hiring/routes/reviewer.tsx
@@ -62,7 +62,7 @@ export async function loader({ request }: Route.LoaderArgs) {
 
   // Fetch all CycleReviewer records for this member in this cycle (may span multiple domains)
   const myReviewerIds = await prisma.cycleReviewer.findMany({
-    where: { userId: member.id, applicationCycleId: active.id },
+    where: { userId: auth.user.sub, applicationCycleId: active.id },
     select: { id: true, domainId: true },
   })
   if (myReviewerIds.length === 0) return { ...empty, reviewerUserId: auth.user.sub }
@@ -102,13 +102,13 @@ export async function loader({ request }: Route.LoaderArgs) {
   // Infer the sub-stage within UnderReview from actual data
   let currentStage = cycleStatusToStage(activeCycleStatus);
   if (activeCycleStatus === 'UnderReview') {
-    currentStage = await inferUnderReviewStage(active.id, member.id, reviewerIds);
+    currentStage = await inferUnderReviewStage(active.id, auth.user.sub, reviewerIds);
   }
 
   // Check if this member is a cycle interviewer with no availability set yet
   // (so we can prompt them once interview config is set up).
   const cycleInterviewers = await prisma.cycleInterviewer.findMany({
-    where: { userId: member.id, applicationCycleId: active.id },
+    where: { userId: auth.user.sub, applicationCycleId: active.id },
     select: { id: true },
   });
   const isCycleInterviewer = cycleInterviewers.length > 0;

--- a/dali-api/app/hiring/routes/reviewer.tsx
+++ b/dali-api/app/hiring/routes/reviewer.tsx
@@ -50,7 +50,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   const auth = await requireAuth(request)
   if (!auth.ok) return empty
 
-  const member = await prisma.dALIMember.findFirst({ where: { userId: auth.user.sub } })
+  const member = await prisma.dALIMember.findUnique({ where: { userId: auth.user.sub } })
   if (!member) return { ...empty, reviewerUserId: auth.user.sub }
 
   // Anchor on the single active cycle (invariant: at most one cycle is in
@@ -62,7 +62,7 @@ export async function loader({ request }: Route.LoaderArgs) {
 
   // Fetch all CycleReviewer records for this member in this cycle (may span multiple domains)
   const myReviewerIds = await prisma.cycleReviewer.findMany({
-    where: { daliMemberId: member.id, applicationCycleId: active.id },
+    where: { userId: member.id, applicationCycleId: active.id },
     select: { id: true, domainId: true },
   })
   if (myReviewerIds.length === 0) return { ...empty, reviewerUserId: auth.user.sub }
@@ -108,7 +108,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   // Check if this member is a cycle interviewer with no availability set yet
   // (so we can prompt them once interview config is set up).
   const cycleInterviewers = await prisma.cycleInterviewer.findMany({
-    where: { daliMemberId: member.id, applicationCycleId: active.id },
+    where: { userId: member.id, applicationCycleId: active.id },
     select: { id: true },
   });
   const isCycleInterviewer = cycleInterviewers.length > 0;

--- a/dali-api/app/lib/__tests__/collabAuth.test.ts
+++ b/dali-api/app/lib/__tests__/collabAuth.test.ts
@@ -3,7 +3,6 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 vi.mock("~/lib/db", () => ({
   prisma: {
     applicationReview: { findUnique: vi.fn() },
-    dALIMember: { findFirst: vi.fn() },
     interviewAssignment: { findFirst: vi.fn() },
     interview: { findUnique: vi.fn() },
   },
@@ -21,13 +20,12 @@ vi.mock("~/hiring/lib/confidentiality", () => ({
 import { prisma } from "~/lib/db";
 import { isDomainLead, isHiringLead } from "~/lib/roles";
 import { getCycleConfidentialityState } from "~/hiring/lib/confidentiality";
-import { authorizeCollabDoc, hydrateAuthors } from "../collabAuth";
+import { authorizeCollabDoc } from "../collabAuth";
 
 const mockPrisma = prisma as any;
 
 beforeEach(() => {
   vi.resetAllMocks();
-  // Restore defaults
   (isDomainLead as any).mockResolvedValue(false);
   (isHiringLead as any).mockResolvedValue(false);
   (getCycleConfidentialityState as any).mockResolvedValue({ status: "signed", activeVersionId: "v1" });
@@ -49,9 +47,8 @@ describe("authorizeCollabDoc", () => {
     it("allows the reviewer who owns the review", async () => {
       mockPrisma.applicationReview.findUnique.mockResolvedValue({
         id: "r1",
-        cycleReviewer: { daliMemberId: "member1" },
+        cycleReviewer: { userId: "user1" },
       });
-      mockPrisma.dALIMember.findFirst.mockResolvedValue({ id: "member1" });
 
       expect(await authorizeCollabDoc("user1", "review:r1:feedback")).toBe(true);
     });
@@ -59,9 +56,8 @@ describe("authorizeCollabDoc", () => {
     it("rejects non-owner non-lead", async () => {
       mockPrisma.applicationReview.findUnique.mockResolvedValue({
         id: "r1",
-        cycleReviewer: { daliMemberId: "other-member" },
+        cycleReviewer: { userId: "other-user" },
       });
-      mockPrisma.dALIMember.findFirst.mockResolvedValue({ id: "member1" });
 
       expect(await authorizeCollabDoc("user1", "review:r1:feedback")).toBe(false);
     });
@@ -69,9 +65,8 @@ describe("authorizeCollabDoc", () => {
     it("allows domain leads", async () => {
       mockPrisma.applicationReview.findUnique.mockResolvedValue({
         id: "r1",
-        cycleReviewer: { daliMemberId: "other-member" },
+        cycleReviewer: { userId: "other-user" },
       });
-      mockPrisma.dALIMember.findFirst.mockResolvedValue({ id: "member1" });
       (isDomainLead as any).mockResolvedValue(true);
 
       expect(await authorizeCollabDoc("user1", "review:r1:feedback")).toBe(true);
@@ -80,9 +75,8 @@ describe("authorizeCollabDoc", () => {
     it("allows hiring leads", async () => {
       mockPrisma.applicationReview.findUnique.mockResolvedValue({
         id: "r1",
-        cycleReviewer: { daliMemberId: "other-member" },
+        cycleReviewer: { userId: "other-user" },
       });
-      mockPrisma.dALIMember.findFirst.mockResolvedValue({ id: "member1" });
       (isHiringLead as any).mockResolvedValue(true);
 
       expect(await authorizeCollabDoc("user1", "review:r1:feedback")).toBe(true);
@@ -96,31 +90,22 @@ describe("authorizeCollabDoc", () => {
 
   describe("interview docs", () => {
     it("allows assigned interviewer", async () => {
-      mockPrisma.dALIMember.findFirst.mockResolvedValue({ id: "member1" });
       mockPrisma.interviewAssignment.findFirst.mockResolvedValue({ id: "a1" });
 
       expect(await authorizeCollabDoc("user1", "interview:int1:notes")).toBe(true);
     });
 
     it("rejects unassigned non-lead", async () => {
-      mockPrisma.dALIMember.findFirst.mockResolvedValue({ id: "member1" });
       mockPrisma.interviewAssignment.findFirst.mockResolvedValue(null);
 
       expect(await authorizeCollabDoc("user1", "interview:int1:notes")).toBe(false);
     });
 
     it("allows hiring leads even when not assigned", async () => {
-      mockPrisma.dALIMember.findFirst.mockResolvedValue({ id: "member1" });
       mockPrisma.interviewAssignment.findFirst.mockResolvedValue(null);
       (isHiringLead as any).mockResolvedValue(true);
 
       expect(await authorizeCollabDoc("user1", "interview:int1:notes")).toBe(true);
     });
-  });
-});
-
-describe("hydrateAuthors", () => {
-  it("returns empty array for empty input", async () => {
-    expect(await hydrateAuthors([])).toEqual([]);
   });
 });

--- a/dali-api/app/lib/__tests__/google-calendar.test.ts
+++ b/dali-api/app/lib/__tests__/google-calendar.test.ts
@@ -117,31 +117,18 @@ describe("fetchBusyEvents", () => {
     expect(out[0]).toEqual({ start: "2026-05-12T13:00:00Z", end: "2026-05-12T14:00:00Z" });
   });
 
-  it("falls back to legacy User.google* tokens when no link exists", async () => {
+  it("returns [] when no UserCalendarLink exists (Phase 2: no legacy User.google* fallback)", async () => {
     prismaMock.userCalendarLink.findMany.mockResolvedValueOnce([]);
-    prismaMock.user.findUnique.mockResolvedValueOnce({
-      googleAccessToken: "legacy-tok",
-      googleRefreshToken: "legacy-rt",
-      googleTokenExpiresAt: new Date(Date.now() + 10 * 60_000),
-    });
-    mockFetchOnce({
-      calendars: { primary: { busy: [{ start: "2026-05-12T19:00:00Z", end: "2026-05-12T20:00:00Z" }] } },
-    });
     const out = await fetchBusyEvents(
       "userX",
       new Date("2026-05-12T00:00:00Z"),
       new Date("2026-05-13T00:00:00Z"),
     );
-    expect(out).toEqual([{ start: "2026-05-12T19:00:00Z", end: "2026-05-12T20:00:00Z" }]);
+    expect(out).toEqual([]);
   });
 
-  it("returns [] when user has no link and no legacy tokens", async () => {
+  it("returns [] when user has no link", async () => {
     prismaMock.userCalendarLink.findMany.mockResolvedValueOnce([]);
-    prismaMock.user.findUnique.mockResolvedValueOnce({
-      googleAccessToken: null,
-      googleRefreshToken: null,
-      googleTokenExpiresAt: null,
-    });
     const out = await fetchBusyEvents(
       "userX",
       new Date("2026-05-12T00:00:00Z"),

--- a/dali-api/app/lib/__tests__/roles.test.ts
+++ b/dali-api/app/lib/__tests__/roles.test.ts
@@ -5,8 +5,15 @@ vi.mock("~/lib/db");
 import { prisma } from "~/lib/db";
 import { hasCycleAccess } from "~/lib/roles";
 
+// Phase 2: roles helpers now query AdminMembership / CoreAssignment /
+// DomainLeadAssignment / cycleReviewer / cycleInterviewer (all keyed on
+// userId). DALIMember is only used as a presence marker via findUnique.
+
 const mockPrisma = prisma as unknown as {
-  dALIMember: { findFirst: ReturnType<typeof vi.fn> };
+  dALIMember: { findUnique: ReturnType<typeof vi.fn> };
+  adminMembership: { findUnique: ReturnType<typeof vi.fn> };
+  coreAssignment: { findFirst: ReturnType<typeof vi.fn> };
+  domainLeadAssignment: { findFirst: ReturnType<typeof vi.fn> };
   cycleReviewer: { findFirst: ReturnType<typeof vi.fn> };
   cycleInterviewer: { findFirst: ReturnType<typeof vi.fn> };
 };
@@ -15,58 +22,52 @@ beforeEach(() => {
   vi.clearAllMocks();
   delete process.env.ADMIN_USER_IDS;
 
-  (mockPrisma as any).dALIMember = { findFirst: vi.fn() };
+  (mockPrisma as any).dALIMember = { findUnique: vi.fn() };
+  (mockPrisma as any).adminMembership = { findUnique: vi.fn() };
+  (mockPrisma as any).coreAssignment = { findFirst: vi.fn() };
+  (mockPrisma as any).domainLeadAssignment = { findFirst: vi.fn() };
   (mockPrisma as any).cycleReviewer = { findFirst: vi.fn() };
   (mockPrisma as any).cycleInterviewer = { findFirst: vi.fn() };
 });
 
 const CYCLE_ID = "cycle-1";
 
+// Helper — set up the typical "is a lab member" baseline.
+function setRoleFlags(opts: { member?: boolean; admin?: boolean; core?: boolean; domainLead?: boolean } = {}) {
+  mockPrisma.dALIMember.findUnique.mockResolvedValue(opts.member !== false ? { id: "m1" } : null);
+  mockPrisma.adminMembership.findUnique.mockResolvedValue(opts.admin ? { id: "a1" } : null);
+  mockPrisma.coreAssignment.findFirst.mockResolvedValue(opts.core ? { id: "c1" } : null);
+  mockPrisma.domainLeadAssignment.findFirst.mockResolvedValue(opts.domainLead ? { id: "d1" } : null);
+}
+
 describe("hasCycleAccess", () => {
   it("returns true for a hiring lead (via ADMIN_USER_IDS)", async () => {
     process.env.ADMIN_USER_IDS = "admin-user";
-    mockPrisma.dALIMember.findFirst.mockResolvedValue({
-      id: "m1",
-      roles: [],
-      domainLeadAssignments: [],
-    });
+    setRoleFlags({ member: true });
 
     const result = await hasCycleAccess("admin-user", CYCLE_ID);
 
     expect(result).toBe(true);
-    // Should NOT query reviewer/interviewer tables
     expect(mockPrisma.cycleReviewer.findFirst).not.toHaveBeenCalled();
     expect(mockPrisma.cycleInterviewer.findFirst).not.toHaveBeenCalled();
   });
 
-  it("returns true for a hiring lead (via HiringLead role)", async () => {
-    mockPrisma.dALIMember.findFirst.mockResolvedValue({
-      id: "m2",
-      roles: ["HiringLead"],
-      domainLeadAssignments: [],
-    });
+  it("returns true for a hiring lead (via Core assignment)", async () => {
+    setRoleFlags({ member: true, core: true });
 
     expect(await hasCycleAccess("user-hl", CYCLE_ID)).toBe(true);
     expect(mockPrisma.cycleReviewer.findFirst).not.toHaveBeenCalled();
   });
 
   it("returns true for a domain lead", async () => {
-    mockPrisma.dALIMember.findFirst.mockResolvedValue({
-      id: "m3",
-      roles: [],
-      domainLeadAssignments: [{ id: "dla-1" }],
-    });
+    setRoleFlags({ member: true, domainLead: true });
 
     expect(await hasCycleAccess("user-dl", CYCLE_ID)).toBe(true);
     expect(mockPrisma.cycleReviewer.findFirst).not.toHaveBeenCalled();
   });
 
   it("returns true for a cycle reviewer", async () => {
-    mockPrisma.dALIMember.findFirst.mockResolvedValue({
-      id: "m4",
-      roles: [],
-      domainLeadAssignments: [],
-    });
+    setRoleFlags({ member: true });
     mockPrisma.cycleReviewer.findFirst.mockResolvedValue({ id: "cr-1" });
     mockPrisma.cycleInterviewer.findFirst.mockResolvedValue(null);
 
@@ -74,11 +75,7 @@ describe("hasCycleAccess", () => {
   });
 
   it("returns true for a cycle interviewer", async () => {
-    mockPrisma.dALIMember.findFirst.mockResolvedValue({
-      id: "m5",
-      roles: [],
-      domainLeadAssignments: [],
-    });
+    setRoleFlags({ member: true });
     mockPrisma.cycleReviewer.findFirst.mockResolvedValue(null);
     mockPrisma.cycleInterviewer.findFirst.mockResolvedValue({ id: "ci-1" });
 
@@ -86,11 +83,7 @@ describe("hasCycleAccess", () => {
   });
 
   it("returns false for a member who is neither lead nor participant", async () => {
-    mockPrisma.dALIMember.findFirst.mockResolvedValue({
-      id: "m6",
-      roles: [],
-      domainLeadAssignments: [],
-    });
+    setRoleFlags({ member: true });
     mockPrisma.cycleReviewer.findFirst.mockResolvedValue(null);
     mockPrisma.cycleInterviewer.findFirst.mockResolvedValue(null);
 
@@ -98,7 +91,7 @@ describe("hasCycleAccess", () => {
   });
 
   it("returns false for a non-member (no DALIMember record)", async () => {
-    mockPrisma.dALIMember.findFirst.mockResolvedValue(null);
+    setRoleFlags({ member: false });
 
     const result = await hasCycleAccess("applicant-user", CYCLE_ID);
 
@@ -107,12 +100,7 @@ describe("hasCycleAccess", () => {
   });
 
   it("returns false for a reviewer on a different cycle", async () => {
-    mockPrisma.dALIMember.findFirst.mockResolvedValue({
-      id: "m7",
-      roles: [],
-      domainLeadAssignments: [],
-    });
-    // findFirst returns null because the where clause won't match
+    setRoleFlags({ member: true });
     mockPrisma.cycleReviewer.findFirst.mockResolvedValue(null);
     mockPrisma.cycleInterviewer.findFirst.mockResolvedValue(null);
 

--- a/dali-api/app/lib/__tests__/user-provisioning.test.ts
+++ b/dali-api/app/lib/__tests__/user-provisioning.test.ts
@@ -12,6 +12,9 @@ import {
   upsertUserFromCas,
 } from "~/lib/user-provisioning";
 
+// Phase 2: upsertUserFromGoogle is member-only (@dali.dartmouth.edu).
+// Non-DALI branches throw — partners auth via magic-link instead.
+
 const mockPrisma = prisma as unknown as {
   user: {
     upsert: ReturnType<typeof vi.fn>;
@@ -20,9 +23,7 @@ const mockPrisma = prisma as unknown as {
     update: ReturnType<typeof vi.fn>;
   };
   dALIMember: {
-    findFirst: ReturnType<typeof vi.fn>;
-    create: ReturnType<typeof vi.fn>;
-    update: ReturnType<typeof vi.fn>;
+    upsert: ReturnType<typeof vi.fn>;
   };
 };
 
@@ -37,17 +38,14 @@ beforeEach(() => {
     update: vi.fn(),
   } as any;
   mockPrisma.dALIMember = {
-    findFirst: vi.fn(),
-    create: vi.fn().mockResolvedValue({}),
-    update: vi.fn().mockResolvedValue({}),
+    upsert: vi.fn().mockResolvedValue({}),
   } as any;
 });
 
 describe("upsertUserFromGoogle", () => {
-  it("@dali.dartmouth.edu → upserts by daliEmail and returns member authType", async () => {
+  it("@dali.dartmouth.edu → upserts user by daliEmail and the DALIMember marker", async () => {
     const userRow = { id: "u-1", netId: null };
     mockPrisma.user.upsert.mockResolvedValue(userRow);
-    mockPrisma.dALIMember.findFirst.mockResolvedValue({ id: "m-1", userId: "u-1" });
 
     const result = await upsertUserFromGoogle({
       email: "k@dali.dartmouth.edu",
@@ -60,112 +58,37 @@ describe("upsertUserFromGoogle", () => {
     expect(mockPrisma.user.upsert).toHaveBeenCalledWith(
       expect.objectContaining({ where: { daliEmail: "k@dali.dartmouth.edu" } }),
     );
-  });
-
-  it("@dali.dartmouth.edu with no existing DALIMember row → creates one", async () => {
-    mockPrisma.user.upsert.mockResolvedValue({ id: "u-1", netId: null });
-    mockPrisma.dALIMember.findFirst.mockResolvedValue(null);
-
-    await upsertUserFromGoogle({
-      email: "new@dali.dartmouth.edu",
-      firstName: "New",
-      lastName: "Member",
-    });
-
-    expect(mockPrisma.dALIMember.create).toHaveBeenCalledWith({
-      data: { userId: "u-1", daliEmail: "new@dali.dartmouth.edu" },
+    expect(mockPrisma.dALIMember.upsert).toHaveBeenCalledWith({
+      where: { userId: "u-1" },
+      update: {},
+      create: { userId: "u-1" },
     });
   });
 
-  it("@dali.dartmouth.edu with orphan DALIMember (no userId) → links userId", async () => {
-    mockPrisma.user.upsert.mockResolvedValue({ id: "u-2", netId: null });
-    mockPrisma.dALIMember.findFirst.mockResolvedValue({ id: "m-2", userId: null });
-
-    await upsertUserFromGoogle({
-      email: "orphan@dali.dartmouth.edu",
-      firstName: "O",
-      lastName: "P",
-    });
-
-    expect(mockPrisma.dALIMember.update).toHaveBeenCalledWith({
-      where: { id: "m-2" },
-      data: { userId: "u-2" },
-    });
-    expect(mockPrisma.dALIMember.create).not.toHaveBeenCalled();
+  it("@dartmouth.edu (non-DALI) → throws (Phase 2 dropped the dartmouth branch)", async () => {
+    await expect(
+      upsertUserFromGoogle({
+        email: "stu@dartmouth.edu",
+        firstName: "Stu",
+        lastName: "Dent",
+      }),
+    ).rejects.toThrow(/@dali\.dartmouth\.edu/);
+    expect(mockPrisma.user.upsert).not.toHaveBeenCalled();
   });
 
-  it("@dali.dartmouth.edu with already-linked DALIMember → no-op on member side", async () => {
-    mockPrisma.user.upsert.mockResolvedValue({ id: "u-3", netId: null });
-    mockPrisma.dALIMember.findFirst.mockResolvedValue({ id: "m-3", userId: "u-3" });
-
-    await upsertUserFromGoogle({
-      email: "linked@dali.dartmouth.edu",
-      firstName: "L",
-      lastName: "K",
-    });
-
-    expect(mockPrisma.dALIMember.update).not.toHaveBeenCalled();
-    expect(mockPrisma.dALIMember.create).not.toHaveBeenCalled();
-  });
-
-  it("@dartmouth.edu non-DALI → upserts by dartmouthEmail and returns dartmouth authType", async () => {
-    const userRow = { id: "u-d", netId: null };
-    mockPrisma.user.upsert.mockResolvedValue(userRow);
-
-    const result = await upsertUserFromGoogle({
-      email: "stu@dartmouth.edu",
-      firstName: "Stu",
-      lastName: "Dent",
-    });
-
-    expect(result.authType).toBe("dartmouth");
-    expect(mockPrisma.user.upsert).toHaveBeenCalledWith(
-      expect.objectContaining({ where: { dartmouthEmail: "stu@dartmouth.edu" } }),
-    );
-    expect(mockPrisma.dALIMember.findFirst).not.toHaveBeenCalled();
-  });
-
-  it("partner email (existing) → findFirst + update, returns partner authType", async () => {
-    mockPrisma.user.findFirst.mockResolvedValue({ id: "u-p", netId: null });
-    mockPrisma.user.update.mockResolvedValue({ id: "u-p", netId: null });
-
-    const result = await upsertUserFromGoogle({
-      email: "partner@example.com",
-      firstName: "Pa",
-      lastName: "Rt",
-    });
-
-    expect(result.authType).toBe("partner");
-    expect(mockPrisma.user.findFirst).toHaveBeenCalledWith({
-      where: { dartmouthEmail: "partner@example.com" },
-    });
-    expect(mockPrisma.user.update).toHaveBeenCalled();
-    expect(mockPrisma.user.create).not.toHaveBeenCalled();
-  });
-
-  it("partner email (new) → findFirst + create, returns partner authType", async () => {
-    mockPrisma.user.findFirst.mockResolvedValue(null);
-    mockPrisma.user.create.mockResolvedValue({ id: "u-newp", netId: null });
-
-    const result = await upsertUserFromGoogle({
-      email: "newpartner@example.com",
-      firstName: "Ne",
-      lastName: "Wp",
-    });
-
-    expect(result.authType).toBe("partner");
-    expect(mockPrisma.user.create).toHaveBeenCalledWith({
-      data: {
-        dartmouthEmail: "newpartner@example.com",
-        firstName: "Ne",
-        lastName: "Wp",
-      },
-    });
+  it("external partner email → throws (Phase 2 dropped the partner branch)", async () => {
+    await expect(
+      upsertUserFromGoogle({
+        email: "partner@example.com",
+        firstName: "Pa",
+        lastName: "Rt",
+      }),
+    ).rejects.toThrow(/@dali\.dartmouth\.edu/);
+    expect(mockPrisma.user.upsert).not.toHaveBeenCalled();
   });
 
   it("never writes googleAccessToken / googleRefreshToken / googleTokenExpiresAt", async () => {
     mockPrisma.user.upsert.mockResolvedValue({ id: "u-1", netId: null });
-    mockPrisma.dALIMember.findFirst.mockResolvedValue({ id: "m-1", userId: "u-1" });
 
     await upsertUserFromGoogle({
       email: "k@dali.dartmouth.edu",

--- a/dali-api/app/lib/collabAuth.ts
+++ b/dali-api/app/lib/collabAuth.ts
@@ -47,10 +47,7 @@ export async function authorizeCollabDoc(
     const cycleId = review.cycleReviewer.applicationCycleId;
     const confState = await getCycleConfidentialityState(userSub, cycleId);
     if (confState.status !== "signed") return false;
-    const member = await prisma.dALIMember.findFirst({
-      where: { userId: userSub },
-    });
-    if (member && review.cycleReviewer.daliMemberId === member.id) return true;
+    if (review.cycleReviewer.userId === userSub) return true;
     if (await isDomainLead(userSub)) return true;
     if (await isHiringLead(userSub)) return true;
     return false;
@@ -67,19 +64,14 @@ export async function authorizeCollabDoc(
       interview.applicationCycleId,
     );
     if (confState.status !== "signed") return false;
-    const member = await prisma.dALIMember.findFirst({
-      where: { userId: userSub },
+    const assignment = await prisma.interviewAssignment.findFirst({
+      where: {
+        interviewId: id,
+        cycleInterviewer: { userId: userSub },
+      },
+      select: { id: true },
     });
-    if (member) {
-      const assignment = await prisma.interviewAssignment.findFirst({
-        where: {
-          interviewId: id,
-          cycleInterviewer: { daliMemberId: member.id },
-        },
-        select: { id: true },
-      });
-      if (assignment) return true;
-    }
+    if (assignment) return true;
     if (await isHiringLead(userSub)) return true;
     return false;
   }

--- a/dali-api/app/lib/gmail-integration.ts
+++ b/dali-api/app/lib/gmail-integration.ts
@@ -1,0 +1,37 @@
+import { prisma } from "~/lib/db";
+
+// Phase 2: Gmail send-as credentials moved from User.google* to the
+// GmailIntegration model. This helper is the single read path for callers
+// that previously looked up `User.googleRefreshToken` by daliEmail.
+
+const GMAIL_USER = "applications@dali.dartmouth.edu";
+
+/**
+ * Returns the refresh token for the Gmail send-as integration tied to the
+ * configured GMAIL_USER (`applications@dali.dartmouth.edu`), or null when
+ * the integration isn't linked or has been disabled.
+ *
+ * Phase 2 note: the migration backfills GmailIntegration rows from any
+ * legacy User.google* values during deploy. The encrypted-at-rest token
+ * format will eventually replace plaintext; for now the column stores the
+ * raw refresh_token as historically used by `lib/gmail.ts:sendEmail`.
+ */
+export async function getApplicationsGmailRefreshToken(): Promise<string | null> {
+  const integration = await prisma.gmailIntegration.findFirst({
+    where: { sendAsEmail: GMAIL_USER, enabled: true },
+    select: { oauthTokens: true },
+  });
+  return integration?.oauthTokens ?? null;
+}
+
+/**
+ * Returns whether the Applications Gmail integration is connected and
+ * enabled. Used by the email-templates UI's "Gmail connected" indicator.
+ */
+export async function isApplicationsGmailConnected(): Promise<boolean> {
+  const row = await prisma.gmailIntegration.findFirst({
+    where: { sendAsEmail: GMAIL_USER, enabled: true },
+    select: { id: true },
+  });
+  return row !== null;
+}

--- a/dali-api/app/lib/google-calendar.ts
+++ b/dali-api/app/lib/google-calendar.ts
@@ -161,9 +161,10 @@ async function fetchBusyForLink(
 
 /**
  * Fetch busy events for a user across all enabled Google calendar links.
- * Falls back to legacy User.google* tokens if no link exists yet (preserves
- * the existing /api/google-calendar/busy contract used by the hiring reviewer
- * flow).
+ * Phase 2: the legacy fallback (`fetchBusyFromLegacyUserTokens`) was removed
+ * alongside the drop of `User.google*` columns. Users without a
+ * UserCalendarLink return an empty array — the calling UI should prompt
+ * them to link a calendar in Settings.
  */
 export async function fetchBusyEvents(
   userId: string,
@@ -174,93 +175,26 @@ export async function fetchBusyEvents(
     where: { userId, provider: "Google", enabled: true },
     select: { id: true, subCalendarIds: true },
   });
-  if (links.length > 0) {
-    const results = await Promise.all(
-      links.map(async (l) => {
-        try {
-          const events = await fetchBusyForLink(l.id, l.subCalendarIds, start, end);
-          await prisma.userCalendarLink.update({
-            where: { id: l.id },
-            data: { lastSyncedAt: new Date(), syncError: null },
-          });
-          return events;
-        } catch (err) {
-          const message = err instanceof Error ? err.message : "Unknown error";
-          await prisma.userCalendarLink
-            .update({ where: { id: l.id }, data: { syncError: message } })
-            .catch(() => {});
-          return [];
-        }
-      }),
-    );
-    return results.flat();
-  }
-
-  // Legacy fallback — uses tokens from User.google* (login-OAuth scope).
-  return fetchBusyFromLegacyUserTokens(userId, start, end);
-}
-
-async function fetchBusyFromLegacyUserTokens(
-  userId: string,
-  start: Date,
-  end: Date,
-): Promise<BusyEvent[]> {
-  const user = await prisma.user.findUnique({
-    where: { id: userId },
-    select: {
-      googleAccessToken: true,
-      googleRefreshToken: true,
-      googleTokenExpiresAt: true,
-    },
-  });
-  if (!user?.googleAccessToken) return [];
-
-  let token = user.googleAccessToken;
-  if (
-    user.googleTokenExpiresAt &&
-    user.googleTokenExpiresAt.getTime() <= Date.now() + REFRESH_BUFFER_MS &&
-    user.googleRefreshToken
-  ) {
-    const res = await fetch("https://oauth2.googleapis.com/token", {
-      method: "POST",
-      headers: { "Content-Type": "application/x-www-form-urlencoded" },
-      body: new URLSearchParams({
-        client_id: process.env.GOOGLE_CLIENT_ID!,
-        client_secret: process.env.GOOGLE_CLIENT_SECRET!,
-        refresh_token: user.googleRefreshToken,
-        grant_type: "refresh_token",
-      }),
-    });
-    if (res.ok) {
-      const data = (await res.json()) as { access_token: string; expires_in: number };
-      token = data.access_token;
-      await prisma.user.update({
-        where: { id: userId },
-        data: {
-          googleAccessToken: data.access_token,
-          googleTokenExpiresAt: new Date(Date.now() + data.expires_in * 1000),
-        },
-      });
-    }
-  }
-
-  const res = await fetch("https://www.googleapis.com/calendar/v3/freeBusy", {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${token}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      timeMin: start.toISOString(),
-      timeMax: end.toISOString(),
-      items: [{ id: "primary" }],
+  if (links.length === 0) return [];
+  const results = await Promise.all(
+    links.map(async (l) => {
+      try {
+        const events = await fetchBusyForLink(l.id, l.subCalendarIds, start, end);
+        await prisma.userCalendarLink.update({
+          where: { id: l.id },
+          data: { lastSyncedAt: new Date(), syncError: null },
+        });
+        return events;
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Unknown error";
+        await prisma.userCalendarLink
+          .update({ where: { id: l.id }, data: { syncError: message } })
+          .catch(() => {});
+        return [];
+      }
     }),
-  });
-  if (!res.ok) return [];
-  const data = (await res.json()) as {
-    calendars?: { primary?: { busy?: { start: string; end: string }[] } };
-  };
-  return (data.calendars?.primary?.busy ?? []).map((b) => ({ start: b.start, end: b.end }));
+  );
+  return results.flat();
 }
 
 // ─── events.insert / events.patch ──────────────────────────────────────────

--- a/dali-api/app/lib/roles.ts
+++ b/dali-api/app/lib/roles.ts
@@ -1,91 +1,149 @@
 import { prisma } from "~/lib/db";
-import type { MemberRole } from "~/generated/prisma/enums";
 
-// ─── Core lookup ─────────────────────────────────────────────────────────────
+// Phase 2 rewrite: role flags derived from the new typed assignment tables
+// (AdminMembership, CoreAssignment, DomainLeadAssignment) rather than the
+// dropped DALIMember.roles[] enum. See V0_PLAN.md §"Identity model".
+//
+// API shape preserves field names where the value semantics still apply
+// (`isHiringLead`, `isAdmin`, `isDomainLead`) and renames `memberId` →
+// `isLabMember` (boolean) since the new schema keys hiring FKs on userId
+// directly — callers use `auth.user.sub` instead of indirecting through a
+// DALIMember.id.
 
-/** Fetch the DALIMember record (with roles + domain lead assignments) for a user. */
-async function getMember(userId: string) {
-  return prisma.dALIMember.findFirst({
-    where: { userId },
-    select: {
-      id: true,
-      roles: true,
-      domainLeadAssignments: { select: { id: true }, take: 1 },
-    },
-  });
-}
-
-// ─── Bulk check (one query) ───────────────────────────────────────────────────
+// ─── Bulk check (parallel queries) ───────────────────────────────────────────
 
 export interface UserRoles {
-  memberId: string | null;
+  isLabMember: boolean;
   isHiringLead: boolean;
   isAdmin: boolean;
   isDomainLead: boolean;
 }
 
 /**
- * Resolve all role flags for a user in a single DB query.
- * Use this in layout loaders instead of calling individual checks in parallel.
+ * Resolve all role flags for a user with one round of parallel queries.
+ * Use this in layout loaders instead of calling individual checks separately.
  */
 export async function getUserRoles(userId: string): Promise<UserRoles> {
-  const envIds = (process.env.ADMIN_USER_IDS ?? "").split(",").filter(Boolean);
-  const member = await getMember(userId);
+  const envIds = (process.env.ADMIN_USER_IDS ?? "")
+    .split(",")
+    .filter(Boolean);
+
+  const [member, admin, core, domainLead] = await Promise.all([
+    prisma.dALIMember.findUnique({ where: { userId }, select: { id: true } }),
+    prisma.adminMembership.findUnique({ where: { userId }, select: { id: true } }),
+    // Any CoreAssignment is sufficient for "hiring lead-equivalent" access.
+    // Per V0_PLAN.md: Core members have broad access; we don't gate on
+    // leadTitle. Term scoping is not required here — Core seats are
+    // year-long and the few minutes around term rollover don't warrant a
+    // current-term filter at this layer.
+    prisma.coreAssignment.findFirst({ where: { userId }, select: { id: true } }),
+    // DomainLeadAssignment.termId is required post-Phase-2; any row signals
+    // domain-lead authority for that user.
+    prisma.domainLeadAssignment.findFirst({ where: { userId }, select: { id: true } }),
+  ]);
+
+  const isAdminVal = admin !== null || envIds.includes(userId);
+  const isCoreVal = core !== null;
 
   return {
-    memberId: member?.id ?? null,
-    isHiringLead: envIds.includes(userId) || (member?.roles.includes("HiringLead") ?? false),
-    isAdmin: member?.roles.includes("Admin") ?? false,
-    isDomainLead: (member?.domainLeadAssignments.length ?? 0) > 0,
+    isLabMember: member !== null,
+    // HiringLead semantics: Core members have hiring-lead-equivalent access
+    // (V0_PLAN.md). Admins are a superset of Core. The legacy
+    // DALIMember.roles[].HiringLead enum is gone.
+    isHiringLead: isAdminVal || isCoreVal,
+    isAdmin: isAdminVal,
+    isDomainLead: domainLead !== null,
   };
 }
 
-// ─── Individual checks (for route-level guards) ───────────────────────────────
+// ─── Individual checks (for route-level guards) ──────────────────────────────
 
-/** HiringLead: manages cycles, forms, challenges, rubrics. */
+/** HiringLead-equivalent: Core or Admin. */
 export async function isHiringLead(userId: string): Promise<boolean> {
-  const envIds = (process.env.ADMIN_USER_IDS ?? "").split(",").filter(Boolean);
+  const envIds = (process.env.ADMIN_USER_IDS ?? "")
+    .split(",")
+    .filter(Boolean);
   if (envIds.includes(userId)) return true;
-  const member = await getMember(userId);
-  return member?.roles.includes("HiringLead") ?? false;
+  const [admin, core] = await Promise.all([
+    prisma.adminMembership.findUnique({ where: { userId }, select: { id: true } }),
+    prisma.coreAssignment.findFirst({ where: { userId }, select: { id: true } }),
+  ]);
+  return admin !== null || core !== null;
 }
 
-/** Admin: view member list, assign hiring leads and domain leads. */
+/** Admin: full-time staff. */
 export async function isAdmin(userId: string): Promise<boolean> {
-  const member = await getMember(userId);
-  return member?.roles.includes("Admin") ?? false;
+  const envIds = (process.env.ADMIN_USER_IDS ?? "")
+    .split(",")
+    .filter(Boolean);
+  if (envIds.includes(userId)) return true;
+  const row = await prisma.adminMembership.findUnique({
+    where: { userId },
+    select: { id: true },
+  });
+  return row !== null;
 }
 
 /** DomainLead: has at least one DomainLeadAssignment. */
 export async function isDomainLead(userId: string): Promise<boolean> {
-  const member = await getMember(userId);
-  return (member?.domainLeadAssignments.length ?? 0) > 0;
+  const row = await prisma.domainLeadAssignment.findFirst({
+    where: { userId },
+    select: { id: true },
+  });
+  return row !== null;
 }
 
+/**
+ * Lab-membership gate. Returns the DALIMember row (thin marker — just
+ * `{ id, userId, createdAt, updatedAt }`) if the user is a member, null
+ * otherwise. The row is now a presence-only marker; callers should not
+ * read display fields from it.
+ */
 export async function requireMember(userId: string) {
-  return prisma.dALIMember.findFirst({ where: { userId } });
+  return prisma.dALIMember.findUnique({ where: { userId } });
 }
 
-// ─── Cycle-scoped access ────────────────────────────────────────────────────
+// ─── Term helper ─────────────────────────────────────────────────────────────
+
+/**
+ * Resolves the current Term. If now() falls between terms (e.g. the week
+ * between Spring's endDate and Summer's startDate), returns the next
+ * upcoming Term so role-checks don't briefly drop members to "Alumni".
+ * Returns null only if the Term table is empty (i.e. v0-reference seed
+ * hasn't run).
+ */
+export async function currentTerm() {
+  const now = new Date();
+  const active = await prisma.term.findFirst({
+    where: { startDate: { lte: now }, endDate: { gte: now } },
+    orderBy: { sortKey: "desc" },
+  });
+  if (active) return active;
+  return prisma.term.findFirst({
+    where: { startDate: { gt: now } },
+    orderBy: { sortKey: "asc" },
+  });
+}
+
+// ─── Cycle-scoped access ─────────────────────────────────────────────────────
 
 /**
  * Check whether a user may read cycle-scoped hiring data.
- * Hiring leads and domain leads pass immediately (1 DB query).
- * Other DALI members pass only if they are a CycleReviewer or
- * CycleInterviewer for the given cycle.
+ * Hiring leads and domain leads pass immediately. Other lab members pass
+ * only if they are a CycleReviewer or CycleInterviewer for the given cycle.
  */
 export async function hasCycleAccess(userId: string, cycleId: string): Promise<boolean> {
   const roles = await getUserRoles(userId);
   if (roles.isHiringLead || roles.isDomainLead) return true;
-  if (!roles.memberId) return false;
+  if (!roles.isLabMember) return false;
 
   const [reviewer, interviewer] = await Promise.all([
     prisma.cycleReviewer.findFirst({
-      where: { daliMemberId: roles.memberId, applicationCycleId: cycleId },
+      where: { userId, applicationCycleId: cycleId },
       select: { id: true },
     }),
     prisma.cycleInterviewer.findFirst({
-      where: { daliMemberId: roles.memberId, applicationCycleId: cycleId },
+      where: { userId, applicationCycleId: cycleId },
       select: { id: true },
     }),
   ]);

--- a/dali-api/app/lib/user-provisioning.ts
+++ b/dali-api/app/lib/user-provisioning.ts
@@ -1,33 +1,15 @@
 import { prisma } from "~/lib/db";
 import { linkCasToGoogleUser } from "~/lib/linking";
 
-// Shared user-provisioning helpers used by all four auth callbacks
-// (/auth/callback/{google,cas} and /oauth/callback/{google,cas}).
+// Shared user-provisioning helpers used by /auth/callback/{google,cas} and
+// /oauth/callback/{google,cas}.
 //
-// Prior to this module, each callback inlined its own upsert logic and the
-// two Google paths had drifted in three ways:
-//   - first-party auto-created a DALIMember row for @dali.dartmouth.edu
-//     accounts; OAuth-provider did not
-//   - OAuth-provider persisted googleAccessToken / googleRefreshToken /
-//     googleTokenExpiresAt on the User row; first-party did not
-//   - first-party handled all three branches (member / dartmouth / partner);
-//     OAuth-provider only handled the member branch and rejected the rest
-//
-// Unified behavior here:
-//   - both Google callbacks auto-create the DALIMember row on the
-//     @dali.dartmouth.edu branch. The MCP `requireMembership` constraint
-//     (see dali-os-mcp.md) is satisfied by row existence.
-//   - neither callback persists googleAccessToken / RT / expiresAt on User.
-//     That belonged to the calendar-link / gmail flows and has been moved
-//     out of the standard login path. Calendar tokens land in
-//     UserCalendarLink via /oauth/calendar/google/start, gmail tokens via
-//     /admin/authorize-gmail. The OAuth provider Google authorize URL no
-//     longer requests calendar.readonly scope either (see
-//     lib/oauth.ts → calendar scope stripped).
-//   - both callbacks handle all three account-type branches. Whether a
-//     given branch is acceptable for the calling route is a separate
-//     concern (e.g. an MCP client's OAuthClient row has
-//     `requiredAccountType: "member"` and the caller rejects upstream).
+// Phase 2: collapsed to `member` only for Google. The dartmouth (@dartmouth
+// .edu Google) and partner (external Google) branches were dead — the
+// website login page only offers Google for members and CAS for Dartmouth
+// students, and the OAuth-provider path is MCP-only (members-only per
+// V0_PLAN.md Q18). Partners auth through magic-link via OneTimeToken (Phase
+// 1 model; Partner portal track wires up the UI).
 
 export type GoogleClaims = {
   email: string;
@@ -41,7 +23,9 @@ export type CasClaims = {
   lastName: string;
 };
 
-export type GoogleAuthType = "member" | "dartmouth" | "partner";
+// Member is the only Google auth type post-Phase-2. Kept as a type alias
+// for clarity and forward compatibility (future expansion may add more).
+export type GoogleAuthType = "member";
 
 export type ProvisionedGoogleUser = {
   user: { id: string; netId: string | null };
@@ -51,74 +35,35 @@ export type ProvisionedGoogleUser = {
 export async function upsertUserFromGoogle(
   google: GoogleClaims,
 ): Promise<ProvisionedGoogleUser> {
-  if (google.email.endsWith("@dali.dartmouth.edu")) {
-    const user = await prisma.user.upsert({
-      where: { daliEmail: google.email },
-      update: { firstName: google.firstName, lastName: google.lastName },
-      create: {
-        daliEmail: google.email,
-        firstName: google.firstName,
-        lastName: google.lastName,
-      },
-    });
-
-    // Ensure a DALIMember row exists. Unifies the prior asymmetry where
-    // first-party login auto-created and the OAuth provider didn't.
-    const existingMember = await prisma.dALIMember.findFirst({
-      where: { OR: [{ userId: user.id }, { daliEmail: google.email }] },
-    });
-    if (existingMember) {
-      if (!existingMember.userId) {
-        await prisma.dALIMember.update({
-          where: { id: existingMember.id },
-          data: { userId: user.id },
-        });
-      }
-    } else {
-      await prisma.dALIMember.create({
-        data: { userId: user.id, daliEmail: google.email },
-      });
-    }
-
-    return { user, authType: "member" };
+  // Member branch only. The non-@dali.dartmouth.edu branches were removed
+  // in Phase 2 — they were dead code paths.
+  if (!google.email.endsWith("@dali.dartmouth.edu")) {
+    throw new Error(
+      "upsertUserFromGoogle called with non-@dali.dartmouth.edu email; " +
+        "callers must filter upstream (per Phase 2 — OAuth provider is MCP " +
+        "members-only and website login enforces the domain in the route).",
+    );
   }
 
-  if (google.email.endsWith("@dartmouth.edu")) {
-    const user = await prisma.user.upsert({
-      where: { dartmouthEmail: google.email },
-      update: { firstName: google.firstName, lastName: google.lastName },
-      create: {
-        dartmouthEmail: google.email,
-        firstName: google.firstName,
-        lastName: google.lastName,
-      },
-    });
-    return { user, authType: "dartmouth" };
-  }
-
-  // External partner — any other Google account. Stored in `dartmouthEmail`
-  // because there's no separate column today (known schema-naming wart —
-  // see dali-os-mcp.md "Known auth-surface issues" #D). findFirst+create
-  // because there is no unique index on `dartmouthEmail` for generic
-  // (non-Dartmouth) emails.
-  const existing = await prisma.user.findFirst({
-    where: { dartmouthEmail: google.email },
-  });
-  if (existing) {
-    const user = await prisma.user.update({
-      where: { id: existing.id },
-      data: { firstName: google.firstName, lastName: google.lastName },
-    });
-    return { user, authType: "partner" };
-  }
-  const user = await prisma.user.create({
-    data: {
-      dartmouthEmail: google.email,
+  const user = await prisma.user.upsert({
+    where: { daliEmail: google.email },
+    update: { firstName: google.firstName, lastName: google.lastName },
+    create: {
+      daliEmail: google.email,
       firstName: google.firstName,
       lastName: google.lastName,
     },
   });
-  return { user, authType: "partner" };
+
+  // Ensure a DALIMember marker row exists for this user. DALIMember.userId
+  // is NOT NULL after Phase 2; we upsert by userId.
+  await prisma.dALIMember.upsert({
+    where: { userId: user.id },
+    update: {},
+    create: { userId: user.id },
+  });
+
+  return { user, authType: "member" };
 }
 
 export type ProvisionedCasUser = {

--- a/dali-api/app/routes/__tests__/api.email.send.test.ts
+++ b/dali-api/app/routes/__tests__/api.email.send.test.ts
@@ -18,7 +18,7 @@ const USER_ID = "user-1";
 const OTHER_USER_ID = "user-2";
 
 const mockPrisma = prisma as unknown as {
-  user: { findUnique: ReturnType<typeof vi.fn> };
+  gmailIntegration: { findFirst: ReturnType<typeof vi.fn> };
 };
 
 function makeRequest(
@@ -43,8 +43,8 @@ beforeEach(() => {
     ok: true,
     user: { sub: USER_ID, email: "u@x.com", type: "user" },
   } as any);
-  (mockPrisma as any).user = {
-    findUnique: vi.fn().mockResolvedValue({ googleRefreshToken: "refresh-token" }),
+  (mockPrisma as any).gmailIntegration = {
+    findFirst: vi.fn().mockResolvedValue({ oauthTokens: "refresh-token" }),
   };
 });
 

--- a/dali-api/app/routes/__tests__/portal.apply.test.ts
+++ b/dali-api/app/routes/__tests__/portal.apply.test.ts
@@ -47,6 +47,7 @@ const mockPrisma = prisma as unknown as {
   };
   user: { findUnique: ReturnType<typeof vi.fn> };
   cycleNotificationEmail: { findUnique: ReturnType<typeof vi.fn> };
+  gmailIntegration: { findFirst: ReturnType<typeof vi.fn> };
 };
 
 const USER_ID = "user-1";
@@ -107,6 +108,9 @@ beforeEach(() => {
   (mockPrisma as any).user = { findUnique: vi.fn().mockResolvedValue(null) };
   (mockPrisma as any).cycleNotificationEmail = {
     findUnique: vi.fn().mockResolvedValue(null),
+  };
+  (mockPrisma as any).gmailIntegration = {
+    findFirst: vi.fn().mockResolvedValue(null),
   };
   vi.mocked(requireAuth).mockResolvedValue({
     ok: true,
@@ -340,14 +344,13 @@ describe("POST /portal/apply (submit) confirmation email", () => {
   const CYCLE_ID = "cycle-1";
 
   function mockApplicantsAndGmail() {
-    (mockPrisma as any).user.findUnique
-      .mockResolvedValueOnce({ googleRefreshToken: "rt" })
-      .mockResolvedValueOnce({
-        id: USER_ID,
-        firstName: "Ada",
-        dartmouthEmail: "ada@dartmouth.edu",
-        daliEmail: null,
-      });
+    (mockPrisma as any).gmailIntegration.findFirst.mockResolvedValue({ oauthTokens: "rt" });
+    (mockPrisma as any).user.findUnique.mockResolvedValueOnce({
+      id: USER_ID,
+      firstName: "Ada",
+      dartmouthEmail: "ada@dartmouth.edu",
+      daliEmail: null,
+    });
   }
 
   it("sends a confirmation email on first submission when a binding exists", async () => {

--- a/dali-api/app/routes/admin.authorize-gmail.callback.ts
+++ b/dali-api/app/routes/admin.authorize-gmail.callback.ts
@@ -87,25 +87,40 @@ export async function loader({ request }: { request: Request }) {
         })
   }
 
-  // Store the refresh token on the applications@ user row (upsert in case it doesn't exist yet)
-  await prisma.user.upsert({
+  // Phase 2: store tokens in GmailIntegration. The applications@ user row
+  // must already exist (created via Google sign-in or seeded). If it
+  // doesn't, we error — there's no longer a path for /admin/authorize-gmail
+  // to create a User row out of thin air without auth identity.
+  const user = await prisma.user.upsert({
     where: { daliEmail: GMAIL_USER },
-    update: {
-      googleRefreshToken: refreshToken,
-      googleAccessToken: tokens.access_token ?? null,
-      googleTokenExpiresAt: tokens.expires_in
-        ? new Date(Date.now() + tokens.expires_in * 1000)
-        : null,
-    },
+    update: {},
     create: {
       daliEmail: GMAIL_USER,
       firstName: 'DALI',
       lastName: 'Applications',
-      googleRefreshToken: refreshToken,
-      googleAccessToken: tokens.access_token ?? null,
-      googleTokenExpiresAt: tokens.expires_in
-        ? new Date(Date.now() + tokens.expires_in * 1000)
-        : null,
+    },
+    select: { id: true },
+  })
+
+  const tokenExpiresAt = tokens.expires_in
+    ? new Date(Date.now() + tokens.expires_in * 1000)
+    : null;
+
+  await prisma.gmailIntegration.upsert({
+    where: { userId: user.id },
+    update: {
+      sendAsEmail: GMAIL_USER,
+      oauthTokens: refreshToken,
+      tokenExpiresAt,
+      enabled: true,
+      syncError: null,
+    },
+    create: {
+      userId: user.id,
+      sendAsEmail: GMAIL_USER,
+      oauthTokens: refreshToken,
+      tokenExpiresAt,
+      enabled: true,
     },
   })
 

--- a/dali-api/app/routes/api.email.send.ts
+++ b/dali-api/app/routes/api.email.send.ts
@@ -7,25 +7,20 @@
 // Requires authenticated user.
 
 import { requireAuth } from "~/lib/auth";
-import { prisma } from '~/lib/db'
 import { sendEmail } from '~/lib/gmail'
+import { getApplicationsGmailRefreshToken } from "~/lib/gmail-integration";
 import { logAuditEvent } from '~/lib/audit'
 import { checkRateLimit } from '~/lib/rate-limit'
-
-const GMAIL_USER = 'applications@dali.dartmouth.edu'
 
 const RATE_LIMIT_MAX = 100
 const RATE_LIMIT_WINDOW_MS = 60_000
 
 async function getGmailRefreshToken(): Promise<string> {
-  const user = await prisma.user.findUnique({
-    where: { daliEmail: GMAIL_USER },
-    select: { googleRefreshToken: true },
-  })
-  if (!user?.googleRefreshToken) {
+  const token = await getApplicationsGmailRefreshToken();
+  if (!token) {
     throw new Error('Gmail not authorized. Visit /admin/authorize-gmail first.')
   }
-  return user.googleRefreshToken
+  return token;
 }
 
 export async function action({ request }: { request: Request }) {

--- a/dali-api/app/routes/dev-login.ts
+++ b/dali-api/app/routes/dev-login.ts
@@ -1,6 +1,6 @@
-// DEV-ONLY: shows a list of all users and unlinked DALI members.
-// Click an existing user to log in; click an unlinked member to create a user on the fly.
-// This route should never exist in production.
+// DEV-ONLY: shows a list of all users to log in as. Post-Phase-2, all lab
+// members live as User rows (the prior "unlinked DALIMember" concept was
+// migrated during deploy). This route should never exist in production.
 
 import type { Route } from "./+types/dev-login";
 import { isDevLoginEnabled } from "~/lib/dev-login";
@@ -15,63 +15,26 @@ export async function loader({ request }: Route.LoaderArgs) {
 
   const url = new URL(request.url);
   const userId = url.searchParams.get("userId");
-  const memberId = url.searchParams.get("memberId");
 
-  // Log in as an existing user
   if (userId) {
     const user = await prisma.user.findUnique({ where: { id: userId } });
     if (!user) return new Response("User not found", { status: 404 });
     return loginAsUser(user);
   }
 
-  // Create a user for an unlinked DALI member, then log in
-  if (memberId) {
-    const member = await prisma.dALIMember.findUnique({ where: { id: memberId } });
-    if (!member) return new Response("Member not found", { status: 404 });
-    if (member.userId) {
-      const user = await prisma.user.findUnique({ where: { id: member.userId } });
-      if (user) return loginAsUser(user);
-    }
-
-    const user = await prisma.user.create({
-      data: {
-        daliEmail: member.daliEmail,
-        dartmouthEmail: member.dartmouthEmail,
-        firstName: member.firstName ?? "Unknown",
-        lastName: member.lastName ?? "Member",
-      },
-    });
-    await prisma.dALIMember.update({
-      where: { id: memberId },
-      data: { userId: user.id },
-    });
-    return loginAsUser(user);
-  }
-
-  // Show the user picker
   const users = await prisma.user.findMany({
     include: {
-      daliMember: {
-        include: {
-          domainLeadAssignments: { include: { domain: true } },
-          cycleReviewers: { include: { domain: true } },
-        },
-      },
-    },
-    orderBy: [{ daliEmail: "asc" }, { dartmouthEmail: "asc" }],
-  });
-
-  const unlinkedMembers = await prisma.dALIMember.findMany({
-    where: { userId: null },
-    include: {
-      domainLeadAssignments: { include: { domain: true } },
+      daliMember: { select: { id: true } },
+      adminMembership: { select: { id: true } },
+      coreAssignments: { select: { leadTitle: true } },
+      domainLeadAssignmentsAsUser: { include: { domain: true } },
       cycleReviewers: { include: { domain: true } },
     },
-    orderBy: [{ daliEmail: "asc" }, { lastName: "asc" }],
+    orderBy: [{ lastName: "asc" }, { firstName: "asc" }],
   });
 
-  const daliUsers = users.filter(u => u.daliEmail);
-  const applicantUsers = users.filter(u => !u.daliEmail);
+  const daliUsers = users.filter((u) => u.daliMember !== null);
+  const applicantUsers = users.filter((u) => u.daliMember === null);
 
   const html = `<!DOCTYPE html>
 <html lang="en">
@@ -91,8 +54,6 @@ export async function loader({ request }: Route.LoaderArgs) {
     .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); gap: 0.5rem; }
     .card { background: #fff; border: 1px solid #e5e5e5; border-radius: 0.5rem; padding: 0.75rem 1rem; display: flex; align-items: center; justify-content: space-between; transition: all 0.15s; cursor: pointer; text-decoration: none; color: inherit; }
     .card:hover { border-color: #3b82f6; background: #eff6ff; }
-    .card-unlinked { background: #fafafa; border: 1px dashed #d1d5db; }
-    .card-unlinked:hover { border-color: #f59e0b; border-style: solid; background: #fffbeb; }
     .name { font-weight: 600; font-size: 0.875rem; }
     .email { font-size: 0.75rem; color: #666; }
     .badges { display: flex; gap: 0.25rem; flex-wrap: wrap; margin-top: 0.25rem; }
@@ -102,10 +63,8 @@ export async function loader({ request }: Route.LoaderArgs) {
     .badge-lead { background: #d1fae5; color: #065f46; }
     .badge-reviewer { background: #ede9fe; color: #5b21b6; }
     .badge-admin { background: #fce7f3; color: #9d174d; }
-    .badge-unlinked { background: #f3f4f6; color: #6b7280; border: 1px solid #d1d5db; }
     .action { color: #999; font-size: 0.75rem; font-weight: 500; text-align: right; min-width: 5rem; }
     .card:hover .action { color: #3b82f6; }
-    .card-unlinked:hover .action { color: #d97706; }
   </style>
 </head>
 <body>
@@ -114,20 +73,19 @@ export async function loader({ request }: Route.LoaderArgs) {
   <input type="text" class="search" id="search" placeholder="Search by name or email..." autofocus />
 
   <div id="users">
-    ${renderSection("DALI Members with Accounts", daliUsers.map(u => renderUserCard(u)))}
-    ${renderSection("Applicants", applicantUsers.map(u => renderUserCard(u)))}
-    ${renderSection("Unlinked DALI Members (will create account)", unlinkedMembers.map(m => renderMemberCard(m)))}
+    ${renderSection("DALI Members", daliUsers.map((u) => renderUserCard(u, true)))}
+    ${renderSection("Applicants / Other", applicantUsers.map((u) => renderUserCard(u, false)))}
   </div>
 
   <script>
     document.getElementById('search').addEventListener('input', function(e) {
       const q = e.target.value.toLowerCase();
-      document.querySelectorAll('.card, .card-unlinked').forEach(card => {
+      document.querySelectorAll('.card').forEach(card => {
         const text = card.textContent.toLowerCase();
         card.style.display = text.includes(q) ? '' : 'none';
       });
       document.querySelectorAll('.section').forEach(section => {
-        const cards = section.querySelectorAll('.card, .card-unlinked');
+        const cards = section.querySelectorAll('.card');
         const anyVisible = Array.from(cards).some(c => c.style.display !== 'none');
         section.style.display = anyVisible ? '' : 'none';
       });
@@ -163,9 +121,9 @@ function renderSection(title: string, cards: string[]): string {
     </div>`;
 }
 
-function renderUserCard(user: any): string {
+function renderUserCard(user: any, isMember: boolean): string {
   const email = user.daliEmail ?? user.dartmouthEmail ?? "no email";
-  const badges = getBadges(user.daliEmail ? "member" : "applicant", user.daliMember);
+  const badges = getBadges(isMember, user);
 
   return `
     <a href="/dev-login?userId=${user.id}" class="card">
@@ -178,42 +136,25 @@ function renderUserCard(user: any): string {
     </a>`;
 }
 
-function renderMemberCard(member: any): string {
-  const name = member.firstName && member.lastName
-    ? `${member.firstName} ${member.lastName}`
-    : "Unknown Name";
-  const email = member.daliEmail ?? member.dartmouthEmail ?? "no email";
-  const badges = getBadges("unlinked", member);
-
-  return `
-    <a href="/dev-login?memberId=${member.id}" class="card card-unlinked">
-      <div>
-        <div class="name">${esc(name)}</div>
-        <div class="email">${esc(email)}</div>
-        <div class="badges">${badges}</div>
-      </div>
-      <span class="action">Create &amp; log in &rarr;</span>
-    </a>`;
-}
-
-function getBadges(type: "member" | "applicant" | "unlinked", member: any): string {
+function getBadges(isMember: boolean, user: any): string {
   const badges: string[] = [];
 
-  if (type === "unlinked") badges.push('<span class="badge badge-unlinked">No Account</span>');
-  else if (type === "member") badges.push('<span class="badge badge-member">Member</span>');
+  if (isMember) badges.push('<span class="badge badge-member">Member</span>');
   else badges.push('<span class="badge badge-applicant">Applicant</span>');
 
-  if (member) {
-    const roles: string[] = member.roles ?? [];
-    if (roles.includes("Admin")) badges.push('<span class="badge badge-admin">Admin</span>');
-    if (roles.includes("HiringLead")) badges.push('<span class="badge badge-admin">Hiring Lead</span>');
-    if (member.domainLeadAssignments?.length > 0) {
-      const domains = member.domainLeadAssignments.map((a: any) => a.domain.name).join(", ");
-      badges.push(`<span class="badge badge-lead">Lead: ${domains}</span>`);
-    }
-    if (member.cycleReviewers?.length > 0) {
-      badges.push('<span class="badge badge-reviewer">Reviewer</span>');
-    }
+  if (user.adminMembership) badges.push('<span class="badge badge-admin">Admin</span>');
+  const coreTitles: string[] = (user.coreAssignments ?? [])
+    .map((c: any) => c.leadTitle)
+    .filter((t: string | null) => !!t);
+  if (coreTitles.length > 0) {
+    badges.push(`<span class="badge badge-admin">Core: ${esc(coreTitles.join(", "))}</span>`);
+  }
+  if (user.domainLeadAssignmentsAsUser?.length > 0) {
+    const domains = user.domainLeadAssignmentsAsUser.map((a: any) => a.domain.displayName ?? a.domain.name).join(", ");
+    badges.push(`<span class="badge badge-lead">Lead: ${esc(domains)}</span>`);
+  }
+  if (user.cycleReviewers?.length > 0) {
+    badges.push('<span class="badge badge-reviewer">Reviewer</span>');
   }
 
   return badges.join("");

--- a/dali-api/app/routes/layout.tsx
+++ b/dali-api/app/routes/layout.tsx
@@ -11,14 +11,14 @@ export async function loader({ request }: Route.LoaderArgs) {
   const auth = await requireAuth(request)
   if (!auth.ok) return redirect('/login')
   if (auth.user.type === 'applicant') return redirect('/portal')
-  const { memberId, isHiringLead: hiringLead, isAdmin: admin, isDomainLead: domainLead } = await getUserRoles(auth.user.sub)
+  const { isLabMember, isHiringLead: hiringLead, isAdmin: admin, isDomainLead: domainLead } = await getUserRoles(auth.user.sub)
 
   let isInterviewer = false
-  if (memberId) {
+  if (isLabMember) {
     const active = await getActiveCycle()
     if (active) {
       const interviewer = await prisma.cycleInterviewer.findFirst({
-        where: { daliMemberId: memberId, applicationCycleId: active.id },
+        where: { userId: auth.user.sub, applicationCycleId: active.id },
       })
       isInterviewer = !!interviewer
     }

--- a/dali-api/app/routes/oauth.authorize.ts
+++ b/dali-api/app/routes/oauth.authorize.ts
@@ -8,11 +8,8 @@ import {
 import { checkRateLimit } from "~/lib/rate-limit";
 import type { OAuthAccountType } from "~/generated/prisma/enums";
 
-const VALID_ACCOUNT_TYPES: ReadonlyArray<OAuthAccountType> = [
-  "member",
-  "dartmouth",
-  "partner",
-];
+// Phase 2: OAuthAccountType collapsed to `member` only (MCP is members-only).
+const VALID_ACCOUNT_TYPES: ReadonlyArray<OAuthAccountType> = ["member"];
 
 const RATE_LIMIT_MAX = 10;
 const RATE_LIMIT_WINDOW_MS = 60_000;

--- a/dali-api/app/routes/oauth.calendar.google.start.ts
+++ b/dali-api/app/routes/oauth.calendar.google.start.ts
@@ -12,7 +12,9 @@ export const CAL_STATE_COOKIE = "__dali_cal_oauth_state";
 const SCOPES = [
   "openid",
   "email",
-  "https://www.googleapis.com/auth/calendar.readonly",
+  // Full calendar scope: needed for events.insert / events.patch when pushing
+  // scheduled meetings and RSVP updates, plus calendarList + freebusy reads.
+  "https://www.googleapis.com/auth/calendar",
 ].join(" ");
 
 export async function loader({ request }: { request: Request }) {

--- a/dali-api/app/routes/portal.apply.tsx
+++ b/dali-api/app/routes/portal.apply.tsx
@@ -4,6 +4,7 @@ import type { Route } from "./+types/portal.apply";
 import { prisma } from "~/lib/db";
 import { requireAuth } from "~/lib/auth";
 import { sendEmail } from "~/lib/gmail";
+import { getApplicationsGmailRefreshToken } from "~/lib/gmail-integration";
 import { renderForSlot, notificationSlot } from "~/hiring/lib/email-variables";
 import { getActiveCycle } from "~/hiring/lib/cycles";
 import { checkGitHubUrl, checkFigmaUrl, checkDriveUrl } from "~/hiring/lib/submission-check";
@@ -23,7 +24,6 @@ import {
 
 export const meta: Route.MetaFunction = () => [{ title: "Apply · DALI OS" }];
 
-const GMAIL_USER = "applications@dali.dartmouth.edu";
 
 // ─── Loader ──────────────────────────────────────────────────────────────────
 
@@ -487,12 +487,9 @@ export async function action({ request }: Route.ActionArgs) {
 
       // Best-effort confirmation email — Gmail failure must not block the submission.
       try {
-        const gmailUser = await prisma.user.findUnique({
-          where: { daliEmail: GMAIL_USER },
-          select: { googleRefreshToken: true },
-        });
+        const refreshToken = await getApplicationsGmailRefreshToken();
         const user = await prisma.user.findUnique({ where: { id: auth.user.sub } });
-        if (gmailUser?.googleRefreshToken && user) {
+        if (refreshToken && user) {
           const to = user.dartmouthEmail ?? user.daliEmail ?? "";
           if (to) {
             const binding = await prisma.cycleNotificationEmail.findUnique({
@@ -514,7 +511,7 @@ export async function action({ request }: Route.ActionArgs) {
                 binding.emailTemplateVersion,
                 { firstName: user.firstName },
               );
-              await sendEmail({ refreshToken: gmailUser.googleRefreshToken, to, subject, html });
+              await sendEmail({ refreshToken, to, subject, html });
             }
           }
         }

--- a/dali-api/prisma/migrations/20260514130959_v0_phase2_identity_refactor/migration.sql
+++ b/dali-api/prisma/migrations/20260514130959_v0_phase2_identity_refactor/migration.sql
@@ -14,9 +14,8 @@
 --   M3: Backfill data from DALIMember → User, hiring FKs → userId, etc.
 --   M4: Drop old columns, tighten constraints, drop dead enums.
 --
--- All four run inside one transaction.
-
-BEGIN;
+-- Prisma wraps each migration in its own transaction; no explicit
+-- BEGIN/COMMIT needed (and an explicit pair can mask abort errors).
 
 -- ═══ M1: staging columns for hiring FK renames ════════════════════════════
 -- The old daliMemberId/memberId columns hold DALIMember.id values; we need
@@ -86,12 +85,31 @@ WHERE m."userId" IS NOT NULL AND 'Admin' = ANY(m."roles")
 ON CONFLICT ("userId") DO NOTHING;
 
 -- HiringLead → CoreAssignment with the current term + leadTitle="Hiring Lead".
--- Skipped if no Term row covers now() (would mean v0-reference seed never
--- ran; halt the migration in that case rather than silently dropping data).
+-- Also backfills DomainLeadAssignment.termId for rows that still have it
+-- NULL after Phase 1.
+--
+-- Tolerant of an empty Term table (CI runs migrations against a fresh DB
+-- before seeding; in prod the operator runs v0-reference seed first). If
+-- there's no Term row AND there's actual data that needs one, raise — the
+-- NOT NULL ALTER below would catch a NULL termId anyway, but a clear error
+-- message is friendlier.
 DO $$
 DECLARE
   cur_term_id text;
+  hiring_lead_count int;
+  null_term_dla_count int;
 BEGIN
+  SELECT COUNT(*) INTO hiring_lead_count
+  FROM "DALIMember" WHERE 'HiringLead' = ANY("roles") AND "userId" IS NOT NULL;
+
+  SELECT COUNT(*) INTO null_term_dla_count
+  FROM "DomainLeadAssignment" WHERE "termId" IS NULL;
+
+  IF hiring_lead_count = 0 AND null_term_dla_count = 0 THEN
+    -- No data needs a Term reference. Skip the rest cleanly.
+    RETURN;
+  END IF;
+
   SELECT id INTO cur_term_id
   FROM "Term"
   WHERE "startDate" <= NOW() AND "endDate" >= NOW()
@@ -106,7 +124,7 @@ BEGIN
   END IF;
 
   IF cur_term_id IS NULL THEN
-    RAISE EXCEPTION 'Phase 2 migration: no Term rows exist. Run npm run db:seed:v0-reference before deploying.';
+    RAISE EXCEPTION 'Phase 2 migration: data requires a Term but none exists (% HiringLead members, % DomainLeadAssignment rows with NULL termId). Run npm run db:seed:v0-reference before deploying.', hiring_lead_count, null_term_dla_count;
   END IF;
 
   INSERT INTO "CoreAssignment" (id, "userId", "termId", "leadTitle")
@@ -328,5 +346,3 @@ ALTER TABLE "DomainLeadAssignment"
 ALTER TABLE "DomainLeadAssignment"
   ADD CONSTRAINT "DomainLeadAssignment_termId_fkey"
   FOREIGN KEY ("termId") REFERENCES "Term"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-
-COMMIT;

--- a/dali-api/prisma/migrations/20260514130959_v0_phase2_identity_refactor/migration.sql
+++ b/dali-api/prisma/migrations/20260514130959_v0_phase2_identity_refactor/migration.sql
@@ -1,0 +1,332 @@
+-- ═══ V0 Phase 2: Destructive Identity Refactor ═══════════════════════════════
+--
+-- Coordinated with cycle staff (cycle is Completed before this runs) and
+-- executed during a maintenance window with zero active write traffic. Total
+-- expected runtime < 5 seconds on <10k rows. Single transaction so a
+-- mid-statement failure rolls back cleanly.
+--
+-- See V0_PHASE2_PLAN.md for the design and rollback path (Neon snapshot
+-- taken immediately before deploy).
+--
+-- The migration is broken into:
+--   M1: Add staging columns + indexes that the backfill needs.
+--   M2: Migrate orphan DALIMember rows (NULL userId) → new User rows.
+--   M3: Backfill data from DALIMember → User, hiring FKs → userId, etc.
+--   M4: Drop old columns, tighten constraints, drop dead enums.
+--
+-- All four run inside one transaction.
+
+BEGIN;
+
+-- ═══ M1: staging columns for hiring FK renames ════════════════════════════
+-- The old daliMemberId/memberId columns hold DALIMember.id values; we need
+-- to populate userId from DALIMember.userId before swapping.
+
+ALTER TABLE "CycleReviewer"        ADD COLUMN "userId_new" TEXT;
+ALTER TABLE "CycleInterviewer"     ADD COLUMN "userId_new" TEXT;
+ALTER TABLE "DomainLeadAssignment" ADD COLUMN "userId_new" TEXT;
+
+-- ═══ M2: migrate orphan DALIMember rows (NULL userId) ═════════════════════
+-- These are contact-info-only rows from the legacy Notion sync. Promote
+-- each to a real User row so the upcoming `userId SET NOT NULL` succeeds.
+-- We reuse the DALIMember.id as the new User.id (both cuids; no collision
+-- since DALIMember.id is unique and no existing User shares it).
+
+INSERT INTO "User" (id, "createdAt", "updatedAt", "firstName", "lastName", "daliEmail", "netId")
+SELECT
+  m.id,
+  m."createdAt",
+  m."updatedAt",
+  COALESCE(NULLIF(m."firstName", ''), 'Unknown'),
+  COALESCE(NULLIF(m."lastName",  ''), ''),
+  m."daliEmail",
+  LOWER(m."did")
+FROM "DALIMember" m
+WHERE m."userId" IS NULL
+  AND m."daliEmail" IS NOT NULL
+ON CONFLICT ("daliEmail") DO NOTHING;
+
+-- Link the freshly-created User rows back to their DALIMember.
+UPDATE "DALIMember" m
+SET "userId" = u.id
+FROM "User" u
+WHERE m."userId" IS NULL AND m."daliEmail" = u."daliEmail";
+
+-- Discard any DALIMember row that still has no userId (no daliEmail to
+-- migrate). These should not exist in prod; the DELETE is defensive.
+DELETE FROM "DALIMember" WHERE "userId" IS NULL;
+
+-- ═══ M3: backfills ════════════════════════════════════════════════════════
+
+-- M3a. Backfill User.netId from DALIMember.did where User doesn't already
+-- have a netId. Per V0_PLAN.md: netId === did (same Dartmouth identifier,
+-- case-normalized to lowercase).
+UPDATE "User" u
+SET "netId" = LOWER(m."did")
+FROM "DALIMember" m
+WHERE u.id = m."userId" AND u."netId" IS NULL AND m."did" IS NOT NULL;
+
+-- M3b. Backfill User.firstName/lastName from DALIMember where missing.
+-- (Defensive; in practice User rows have these populated.)
+UPDATE "User" u
+SET "firstName" = COALESCE(NULLIF(u."firstName", ''), m."firstName", 'Unknown'),
+    "lastName"  = COALESCE(NULLIF(u."lastName",  ''), m."lastName",  '')
+FROM "DALIMember" m
+WHERE u.id = m."userId"
+  AND (u."firstName" IS NULL OR u."firstName" = '' OR u."lastName" IS NULL OR u."lastName" = '');
+
+-- M3c. MemberRole[] → AdminMembership / CoreAssignment.
+INSERT INTO "AdminMembership" (id, "userId", "grantedAt")
+SELECT
+  gen_random_uuid()::text,
+  m."userId",
+  NOW()
+FROM "DALIMember" m
+WHERE m."userId" IS NOT NULL AND 'Admin' = ANY(m."roles")
+ON CONFLICT ("userId") DO NOTHING;
+
+-- HiringLead → CoreAssignment with the current term + leadTitle="Hiring Lead".
+-- Skipped if no Term row covers now() (would mean v0-reference seed never
+-- ran; halt the migration in that case rather than silently dropping data).
+DO $$
+DECLARE
+  cur_term_id text;
+BEGIN
+  SELECT id INTO cur_term_id
+  FROM "Term"
+  WHERE "startDate" <= NOW() AND "endDate" >= NOW()
+  ORDER BY "sortKey" DESC LIMIT 1;
+
+  IF cur_term_id IS NULL THEN
+    -- Fall back to the most recent term if none is "current" (e.g., between
+    -- terms during the maintenance window).
+    SELECT id INTO cur_term_id
+    FROM "Term"
+    ORDER BY "sortKey" DESC LIMIT 1;
+  END IF;
+
+  IF cur_term_id IS NULL THEN
+    RAISE EXCEPTION 'Phase 2 migration: no Term rows exist. Run npm run db:seed:v0-reference before deploying.';
+  END IF;
+
+  INSERT INTO "CoreAssignment" (id, "userId", "termId", "leadTitle")
+  SELECT
+    gen_random_uuid()::text,
+    m."userId",
+    cur_term_id,
+    'Hiring Lead'
+  FROM "DALIMember" m
+  WHERE m."userId" IS NOT NULL
+    AND 'HiringLead' = ANY(m."roles")
+    AND NOT EXISTS (
+      SELECT 1 FROM "CoreAssignment" ca
+      WHERE ca."userId" = m."userId"
+        AND ca."termId" = cur_term_id
+        AND ca."leadTitle" = 'Hiring Lead'
+    );
+
+  -- M3d. DomainLeadAssignment.termId: backfill any NULL to the current term.
+  UPDATE "DomainLeadAssignment" SET "termId" = cur_term_id WHERE "termId" IS NULL;
+END $$;
+
+-- M3e. CycleReviewer / CycleInterviewer / DomainLeadAssignment: populate
+-- userId_new from the existing daliMemberId/memberId join.
+UPDATE "CycleReviewer" cr
+SET "userId_new" = m."userId"
+FROM "DALIMember" m
+WHERE cr."daliMemberId" = m.id;
+
+UPDATE "CycleInterviewer" ci
+SET "userId_new" = m."userId"
+FROM "DALIMember" m
+WHERE ci."daliMemberId" = m.id;
+
+UPDATE "DomainLeadAssignment" dla
+SET "userId_new" = m."userId"
+FROM "DALIMember" m
+WHERE dla."memberId" = m.id;
+
+-- M3f. Translate DALIMember.id → User.id for the six FK columns that point
+-- at DALIMember today. The column NAME stays (madeById, submittedById,
+-- openedById, createdById); only the referenced table changes.
+UPDATE "Decision" d
+SET "madeById" = m."userId"
+FROM "DALIMember" m
+WHERE d."madeById" = m.id;
+
+UPDATE "ApplicationReview" ar
+SET "submittedById" = m."userId"
+FROM "DALIMember" m
+WHERE ar."submittedById" = m.id;
+
+UPDATE "DelibsSession" ds
+SET "openedById" = m."userId"
+FROM "DALIMember" m
+WHERE ds."openedById" = m.id;
+
+UPDATE "LegacyEmailTemplate" lt
+SET "createdById" = m."userId"
+FROM "DALIMember" m
+WHERE lt."createdById" = m.id;
+
+UPDATE "EmailTemplateVersion" etv
+SET "createdById" = m."userId"
+FROM "DALIMember" m
+WHERE etv."createdById" = m.id;
+
+UPDATE "ConfidentialityAgreementVersion" cav
+SET "createdById" = m."userId"
+FROM "DALIMember" m
+WHERE cav."createdById" = m.id;
+
+-- M3g. GmailIntegration backfill from User.google*. Affects the 1–2 admin
+-- accounts that have completed /admin/authorize-gmail. Phase 1 added
+-- GmailIntegration; this migrates the credentials over so the Phase 2 code
+-- (which reads GmailIntegration, not User.google*) keeps working.
+INSERT INTO "GmailIntegration" (id, "userId", "sendAsEmail", "oauthTokens", "tokenExpiresAt", "enabled", "linkedAt")
+SELECT
+  gen_random_uuid()::text,
+  u.id,
+  COALESCE(u."daliEmail", u."dartmouthEmail", 'unknown@dali.dartmouth.edu'),
+  u."googleRefreshToken",
+  u."googleTokenExpiresAt",
+  TRUE,
+  NOW()
+FROM "User" u
+WHERE u."googleRefreshToken" IS NOT NULL
+  AND NOT EXISTS (SELECT 1 FROM "GmailIntegration" g WHERE g."userId" = u.id);
+
+-- M3h. Defensive Domain.code/displayName backfill (Phase 1 reference seed
+-- should already populate these; this catches any rows added between Phase
+-- 1 and Phase 2 that skipped the seed path).
+UPDATE "Domain" SET "code" = REPLACE("name", ' ', '') WHERE "code" IS NULL;
+UPDATE "Domain" SET "displayName" = "name" WHERE "displayName" IS NULL;
+
+-- ═══ M4: structural changes (drops, renames, constraint tightening) ══════
+
+-- OAuthAccountType: collapse to `member` only. OAuthSession.accountType
+-- rows with non-member values become NULL (and the row is short-lived
+-- anyway — 10 min TTL — so this is benign).
+CREATE TYPE "OAuthAccountType_new" AS ENUM ('member');
+ALTER TABLE "OAuthSession" ALTER COLUMN "accountType" TYPE "OAuthAccountType_new"
+  USING (CASE WHEN "accountType"::text = 'member' THEN 'member'::"OAuthAccountType_new" ELSE NULL END);
+ALTER TYPE "OAuthAccountType" RENAME TO "OAuthAccountType_old";
+ALTER TYPE "OAuthAccountType_new" RENAME TO "OAuthAccountType";
+DROP TYPE "OAuthAccountType_old";
+
+-- Drop old foreign keys.
+ALTER TABLE "DALIMember"                      DROP CONSTRAINT "DALIMember_userId_fkey";
+ALTER TABLE "CycleReviewer"                   DROP CONSTRAINT "CycleReviewer_daliMemberId_fkey";
+ALTER TABLE "CycleInterviewer"                DROP CONSTRAINT "CycleInterviewer_daliMemberId_fkey";
+ALTER TABLE "Decision"                        DROP CONSTRAINT "Decision_madeById_fkey";
+ALTER TABLE "ApplicationReview"               DROP CONSTRAINT "ApplicationReview_submittedById_fkey";
+ALTER TABLE "DelibsSession"                   DROP CONSTRAINT "DelibsSession_openedById_fkey";
+ALTER TABLE "LegacyEmailTemplate"             DROP CONSTRAINT "LegacyEmailTemplate_createdById_fkey";
+ALTER TABLE "EmailTemplateVersion"            DROP CONSTRAINT "EmailTemplateVersion_createdById_fkey";
+ALTER TABLE "ConfidentialityAgreementVersion" DROP CONSTRAINT "ConfidentialityAgreementVersion_createdById_fkey";
+ALTER TABLE "DomainLeadAssignment"            DROP CONSTRAINT "DomainLeadAssignment_memberId_fkey";
+ALTER TABLE "DomainLeadAssignment"            DROP CONSTRAINT "DomainLeadAssignment_termId_fkey";
+
+-- Drop old indexes.
+DROP INDEX "DALIMember_daliEmail_key";
+DROP INDEX "DALIMember_dartmouthEmail_key";
+DROP INDEX "DALIMember_did_key";
+DROP INDEX "CycleReviewer_daliMemberId_applicationCycleId_domainId_key";
+DROP INDEX "CycleInterviewer_daliMemberId_applicationCycleId_domainId_key";
+DROP INDEX "DomainLeadAssignment_memberId_domainId_key";
+
+-- User: drop google* columns. Backfill in M3g already moved any live data.
+ALTER TABLE "User"
+  DROP COLUMN "googleAccessToken",
+  DROP COLUMN "googleRefreshToken",
+  DROP COLUMN "googleTokenExpiresAt";
+
+-- DALIMember: slim down to thin marker.
+ALTER TABLE "DALIMember"
+  DROP COLUMN "daliEmail",
+  DROP COLUMN "dartmouthEmail",
+  DROP COLUMN "did",
+  DROP COLUMN "firstName",
+  DROP COLUMN "lastName",
+  DROP COLUMN "roles",
+  ALTER COLUMN "userId" SET NOT NULL;
+
+-- Domain: tighten code/displayName.
+ALTER TABLE "Domain"
+  ALTER COLUMN "code"        SET NOT NULL,
+  ALTER COLUMN "displayName" SET NOT NULL;
+
+-- CycleReviewer: complete the column rename.
+ALTER TABLE "CycleReviewer" DROP COLUMN "daliMemberId";
+ALTER TABLE "CycleReviewer" RENAME COLUMN "userId_new" TO "userId";
+ALTER TABLE "CycleReviewer" ALTER COLUMN "userId" SET NOT NULL;
+
+-- CycleInterviewer: same.
+ALTER TABLE "CycleInterviewer" DROP COLUMN "daliMemberId";
+ALTER TABLE "CycleInterviewer" RENAME COLUMN "userId_new" TO "userId";
+ALTER TABLE "CycleInterviewer" ALTER COLUMN "userId" SET NOT NULL;
+
+-- DomainLeadAssignment: complete column rename, tighten termId.
+ALTER TABLE "DomainLeadAssignment" DROP COLUMN "memberId";
+ALTER TABLE "DomainLeadAssignment" RENAME COLUMN "userId_new" TO "userId";
+ALTER TABLE "DomainLeadAssignment"
+  ALTER COLUMN "userId" SET NOT NULL,
+  ALTER COLUMN "termId" SET NOT NULL;
+
+-- Drop the now-unused MemberRole enum.
+DROP TYPE "MemberRole";
+
+-- Recreate unique constraints on the new column names.
+CREATE UNIQUE INDEX "CycleReviewer_userId_applicationCycleId_domainId_key"
+  ON "CycleReviewer"("userId", "applicationCycleId", "domainId");
+CREATE UNIQUE INDEX "CycleInterviewer_userId_applicationCycleId_domainId_key"
+  ON "CycleInterviewer"("userId", "applicationCycleId", "domainId");
+CREATE UNIQUE INDEX "DomainLeadAssignment_userId_domainId_termId_key"
+  ON "DomainLeadAssignment"("userId", "domainId", "termId");
+
+-- Recreate foreign keys, now pointing at User (and Term).
+ALTER TABLE "DALIMember"
+  ADD CONSTRAINT "DALIMember_userId_fkey"
+  FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "CycleReviewer"
+  ADD CONSTRAINT "CycleReviewer_userId_fkey"
+  FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "CycleInterviewer"
+  ADD CONSTRAINT "CycleInterviewer_userId_fkey"
+  FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "Decision"
+  ADD CONSTRAINT "Decision_madeById_fkey"
+  FOREIGN KEY ("madeById") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "ApplicationReview"
+  ADD CONSTRAINT "ApplicationReview_submittedById_fkey"
+  FOREIGN KEY ("submittedById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "DelibsSession"
+  ADD CONSTRAINT "DelibsSession_openedById_fkey"
+  FOREIGN KEY ("openedById") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "LegacyEmailTemplate"
+  ADD CONSTRAINT "LegacyEmailTemplate_createdById_fkey"
+  FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "EmailTemplateVersion"
+  ADD CONSTRAINT "EmailTemplateVersion_createdById_fkey"
+  FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "ConfidentialityAgreementVersion"
+  ADD CONSTRAINT "ConfidentialityAgreementVersion_createdById_fkey"
+  FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "DomainLeadAssignment"
+  ADD CONSTRAINT "DomainLeadAssignment_userId_fkey"
+  FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "DomainLeadAssignment"
+  ADD CONSTRAINT "DomainLeadAssignment_termId_fkey"
+  FOREIGN KEY ("termId") REFERENCES "Term"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+COMMIT;

--- a/dali-api/prisma/schema.prisma
+++ b/dali-api/prisma/schema.prisma
@@ -34,14 +34,6 @@ model User {
   firstName String
   lastName  String
 
-  // ─── Google API tokens (Phase 1: retained for transition) ─────────────────
-  // Read by /admin/authorize-gmail (Gmail send-as) and the legacy free-busy
-  // fallback in lib/google-calendar.ts:fetchBusyFromLegacyUserTokens. Both
-  // move to GmailIntegration in Phase 2; these columns are then dropped.
-  googleAccessToken    String?
-  googleRefreshToken   String?
-  googleTokenExpiresAt DateTime?
-
   // IANA zone, e.g. "America/New_York". Used by calendar/scheduling.
   timeZone String?
 
@@ -128,35 +120,33 @@ model User {
   // ─── Notification relations ────────────────────────────────────────────────
   receivedNotifications Notification[] @relation("NotificationRecipient")
   authoredNotifications Notification[] @relation("NotificationAuthor")
+
+  // ─── Phase 2: hiring FK back-relations (formerly via DALIMember) ──────────
+  cycleReviewers                          CycleReviewer[]
+  cycleInterviewers                       CycleInterviewer[]
+  domainLeadAssignmentsAsUser             DomainLeadAssignment[]
+  decisionsMade                           Decision[]                        @relation("DecisionMadeBy")
+  applicationReviewsSubmitted             ApplicationReview[]               @relation("ApplicationReviewSubmittedBy")
+  delibsSessionsOpened                    DelibsSession[]
+  legacyEmailTemplatesCreated             LegacyEmailTemplate[]
+  emailTemplateVersionsCreated            EmailTemplateVersion[]
+  confidentialityAgreementVersionsCreated ConfidentialityAgreementVersion[]
 }
 
 // A DALI lab member. userId is optional because a member may be known (e.g. via daliEmail)
 // before they have created a User account.
+// Thin lab-membership marker. Presence = the User is a hired lab member.
+// All display/identity fields live on User (firstName, lastName, daliEmail,
+// dartmouthEmail, netId, did-equivalent). Hiring FKs now point at User
+// directly; this model exists only to discriminate Member from
+// non-Member Users.
 model DALIMember {
   id        String   @id @default(cuid())
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  userId String? @unique
-  user   User?   @relation(fields: [userId], references: [id])
-
-  firstName      String?
-  lastName       String?
-  daliEmail      String? @unique
-  dartmouthEmail String? @unique
-  did            String? @unique // Dartmouth D-number e.g. "F00709M"
-
-  roles MemberRole[] @default([])
-
-  cycleReviewers                   CycleReviewer[]
-  cycleInterviewers                CycleInterviewer[]
-  decisions                        Decision[]
-  applicationReviews               ApplicationReview[]               @relation("SubmittedBy")
-  delibSessions                    DelibsSession[]
-  legacyEmailTemplates             LegacyEmailTemplate[]
-  emailTemplateVersions            EmailTemplateVersion[]
-  confidentialityAgreementVersions ConfidentialityAgreementVersion[]
-  domainLeadAssignments            DomainLeadAssignment[]
+  userId String @unique
+  user   User   @relation(fields: [userId], references: [id])
 }
 
 model ApplicationCycle {
@@ -301,15 +291,16 @@ model Domain {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  // Legacy display name. Retained through Phase 1; Phase 2 enforces NOT NULL
-  // on the new `code` + `displayName` columns and drops this.
+  // Legacy display name. Retained as a soft fallback (some old fixtures
+  // still read .name). Going forward, app code reads `displayName`.
+  // Future cleanup can drop `name` once display.ts and tests stop reading it.
   name String
 
-  // ─── Phase 1 additions (all nullable; backfilled in seed) ─────────────────
+  // Phase 2: code/displayName now required.
   // Stable code referenced from app code (e.g. "Fullstack", "UIUX", "ERAS").
-  code            String? @unique
+  code            String  @unique
   // Human-friendly display label (e.g. "Fullstack Dev").
-  displayName     String?
+  displayName     String
   // Intern programs (ERAS, EEJUST, WISP) are domains with this set true.
   // After the intern term, members apply normally and get a fresh
   // DomainEligibility in their actual hire domain.
@@ -436,8 +427,8 @@ model CycleReviewer {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  daliMemberId       String
-  daliMember         DALIMember       @relation(fields: [daliMemberId], references: [id])
+  userId             String
+  user               User             @relation(fields: [userId], references: [id])
   applicationCycleId String
   applicationCycle   ApplicationCycle @relation(fields: [applicationCycleId], references: [id])
   domainId           String
@@ -445,7 +436,7 @@ model CycleReviewer {
 
   reviews ApplicationReview[]
 
-  @@unique([daliMemberId, applicationCycleId, domainId])
+  @@unique([userId, applicationCycleId, domainId])
 }
 
 // A DALI member assigned to conduct interviews for a domain in a cycle.
@@ -455,8 +446,8 @@ model CycleInterviewer {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  daliMemberId       String
-  daliMember         DALIMember       @relation(fields: [daliMemberId], references: [id])
+  userId             String
+  user               User             @relation(fields: [userId], references: [id])
   applicationCycleId String
   applicationCycle   ApplicationCycle @relation(fields: [applicationCycleId], references: [id])
   domainId           String
@@ -465,7 +456,7 @@ model CycleInterviewer {
   availabilityBlocks   InterviewerAvailability[]
   interviewAssignments InterviewAssignment[]
 
-  @@unique([daliMemberId, applicationCycleId, domainId])
+  @@unique([userId, applicationCycleId, domainId])
 }
 
 model InterviewerAvailability {
@@ -540,10 +531,9 @@ enum AssignmentStatus {
   Replaced
 }
 
-enum MemberRole {
-  Admin
-  HiringLead
-}
+// MemberRole enum dropped in Phase 2. Admin → AdminMembership row;
+// HiringLead → CoreAssignment row with leadTitle="Hiring Lead". See
+// V0_PHASE2_PLAN.md M3 backfill.
 
 model InterviewAssignment {
   id        String   @id @default(cuid())
@@ -606,7 +596,7 @@ model Decision {
   stage DecisionStage
 
   madeById String
-  madeBy   DALIMember @relation(fields: [madeById], references: [id])
+  madeBy   User   @relation("DecisionMadeBy", fields: [madeById], references: [id])
 
   notes        String?
   waitlistRank Int? // set when type == Waitlisted; current rank = latest record's value
@@ -643,7 +633,7 @@ model ApplicationReview {
 
   submittedAt   DateTime? // null = in progress; non-null = read-only while set
   submittedById String? // records who authored the final review (set on submit, cleared on unsubmit)
-  submittedBy   DALIMember? @relation("SubmittedBy", fields: [submittedById], references: [id])
+  submittedBy   User?   @relation("ApplicationReviewSubmittedBy", fields: [submittedById], references: [id])
 
   @@unique([cycleReviewerId, domainApplicationId])
 }
@@ -683,7 +673,7 @@ model DelibsSession {
   columnOrder Json @default("{}")
 
   openedById String
-  openedBy   DALIMember @relation(fields: [openedById], references: [id])
+  openedBy   User   @relation(fields: [openedById], references: [id])
 
   @@unique([domainId, applicationCycleId, type])
 }
@@ -760,10 +750,12 @@ enum OAuthProvider {
   cas
 }
 
+// Phase 2: collapsed to `member` only. MCP clients are members-only (per
+// V0_PLAN.md Q18). The `dartmouth` and `partner` values were never used in
+// production — first-party login (/auth/callback/*) doesn't go through this
+// type, and the OAuth provider surface (/oauth/*) is MCP-only.
 enum OAuthAccountType {
   member
-  dartmouth
-  partner
 }
 
 model OAuthSession {
@@ -862,7 +854,7 @@ model LegacyEmailTemplate {
   version Int
 
   createdById String
-  createdBy   DALIMember @relation(fields: [createdById], references: [id])
+  createdBy   User   @relation(fields: [createdById], references: [id])
 
   @@index([type, createdAt])
 }
@@ -894,7 +886,7 @@ model EmailTemplateVersion {
   template   EmailTemplate @relation(fields: [templateId], references: [id])
 
   createdById String
-  createdBy   DALIMember @relation(fields: [createdById], references: [id])
+  createdBy   User   @relation(fields: [createdById], references: [id])
 
   cycleDecisionEmails     CycleDecisionEmail[]
   cycleNotificationEmails CycleNotificationEmail[]
@@ -1010,7 +1002,7 @@ model ConfidentialityAgreementVersion {
   agreement   ConfidentialityAgreement @relation(fields: [agreementId], references: [id])
 
   createdById String
-  createdBy   DALIMember @relation(fields: [createdById], references: [id])
+  createdBy   User   @relation(fields: [createdById], references: [id])
 
   cycleBindings CycleConfidentialityAgreement[]
   signatures    ConfidentialityAgreementSignature[]
@@ -1056,19 +1048,17 @@ model DomainLeadAssignment {
   id        String   @id @default(cuid())
   createdAt DateTime @default(now())
 
-  memberId String
+  // Phase 2: memberId column dropped; userId column added pointing at User.
+  // termId NOT NULL after backfill to current term.
+  userId   String
   domainId String
+  termId   String
 
-  // Phase 1: termId nullable. Phase 2 backfills existing rows to the current
-  // term then enforces NOT NULL. Phase 2 also renames memberId → userId
-  // (pointing at User instead of DALIMember).
-  termId String?
+  user   User   @relation(fields: [userId], references: [id])
+  domain Domain @relation(fields: [domainId], references: [id])
+  term   Term   @relation(fields: [termId], references: [id])
 
-  member DALIMember @relation(fields: [memberId], references: [id])
-  domain Domain     @relation(fields: [domainId], references: [id])
-  term   Term?      @relation(fields: [termId], references: [id])
-
-  @@unique([memberId, domainId])
+  @@unique([userId, domainId, termId])
   @@index([domainId])
   @@index([termId])
 }

--- a/dali-api/prisma/seed-members.ts
+++ b/dali-api/prisma/seed-members.ts
@@ -6,7 +6,11 @@ import { PrismaPg } from "@prisma/adapter-pg";
 const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL! });
 const prisma = new PrismaClient({ adapter });
 
-interface Member {
+// Phase 2: contact-info fields (firstName, lastName, daliEmail, dartmouthEmail,
+// did/netId) live on User. DALIMember is a thin "is a lab member" marker.
+// Legacy MemberRole[] is gone — Admin → AdminMembership, HiringLead →
+// CoreAssignment.
+interface MemberSeed {
   firstName: string | null;
   lastName: string | null;
   daliEmail: string | null;
@@ -16,18 +20,61 @@ interface Member {
 }
 
 async function main() {
-  const members: Member[] = JSON.parse(
+  const members: MemberSeed[] = JSON.parse(
     readFileSync(join(import.meta.dirname, "data/members.json"), "utf-8")
   );
 
   let seeded = 0;
   for (const { firstName, lastName, daliEmail, dartmouthEmail, did, roles } of members) {
     if (!daliEmail) continue;
-    await prisma.dALIMember.upsert({
+
+    // Upsert User row with the contact info.
+    const user = await prisma.user.upsert({
       where: { daliEmail },
-      update: { firstName, lastName, dartmouthEmail, did, ...(roles ? { roles: roles as any } : {}) },
-      create: { firstName, lastName, daliEmail, dartmouthEmail, did, roles: (roles ?? []) as any },
+      update: {
+        firstName: firstName ?? "Unknown",
+        lastName: lastName ?? "",
+        dartmouthEmail: dartmouthEmail ?? undefined,
+        netId: did ? did.toLowerCase() : undefined,
+      },
+      create: {
+        daliEmail,
+        firstName: firstName ?? "Unknown",
+        lastName: lastName ?? "",
+        dartmouthEmail: dartmouthEmail ?? undefined,
+        netId: did ? did.toLowerCase() : undefined,
+      },
     });
+
+    // Mark as lab member.
+    await prisma.dALIMember.upsert({
+      where: { userId: user.id },
+      update: {},
+      create: { userId: user.id },
+    });
+
+    // Translate legacy roles → AdminMembership / CoreAssignment.
+    if (roles?.includes("Admin")) {
+      await prisma.adminMembership.upsert({
+        where: { userId: user.id },
+        update: {},
+        create: { userId: user.id },
+      });
+    }
+    if (roles?.includes("HiringLead")) {
+      const term = await prisma.term.findFirst({ orderBy: { sortKey: "desc" } });
+      if (term) {
+        const exists = await prisma.coreAssignment.findFirst({
+          where: { userId: user.id, termId: term.id, leadTitle: "Hiring Lead" },
+        });
+        if (!exists) {
+          await prisma.coreAssignment.create({
+            data: { userId: user.id, termId: term.id, leadTitle: "Hiring Lead" },
+          });
+        }
+      }
+    }
+
     seeded++;
   }
 

--- a/dali-api/prisma/seed.ts
+++ b/dali-api/prisma/seed.ts
@@ -25,10 +25,28 @@ async function main() {
     create: { userId: admin.id },
   });
 
+  // ── Term ───────────────────────────────────────────────────────────────────
+  // Phase 2: CoreAssignment and DomainLeadAssignment require a termId. The
+  // local seed below references this term for the test hiring lead +
+  // domain leads. Prod seeds a full 12-term window via
+  // prisma/seeds/v0-reference.ts; locally one term is enough.
+  await prisma.term.upsert({
+    where: { code: "26S" },
+    update: {},
+    create: {
+      code: "26S",
+      year: 2026,
+      season: "S",
+      sortKey: 20262,
+      startDate: new Date("2026-03-28"),
+      endDate: new Date("2026-06-05"),
+    },
+  });
+
   // ── Domains ────────────────────────────────────────────────────────────────
   // Phase 1 adds `code` + `displayName` to Domain. Local seeds populate them
   // so a fresh dev DB has consistent values; prod backfill is handled by the
-  // v0 reference-data script (prisma/data/v0-reference-seed.ts).
+  // v0 reference-data script (prisma/seeds/v0-reference.ts).
   const [designDomain, engDomain, pmDomain] = await Promise.all([
     prisma.domain.upsert({
       where: { id: "domain-design" },

--- a/dali-api/prisma/seed.ts
+++ b/dali-api/prisma/seed.ts
@@ -6,6 +6,9 @@ const prisma = new PrismaClient({ adapter });
 
 async function main() {
   // ── Admin user (creates forms, challenges, and cycle) ──────────────────────
+  // Phase 2: DALIMember is a thin marker (no display fields). AdminMembership
+  // confers the Admin role; CoreAssignment with leadTitle="Hiring Lead"
+  // confers the legacy "HiringLead" semantic.
   const admin = await prisma.user.upsert({
     where: { daliEmail: "admin@dali.dartmouth.edu" },
     update: { firstName: "Admin", lastName: "User" },
@@ -13,19 +16,13 @@ async function main() {
       daliEmail: "admin@dali.dartmouth.edu",
       firstName: "Admin",
       lastName: "User",
-      daliMember: {
-        create: {
-          daliEmail: "admin@dali.dartmouth.edu",
-          firstName: "Admin",
-          lastName: "User",
-          roles: ["Admin"],
-        },
-      },
+      daliMember: { create: {} },
     },
   });
-  await prisma.dALIMember.update({
-    where: { daliEmail: "admin@dali.dartmouth.edu" },
-    data: { firstName: "Admin", lastName: "User", roles: ["Admin"] },
+  await prisma.adminMembership.upsert({
+    where: { userId: admin.id },
+    update: {},
+    create: { userId: admin.id },
   });
 
   // ── Domains ────────────────────────────────────────────────────────────────
@@ -1844,22 +1841,29 @@ async function main() {
       daliEmail: "eng.lead@dali.dartmouth.edu",
       firstName: "Mira",
       lastName: "Chen",
-      daliMember: { create: { daliEmail: "eng.lead@dali.dartmouth.edu", firstName: "Mira", lastName: "Chen" } },
+      daliMember: { create: {} },
     },
   });
 
-  const engLeadMember = await prisma.dALIMember.update({
-    where: { daliEmail: "eng.lead@dali.dartmouth.edu" },
-    data: { firstName: "Mira", lastName: "Chen", userId: engLead.id },
+  await prisma.dALIMember.upsert({
+    where: { userId: engLead.id },
+    update: {},
+    create: { userId: engLead.id },
   });
+
+  const currentTermForSeed = await prisma.term.findFirst({
+    orderBy: { sortKey: "desc" },
+  });
+  const termIdForSeed = currentTermForSeed?.id;
 
   await prisma.domainLeadAssignment.upsert({
     where: { id: "dla-eng-lead" },
     update: {},
     create: {
       id: "dla-eng-lead",
-      memberId: engLeadMember.id,
+      userId: engLead.id,
       domainId: engDomain.id,
+      termId: termIdForSeed!,
     },
   });
 
@@ -1871,30 +1875,37 @@ async function main() {
       daliEmail: "jordan.taylor@dali.dartmouth.edu",
       firstName: "Jordan",
       lastName: "Taylor",
-      daliMember: {
-        create: {
-          daliEmail: "jordan.taylor@dali.dartmouth.edu",
-          firstName: "Jordan",
-          lastName: "Taylor",
-          roles: ["HiringLead"],
-        },
-      },
+      daliMember: { create: {} },
     },
     include: { daliMember: true },
   });
 
-  const jordanMember = await prisma.dALIMember.update({
-    where: { daliEmail: "jordan.taylor@dali.dartmouth.edu" },
-    data: { firstName: "Jordan", lastName: "Taylor", userId: jordan.id },
+  await prisma.dALIMember.upsert({
+    where: { userId: jordan.id },
+    update: {},
+    create: { userId: jordan.id },
   });
+
+  // HiringLead semantic via CoreAssignment.
+  if (termIdForSeed) {
+    const existingCore = await prisma.coreAssignment.findFirst({
+      where: { userId: jordan.id, termId: termIdForSeed, leadTitle: "Hiring Lead" },
+    });
+    if (!existingCore) {
+      await prisma.coreAssignment.create({
+        data: { userId: jordan.id, termId: termIdForSeed, leadTitle: "Hiring Lead" },
+      });
+    }
+  }
 
   await prisma.domainLeadAssignment.upsert({
     where: { id: "dla-jordan-eng" },
     update: {},
     create: {
       id: "dla-jordan-eng",
-      memberId: jordanMember.id,
+      userId: jordan.id,
       domainId: engDomain.id,
+      termId: termIdForSeed!,
     },
   });
 
@@ -1914,7 +1925,7 @@ async function main() {
       versionNumber: 1,
       body: { type: "doc", content: [] },
       agreementId: "ca-fall-2026",
-      createdById: jordanMember.id,
+      createdById: jordan.id,
     },
   });
   await prisma.cycleConfidentialityAgreement.upsert({
@@ -1987,7 +1998,7 @@ async function main() {
     { email: "pm.lead@dali.dartmouth.edu", first: "Theo", last: "Abernathy", domainId: pmDomain.id, signed: false },
   ];
 
-  const reviewerMembers: Array<{ id: string; domainId: string }> = [];
+  const reviewerUsers: Array<{ id: string; domainId: string }> = [];
 
   for (const r of reviewerData) {
     const user = await prisma.user.upsert({
@@ -1997,32 +2008,31 @@ async function main() {
         daliEmail: r.email,
         firstName: r.first,
         lastName: r.last,
-        daliMember: { create: { daliEmail: r.email, firstName: r.first, lastName: r.last } },
+        daliMember: { create: {} },
       },
-      include: { daliMember: true },
     });
 
-    if (!user.daliMember) continue;
-    // Sync names onto the DALIMember row — the dashboard renders from there,
-    // and older seeds created members without names.
-    await prisma.dALIMember.update({
-      where: { id: user.daliMember.id },
-      data: { firstName: r.first, lastName: r.last },
+    // Ensure DALIMember marker exists (Phase 2).
+    await prisma.dALIMember.upsert({
+      where: { userId: user.id },
+      update: {},
+      create: { userId: user.id },
     });
-    reviewerMembers.push({ id: user.daliMember.id, domainId: r.domainId });
+
+    reviewerUsers.push({ id: user.id, domainId: r.domainId });
 
     // CycleReviewer (for written reviews)
     await prisma.cycleReviewer.upsert({
       where: {
-        daliMemberId_applicationCycleId_domainId: {
-          daliMemberId: user.daliMember.id,
+        userId_applicationCycleId_domainId: {
+          userId: user.id,
           applicationCycleId: cycle.id,
           domainId: r.domainId,
         },
       },
       update: {},
       create: {
-        daliMemberId: user.daliMember.id,
+        userId: user.id,
         applicationCycleId: cycle.id,
         domainId: r.domainId,
       },
@@ -2031,15 +2041,15 @@ async function main() {
     // CycleInterviewer (for conducting interviews)
     await prisma.cycleInterviewer.upsert({
       where: {
-        daliMemberId_applicationCycleId_domainId: {
-          daliMemberId: user.daliMember.id,
+        userId_applicationCycleId_domainId: {
+          userId: user.id,
           applicationCycleId: cycle.id,
           domainId: r.domainId,
         },
       },
       update: {},
       create: {
-        daliMemberId: user.daliMember.id,
+        userId: user.id,
         applicationCycleId: cycle.id,
         domainId: r.domainId,
       },
@@ -2059,18 +2069,18 @@ async function main() {
   }
 
   // ── Engineering reviewers for Winter 2027 ──────────────────────────────────
-  for (const rm of reviewerMembers.filter(r => r.domainId === engDomain.id)) {
+  for (const ru of reviewerUsers.filter(r => r.domainId === engDomain.id)) {
     await prisma.cycleReviewer.upsert({
       where: {
-        daliMemberId_applicationCycleId_domainId: {
-          daliMemberId: rm.id,
+        userId_applicationCycleId_domainId: {
+          userId: ru.id,
           applicationCycleId: cycleWinter2027.id,
           domainId: engDomain.id,
         },
       },
       update: {},
       create: {
-        daliMemberId: rm.id,
+        userId: ru.id,
         applicationCycleId: cycleWinter2027.id,
         domainId: engDomain.id,
       },
@@ -2107,7 +2117,7 @@ async function main() {
         domainApplicationId: spec.domainAppId,
         type: spec.type,
         stage: "Released",
-        madeById: jordanMember.id,
+        madeById: jordan.id,
         // Waitlist rank is taken from the position inside the Waitlisted
         // subset (stable, deterministic).
         waitlistRank: spec.type === "Waitlisted"
@@ -2150,29 +2160,29 @@ async function main() {
   }
 
   // ── Fall 2026 review + delibs + decision + interview seeding ─────────────
-  // Look up every CycleReviewer by its member email so we can reference them
-  // as either a reviewer or (later) as an interviewer.
-  const designLeadMember = await prisma.dALIMember.findUniqueOrThrow({
+  // Look up every CycleReviewer by its user.id (Phase 2 — hiring FKs key on
+  // userId, not DALIMember.id).
+  const designLeadUser = await prisma.user.findUniqueOrThrow({
     where: { daliEmail: "design.lead@dali.dartmouth.edu" },
   });
-  const pmLeadMember = await prisma.dALIMember.findUniqueOrThrow({
+  const pmLeadUser = await prisma.user.findUniqueOrThrow({
     where: { daliEmail: "pm.lead@dali.dartmouth.edu" },
   });
-  const rileyMember = await prisma.dALIMember.findUniqueOrThrow({
+  const rileyUser = await prisma.user.findUniqueOrThrow({
     where: { daliEmail: "reviewer1@dali.dartmouth.edu" },
   });
-  const samMember = await prisma.dALIMember.findUniqueOrThrow({
+  const samUser = await prisma.user.findUniqueOrThrow({
     where: { daliEmail: "reviewer2@dali.dartmouth.edu" },
   });
-  const patMember = await prisma.dALIMember.findUniqueOrThrow({
+  const patUser = await prisma.user.findUniqueOrThrow({
     where: { daliEmail: "reviewer3@dali.dartmouth.edu" },
   });
 
-  async function getCycleReviewer(daliMemberId: string, domainId: string) {
+  async function getCycleReviewer(userId: string, domainId: string) {
     return prisma.cycleReviewer.findUniqueOrThrow({
       where: {
-        daliMemberId_applicationCycleId_domainId: {
-          daliMemberId,
+        userId_applicationCycleId_domainId: {
+          userId,
           applicationCycleId: cycle.id,
           domainId,
         },
@@ -2180,12 +2190,12 @@ async function main() {
     });
   }
 
-  const rileyEngRv = await getCycleReviewer(rileyMember.id, engDomain.id);
-  const engLeadRv = await getCycleReviewer(engLeadMember.id, engDomain.id);
-  const samDesignRv = await getCycleReviewer(samMember.id, designDomain.id);
-  const designLeadRv = await getCycleReviewer(designLeadMember.id, designDomain.id);
-  const patPmRv = await getCycleReviewer(patMember.id, pmDomain.id);
-  const pmLeadRv = await getCycleReviewer(pmLeadMember.id, pmDomain.id);
+  const rileyEngRv = await getCycleReviewer(rileyUser.id, engDomain.id);
+  const engLeadRv = await getCycleReviewer(engLead.id, engDomain.id);
+  const samDesignRv = await getCycleReviewer(samUser.id, designDomain.id);
+  const designLeadRv = await getCycleReviewer(designLeadUser.id, designDomain.id);
+  const patPmRv = await getCycleReviewer(patUser.id, pmDomain.id);
+  const pmLeadRv = await getCycleReviewer(pmLeadUser.id, pmDomain.id);
 
   // Strong/plausible scores — full 5s where it's a clear "Strong Hire", 3s
   // where it's borderline, 1–2s for the reject case. Keep the existing Alice
@@ -2351,7 +2361,7 @@ async function main() {
       overallRecommendation: spec.overallRecommendation || null,
       annotations: [],
       submittedAt: spec.submitted ? ts(-500) : null,
-      submittedById: spec.submitted ? engLeadMember.id : null,
+      submittedById: spec.submitted ? engLead.id : null,
     };
     await prisma.applicationReview.upsert({
       where: {
@@ -2395,7 +2405,7 @@ async function main() {
       applicationCycleId: cycle.id,
       type: "Initial",
       status: "Closed",
-      openedById: engLeadMember.id,
+      openedById: engLead.id,
       columnOrder: {
         "No Decision": [],
         "Interview": ["da-alice-eng", "da-diego-eng"],
@@ -2425,7 +2435,7 @@ async function main() {
       applicationCycleId: cycle.id,
       type: "Initial",
       status: "Closed",
-      openedById: designLeadMember.id,
+      openedById: designLeadUser.id,
       columnOrder: {
         "No Decision": [],
         "Interview": ["da-bob-design", "da-eve-design"],
@@ -2455,7 +2465,7 @@ async function main() {
       applicationCycleId: cycle.id,
       type: "Initial",
       status: "Closed",
-      openedById: pmLeadMember.id,
+      openedById: pmLeadUser.id,
       columnOrder: {
         "No Decision": [],
         "Interview": ["da-bob-pm", "da-felix-pm"],
@@ -2476,13 +2486,13 @@ async function main() {
     notes?: string;
   };
   const decisionSpecs: DecisionSpec[] = [
-    { slug: "alice-eng", domainAppId: "da-alice-eng", type: "InvitedToInterview", madeBy: engLeadMember.id, notes: "Strong across both reviews." },
-    { slug: "bob-design", domainAppId: "da-bob-design", type: "InvitedToInterview", madeBy: designLeadMember.id },
-    { slug: "bob-pm", domainAppId: "da-bob-pm", type: "InvitedToInterview", madeBy: pmLeadMember.id },
-    { slug: "diego-eng", domainAppId: "da-diego-eng", type: "InvitedToInterview", madeBy: engLeadMember.id, notes: "Top signal in the Engineering round." },
-    { slug: "eve-design", domainAppId: "da-eve-design", type: "InvitedToInterview", madeBy: designLeadMember.id },
-    { slug: "felix-pm", domainAppId: "da-felix-pm", type: "InvitedToInterview", madeBy: pmLeadMember.id },
-    { slug: "grace-eng", domainAppId: "da-grace-eng", type: "Rejected", madeBy: engLeadMember.id, notes: "Both reviewers recommended no-hire." },
+    { slug: "alice-eng", domainAppId: "da-alice-eng", type: "InvitedToInterview", madeBy: engLead.id, notes: "Strong across both reviews." },
+    { slug: "bob-design", domainAppId: "da-bob-design", type: "InvitedToInterview", madeBy: designLeadUser.id },
+    { slug: "bob-pm", domainAppId: "da-bob-pm", type: "InvitedToInterview", madeBy: pmLeadUser.id },
+    { slug: "diego-eng", domainAppId: "da-diego-eng", type: "InvitedToInterview", madeBy: engLead.id, notes: "Top signal in the Engineering round." },
+    { slug: "eve-design", domainAppId: "da-eve-design", type: "InvitedToInterview", madeBy: designLeadUser.id },
+    { slug: "felix-pm", domainAppId: "da-felix-pm", type: "InvitedToInterview", madeBy: pmLeadUser.id },
+    { slug: "grace-eng", domainAppId: "da-grace-eng", type: "Rejected", madeBy: engLead.id, notes: "Both reviewers recommended no-hire." },
   ];
 
   for (const spec of decisionSpecs) {
@@ -2525,7 +2535,7 @@ async function main() {
           domainApplicationId: spec.domainAppId,
           type: spec.type,
           stage: "Released",
-          madeById: jordanMember.id,
+          madeById: jordan.id,
           createdAt: ts(-250),
           notes: spec.notes ?? null,
         },
@@ -2537,11 +2547,11 @@ async function main() {
   // Use the first two availabilityWindows entries (consecutive weekdays,
   // 14:00–16:00 UTC), pick the first 30-minute slot in each. Different days
   // guarantee Riley (shared InDomain interviewer) is never double-booked.
-  async function getCycleInterviewer(daliMemberId: string, domainId: string) {
+  async function getCycleInterviewer(userId: string, domainId: string) {
     return prisma.cycleInterviewer.findUniqueOrThrow({
       where: {
-        daliMemberId_applicationCycleId_domainId: {
-          daliMemberId,
+        userId_applicationCycleId_domainId: {
+          userId,
           applicationCycleId: cycle.id,
           domainId,
         },
@@ -2549,9 +2559,9 @@ async function main() {
     });
   }
 
-  const rileyCI = await getCycleInterviewer(rileyMember.id, engDomain.id);
-  const samCI = await getCycleInterviewer(samMember.id, designDomain.id);
-  const patCI = await getCycleInterviewer(patMember.id, pmDomain.id);
+  const rileyCI = await getCycleInterviewer(rileyUser.id, engDomain.id);
+  const samCI = await getCycleInterviewer(samUser.id, designDomain.id);
+  const patCI = await getCycleInterviewer(patUser.id, pmDomain.id);
 
   const interviewBookings: {
     id: string;
@@ -2728,7 +2738,7 @@ async function main() {
     const existing = await prisma.legacyEmailTemplate.findFirst({ where: { type: legacyType } })
     if (!existing) {
       await prisma.legacyEmailTemplate.create({
-        data: { type: legacyType, subject: t.subject, body: t.body, version: 1, createdById: engLeadMember.id },
+        data: { type: legacyType, subject: t.subject, body: t.body, version: 1, createdById: engLead.id },
       })
     }
   }
@@ -2753,7 +2763,7 @@ async function main() {
           versionNumber: 1,
           subject: t.subject,
           body: t.body,
-          createdById: engLeadMember.id,
+          createdById: engLead.id,
         },
       })
     }

--- a/dali-api/prisma/seed.ts
+++ b/dali-api/prisma/seed.ts
@@ -47,35 +47,39 @@ async function main() {
   // Phase 1 adds `code` + `displayName` to Domain. Local seeds populate them
   // so a fresh dev DB has consistent values; prod backfill is handled by the
   // v0 reference-data script (prisma/seeds/v0-reference.ts).
+  // Local-seed displayName intentionally mirrors `name` so existing e2e tests
+  // (which match on the legacy "Design"/"Engineering"/"Product" labels) keep
+  // working. Prod uses the canonical catalog via prisma/seeds/v0-reference.ts
+  // where displayName is the real catalog label (e.g. "UI/UX Design").
   const [designDomain, engDomain, pmDomain] = await Promise.all([
     prisma.domain.upsert({
       where: { id: "domain-design" },
-      update: { code: "UIUX", displayName: "UI/UX Design" },
+      update: { code: "UIUX", displayName: "Design" },
       create: {
         id: "domain-design",
         name: "Design",
         code: "UIUX",
-        displayName: "UI/UX Design",
+        displayName: "Design",
       },
     }),
     prisma.domain.upsert({
       where: { id: "domain-eng" },
-      update: { code: "Fullstack", displayName: "Fullstack Dev" },
+      update: { code: "Fullstack", displayName: "Engineering" },
       create: {
         id: "domain-eng",
         name: "Engineering",
         code: "Fullstack",
-        displayName: "Fullstack Dev",
+        displayName: "Engineering",
       },
     }),
     prisma.domain.upsert({
       where: { id: "domain-pm" },
-      update: { code: "PM", displayName: "Product Management" },
+      update: { code: "PM", displayName: "Product" },
       create: {
         id: "domain-pm",
         name: "Product",
         code: "PM",
-        displayName: "Product Management",
+        displayName: "Product",
       },
     }),
   ]);

--- a/dali-api/prisma/seeds/v0-reference.ts
+++ b/dali-api/prisma/seeds/v0-reference.ts
@@ -35,22 +35,32 @@ type DomainSeed = {
   code: string;
   displayName: string;
   isInternProgram: boolean;
+  // Legacy `name` values that should be matched and merged into this row
+  // when running against a database that pre-dates Phase 1. The first run of
+  // this seed against staging created v0-reference rows alongside the legacy
+  // ones (because the upsert keyed on code, which the legacy rows didn't
+  // have). This list lets the heal step below find the live legacy row by
+  // name and assign it the canonical code instead — preserving all the
+  // ChallengeVersion / DomainApplicationCycle / DomainLeadAssignment /
+  // CycleReviewer / CycleInterviewer / DelibsSession references already
+  // pointing at it.
+  legacyNames?: string[];
 };
 
 const DOMAINS: DomainSeed[] = [
-  { code: "Fullstack", displayName: "Fullstack Dev", isInternProgram: false },
-  { code: "UIUX", displayName: "UI/UX Design", isInternProgram: false },
-  { code: "ARVR", displayName: "AR/VR Dev", isInternProgram: false },
-  { code: "Data", displayName: "Data Dev", isInternProgram: false },
-  { code: "Engineering", displayName: "Engineering", isInternProgram: false },
-  { code: "ThreeDModeling", displayName: "3D Modeling", isInternProgram: false },
-  { code: "Animation", displayName: "Animation", isInternProgram: false },
-  { code: "Graphics", displayName: "Graphics", isInternProgram: false },
-  { code: "Writing", displayName: "Writing", isInternProgram: false },
-  { code: "Videography", displayName: "Videography", isInternProgram: false },
-  { code: "Photography", displayName: "Photography", isInternProgram: false },
+  { code: "Fullstack", displayName: "Fullstack Dev", isInternProgram: false, legacyNames: ["Fullstack Development"] },
+  { code: "UIUX", displayName: "UI/UX Design", isInternProgram: false, legacyNames: ["UI/UX Design"] },
+  { code: "ARVR", displayName: "AR/VR Dev", isInternProgram: false, legacyNames: ["AR/VR Development"] },
+  { code: "Data", displayName: "Data Dev", isInternProgram: false, legacyNames: ["Data Development"] },
+  { code: "Engineering", displayName: "Engineering", isInternProgram: false, legacyNames: ["Engineering"] },
+  { code: "ThreeDModeling", displayName: "3D Modeling", isInternProgram: false, legacyNames: ["3D Modeling"] },
+  { code: "Animation", displayName: "Animation", isInternProgram: false, legacyNames: ["Animation"] },
+  { code: "Graphics", displayName: "Graphics", isInternProgram: false, legacyNames: ["Graphics"] },
+  { code: "Writing", displayName: "Writing", isInternProgram: false, legacyNames: ["Writing"] },
+  { code: "Videography", displayName: "Videography", isInternProgram: false, legacyNames: ["Videography"] },
+  { code: "Photography", displayName: "Photography", isInternProgram: false, legacyNames: ["Photography"] },
   { code: "Production", displayName: "Production", isInternProgram: false },
-  { code: "PM", displayName: "Product Management", isInternProgram: false },
+  { code: "PM", displayName: "Product Management", isInternProgram: false, legacyNames: ["Product Management"] },
   { code: "DigitalArts", displayName: "Digital Arts Design", isInternProgram: false },
   { code: "ERAS", displayName: "ERAS Intern", isInternProgram: true },
   { code: "EEJUST", displayName: "EE Just Intern", isInternProgram: true },
@@ -77,11 +87,51 @@ function quarterDates(year: number, season: Season): { start: Date; end: Date } 
 }
 
 async function seedDomains() {
+  let healed = 0;
+  let mergedDuplicates = 0;
+
   for (const d of DOMAINS) {
+    // ── Heal step ──────────────────────────────────────────────────────────
+    // If a legacy row (pre-Phase-1) exists for one of this domain's
+    // `legacyNames` with no `code` yet, assign it the canonical code +
+    // displayName. This preserves all FK references attached to the legacy
+    // row (ChallengeVersion, DomainApplicationCycle, etc.).
+    let healedRow: { id: string } | null = null;
+    if (d.legacyNames && d.legacyNames.length > 0) {
+      const legacy = await prisma.domain.findFirst({
+        where: { code: null as any, name: { in: d.legacyNames } },
+      });
+      if (legacy) {
+        // If a prior run of this seed already created a duplicate by code,
+        // delete it first to free the unique constraint. The duplicate has
+        // no FK references (it was just created and never used).
+        const duplicate = await prisma.domain.findUnique({
+          where: { code: d.code },
+        });
+        if (duplicate && duplicate.id !== legacy.id) {
+          await prisma.domain.delete({ where: { id: duplicate.id } });
+          mergedDuplicates++;
+        }
+        healedRow = await prisma.domain.update({
+          where: { id: legacy.id },
+          data: {
+            code: d.code,
+            displayName: d.displayName,
+            isInternProgram: d.isInternProgram,
+            active: true,
+          },
+        });
+        healed++;
+      }
+    }
+
+    if (healedRow) continue;
+
+    // ── Upsert step ────────────────────────────────────────────────────────
+    // Either no legacy row to heal, or it was already healed on a prior run.
+    // Regular upsert by code; create the row if it doesn't exist yet.
     await prisma.domain.upsert({
       where: { code: d.code },
-      // If the row already exists, update only the new Phase 1 fields.
-      // Legacy `name` is left alone (Phase 2 drops it).
       update: {
         displayName: d.displayName,
         isInternProgram: d.isInternProgram,
@@ -96,7 +146,10 @@ async function seedDomains() {
       },
     });
   }
-  console.log(`✓ Seeded ${DOMAINS.length} domains.`);
+  console.log(
+    `✓ Seeded ${DOMAINS.length} domains (healed ${healed} legacy rows, ` +
+    `merged ${mergedDuplicates} duplicate v0-reference rows).`,
+  );
 }
 
 async function seedTerms() {

--- a/dali-api/prisma/seeds/v0-reference.ts
+++ b/dali-api/prisma/seeds/v0-reference.ts
@@ -98,9 +98,14 @@ async function seedDomains() {
     // row (ChallengeVersion, DomainApplicationCycle, etc.).
     let healedRow: { id: string } | null = null;
     if (d.legacyNames && d.legacyNames.length > 0) {
-      const legacy = await prisma.domain.findFirst({
-        where: { code: null as any, name: { in: d.legacyNames } },
-      });
+      // Prisma 7's generated `StringFilter` for the nullable `code` column
+      // doesn't include `null` in the type union, even though the runtime
+      // accepts it. Raw SQL bypasses the typing issue and is clearer here.
+      const [legacy] = await prisma.$queryRaw<Array<{ id: string }>>`
+        SELECT id FROM "Domain"
+        WHERE code IS NULL AND name = ANY(${d.legacyNames}::text[])
+        LIMIT 1
+      `;
       if (legacy) {
         // If a prior run of this seed already created a duplicate by code,
         // delete it first to free the unique constraint. The duplicate has

--- a/dali-api/scripts/add-test-interviewer.ts
+++ b/dali-api/scripts/add-test-interviewer.ts
@@ -53,32 +53,24 @@ async function main() {
     },
   });
 
-  let member = await prisma.dALIMember.findFirst({
-    where: { OR: [{ userId: user.id }, { daliEmail: user.daliEmail! }] },
+  await prisma.dALIMember.upsert({
+    where: { userId: user.id },
+    update: {},
+    create: { userId: user.id },
   });
-  if (!member) {
-    member = await prisma.dALIMember.create({
-      data: { userId: user.id, daliEmail: user.daliEmail! },
-    });
-  } else if (!member.userId) {
-    member = await prisma.dALIMember.update({
-      where: { id: member.id },
-      data: { userId: user.id },
-    });
-  }
 
   // Create CycleInterviewer for the cross-domain
   const ci = await prisma.cycleInterviewer.upsert({
     where: {
-      daliMemberId_applicationCycleId_domainId: {
-        daliMemberId: member.id,
+      userId_applicationCycleId_domainId: {
+        userId: user.id,
         applicationCycleId: cycleId,
         domainId: domainForInterviewer.domainId,
       },
     },
     update: {},
     create: {
-      daliMemberId: member.id,
+      userId: user.id,
       applicationCycleId: cycleId,
       domainId: domainForInterviewer.domainId,
     },

--- a/dali-api/scripts/find-phantom-reviews.ts
+++ b/dali-api/scripts/find-phantom-reviews.ts
@@ -34,7 +34,7 @@ const phantoms = await prisma.applicationReview.findMany({
       },
     },
     cycleReviewer: {
-      include: { daliMember: { select: { firstName: true, lastName: true, daliEmail: true } } },
+      include: { user: { select: { firstName: true, lastName: true, daliEmail: true } } },
     },
   },
   orderBy: { createdAt: "asc" },
@@ -50,7 +50,7 @@ for (const r of phantoms) {
   const applicant = `${u.firstName} ${u.lastName} <${u.daliEmail ?? u.dartmouthEmail ?? u.netId ?? "?"}>`;
   const domain = r.domainApplication.challengeVersion.domain?.name ?? "?";
   const cycle = r.domainApplication.application.applicationCycle.name;
-  const m = r.cycleReviewer.daliMember;
+  const m = r.cycleReviewer.user;
   const reviewer = `${m.firstName} ${m.lastName} <${m.daliEmail}>`;
 
   const scores = r.scores as Record<string, unknown>;

--- a/dali-api/scripts/fix-cross-domain.ts
+++ b/dali-api/scripts/fix-cross-domain.ts
@@ -17,7 +17,9 @@ async function main() {
   // Find or create a "Design" domain
   let designDomain = await prisma.domain.findFirst({ where: { name: "Design" } });
   if (!designDomain) {
-    designDomain = await prisma.domain.create({ data: { name: "Design" } });
+    designDomain = await prisma.domain.create({
+      data: { name: "Design", code: "UIUX", displayName: "UI/UX Design" },
+    });
     console.log(`Created Design domain: ${designDomain.id}`);
   }
 
@@ -29,15 +31,15 @@ async function main() {
   });
   console.log(`Design domain linked to cycle`);
 
-  // Find Morgan's member record
-  const morgan = await prisma.dALIMember.findFirst({
+  // Find Morgan's user record
+  const morgan = await prisma.user.findFirst({
     where: { daliEmail: "test.interviewer@dali.dartmouth.edu" },
   });
   if (!morgan) { console.error("Morgan not found"); process.exit(1); }
 
   // Delete old Engineering CycleInterviewer (and its availability)
   const oldCI = await prisma.cycleInterviewer.findFirst({
-    where: { daliMemberId: morgan.id, applicationCycleId: cycleId },
+    where: { userId: morgan.id, applicationCycleId: cycleId },
   });
   if (oldCI) {
     await prisma.interviewerAvailability.deleteMany({ where: { cycleInterviewerId: oldCI.id } });
@@ -48,7 +50,7 @@ async function main() {
   // Create new CycleInterviewer under Design
   const newCI = await prisma.cycleInterviewer.create({
     data: {
-      daliMemberId: morgan.id,
+      userId: morgan.id,
       applicationCycleId: cycleId,
       domainId: designDomain.id,
     },

--- a/dali-api/scripts/verify-v0-phase1.sql
+++ b/dali-api/scripts/verify-v0-phase1.sql
@@ -1,0 +1,134 @@
+-- Verify v0 Phase 1 migration landed cleanly.
+--
+-- Run against staging Neon (or any post-Phase-1 DB):
+--   flyctl proxy 5432:5432 -a dali-api-staging &
+--   psql 'postgres://...localhost:5432/neondb' -f scripts/verify-v0-phase1.sql
+-- or paste into Neon's SQL editor for the staging branch.
+--
+-- Each query is labeled. Look for:
+--   - "PASS" / "FAIL" lines
+--   - row counts that match expectations
+--   - empty result sets in the integrity-check section
+
+\echo '=== 1. New tables present (expect 43 rows) ==='
+SELECT COUNT(*) AS new_tables_count
+FROM information_schema.tables
+WHERE table_schema = 'public'
+  AND table_name IN (
+    'Term', 'DomainEligibility', 'ProjectAssignment', 'MentorshipPair',
+    'CoreAssignment', 'InstructorAssignment', 'AdminMembership', 'JobCodeLookup',
+    'Project', 'ProjectTermStatus', 'ProjectRoleRequest', 'Epic', 'Sprint',
+    'Task', 'TaskAssignee', 'TaskComment',
+    'EducationOffering', 'EducationSession', 'EducationApplication',
+    'EducationApplicationQuestion', 'EducationApplicationAnswer',
+    'EducationAttendance', 'EducationAssignment', 'EducationSubmission',
+    'EducationAnnouncement',
+    'StaffingCycle', 'StaffingPreference', 'EssentialityForm',
+    'EssentialityRating', 'StaffingAssignment',
+    'Page', 'PageTemplate', 'MentorNote', 'MentorNoteTemplate',
+    'NotificationEvent', 'NotificationPreference',
+    'PartnerOrg', 'PartnerUser', 'ProjectPartner',
+    'OAuthClient', 'OAuthGrant', 'OneTimeToken', 'GmailIntegration'
+  );
+-- Expect: 43. Any other number → some new tables missing.
+
+\echo '=== 2. New User columns present (expect 11 rows) ==='
+SELECT column_name, data_type, is_nullable
+FROM information_schema.columns
+WHERE table_schema = 'public' AND table_name = 'User'
+  AND column_name IN (
+    'classYear','graduatedAt','pronouns','photoUrl','bioDocId','major',
+    'hometown','linkedinUrl','githubUrl','personalSite','personalEmail'
+  )
+ORDER BY column_name;
+-- Expect: 11 rows, all nullable.
+
+\echo '=== 3. Legacy columns still present (Phase 1 is additive — these survive until Phase 2) ==='
+SELECT
+  EXISTS(SELECT 1 FROM information_schema.columns WHERE table_name='User' AND column_name='googleAccessToken') AS user_google_access_token,
+  EXISTS(SELECT 1 FROM information_schema.columns WHERE table_name='DALIMember' AND column_name='firstName') AS dalimember_firstName,
+  EXISTS(SELECT 1 FROM information_schema.columns WHERE table_name='DALIMember' AND column_name='roles') AS dalimember_roles,
+  EXISTS(SELECT 1 FROM information_schema.columns WHERE table_name='CycleReviewer' AND column_name='daliMemberId') AS cyclereviewer_daliMemberId,
+  EXISTS(SELECT 1 FROM information_schema.columns WHERE table_name='DomainLeadAssignment' AND column_name='memberId') AS dla_memberId;
+-- Expect: all `true` (Phase 1 didn't drop anything).
+
+\echo '=== 4. New columns on existing models ==='
+SELECT
+  EXISTS(SELECT 1 FROM information_schema.columns WHERE table_name='Application' AND column_name='applicationType') AS application_applicationType,
+  EXISTS(SELECT 1 FROM information_schema.columns WHERE table_name='Domain' AND column_name='code') AS domain_code,
+  EXISTS(SELECT 1 FROM information_schema.columns WHERE table_name='Domain' AND column_name='displayName') AS domain_displayName,
+  EXISTS(SELECT 1 FROM information_schema.columns WHERE table_name='Domain' AND column_name='isInternProgram') AS domain_isInternProgram,
+  EXISTS(SELECT 1 FROM information_schema.columns WHERE table_name='Domain' AND column_name='active') AS domain_active,
+  EXISTS(SELECT 1 FROM information_schema.columns WHERE table_name='DomainLeadAssignment' AND column_name='termId') AS dla_termId;
+-- Expect: all `true`.
+
+\echo '=== 5. Existing data unchanged — User table ==='
+SELECT COUNT(*) AS total_users, COUNT(*) FILTER (WHERE "daliEmail" IS NOT NULL) AS users_with_daliEmail
+FROM "User";
+
+\echo '=== 6. Existing data unchanged — DALIMember ==='
+SELECT
+  COUNT(*) AS total_members,
+  COUNT(*) FILTER (WHERE "userId" IS NULL) AS orphan_members,
+  COUNT(*) FILTER (WHERE 'Admin' = ANY("roles")) AS admin_members,
+  COUNT(*) FILTER (WHERE 'HiringLead' = ANY("roles")) AS hiring_lead_members
+FROM "DALIMember";
+-- Expect: total > 0; orphan ~116 (these will migrate in Phase 2);
+-- admin + hiring_lead counts non-zero.
+
+\echo '=== 7. Application cycle still intact ==='
+SELECT
+  c.id, c.name,
+  (SELECT "newStatus" FROM "ApplicationCycleStatusUpdate" WHERE "applicationCycleId" = c.id ORDER BY "createdAt" DESC LIMIT 1) AS current_status,
+  (SELECT COUNT(*) FROM "Application" WHERE "applicationCycleId" = c.id) AS application_count
+FROM "ApplicationCycle" c
+ORDER BY c."createdAt" DESC
+LIMIT 5;
+
+\echo '=== 8. Hiring FK integrity (Phase 1 left these unchanged) ==='
+SELECT
+  (SELECT COUNT(*) FROM "CycleReviewer") AS reviewers,
+  (SELECT COUNT(*) FROM "CycleInterviewer") AS interviewers,
+  (SELECT COUNT(*) FROM "ApplicationReview") AS reviews,
+  (SELECT COUNT(*) FROM "Decision") AS decisions,
+  (SELECT COUNT(*) FROM "Interview") AS interviews,
+  (SELECT COUNT(*) FROM "DomainLeadAssignment") AS domain_lead_assignments;
+
+\echo '=== 9. v0 reference data status (informational — need to run v0-reference seed before Phase 2) ==='
+SELECT
+  (SELECT COUNT(*) FROM "Term") AS term_count,
+  (SELECT COUNT(*) FROM "Domain" WHERE "code" IS NOT NULL) AS domains_with_code,
+  (SELECT COUNT(*) FROM "Domain" WHERE "code" IS NULL) AS domains_missing_code,
+  (SELECT COUNT(*) FROM "PageTemplate") AS page_templates,
+  (SELECT COUNT(*) FROM "MentorNoteTemplate") AS mentor_templates;
+-- Expect Term > 0 and 17 domains with code (after v0-reference seed).
+-- If Term = 0 — run `npm run db:seed:v0-reference` against staging
+-- before deploying Phase 2.
+
+\echo '=== 10. New tables empty (Phase 1 creates them; population happens in feature tracks) ==='
+SELECT
+  (SELECT COUNT(*) FROM "ProjectAssignment") AS project_assignments,
+  (SELECT COUNT(*) FROM "CoreAssignment") AS core_assignments,
+  (SELECT COUNT(*) FROM "AdminMembership") AS admin_memberships,
+  (SELECT COUNT(*) FROM "DomainEligibility") AS domain_eligibilities,
+  (SELECT COUNT(*) FROM "Project") AS projects,
+  (SELECT COUNT(*) FROM "EducationOffering") AS offerings,
+  (SELECT COUNT(*) FROM "StaffingCycle") AS staffing_cycles,
+  (SELECT COUNT(*) FROM "OAuthClient") AS oauth_clients,
+  (SELECT COUNT(*) FROM "GmailIntegration") AS gmail_integrations;
+-- Expect all 0 except possibly gmail_integrations if anything's run since deploy.
+
+\echo '=== 11. Session.grantId FK constraint added ==='
+SELECT conname, pg_get_constraintdef(oid) AS def
+FROM pg_constraint
+WHERE conrelid = '"Session"'::regclass
+  AND conname LIKE '%grantId%';
+-- Expect: 1 row referencing OAuthGrant("id").
+
+\echo '=== 12. Migration history ==='
+SELECT migration_name, finished_at
+FROM _prisma_migrations
+WHERE migration_name LIKE '%v0_phase1%' OR migration_name LIKE '%calendar_v0%'
+ORDER BY finished_at DESC
+LIMIT 5;
+-- Expect: 20260514040346_v0_phase1_additive finished_at non-null.


### PR DESCRIPTION
## Summary

Companion to #521 (v0 Phase 1 — additive). This is the destructive half of the v0 plan: drops dead columns, slims `DALIMember` to a thin marker, renames hiring FKs from `daliMemberId`/`memberId` → `userId`, drops the `MemberRole` enum, and collapses `OAuthAccountType` to `member`-only. Coordinated against [`V0_PHASE2_PLAN.md`](https://github.com/dali-lab/dali-os/blob/dev/V0_PHASE2_PLAN.md).

**Do not merge until the 2026-S cycle status is `Completed` and a maintenance window with zero active write traffic is scheduled.** Take a Neon snapshot of prod immediately before the Fly release — that's the rollback path.

## Schema diff

- **User**: drop `googleAccessToken`, `googleRefreshToken`, `googleTokenExpiresAt` (moved to new `GmailIntegration`).
- **DALIMember**: slim to thin marker — drop `firstName`, `lastName`, `daliEmail`, `dartmouthEmail`, `did`, `roles`. `userId` → NOT NULL. `did` data backfills into `User.netId` (case-normalized).
- **Hiring FKs (9 tables)** now point at `User` instead of `DALIMember`:
  - `CycleReviewer.daliMemberId` → `CycleReviewer.userId`
  - `CycleInterviewer.daliMemberId` → `CycleInterviewer.userId`
  - `DomainLeadAssignment.memberId` → `DomainLeadAssignment.userId` (+ `termId` → NOT NULL)
  - `Decision.madeById`, `ApplicationReview.submittedById`, `DelibsSession.openedById`, `LegacyEmailTemplate.createdById`, `EmailTemplateVersion.createdById`, `ConfidentialityAgreementVersion.createdById`: column names unchanged; FK target swapped to User; values translated.
- **Domain**: `code` + `displayName` → NOT NULL.
- **OAuthAccountType** enum collapsed to `member` only.
- **MemberRole** enum dropped (Admin → `AdminMembership` rows, HiringLead → `CoreAssignment` with `leadTitle="Hiring Lead"` in current term).

## Migration: `20260514130959_v0_phase2_identity_refactor`

Single transaction. Expected runtime < 5s on <10k rows. Halts with a clear error if no `Term` row covers `now()` (run `npm run db:seed:v0-reference` first).

Order of operations is critical and is documented in the migration SQL itself:

- **M1** — add staging columns (`userId_new` on the 3 renamed FK tables).
- **M2** — promote the 116 orphan `DALIMember` rows (NULL userId) to real User rows, reusing the DALIMember.id as User.id.
- **M3** — backfills: `User.netId` from `DALIMember.did`; `MemberRole[]` → `AdminMembership` + `CoreAssignment`; `DomainLeadAssignment.termId` to current term; hiring `userId_new` columns; `Decision.madeById`/etc. translated from DALIMember.id → User.id; `GmailIntegration` absorbs legacy `User.google*` for the 1–2 admin Gmail-authorize accounts.
- **M4** — column drops, constraint tightening (`NOT NULL`), enum drops, FK recreation (now pointing at User), unique index recreation.

## Code changes (~80 files)

- **`lib/roles.ts`** rewritten. `UserRoles` shape: `{ isLabMember, isHiringLead, isAdmin, isDomainLead }` (memberId renamed to isLabMember). New helpers: `currentTerm()`, `requireMember()`. HiringLead semantic now resolves to Core or Admin per V0_PLAN.md.
- **`lib/user-provisioning.ts`** — `upsertUserFromGoogle` collapsed to the `@dali.dartmouth.edu` branch only. Non-DALI Google emails throw (the dartmouth + partner branches were dead code post-#520; the website login enforces the domain in the route, and `/oauth/*` is MCP-only and members-only per #516 / `V0_PLAN.md` Q18).
- **`lib/collabAuth.ts`** — ownership checks compare `auth.user.sub` directly. Also fixes a latent Phase-1 bug where `cycleReviewer.userId === member.id` was comparing User.id to DALIMember.id (always false).
- **`lib/google-calendar.ts`** — `fetchBusyFromLegacyUserTokens` removed. Free-busy is exclusively via `UserCalendarLink`.
- **`lib/gmail-integration.ts`** (new) — `getApplicationsGmailRefreshToken`, `isApplicationsGmailConnected`. Six Gmail-send call sites switched off `User.googleRefreshToken` onto this helper.
- **~30 hiring routes** migrated off the `prisma.dALIMember.findFirst({where:{userId}})` indirection. Direct User reads via `auth.user.sub`. `include: { daliMember: { include: { user: ... } } }` → `include: { user: ... }`.
- **Admin Console** members/domains pages rewritten: the `DALIMember.roles[]` editor is replaced with toggles that insert/delete `AdminMembership` / `CoreAssignment` / `DomainLeadAssignment` rows. Shared types in `admin-console-shared.tsx` reshaped (`Member` is User-rooted with `isLabMember`/`isAdmin`/`isCore` flags).
- **`/oauth/authorize`** — `VALID_ACCOUNT_TYPES` collapsed to `["member"]`.
- **Test suite** updated to match the new schema. Mocks now reference `prisma.dALIMember.findUnique`, `prisma.adminMembership`, `prisma.coreAssignment`, `prisma.gmailIntegration` where appropriate. `user-provisioning.test.ts` rewritten to assert the throwing behavior on non-DALI emails. **698/698 tests passing.**

## Deferred to a follow-up (intentionally)

- `lib/auth/` directory split (`lib/auth.ts` → `lib/auth/cookie-login.ts`, etc.). Pure path refactor, no behavior change. Not load-bearing for the data model and risks adding noise to the destructive PR.
- `Domain.name` removal (kept as soft fallback for `display.ts`). Drop when `display.ts` reads `displayName` instead.

## Test plan

- [x] `npm run typecheck` — clean for tracked files
- [x] `npm test` (Vitest) — 698/698 passing
- [ ] `npm run test:e2e` against seeded Postgres
- [ ] `migration-check.yml` (pgfence) green — expect a flag on the destructive operations; this is intentional and gated on the maintenance window
- [ ] Reset staging Neon from a fresh prod snapshot
- [ ] `npm run db:seed:v0-reference` on staging to ensure Term rows exist (migration halts otherwise)
- [ ] `npx prisma migrate deploy` applies cleanly on staging
- [ ] Post-deploy on staging: confirm 0 NULL backfill values:
  - `SELECT COUNT(*) FROM "DALIMember" WHERE "userId" IS NULL;` → 0
  - `SELECT COUNT(*) FROM "CycleReviewer" WHERE "userId" IS NULL;` → 0 (and same for the 9 renamed FK tables)
  - `SELECT COUNT(*) FROM "DomainLeadAssignment" WHERE "termId" IS NULL;` → 0
- [ ] Hiring smoke tests on staging: reviewer submit, decision release, interview schedule, delibs open, Gmail send-as
- [ ] Production rollout in a scheduled maintenance window after 2026-S cycle closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)