### PR TITLE
chore: add Phase 2 behavioral test script

### DIFF
--- a/dali-api/prisma/migrations/20260514130959_v0_phase2_identity_refactor/migration.sql
+++ b/dali-api/prisma/migrations/20260514130959_v0_phase2_identity_refactor/migration.sql
@@ -31,6 +31,10 @@ ALTER TABLE "DomainLeadAssignment" ADD COLUMN "userId_new" TEXT;
 -- We reuse the DALIMember.id as the new User.id (both cuids; no collision
 -- since DALIMember.id is unique and no existing User shares it).
 
+-- INSERT uses ON CONFLICT DO NOTHING (without column spec) so that
+-- conflicts on ANY unique constraint (daliEmail, netId, or did's lowercase
+-- collision with a pre-existing User.netId) skip cleanly. Skipped rows are
+-- handled by the linking UPDATE below, which keys on daliEmail.
 INSERT INTO "User" (id, "createdAt", "updatedAt", "firstName", "lastName", "daliEmail", "netId")
 SELECT
   m.id,
@@ -39,11 +43,18 @@ SELECT
   COALESCE(NULLIF(m."firstName", ''), 'Unknown'),
   COALESCE(NULLIF(m."lastName",  ''), ''),
   m."daliEmail",
-  LOWER(m."did")
+  -- Only set netId if no existing User already owns this value. Otherwise
+  -- leave NULL and let the user complete their identity by signing in.
+  CASE
+    WHEN m."did" IS NULL THEN NULL
+    WHEN EXISTS (SELECT 1 FROM "User" u WHERE u."netId" = LOWER(m."did"))
+      THEN NULL
+    ELSE LOWER(m."did")
+  END
 FROM "DALIMember" m
 WHERE m."userId" IS NULL
   AND m."daliEmail" IS NOT NULL
-ON CONFLICT ("daliEmail") DO NOTHING;
+ON CONFLICT DO NOTHING;
 
 -- Link the freshly-created User rows back to their DALIMember.
 UPDATE "DALIMember" m
@@ -52,18 +63,30 @@ FROM "User" u
 WHERE m."userId" IS NULL AND m."daliEmail" = u."daliEmail";
 
 -- Discard any DALIMember row that still has no userId (no daliEmail to
--- migrate). These should not exist in prod; the DELETE is defensive.
+-- migrate, or daliEmail collided with a non-member User during INSERT).
+-- These should be rare; the DELETE is defensive.
 DELETE FROM "DALIMember" WHERE "userId" IS NULL;
 
 -- ═══ M3: backfills ════════════════════════════════════════════════════════
 
--- M3a. Backfill User.netId from DALIMember.did where User doesn't already
--- have a netId. Per V0_PLAN.md: netId === did (same Dartmouth identifier,
--- case-normalized to lowercase).
+-- M3a. Backfill User.netId from DALIMember.did where:
+--   (a) the User doesn't already have a netId, AND
+--   (b) no other User already owns the target netId value.
+-- Per V0_PLAN.md: netId === did (same Dartmouth identifier, case-normalized).
+-- Case (b) typically arises when a member logged in via CAS first (got
+-- netId='f006jnh'), and a separate DALIMember row linked to a DIFFERENT
+-- User has did='F006JNH'. We skip rather than collide — the second User
+-- can still operate without a netId; if they later log in via CAS,
+-- linkCasToGoogleUser will merge them into the correct User row.
 UPDATE "User" u
 SET "netId" = LOWER(m."did")
 FROM "DALIMember" m
-WHERE u.id = m."userId" AND u."netId" IS NULL AND m."did" IS NOT NULL;
+WHERE u.id = m."userId"
+  AND u."netId" IS NULL
+  AND m."did" IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM "User" u2 WHERE u2."netId" = LOWER(m."did") AND u2.id <> u.id
+  );
 
 -- M3b. Backfill User.firstName/lastName from DALIMember where missing.
 -- (Defensive; in practice User rows have these populated.)
@@ -147,6 +170,22 @@ BEGIN
   UPDATE "DomainLeadAssignment" SET "termId" = cur_term_id WHERE "termId" IS NULL;
 END $$;
 
+-- M3-pre. Drop the OLD foreign keys that reference DALIMember BEFORE we
+-- translate their values. Postgres validates FKs on every UPDATE, so
+-- changing submittedById/madeById/etc. from a DALIMember.id to a User.id
+-- with the old FK still in place would fail with "Key is not present in
+-- DALIMember". We drop them here, translate in M3e/M3f, and add the new
+-- User-pointing FKs in M4.
+ALTER TABLE "CycleReviewer"                   DROP CONSTRAINT IF EXISTS "CycleReviewer_daliMemberId_fkey";
+ALTER TABLE "CycleInterviewer"                DROP CONSTRAINT IF EXISTS "CycleInterviewer_daliMemberId_fkey";
+ALTER TABLE "DomainLeadAssignment"            DROP CONSTRAINT IF EXISTS "DomainLeadAssignment_memberId_fkey";
+ALTER TABLE "Decision"                        DROP CONSTRAINT IF EXISTS "Decision_madeById_fkey";
+ALTER TABLE "ApplicationReview"               DROP CONSTRAINT IF EXISTS "ApplicationReview_submittedById_fkey";
+ALTER TABLE "DelibsSession"                   DROP CONSTRAINT IF EXISTS "DelibsSession_openedById_fkey";
+ALTER TABLE "LegacyEmailTemplate"             DROP CONSTRAINT IF EXISTS "LegacyEmailTemplate_createdById_fkey";
+ALTER TABLE "EmailTemplateVersion"            DROP CONSTRAINT IF EXISTS "EmailTemplateVersion_createdById_fkey";
+ALTER TABLE "ConfidentialityAgreementVersion" DROP CONSTRAINT IF EXISTS "ConfidentialityAgreementVersion_createdById_fkey";
+
 -- M3e. CycleReviewer / CycleInterviewer / DomainLeadAssignment: populate
 -- userId_new from the existing daliMemberId/memberId join.
 UPDATE "CycleReviewer" cr
