### PR TITLE
v0 Phase 2 follow-up — migration collision handling + verify script

### DIFF
--- a/dali-api/prisma/migrations/20260514130959_v0_phase2_identity_refactor/migration.sql
+++ b/dali-api/prisma/migrations/20260514130959_v0_phase2_identity_refactor/migration.sql
@@ -31,6 +31,10 @@ ALTER TABLE "DomainLeadAssignment" ADD COLUMN "userId_new" TEXT;
 -- We reuse the DALIMember.id as the new User.id (both cuids; no collision
 -- since DALIMember.id is unique and no existing User shares it).
 
+-- INSERT uses ON CONFLICT DO NOTHING (without column spec) so that
+-- conflicts on ANY unique constraint (daliEmail, netId, or did's lowercase
+-- collision with a pre-existing User.netId) skip cleanly. Skipped rows are
+-- handled by the linking UPDATE below, which keys on daliEmail.
 INSERT INTO "User" (id, "createdAt", "updatedAt", "firstName", "lastName", "daliEmail", "netId")
 SELECT
   m.id,
@@ -39,11 +43,18 @@ SELECT
   COALESCE(NULLIF(m."firstName", ''), 'Unknown'),
   COALESCE(NULLIF(m."lastName",  ''), ''),
   m."daliEmail",
-  LOWER(m."did")
+  -- Only set netId if no existing User already owns this value. Otherwise
+  -- leave NULL and let the user complete their identity by signing in.
+  CASE
+    WHEN m."did" IS NULL THEN NULL
+    WHEN EXISTS (SELECT 1 FROM "User" u WHERE u."netId" = LOWER(m."did"))
+      THEN NULL
+    ELSE LOWER(m."did")
+  END
 FROM "DALIMember" m
 WHERE m."userId" IS NULL
   AND m."daliEmail" IS NOT NULL
-ON CONFLICT ("daliEmail") DO NOTHING;
+ON CONFLICT DO NOTHING;
 
 -- Link the freshly-created User rows back to their DALIMember.
 UPDATE "DALIMember" m
@@ -52,18 +63,30 @@ FROM "User" u
 WHERE m."userId" IS NULL AND m."daliEmail" = u."daliEmail";
 
 -- Discard any DALIMember row that still has no userId (no daliEmail to
--- migrate). These should not exist in prod; the DELETE is defensive.
+-- migrate, or daliEmail collided with a non-member User during INSERT).
+-- These should be rare; the DELETE is defensive.
 DELETE FROM "DALIMember" WHERE "userId" IS NULL;
 
 -- ═══ M3: backfills ════════════════════════════════════════════════════════
 
--- M3a. Backfill User.netId from DALIMember.did where User doesn't already
--- have a netId. Per V0_PLAN.md: netId === did (same Dartmouth identifier,
--- case-normalized to lowercase).
+-- M3a. Backfill User.netId from DALIMember.did where:
+--   (a) the User doesn't already have a netId, AND
+--   (b) no other User already owns the target netId value.
+-- Per V0_PLAN.md: netId === did (same Dartmouth identifier, case-normalized).
+-- Case (b) typically arises when a member logged in via CAS first (got
+-- netId='f006jnh'), and a separate DALIMember row linked to a DIFFERENT
+-- User has did='F006JNH'. We skip rather than collide — the second User
+-- can still operate without a netId; if they later log in via CAS,
+-- linkCasToGoogleUser will merge them into the correct User row.
 UPDATE "User" u
 SET "netId" = LOWER(m."did")
 FROM "DALIMember" m
-WHERE u.id = m."userId" AND u."netId" IS NULL AND m."did" IS NOT NULL;
+WHERE u.id = m."userId"
+  AND u."netId" IS NULL
+  AND m."did" IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM "User" u2 WHERE u2."netId" = LOWER(m."did") AND u2.id <> u.id
+  );
 
 -- M3b. Backfill User.firstName/lastName from DALIMember where missing.
 -- (Defensive; in practice User rows have these populated.)
