### PR TITLE
Loosen DCR grant_types/response_types validation

### DIFF
--- a/dali-api/app/routes/__tests__/oauth.register.test.ts
+++ b/dali-api/app/routes/__tests__/oauth.register.test.ts
@@ -135,10 +135,32 @@ describe("POST /oauth/register", () => {
     expect(body.error).toBe("invalid_client_metadata");
   });
 
-  it("rejects unsupported grant_types", async () => {
+  it("accepts grant_types: ['authorization_code']", async () => {
     const req = makeRequest({
       redirect_uris: ["http://127.0.0.1/callback"],
-      grant_types: ["client_credentials"],
+      grant_types: ["authorization_code"],
+    });
+    const res = await action({ request: req } as any);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.grant_types).toEqual(["authorization_code"]);
+  });
+
+  it("accepts grant_types containing authorization_code + refresh_token, echoes only authorization_code", async () => {
+    const req = makeRequest({
+      redirect_uris: ["http://127.0.0.1/callback"],
+      grant_types: ["authorization_code", "refresh_token"],
+    });
+    const res = await action({ request: req } as any);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.grant_types).toEqual(["authorization_code"]);
+  });
+
+  it("rejects grant_types without authorization_code", async () => {
+    const req = makeRequest({
+      redirect_uris: ["http://127.0.0.1/callback"],
+      grant_types: ["refresh_token"],
     });
     const res = await action({ request: req } as any);
     expect(res.status).toBe(400);
@@ -146,7 +168,50 @@ describe("POST /oauth/register", () => {
     expect(body.error).toBe("invalid_client_metadata");
   });
 
-  it("rejects unsupported response_types", async () => {
+  it("rejects empty grant_types array", async () => {
+    const req = makeRequest({
+      redirect_uris: ["http://127.0.0.1/callback"],
+      grant_types: [],
+    });
+    const res = await action({ request: req } as any);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("invalid_client_metadata");
+  });
+
+  it("defaults grant_types to ['authorization_code'] when omitted", async () => {
+    const req = makeRequest({
+      redirect_uris: ["http://127.0.0.1/callback"],
+    });
+    const res = await action({ request: req } as any);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.grant_types).toEqual(["authorization_code"]);
+  });
+
+  it("accepts response_types: ['code']", async () => {
+    const req = makeRequest({
+      redirect_uris: ["http://127.0.0.1/callback"],
+      response_types: ["code"],
+    });
+    const res = await action({ request: req } as any);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.response_types).toEqual(["code"]);
+  });
+
+  it("accepts response_types containing code + token, echoes only code", async () => {
+    const req = makeRequest({
+      redirect_uris: ["http://127.0.0.1/callback"],
+      response_types: ["code", "token"],
+    });
+    const res = await action({ request: req } as any);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.response_types).toEqual(["code"]);
+  });
+
+  it("rejects response_types without code", async () => {
     const req = makeRequest({
       redirect_uris: ["http://127.0.0.1/callback"],
       response_types: ["token"],
@@ -155,6 +220,27 @@ describe("POST /oauth/register", () => {
     expect(res.status).toBe(400);
     const body = await res.json();
     expect(body.error).toBe("invalid_client_metadata");
+  });
+
+  it("rejects empty response_types array", async () => {
+    const req = makeRequest({
+      redirect_uris: ["http://127.0.0.1/callback"],
+      response_types: [],
+    });
+    const res = await action({ request: req } as any);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("invalid_client_metadata");
+  });
+
+  it("defaults response_types to ['code'] when omitted", async () => {
+    const req = makeRequest({
+      redirect_uris: ["http://127.0.0.1/callback"],
+    });
+    const res = await action({ request: req } as any);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.response_types).toEqual(["code"]);
   });
 
   it("rate-limits 6th registration from same IP", async () => {

--- a/dali-api/app/routes/oauth.register.ts
+++ b/dali-api/app/routes/oauth.register.ts
@@ -100,35 +100,38 @@ export async function action({ request }: Route.ActionArgs) {
     );
   }
 
-  // grant_types: only authorization_code (or omitted).
+  // grant_types: must include "authorization_code" if present. Other entries
+  // (e.g. "refresh_token", which Claude Code's MCP SDK sends by default) are
+  // allowed but ignored — we only support authorization_code. Per RFC 7591 §2
+  // the server MAY reject unsupported metadata, but intersecting with what we
+  // support is friendlier and equally safe since we echo back only what's
+  // actually honored.
   if (body.grant_types !== undefined) {
     if (
       !Array.isArray(body.grant_types) ||
-      body.grant_types.length !== 1 ||
-      body.grant_types[0] !== "authorization_code"
+      !body.grant_types.includes("authorization_code")
     ) {
       return withCors(
         request,
         badRequest(
           "invalid_client_metadata",
-          "grant_types must be ['authorization_code']",
+          "grant_types must include 'authorization_code'",
         ),
       );
     }
   }
 
-  // response_types: only "code" (or omitted).
+  // response_types: must include "code" if present. Other entries ignored.
   if (body.response_types !== undefined) {
     if (
       !Array.isArray(body.response_types) ||
-      body.response_types.length !== 1 ||
-      body.response_types[0] !== "code"
+      !body.response_types.includes("code")
     ) {
       return withCors(
         request,
         badRequest(
           "invalid_client_metadata",
-          "response_types must be ['code']",
+          "response_types must include 'code'",
         ),
       );
     }

--- a/dali-api/e2e/mcp-dynamic-registration.spec.ts
+++ b/dali-api/e2e/mcp-dynamic-registration.spec.ts
@@ -29,7 +29,9 @@ test('DCR: register → authorize → consent → token → /mcp whoami', async 
   loginAs,
   request,
 }) => {
-  // 1) Register a new client.
+  // 1) Register a new client. Mirror the Claude Code MCP SDK shape, which sends
+  // the OAuth 2.1 public-client defaults including refresh_token (we ignore it
+  // but must not reject the registration).
   const redirectUri = 'http://127.0.0.1:54113/callback';
   const regRes = await request.post('/oauth/register', {
     headers: freshIpHeaders(),
@@ -37,7 +39,7 @@ test('DCR: register → authorize → consent → token → /mcp whoami', async 
       redirect_uris: [redirectUri],
       client_name: 'Claude Code E2E',
       token_endpoint_auth_method: 'none',
-      grant_types: ['authorization_code'],
+      grant_types: ['authorization_code', 'refresh_token'],
       response_types: ['code'],
     },
   });
@@ -148,6 +150,21 @@ test('DCR: rejects 0.0.0.0 as a redirect_uri host', async ({ request }) => {
   expect(res.status()).toBe(400);
   const body = await res.json();
   expect(body.error).toBe('invalid_redirect_uri');
+});
+
+test('DCR: rejects grant_types without authorization_code', async ({
+  request,
+}) => {
+  const res = await request.post('/oauth/register', {
+    headers: freshIpHeaders(),
+    data: {
+      redirect_uris: ['http://127.0.0.1/callback'],
+      grant_types: ['refresh_token'],
+    },
+  });
+  expect(res.status()).toBe(400);
+  const body = await res.json();
+  expect(body.error).toBe('invalid_client_metadata');
 });
 
 test('DCR: rejects unsupported token_endpoint_auth_method', async ({


### PR DESCRIPTION
## Why

PR #541 added RFC 7591 Dynamic Client Registration at `POST /oauth/register`. Its validation rejected any `grant_types` array that wasn't exactly `["authorization_code"]` and any `response_types` array that wasn't exactly `["code"]`.

Claude Code's MCP SDK sends the OAuth 2.1 public-client defaults — `grant_types: ["authorization_code", "refresh_token"]` — so registration was rejected with `invalid_client_metadata`, breaking `/mcp` auth for real clients.

Per RFC 7591 §2 the server *MAY* reject unsupported metadata, but intersecting with what we support is friendlier and equally safe since the response echoes back only the grants/response types we actually honor. We don't *implement* `refresh_token` grant (sessions auto-extend rolling), but there's no reason to reject the *registration*.

## What changed

- `dali-api/app/routes/oauth.register.ts`
  - `grant_types`: if present, must be an array containing `"authorization_code"`. Other entries (e.g. `"refresh_token"`) are allowed but ignored.
  - `response_types`: if present, must be an array containing `"code"`. Other entries ignored.
  - Response body still always returns `grant_types: ["authorization_code"]` and `response_types: ["code"]` — clients see only what we actually support.
- Unit tests (`oauth.register.test.ts`) — replaced the two "rejects unsupported" cases with full positive/negative/empty/omitted matrices for both fields.
- E2E (`mcp-dynamic-registration.spec.ts`) — happy-path test now registers with the Claude Code SDK shape (`["authorization_code", "refresh_token"]`); added a negative test that `["refresh_token"]` alone is rejected.

## What didn't change

- Loopback redirect URI validation (still strict).
- `token_endpoint_auth_method` (still must be `"none"` — security gate).
- `redirect_uris` required + non-empty.
- Rate limiting.
- `/oauth/token` — still rejects `refresh_token` grant attempts (correct).

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test -- oauth.register` — 19/19 passing locally
- [ ] CI Vitest + Playwright E2E (`test.yml`)
- [ ] CI build / migration / codeql checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)