@@ -166,7 +205,8 @@ WHERE dla."memberId" = m.id;
 
 -- M3f. Translate DALIMember.id → User.id for the six FK columns that point
 -- at DALIMember today. The column NAME stays (madeById, submittedById,
--- openedById, createdById); only the referenced table changes.
+-- openedById, createdById); only the referenced table changes. Possible
+-- only because we dropped the old FKs above.
 UPDATE "Decision" d
 SET "madeById" = m."userId"
 FROM "DALIMember" m
@@ -232,18 +272,11 @@ ALTER TYPE "OAuthAccountType" RENAME TO "OAuthAccountType_old";
 ALTER TYPE "OAuthAccountType_new" RENAME TO "OAuthAccountType";
 DROP TYPE "OAuthAccountType_old";
 
--- Drop old foreign keys.
-ALTER TABLE "DALIMember"                      DROP CONSTRAINT "DALIMember_userId_fkey";
-ALTER TABLE "CycleReviewer"                   DROP CONSTRAINT "CycleReviewer_daliMemberId_fkey";
-ALTER TABLE "CycleInterviewer"                DROP CONSTRAINT "CycleInterviewer_daliMemberId_fkey";
-ALTER TABLE "Decision"                        DROP CONSTRAINT "Decision_madeById_fkey";
-ALTER TABLE "ApplicationReview"               DROP CONSTRAINT "ApplicationReview_submittedById_fkey";
-ALTER TABLE "DelibsSession"                   DROP CONSTRAINT "DelibsSession_openedById_fkey";
-ALTER TABLE "LegacyEmailTemplate"             DROP CONSTRAINT "LegacyEmailTemplate_createdById_fkey";
-ALTER TABLE "EmailTemplateVersion"            DROP CONSTRAINT "EmailTemplateVersion_createdById_fkey";
-ALTER TABLE "ConfidentialityAgreementVersion" DROP CONSTRAINT "ConfidentialityAgreementVersion_createdById_fkey";
-ALTER TABLE "DomainLeadAssignment"            DROP CONSTRAINT "DomainLeadAssignment_memberId_fkey";
-ALTER TABLE "DomainLeadAssignment"            DROP CONSTRAINT "DomainLeadAssignment_termId_fkey";
+-- Drop remaining old foreign keys (the DALIMember-referencing ones were
+-- dropped earlier in M3-pre so M3f could translate values; the rest are
+-- dropped here).
+ALTER TABLE "DALIMember"           DROP CONSTRAINT "DALIMember_userId_fkey";
+ALTER TABLE "DomainLeadAssignment" DROP CONSTRAINT "DomainLeadAssignment_termId_fkey";
 
 -- Drop old indexes.
 DROP INDEX "DALIMember_daliEmail_key";

--- a/dali-api/scripts/test-v0-phase2.sql
+++ b/dali-api/scripts/test-v0-phase2.sql
@@ -103,6 +103,7 @@ WHERE g."sendAsEmail" = 'applications@dali.dartmouth.edu';
 -- ─── 6. WRITE TEST: insert a fake review through the new FK shape ───────────
 \echo ''
 \echo '=== T6: insert a test ApplicationReview via User-based FK + rollback ==='
+SAVEPOINT t6;
 DO $$
 DECLARE
   test_reviewer_user_id text;
@@ -110,7 +111,6 @@ DECLARE
   test_da_id text;
   test_ar_id text;
 BEGIN
-  -- Pick the first CycleReviewer + a DomainApplication in their domain
   SELECT cr."userId", cr.id INTO test_reviewer_user_id, test_cr_id
   FROM "CycleReviewer" cr
   LIMIT 1;
@@ -127,19 +127,28 @@ BEGIN
     RETURN;
   END IF;
 
-  -- Insert a probe review. submittedById references User now.
-  INSERT INTO "ApplicationReview" (id, "cycleReviewerId", "domainApplicationId", "submittedById", "submittedAt", scores, feedback)
-  VALUES (gen_random_uuid()::text, test_cr_id, test_da_id, test_reviewer_user_id, NOW(), '{}'::jsonb, 'TEST — rolled back')
+  INSERT INTO "ApplicationReview" (
+    id, "cycleReviewerId", "domainApplicationId", "submittedById",
+    "submittedAt", "createdAt", "updatedAt",
+    scores, feedback, "rejectionRationale", annotations
+  )
+  VALUES (
+    gen_random_uuid()::text, test_cr_id, test_da_id, test_reviewer_user_id,
+    NOW(), NOW(), NOW(),
+    '{}'::jsonb, 'TEST — rolled back', '', '[]'::jsonb
+  )
   ON CONFLICT ("cycleReviewerId", "domainApplicationId") DO UPDATE
     SET feedback = 'TEST — rolled back'
   RETURNING id INTO test_ar_id;
 
   RAISE NOTICE '  PASS: inserted review id=% with submittedById=%', test_ar_id, test_reviewer_user_id;
 END $$;