@@ -147,6 +170,22 @@ BEGIN
   UPDATE "DomainLeadAssignment" SET "termId" = cur_term_id WHERE "termId" IS NULL;
 END $$;
 
+-- M3-pre. Drop the OLD foreign keys that reference DALIMember BEFORE we
+-- translate their values. Postgres validates FKs on every UPDATE, so
+-- changing submittedById/madeById/etc. from a DALIMember.id to a User.id
+-- with the old FK still in place would fail with "Key is not present in
+-- DALIMember". We drop them here, translate in M3e/M3f, and add the new
+-- User-pointing FKs in M4.
+ALTER TABLE "CycleReviewer"                   DROP CONSTRAINT IF EXISTS "CycleReviewer_daliMemberId_fkey";
+ALTER TABLE "CycleInterviewer"                DROP CONSTRAINT IF EXISTS "CycleInterviewer_daliMemberId_fkey";
+ALTER TABLE "DomainLeadAssignment"            DROP CONSTRAINT IF EXISTS "DomainLeadAssignment_memberId_fkey";
+ALTER TABLE "Decision"                        DROP CONSTRAINT IF EXISTS "Decision_madeById_fkey";
+ALTER TABLE "ApplicationReview"               DROP CONSTRAINT IF EXISTS "ApplicationReview_submittedById_fkey";
+ALTER TABLE "DelibsSession"                   DROP CONSTRAINT IF EXISTS "DelibsSession_openedById_fkey";
+ALTER TABLE "LegacyEmailTemplate"             DROP CONSTRAINT IF EXISTS "LegacyEmailTemplate_createdById_fkey";
+ALTER TABLE "EmailTemplateVersion"            DROP CONSTRAINT IF EXISTS "EmailTemplateVersion_createdById_fkey";
+ALTER TABLE "ConfidentialityAgreementVersion" DROP CONSTRAINT IF EXISTS "ConfidentialityAgreementVersion_createdById_fkey";
+
 -- M3e. CycleReviewer / CycleInterviewer / DomainLeadAssignment: populate
 -- userId_new from the existing daliMemberId/memberId join.
 UPDATE "CycleReviewer" cr
@@ -166,7 +205,8 @@ WHERE dla."memberId" = m.id;
 
 -- M3f. Translate DALIMember.id → User.id for the six FK columns that point
 -- at DALIMember today. The column NAME stays (madeById, submittedById,
--- openedById, createdById); only the referenced table changes.
+-- openedById, createdById); only the referenced table changes. Possible
+-- only because we dropped the old FKs above.
 UPDATE "Decision" d
 SET "madeById" = m."userId"
 FROM "DALIMember" m
@@ -232,18 +272,11 @@ ALTER TYPE "OAuthAccountType" RENAME TO "OAuthAccountType_old";
 ALTER TYPE "OAuthAccountType_new" RENAME TO "OAuthAccountType";
 DROP TYPE "OAuthAccountType_old";
 
--- Drop old foreign keys.
-ALTER TABLE "DALIMember"                      DROP CONSTRAINT "DALIMember_userId_fkey";
-ALTER TABLE "CycleReviewer"                   DROP CONSTRAINT "CycleReviewer_daliMemberId_fkey";
-ALTER TABLE "CycleInterviewer"                DROP CONSTRAINT "CycleInterviewer_daliMemberId_fkey";
-ALTER TABLE "Decision"                        DROP CONSTRAINT "Decision_madeById_fkey";
-ALTER TABLE "ApplicationReview"               DROP CONSTRAINT "ApplicationReview_submittedById_fkey";
-ALTER TABLE "DelibsSession"                   DROP CONSTRAINT "DelibsSession_openedById_fkey";
-ALTER TABLE "LegacyEmailTemplate"             DROP CONSTRAINT "LegacyEmailTemplate_createdById_fkey";
-ALTER TABLE "EmailTemplateVersion"            DROP CONSTRAINT "EmailTemplateVersion_createdById_fkey";
-ALTER TABLE "ConfidentialityAgreementVersion" DROP CONSTRAINT "ConfidentialityAgreementVersion_createdById_fkey";
-ALTER TABLE "DomainLeadAssignment"            DROP CONSTRAINT "DomainLeadAssignment_memberId_fkey";
-ALTER TABLE "DomainLeadAssignment"            DROP CONSTRAINT "DomainLeadAssignment_termId_fkey";
+-- Drop remaining old foreign keys (the DALIMember-referencing ones were
+-- dropped earlier in M3-pre so M3f could translate values; the rest are
+-- dropped here).
+ALTER TABLE "DALIMember"           DROP CONSTRAINT "DALIMember_userId_fkey";
+ALTER TABLE "DomainLeadAssignment" DROP CONSTRAINT "DomainLeadAssignment_termId_fkey";
 
 -- Drop old indexes.
 DROP INDEX "DALIMember_daliEmail_key";