+ROLLBACK TO SAVEPOINT t6;
 
 -- ─── 7. WRITE TEST: insert a Decision via User-based madeById ───────────────
 \echo ''
 \echo '=== T7: insert a test Decision via User-based madeById + rollback ==='
+SAVEPOINT t7;
 DO $$
 DECLARE
   test_admin_user_id text;
@@ -156,22 +165,25 @@ BEGIN
     RETURN;
   END IF;
 
-  INSERT INTO "Decision" (id, "domainApplicationId", type, stage, "madeById", notes)
-  VALUES (gen_random_uuid()::text, test_da_id, 'Rejected', 'Draft', test_admin_user_id, 'TEST — rolled back')
+  INSERT INTO "Decision" (id, "createdAt", "domainApplicationId", type, stage, "madeById", notes)
+  VALUES (gen_random_uuid()::text, NOW(), test_da_id, 'Rejected', 'Draft', test_admin_user_id, 'TEST — rolled back')
   RETURNING id INTO test_dec_id;
 
   RAISE NOTICE '  PASS: inserted decision id=% with madeById=%', test_dec_id, test_admin_user_id;
 END $$;
+ROLLBACK TO SAVEPOINT t7;
 
 -- ─── 8. CONSTRAINT TEST: NOT NULL on hiring FKs is enforced ────────────────
 \echo ''
 \echo '=== T8: constraint test — INSERT with NULL userId should fail ==='
+SAVEPOINT t8;
 DO $$
 BEGIN
   BEGIN