--- a/dali-api/scripts/verify-v0-phase2.sql
+++ b/dali-api/scripts/verify-v0-phase2.sql
@@ -1,0 +1,167 @@
+-- Verify v0 Phase 2 migration landed cleanly.
+--
+-- Run against staging (or any post-Phase-2 DB):
+--   flyctl proxy 5432:5432 -a dali-api-staging &
+--   psql 'postgres://...' -f scripts/verify-v0-phase2.sql
+--
+-- Compare counts to the Phase 1 verification output you captured earlier
+-- (215 users, 142 DALIMembers, 95 orphans, 45 reviewers, 18 interviewers,
+-- 118 reviews, 42 DLAs).
+
+\echo '=== 1. Migration history (expect both phase1_additive + phase2_identity_refactor) ==='
+SELECT migration_name, finished_at, applied_steps_count
+FROM _prisma_migrations
+WHERE migration_name LIKE '%v0_phase%' OR migration_name LIKE '%calendar_v0%'
+ORDER BY finished_at DESC
+LIMIT 5;
+
+\echo ''
+\echo '=== 2. DALIMember slim-down ==='
+-- DALIMember should now have only: id, userId, createdAt, updatedAt.
+-- Dropped: firstName, lastName, daliEmail, dartmouthEmail, did, roles.
+SELECT column_name, data_type, is_nullable
+FROM information_schema.columns
+WHERE table_schema='public' AND table_name='DALIMember'
+ORDER BY column_name;
+-- Expect: 4 rows. Anything else = drops didn't happen.
+
+\echo ''
+\echo '=== 3. User.google* dropped ==='
+SELECT
+  EXISTS(SELECT 1 FROM information_schema.columns WHERE table_name='User' AND column_name='googleAccessToken') AS still_has_googleAccessToken,
+  EXISTS(SELECT 1 FROM information_schema.columns WHERE table_name='User' AND column_name='googleRefreshToken') AS still_has_googleRefreshToken,
+  EXISTS(SELECT 1 FROM information_schema.columns WHERE table_name='User' AND column_name='googleTokenExpiresAt') AS still_has_googleTokenExpiresAt;
+-- Expect: all `false`.
+
+\echo ''
+\echo '=== 4. Hiring FK renames ==='
+SELECT
+  EXISTS(SELECT 1 FROM information_schema.columns WHERE table_name='CycleReviewer' AND column_name='daliMemberId') AS cyclereviewer_still_has_daliMemberId,
+  EXISTS(SELECT 1 FROM information_schema.columns WHERE table_name='CycleReviewer' AND column_name='userId') AS cyclereviewer_has_userId,
+  EXISTS(SELECT 1 FROM information_schema.columns WHERE table_name='CycleInterviewer' AND column_name='daliMemberId') AS cycleinterviewer_still_has_daliMemberId,
+  EXISTS(SELECT 1 FROM information_schema.columns WHERE table_name='CycleInterviewer' AND column_name='userId') AS cycleinterviewer_has_userId,
+  EXISTS(SELECT 1 FROM information_schema.columns WHERE table_name='DomainLeadAssignment' AND column_name='memberId') AS dla_still_has_memberId,
+  EXISTS(SELECT 1 FROM information_schema.columns WHERE table_name='DomainLeadAssignment' AND column_name='userId') AS dla_has_userId;
+-- Expect: still_has_*: all false; has_userId: all true.
+
+\echo ''
+\echo '=== 5. NOT NULL constraints tightened ==='
+SELECT
+  (SELECT is_nullable FROM information_schema.columns WHERE table_name='DALIMember' AND column_name='userId') AS dalimember_userId_nullable,
+  (SELECT is_nullable FROM information_schema.columns WHERE table_name='DomainLeadAssignment' AND column_name='termId') AS dla_termId_nullable,
+  (SELECT is_nullable FROM information_schema.columns WHERE table_name='Domain' AND column_name='code') AS domain_code_nullable,
+  (SELECT is_nullable FROM information_schema.columns WHERE table_name='Domain' AND column_name='displayName') AS domain_displayName_nullable,
+  (SELECT is_nullable FROM information_schema.columns WHERE table_name='CycleReviewer' AND column_name='userId') AS cyclereviewer_userId_nullable,
+  (SELECT is_nullable FROM information_schema.columns WHERE table_name='CycleInterviewer' AND column_name='userId') AS cycleinterviewer_userId_nullable,
+  (SELECT is_nullable FROM information_schema.columns WHERE table_name='DomainLeadAssignment' AND column_name='userId') AS dla_userId_nullable;
+-- Expect: all 'NO'.
+
+\echo ''
+\echo '=== 6. MemberRole enum dropped ==='
+SELECT EXISTS(SELECT 1 FROM pg_type WHERE typname = 'MemberRole') AS member_role_enum_still_exists;
+-- Expect: `false`.
+
+\echo ''
+\echo '=== 7. OAuthAccountType collapsed to member-only ==='
+SELECT array_agg(enumlabel ORDER BY enumsortorder) AS oauth_account_type_values
+FROM pg_enum
+WHERE enumtypid = (SELECT oid FROM pg_type WHERE typname = 'OAuthAccountType');
+-- Expect: {member}. Anything else = collapse didn't happen.
+
+\echo ''
+\echo '=== 8. FK targets now point at User (not DALIMember) ==='
+SELECT
+  conrelid::regclass::text AS table_name,
+  conname,
+  confrelid::regclass::text AS references_table
+FROM pg_constraint
+WHERE contype = 'f'
+  AND conrelid::regclass::text IN ('"CycleReviewer"', '"CycleInterviewer"', '"Decision"', '"ApplicationReview"', '"DelibsSession"', '"LegacyEmailTemplate"', '"EmailTemplateVersion"', '"ConfidentialityAgreementVersion"', '"DomainLeadAssignment"', '"DALIMember"')
+  AND (conname LIKE '%userId%' OR conname LIKE '%madeBy%' OR conname LIKE '%submittedBy%' OR conname LIKE '%openedBy%' OR conname LIKE '%createdBy%')
+ORDER BY conrelid::regclass::text, conname;
+-- Expect: all references_table values = `"User"` (or "Term" for DLA_termId_fkey).
+
+\echo ''
+\echo '=== 9. Data integrity — DALIMember orphans resolved ==='
+SELECT
+  COUNT(*) AS total_members,
+  COUNT(*) FILTER (WHERE "userId" IS NULL) AS orphan_members
+FROM "DALIMember";
+-- Expect: total = 143 (was 142 in Phase 1 + 95 orphan migrations promoted to
+-- User rows; pre-existing DALIMember count survived);
+-- orphan_members = 0.
+
+\echo ''
+\echo '=== 10. Data integrity — User count grew to absorb orphans ==='
+SELECT COUNT(*) AS total_users FROM "User";
+-- Expect: ~310 (215 prior + 95 migrated orphans). May differ slightly if
+-- some orphans had matching daliEmails (ON CONFLICT DO NOTHING).
+
+\echo ''
+\echo '=== 11. Hiring FK rows preserved (counts should match Phase 1 verification) ==='
+SELECT
+  (SELECT COUNT(*) FROM "CycleReviewer") AS reviewers,
+  (SELECT COUNT(*) FROM "CycleInterviewer") AS interviewers,
+  (SELECT COUNT(*) FROM "ApplicationReview") AS reviews,
+  (SELECT COUNT(*) FROM "Decision") AS decisions,
+  (SELECT COUNT(*) FROM "Interview") AS interviews,
+  (SELECT COUNT(*) FROM "DomainLeadAssignment") AS domain_lead_assignments;
+-- Expect: 45 reviewers, 18 interviewers, 118 reviews (was 116 — drift fine),
+-- 0 decisions, 0 interviews, 42 DLAs.
+
+\echo ''
+\echo '=== 12. All hiring FK userId columns populated (no NULLs) ==='
+SELECT
+  (SELECT COUNT(*) FROM "CycleReviewer" WHERE "userId" IS NULL) AS reviewer_nulls,
+  (SELECT COUNT(*) FROM "CycleInterviewer" WHERE "userId" IS NULL) AS interviewer_nulls,
+  (SELECT COUNT(*) FROM "DomainLeadAssignment" WHERE "userId" IS NULL) AS dla_userId_nulls,
+  (SELECT COUNT(*) FROM "DomainLeadAssignment" WHERE "termId" IS NULL) AS dla_termId_nulls,
+  (SELECT COUNT(*) FROM "Decision" WHERE "madeById" IS NULL) AS decision_nulls,
+  (SELECT COUNT(*) FROM "DelibsSession" WHERE "openedById" IS NULL) AS delibs_nulls;
+-- Expect: all 0. (ApplicationReview.submittedById is intentionally nullable —
+-- represents unsubmitted reviews — not checked here.)
+
+\echo ''
+\echo '=== 13. AdminMembership + CoreAssignment backfill ==='
+SELECT
+  (SELECT COUNT(*) FROM "AdminMembership") AS admin_memberships,
+  (SELECT COUNT(*) FROM "CoreAssignment" WHERE "leadTitle" = 'Hiring Lead') AS hiring_lead_core_assignments;
+-- Expect: admin_memberships = 9 (matches Phase 1 admin_members count);
+-- hiring_lead_core_assignments = 8 (matches Phase 1 hiring_lead_members).
+
+\echo ''
+\echo '=== 14. GmailIntegration backfill (admin Gmail-authorize accounts) ==='
+SELECT
+  COUNT(*) AS gmail_integrations,
+  array_agg("sendAsEmail" ORDER BY "sendAsEmail") AS send_as_emails
+FROM "GmailIntegration";
+-- Expect: 1-2 rows for the dali admin accounts that ran /admin/authorize-gmail.
+-- send_as_emails should include applications@dali.dartmouth.edu.
+
+\echo ''
+\echo '=== 15. Cycle data still intact and queryable through new FK shape ==='
+SELECT
+  cr.id AS reviewer_id,
+  u."firstName", u."lastName", u."daliEmail",
+  d."displayName" AS domain
+FROM "CycleReviewer" cr
+JOIN "User" u ON u.id = cr."userId"
+JOIN "Domain" d ON d.id = cr."domainId"
+LIMIT 5;
+-- Expect: 5 rows joined cleanly. Names and domains visible.
+
+\echo ''
+\echo '=== 16. Sample post-Phase-2 user with full role view ==='
+SELECT
+  u.id,
+  u."firstName" || ' ' || u."lastName" AS name,
+  u."daliEmail",
+  (SELECT COUNT(*) > 0 FROM "DALIMember" m WHERE m."userId" = u.id) AS is_lab_member,
+  (SELECT COUNT(*) > 0 FROM "AdminMembership" am WHERE am."userId" = u.id) AS is_admin,
+  (SELECT COUNT(*) FROM "CoreAssignment" ca WHERE ca."userId" = u.id) AS core_assignments,
+  (SELECT array_agg(d."displayName") FROM "DomainLeadAssignment" dla JOIN "Domain" d ON d.id = dla."domainId" WHERE dla."userId" = u.id) AS lead_domains
+FROM "User" u
+WHERE u."daliEmail" IS NOT NULL
+ORDER BY (SELECT COUNT(*) FROM "AdminMembership" am WHERE am."userId" = u.id) DESC,
+         u."lastName"
+LIMIT 10;