-    INSERT INTO "CycleReviewer" (id, "applicationCycleId", "domainId", "userId")
+    INSERT INTO "CycleReviewer" (id, "createdAt", "updatedAt", "applicationCycleId", "domainId", "userId")
     VALUES (
       gen_random_uuid()::text,
+      NOW(), NOW(),
       (SELECT "applicationCycleId" FROM "CycleReviewer" LIMIT 1),
       (SELECT "domainId" FROM "CycleReviewer" LIMIT 1),
       NULL
@@ -181,16 +193,19 @@ BEGIN
     RAISE NOTICE '  PASS: NULL userId rejected as expected';
   END;
 END $$;
+ROLLBACK TO SAVEPOINT t8;
 
 -- ─── 9. CONSTRAINT TEST: FK to User is enforced ─────────────────────────────
 \echo ''
 \echo '=== T9: constraint test — INSERT with non-existent userId should fail ==='
+SAVEPOINT t9;
 DO $$
 BEGIN
   BEGIN
-    INSERT INTO "CycleReviewer" (id, "applicationCycleId", "domainId", "userId")
+    INSERT INTO "CycleReviewer" (id, "createdAt", "updatedAt", "applicationCycleId", "domainId", "userId")
     VALUES (
       gen_random_uuid()::text,
+      NOW(), NOW(),
       (SELECT "applicationCycleId" FROM "CycleReviewer" LIMIT 1),
       (SELECT "domainId" FROM "CycleReviewer" LIMIT 1),
       'does-not-exist-userid'
@@ -200,6 +215,7 @@ BEGIN
     RAISE NOTICE '  PASS: invalid userId rejected as expected (FK to User enforced)';
   END;
 END $$;
+ROLLBACK TO SAVEPOINT t9;
 
 -- ─── 10. BACKFILL SPOT-CHECK: an admin from DALIMember.roles[] is in AdminMembership ───
 \echo ''
@@ -251,6 +267,7 @@ WHERE u."daliEmail" IS NOT NULL
 -- ─── 14. LEGACY DROP VERIFICATION: column references in queries fail ──────
 \echo ''
 \echo '=== T14: verify the old daliMemberId column truly cannot be queried ==='
+SAVEPOINT t14;
 DO $$
 BEGIN
   BEGIN
@@ -260,10 +277,12 @@ BEGIN
     RAISE NOTICE '  PASS: daliMemberId column does not exist (drop succeeded)';
   END;
 END $$;
+ROLLBACK TO SAVEPOINT t14;
 
 -- ─── 15. LEGACY DROP VERIFICATION: User.googleRefreshToken truly dropped ──
 \echo ''
 \echo '=== T15: verify User.googleRefreshToken truly dropped ==='
+SAVEPOINT t15;
 DO $$
 BEGIN
   BEGIN
@@ -273,6 +292,7 @@ BEGIN
     RAISE NOTICE '  PASS: googleRefreshToken column does not exist';
   END;
 END $$;
+ROLLBACK TO SAVEPOINT t15;
 
 ROLLBACK;
 

--- a/dali-api/scripts/test-v0-phase2.sql
+++ b/dali-api/scripts/test-v0-phase2.sql
@@ -1,0 +1,280 @@
+-- Behavioral test for v0 Phase 2 on staging.
+--
+-- Goes beyond verify-v0-phase2.sql (which only checks schema + counts) by
+-- actually running the queries the app does and validating writes work.
+-- All writes happen inside a single transaction with ROLLBACK at the end
+-- so nothing persists.
+--
+-- Usage:
+--   flyctl proxy 5432:5432 -a dali-api-staging &
+--   psql "$URL" -f scripts/test-v0-phase2.sql
+--
+-- Look for the PASS/FAIL labels at the start of each section's last line.
+
+\set ON_ERROR_STOP off
+
+BEGIN;
+
+-- ─── 1. Reviewer dashboard query (app/hiring/routes/reviewer.tsx loader) ────
+\echo ''
+\echo '=== T1: reviewer dashboard — find a reviewer''s assigned reviews via new FK shape ==='
+SELECT
+  cr.id AS cycle_reviewer_id,
+  u."firstName" || ' ' || u."lastName" AS reviewer_name,
+  d."displayName" AS domain,
+  COUNT(ar.id) AS reviews_in_queue
+FROM "CycleReviewer" cr
+JOIN "User" u ON u.id = cr."userId"
+JOIN "Domain" d ON d.id = cr."domainId"
+LEFT JOIN "ApplicationReview" ar ON ar."cycleReviewerId" = cr.id
+GROUP BY cr.id, u."firstName", u."lastName", d."displayName"
+HAVING COUNT(ar.id) > 0
+ORDER BY reviews_in_queue DESC
+LIMIT 5;
+-- PASS: 5 rows with non-zero reviews_in_queue (reviewer has assigned work).
+
+-- ─── 2. Domain Lead view query (app/hiring/routes/domain-lead.tsx loader) ───
+\echo ''
+\echo '=== T2: domain lead view — find a lead''s assigned domains ==='
+SELECT
+  u."firstName" || ' ' || u."lastName" AS name,
+  array_agg(d."displayName" ORDER BY d."displayName") AS lead_for
+FROM "DomainLeadAssignment" dla
+JOIN "User" u ON u.id = dla."userId"
+JOIN "Domain" d ON d.id = dla."domainId"
+GROUP BY u.id, u."firstName", u."lastName"
+ORDER BY array_length(array_agg(d."displayName"), 1) DESC
+LIMIT 5;
+-- PASS: each row has at least one domain in lead_for.
+
+-- ─── 3. Confidentiality signature check (collabAuth.ts pattern) ─────────────
+\echo ''
+\echo '=== T3: a reviewer''s confidentiality state for the active cycle ==='
+WITH active_cycle AS (
+  SELECT id FROM "ApplicationCycle"
+  WHERE id IN (SELECT "applicationCycleId" FROM "ApplicationCycleStatusUpdate" WHERE "newStatus" IN ('Open','UnderReview') ORDER BY "createdAt" DESC LIMIT 1)
+)
+SELECT
+  cr.id AS cycle_reviewer_id,
+  u."firstName" || ' ' || u."lastName" AS name,
+  cas."signedAt" IS NOT NULL AS has_signed
+FROM "CycleReviewer" cr
+JOIN "User" u ON u.id = cr."userId"
+JOIN active_cycle ac ON cr."applicationCycleId" = ac.id
+LEFT JOIN "ConfidentialityAgreementSignature" cas
+  ON cas."userId" = u.id AND cas."applicationCycleId" = ac.id
+LIMIT 5;
+-- PASS: rows return; signed status varies but the join works (User-level
+-- confidentiality signature lookup still works post-rename).
+
+-- ─── 4. Role resolution query (lib/roles.ts:getUserRoles) ───────────────────
+\echo ''
+\echo '=== T4: getUserRoles output for known admins ==='
+SELECT
+  u."daliEmail",
+  EXISTS(SELECT 1 FROM "AdminMembership" am WHERE am."userId" = u.id) AS is_admin,
+  EXISTS(SELECT 1 FROM "CoreAssignment" ca WHERE ca."userId" = u.id) AS is_core,
+  EXISTS(SELECT 1 FROM "DomainLeadAssignment" dla WHERE dla."userId" = u.id) AS is_domain_lead,
+  EXISTS(SELECT 1 FROM "DALIMember" m WHERE m."userId" = u.id) AS is_lab_member
+FROM "User" u
+WHERE u."daliEmail" IN (
+  'kiran.jones@dali.dartmouth.edu',
+  'tim@dali.dartmouth.edu',
+  'madison@dali.dartmouth.edu',
+  'jordan.taylor@dali.dartmouth.edu',
+  'ashna.ghanate@dali.dartmouth.edu'
+)
+ORDER BY u."daliEmail";
+-- PASS: known admins return is_admin=true; the rest match expected role shape.
+
+-- ─── 5. Gmail integration lookup (lib/gmail-integration.ts) ─────────────────
+\echo ''
+\echo '=== T5: applications@dali.dartmouth.edu Gmail integration is wired up ==='
+SELECT
+  g."sendAsEmail",
+  u."daliEmail",
+  g."enabled",
+  LENGTH(g."oauthTokens") > 10 AS has_token
+FROM "GmailIntegration" g
+JOIN "User" u ON u.id = g."userId"
+WHERE g."sendAsEmail" = 'applications@dali.dartmouth.edu';
+-- PASS: 1 row, enabled=true, has_token=true.
+
+-- ─── 6. WRITE TEST: insert a fake review through the new FK shape ───────────
+\echo ''
+\echo '=== T6: insert a test ApplicationReview via User-based FK + rollback ==='
+DO $$
+DECLARE
+  test_reviewer_user_id text;
+  test_cr_id text;
+  test_da_id text;
+  test_ar_id text;
+BEGIN
+  -- Pick the first CycleReviewer + a DomainApplication in their domain
+  SELECT cr."userId", cr.id INTO test_reviewer_user_id, test_cr_id
+  FROM "CycleReviewer" cr
+  LIMIT 1;
+
+  SELECT da.id INTO test_da_id
+  FROM "DomainApplication" da
+  JOIN "ChallengeVersion" cv ON cv.id = da."challengeVersionId"
+  JOIN "CycleReviewer" cr ON cr."domainId" = cv."domainId"
+  WHERE cr.id = test_cr_id AND da.selected = TRUE
+  LIMIT 1;
+
+  IF test_reviewer_user_id IS NULL OR test_da_id IS NULL THEN
+    RAISE NOTICE '  SKIP: no reviewer+app pair found';
+    RETURN;
+  END IF;
+
+  -- Insert a probe review. submittedById references User now.
+  INSERT INTO "ApplicationReview" (id, "cycleReviewerId", "domainApplicationId", "submittedById", "submittedAt", scores, feedback)
+  VALUES (gen_random_uuid()::text, test_cr_id, test_da_id, test_reviewer_user_id, NOW(), '{}'::jsonb, 'TEST — rolled back')
+  ON CONFLICT ("cycleReviewerId", "domainApplicationId") DO UPDATE
+    SET feedback = 'TEST — rolled back'
+  RETURNING id INTO test_ar_id;
+
+  RAISE NOTICE '  PASS: inserted review id=% with submittedById=%', test_ar_id, test_reviewer_user_id;
+END $$;
+
+-- ─── 7. WRITE TEST: insert a Decision via User-based madeById ───────────────
+\echo ''
+\echo '=== T7: insert a test Decision via User-based madeById + rollback ==='
+DO $$
+DECLARE
+  test_admin_user_id text;
+  test_da_id text;
+  test_dec_id text;
+BEGIN
+  SELECT am."userId" INTO test_admin_user_id
+  FROM "AdminMembership" am LIMIT 1;
+
+  SELECT id INTO test_da_id FROM "DomainApplication" WHERE selected = TRUE LIMIT 1;
+
+  IF test_admin_user_id IS NULL OR test_da_id IS NULL THEN
+    RAISE NOTICE '  SKIP: no admin+da pair found';
+    RETURN;
+  END IF;
+
+  INSERT INTO "Decision" (id, "domainApplicationId", type, stage, "madeById", notes)
+  VALUES (gen_random_uuid()::text, test_da_id, 'Rejected', 'Draft', test_admin_user_id, 'TEST — rolled back')
+  RETURNING id INTO test_dec_id;
+
+  RAISE NOTICE '  PASS: inserted decision id=% with madeById=%', test_dec_id, test_admin_user_id;
+END $$;
+
+-- ─── 8. CONSTRAINT TEST: NOT NULL on hiring FKs is enforced ────────────────
+\echo ''
+\echo '=== T8: constraint test — INSERT with NULL userId should fail ==='
+DO $$
+BEGIN
+  BEGIN
+    INSERT INTO "CycleReviewer" (id, "applicationCycleId", "domainId", "userId")
+    VALUES (
+      gen_random_uuid()::text,
+      (SELECT "applicationCycleId" FROM "CycleReviewer" LIMIT 1),
+      (SELECT "domainId" FROM "CycleReviewer" LIMIT 1),
+      NULL
+    );
+    RAISE NOTICE '  FAIL: NULL userId was accepted (constraint missing)';
+  EXCEPTION WHEN not_null_violation THEN
+    RAISE NOTICE '  PASS: NULL userId rejected as expected';
+  END;
+END $$;
+
+-- ─── 9. CONSTRAINT TEST: FK to User is enforced ─────────────────────────────
+\echo ''
+\echo '=== T9: constraint test — INSERT with non-existent userId should fail ==='
+DO $$
+BEGIN
+  BEGIN
+    INSERT INTO "CycleReviewer" (id, "applicationCycleId", "domainId", "userId")
+    VALUES (
+      gen_random_uuid()::text,
+      (SELECT "applicationCycleId" FROM "CycleReviewer" LIMIT 1),
+      (SELECT "domainId" FROM "CycleReviewer" LIMIT 1),
+      'does-not-exist-userid'
+    );
+    RAISE NOTICE '  FAIL: invalid userId was accepted (FK missing or wrong target)';
+  EXCEPTION WHEN foreign_key_violation THEN
+    RAISE NOTICE '  PASS: invalid userId rejected as expected (FK to User enforced)';
+  END;
+END $$;
+
+-- ─── 10. BACKFILL SPOT-CHECK: an admin from DALIMember.roles[] is in AdminMembership ───
+\echo ''
+\echo '=== T10: spot-check role backfill — admins migrated cleanly ==='
+-- Compare AdminMembership count to what *should* be there based on legacy.
+-- Phase 1 verification reported 9 admins via DALIMember.roles[]; we expect
+-- 9 AdminMembership rows. Each one has a User backing it.
+SELECT
+  COUNT(*) AS admin_membership_count,
+  COUNT(DISTINCT u."daliEmail") AS distinct_admin_emails
+FROM "AdminMembership" am
+JOIN "User" u ON u.id = am."userId";
+-- PASS: admin_membership_count = 9 (or matches your Phase 1 count).
+
+-- ─── 11. BACKFILL SPOT-CHECK: hiring leads got CoreAssignment in current term ───
+\echo ''
+\echo '=== T11: spot-check Hiring Lead → CoreAssignment with current term ==='
+SELECT
+  u."daliEmail",
+  t.code AS term_code,
+  ca."leadTitle"
+FROM "CoreAssignment" ca
+JOIN "User" u ON u.id = ca."userId"
+JOIN "Term" t ON t.id = ca."termId"
+WHERE ca."leadTitle" = 'Hiring Lead'
+ORDER BY u."daliEmail";
+-- PASS: 8 rows (matches Phase 1's hiring_lead_members count); all rows have
+-- a real term_code (current term — likely 26S).
+
+-- ─── 12. BACKFILL SPOT-CHECK: DomainLeadAssignment.termId backfilled ───────
+\echo ''
+\echo '=== T12: DLA termId populated for legacy rows ==='
+SELECT
+  COUNT(*) AS total_dlas,
+  COUNT(*) FILTER (WHERE "termId" IS NOT NULL) AS with_termId,
+  COUNT(DISTINCT "termId") AS distinct_terms_used
+FROM "DomainLeadAssignment";
+-- PASS: with_termId = total_dlas (42); distinct_terms_used = 1.
+
+-- ─── 13. BACKFILL SPOT-CHECK: orphan-migrated User rows ────────────────────
+\echo ''
+\echo '=== T13: orphan-migrated Users (newly created in Phase 2 M2) ==='
+SELECT COUNT(*) AS new_users_with_daliEmail_but_no_session
+FROM "User" u
+WHERE u."daliEmail" IS NOT NULL
+  AND NOT EXISTS (SELECT 1 FROM "Session" s WHERE s."userId" = u.id);
+-- PASS: ~95 (matches the orphan migration count from Phase 1).
+
+-- ─── 14. LEGACY DROP VERIFICATION: column references in queries fail ──────
+\echo ''
+\echo '=== T14: verify the old daliMemberId column truly cannot be queried ==='
+DO $$
+BEGIN
+  BEGIN
+    PERFORM "daliMemberId" FROM "CycleReviewer" LIMIT 1;
+    RAISE NOTICE '  FAIL: daliMemberId is still queryable (drop didn''t happen)';
+  EXCEPTION WHEN undefined_column THEN
+    RAISE NOTICE '  PASS: daliMemberId column does not exist (drop succeeded)';
+  END;
+END $$;
+
+-- ─── 15. LEGACY DROP VERIFICATION: User.googleRefreshToken truly dropped ──
+\echo ''
+\echo '=== T15: verify User.googleRefreshToken truly dropped ==='
+DO $$
+BEGIN
+  BEGIN
+    PERFORM "googleRefreshToken" FROM "User" LIMIT 1;
+    RAISE NOTICE '  FAIL: googleRefreshToken is still queryable';
+  EXCEPTION WHEN undefined_column THEN
+    RAISE NOTICE '  PASS: googleRefreshToken column does not exist';
+  END;
+END $$;
+
+ROLLBACK;
+
+\echo ''
+\echo '=== Done — all writes rolled back. Look for PASS/FAIL markers above. ==='

--- a/dali-api/scripts/verify-v0-phase2.sql
+++ b/dali-api/scripts/verify-v0-phase2.sql
@@ -1,0 +1,167 @@
+-- Verify v0 Phase 2 migration landed cleanly.
+--
+-- Run against staging (or any post-Phase-2 DB):
+--   flyctl proxy 5432:5432 -a dali-api-staging &
+--   psql 'postgres://...' -f scripts/verify-v0-phase2.sql
+--
+-- Compare counts to the Phase 1 verification output you captured earlier
+-- (215 users, 142 DALIMembers, 95 orphans, 45 reviewers, 18 interviewers,
+-- 118 reviews, 42 DLAs).
+
+\echo '=== 1. Migration history (expect both phase1_additive + phase2_identity_refactor) ==='
+SELECT migration_name, finished_at, applied_steps_count
+FROM _prisma_migrations
+WHERE migration_name LIKE '%v0_phase%' OR migration_name LIKE '%calendar_v0%'
+ORDER BY finished_at DESC
+LIMIT 5;
+
+\echo ''
+\echo '=== 2. DALIMember slim-down ==='
+-- DALIMember should now have only: id, userId, createdAt, updatedAt.
+-- Dropped: firstName, lastName, daliEmail, dartmouthEmail, did, roles.
+SELECT column_name, data_type, is_nullable
+FROM information_schema.columns
+WHERE table_schema='public' AND table_name='DALIMember'
+ORDER BY column_name;
+-- Expect: 4 rows. Anything else = drops didn't happen.
+
+\echo ''
+\echo '=== 3. User.google* dropped ==='
+SELECT
+  EXISTS(SELECT 1 FROM information_schema.columns WHERE table_name='User' AND column_name='googleAccessToken') AS still_has_googleAccessToken,
+  EXISTS(SELECT 1 FROM information_schema.columns WHERE table_name='User' AND column_name='googleRefreshToken') AS still_has_googleRefreshToken,
+  EXISTS(SELECT 1 FROM information_schema.columns WHERE table_name='User' AND column_name='googleTokenExpiresAt') AS still_has_googleTokenExpiresAt;
+-- Expect: all `false`.
+
+\echo ''
+\echo '=== 4. Hiring FK renames ==='
+SELECT
+  EXISTS(SELECT 1 FROM information_schema.columns WHERE table_name='CycleReviewer' AND column_name='daliMemberId') AS cyclereviewer_still_has_daliMemberId,
+  EXISTS(SELECT 1 FROM information_schema.columns WHERE table_name='CycleReviewer' AND column_name='userId') AS cyclereviewer_has_userId,
+  EXISTS(SELECT 1 FROM information_schema.columns WHERE table_name='CycleInterviewer' AND column_name='daliMemberId') AS cycleinterviewer_still_has_daliMemberId,
+  EXISTS(SELECT 1 FROM information_schema.columns WHERE table_name='CycleInterviewer' AND column_name='userId') AS cycleinterviewer_has_userId,
+  EXISTS(SELECT 1 FROM information_schema.columns WHERE table_name='DomainLeadAssignment' AND column_name='memberId') AS dla_still_has_memberId,
+  EXISTS(SELECT 1 FROM information_schema.columns WHERE table_name='DomainLeadAssignment' AND column_name='userId') AS dla_has_userId;
+-- Expect: still_has_*: all false; has_userId: all true.
+
+\echo ''
+\echo '=== 5. NOT NULL constraints tightened ==='
+SELECT
+  (SELECT is_nullable FROM information_schema.columns WHERE table_name='DALIMember' AND column_name='userId') AS dalimember_userId_nullable,
+  (SELECT is_nullable FROM information_schema.columns WHERE table_name='DomainLeadAssignment' AND column_name='termId') AS dla_termId_nullable,
+  (SELECT is_nullable FROM information_schema.columns WHERE table_name='Domain' AND column_name='code') AS domain_code_nullable,
+  (SELECT is_nullable FROM information_schema.columns WHERE table_name='Domain' AND column_name='displayName') AS domain_displayName_nullable,
+  (SELECT is_nullable FROM information_schema.columns WHERE table_name='CycleReviewer' AND column_name='userId') AS cyclereviewer_userId_nullable,
+  (SELECT is_nullable FROM information_schema.columns WHERE table_name='CycleInterviewer' AND column_name='userId') AS cycleinterviewer_userId_nullable,
+  (SELECT is_nullable FROM information_schema.columns WHERE table_name='DomainLeadAssignment' AND column_name='userId') AS dla_userId_nullable;
+-- Expect: all 'NO'.
+
+\echo ''
+\echo '=== 6. MemberRole enum dropped ==='
+SELECT EXISTS(SELECT 1 FROM pg_type WHERE typname = 'MemberRole') AS member_role_enum_still_exists;
+-- Expect: `false`.
+
+\echo ''
+\echo '=== 7. OAuthAccountType collapsed to member-only ==='
+SELECT array_agg(enumlabel ORDER BY enumsortorder) AS oauth_account_type_values
+FROM pg_enum
+WHERE enumtypid = (SELECT oid FROM pg_type WHERE typname = 'OAuthAccountType');
+-- Expect: {member}. Anything else = collapse didn't happen.
+
+\echo ''
+\echo '=== 8. FK targets now point at User (not DALIMember) ==='
+SELECT
+  conrelid::regclass::text AS table_name,
+  conname,
+  confrelid::regclass::text AS references_table
+FROM pg_constraint
+WHERE contype = 'f'
+  AND conrelid::regclass::text IN ('"CycleReviewer"', '"CycleInterviewer"', '"Decision"', '"ApplicationReview"', '"DelibsSession"', '"LegacyEmailTemplate"', '"EmailTemplateVersion"', '"ConfidentialityAgreementVersion"', '"DomainLeadAssignment"', '"DALIMember"')
+  AND (conname LIKE '%userId%' OR conname LIKE '%madeBy%' OR conname LIKE '%submittedBy%' OR conname LIKE '%openedBy%' OR conname LIKE '%createdBy%')
+ORDER BY conrelid::regclass::text, conname;
+-- Expect: all references_table values = `"User"` (or "Term" for DLA_termId_fkey).
+
+\echo ''
+\echo '=== 9. Data integrity — DALIMember orphans resolved ==='
+SELECT
+  COUNT(*) AS total_members,
+  COUNT(*) FILTER (WHERE "userId" IS NULL) AS orphan_members
+FROM "DALIMember";
+-- Expect: total = 143 (was 142 in Phase 1 + 95 orphan migrations promoted to
+-- User rows; pre-existing DALIMember count survived);
+-- orphan_members = 0.
+
+\echo ''
+\echo '=== 10. Data integrity — User count grew to absorb orphans ==='
+SELECT COUNT(*) AS total_users FROM "User";
+-- Expect: ~310 (215 prior + 95 migrated orphans). May differ slightly if
+-- some orphans had matching daliEmails (ON CONFLICT DO NOTHING).
+
+\echo ''
+\echo '=== 11. Hiring FK rows preserved (counts should match Phase 1 verification) ==='
+SELECT
+  (SELECT COUNT(*) FROM "CycleReviewer") AS reviewers,
+  (SELECT COUNT(*) FROM "CycleInterviewer") AS interviewers,
+  (SELECT COUNT(*) FROM "ApplicationReview") AS reviews,
+  (SELECT COUNT(*) FROM "Decision") AS decisions,
+  (SELECT COUNT(*) FROM "Interview") AS interviews,
+  (SELECT COUNT(*) FROM "DomainLeadAssignment") AS domain_lead_assignments;
+-- Expect: 45 reviewers, 18 interviewers, 118 reviews (was 116 — drift fine),
+-- 0 decisions, 0 interviews, 42 DLAs.
+
+\echo ''
+\echo '=== 12. All hiring FK userId columns populated (no NULLs) ==='
+SELECT
+  (SELECT COUNT(*) FROM "CycleReviewer" WHERE "userId" IS NULL) AS reviewer_nulls,
+  (SELECT COUNT(*) FROM "CycleInterviewer" WHERE "userId" IS NULL) AS interviewer_nulls,
+  (SELECT COUNT(*) FROM "DomainLeadAssignment" WHERE "userId" IS NULL) AS dla_userId_nulls,
+  (SELECT COUNT(*) FROM "DomainLeadAssignment" WHERE "termId" IS NULL) AS dla_termId_nulls,
+  (SELECT COUNT(*) FROM "Decision" WHERE "madeById" IS NULL) AS decision_nulls,
+  (SELECT COUNT(*) FROM "DelibsSession" WHERE "openedById" IS NULL) AS delibs_nulls;
+-- Expect: all 0. (ApplicationReview.submittedById is intentionally nullable —
+-- represents unsubmitted reviews — not checked here.)
+
+\echo ''
+\echo '=== 13. AdminMembership + CoreAssignment backfill ==='
+SELECT
+  (SELECT COUNT(*) FROM "AdminMembership") AS admin_memberships,
+  (SELECT COUNT(*) FROM "CoreAssignment" WHERE "leadTitle" = 'Hiring Lead') AS hiring_lead_core_assignments;
+-- Expect: admin_memberships = 9 (matches Phase 1 admin_members count);
+-- hiring_lead_core_assignments = 8 (matches Phase 1 hiring_lead_members).
+
+\echo ''
+\echo '=== 14. GmailIntegration backfill (admin Gmail-authorize accounts) ==='
+SELECT
+  COUNT(*) AS gmail_integrations,
+  array_agg("sendAsEmail" ORDER BY "sendAsEmail") AS send_as_emails
+FROM "GmailIntegration";
+-- Expect: 1-2 rows for the dali admin accounts that ran /admin/authorize-gmail.
+-- send_as_emails should include applications@dali.dartmouth.edu.
+
+\echo ''
+\echo '=== 15. Cycle data still intact and queryable through new FK shape ==='
+SELECT
+  cr.id AS reviewer_id,
+  u."firstName", u."lastName", u."daliEmail",
+  d."displayName" AS domain
+FROM "CycleReviewer" cr
+JOIN "User" u ON u.id = cr."userId"
+JOIN "Domain" d ON d.id = cr."domainId"
+LIMIT 5;
+-- Expect: 5 rows joined cleanly. Names and domains visible.
+
+\echo ''
+\echo '=== 16. Sample post-Phase-2 user with full role view ==='
+SELECT
+  u.id,
+  u."firstName" || ' ' || u."lastName" AS name,
+  u."daliEmail",
+  (SELECT COUNT(*) > 0 FROM "DALIMember" m WHERE m."userId" = u.id) AS is_lab_member,
+  (SELECT COUNT(*) > 0 FROM "AdminMembership" am WHERE am."userId" = u.id) AS is_admin,
+  (SELECT COUNT(*) FROM "CoreAssignment" ca WHERE ca."userId" = u.id) AS core_assignments,
+  (SELECT array_agg(d."displayName") FROM "DomainLeadAssignment" dla JOIN "Domain" d ON d.id = dla."domainId" WHERE dla."userId" = u.id) AS lead_domains
+FROM "User" u
+WHERE u."daliEmail" IS NOT NULL
+ORDER BY (SELECT COUNT(*) FROM "AdminMembership" am WHERE am."userId" = u.id) DESC,
+         u."lastName"
+LIMIT 10;


### PR DESCRIPTION
## Summary

Single-file follow-up to merged #534. Adds `scripts/test-v0-phase2.sql` — a 15-section behavioral test for the Phase 2 schema that complements the existing `verify-v0-phase2.sql` (which only checks counts).

**Not required for the prod deploy** (the migration fix from #534 already made it). This is purely diagnostic tooling for re-validating Phase 2 on any environment.

## What it tests

| Tests | Coverage |
|---|---|
| T1–T5 | Read paths: reviewer dashboard, domain lead view, confidentiality state, `getUserRoles`, GmailIntegration lookup |
| T6–T7 | Write paths: INSERT `ApplicationReview` + `Decision` with `User`-targeted FKs (rolled back) |
| T8–T9 | Constraint enforcement: NOT NULL + FK-to-User on the renamed columns |
| T10–T13 | Backfill spot-checks: AdminMembership count, Hiring Lead CoreAssignments, DLA termId backfill, orphan migration count |
| T14–T15 | Legacy drops: confirm `daliMemberId` and `User.googleRefreshToken` truly removed |

Each test wraps in a `SAVEPOINT` so one failure doesn't cascade. Outer transaction `ROLLBACK`s at the end so probe writes don't persist.

## Validation

Ran against staging Neon today after #534 was applied — all 15 sections PASS.

## Test plan

- [x] Pass against staging
- [ ] Pass against prod post-deploy (will run as part of cutover smoke test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)