### PR DESCRIPTION
## Summary

Follow-up to merged #525. Two migration fixes + a verification script — **2 files, 220 LOC added, 20 removed**. Both fixes were discovered while validating Phase 2 against real prod-cloned data on staging today.

Without these, **the next staging redeploy and any prod deploy will hit the same failures today's staging deploy did**.

## What's in this PR

### 1. netId unique collision in M2 + M3a

Staging deploy hit:
```
ERROR: duplicate key value violates unique constraint "User_netId_key"
DETAIL: Key ("netId")=(f006jnh) already exists.
```

A member logged into the app via CAS first (`User.netId='f006jnh'`), and a separate DALIMember row linked to a *different* User had `did='F006JNH'`. M3a tried to set the second User's `netId` to `LOWER('F006JNH')` — collision.

Fix:
- M2 `INSERT` computes `netId` as `NULL` when another User already owns the target value
- M2 `ON CONFLICT` widened from `("daliEmail")` to bare `DO NOTHING` so any unique violation skips
- M3a `UPDATE` adds a `NOT EXISTS` guard

The orphaned User can complete their identity via CAS sign-in later; `lib/auth/linking.ts:linkCasToGoogleUser` merges the two Users when that happens.

### 2. FK drop ordering — new M3-pre block

Staging then hit:
```
ERROR: insert or update on table "ApplicationReview" violates FK
DETAIL: Key (submittedById)=(cmox...) is not present in DALIMember.
```

M3f translates six `*ById` columns (`Decision.madeById`, `ApplicationReview.submittedById`, `DelibsSession.openedById`, `LegacyEmailTemplate.createdById`, `EmailTemplateVersion.createdById`, `ConfidentialityAgreementVersion.createdById`) from `DALIMember.id` values to `User.id` values. Postgres validates the FK on every UPDATE, and those FKs still pointed at DALIMember.

Fix: drop the nine DALIMember-referencing FKs in a new M3-pre block *before* the M3e/M3f translations.

### 3. `scripts/verify-v0-phase2.sql`

16-section verification script mirroring `verify-v0-phase1.sql`. Covers schema (DALIMember slim-down, User.google* drop, FK renames, NOT NULL tightening, MemberRole/OAuthAccountType enum cleanup) plus data integrity (no orphans, no NULL FKs, hiring counts preserved, AdminMembership/CoreAssignment/GmailIntegration backfilled).

## Validation status

Today, the migration in this PR was applied successfully against staging Neon (a fresh prod snapshot). All 16 verification sections green:

| Check | Result |
|---|---|
| DALIMember slimmed to 4 cols | ✓ |
| User.google* dropped | ✓ |
| Hiring FKs renamed to userId | ✓ |
| NOT NULL constraints tightened | ✓ |
| MemberRole + OAuthAccountType enum cleanup | ✓ |
| All 10 hiring FKs reference User | ✓ |
| 0 orphan DALIMembers (95 → User rows) | ✓ |
| User count 215 → 311 | ✓ |
| Hiring data preserved (45/18/118/0/0/42) | ✓ |
| AdminMembership × 9 + CoreAssignment Hiring Lead × 8 | ✓ |
| GmailIntegration migrated for applications@dali.dartmouth.edu | ✓ |
| Sample reviewer join through new FK shape | ✓ |

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 698/698 passing
- [x] Migration applied against staging Neon (after 2 instructive failures, both addressed by this PR)
- [x] All 16 `verify-v0-phase2.sql` checks green on staging
- [ ] Merge to `dev` so dev matches the verified state
- [ ] Next staging redeploy applies cleanly on first try (no manual recovery)
- [ ] Promote to prod during maintenance window

🤖 Generated with [Claude Code](https://claude.com/claude-code)