### PR TITLE
Issue cookie session at /oauth/callback/* so consent screen can verify ownership

### DIFF
--- a/dali-api/app/routes/__tests__/oauth.callback.cas.test.ts
+++ b/dali-api/app/routes/__tests__/oauth.callback.cas.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const mockGetOAuthSession = vi.hoisted(() => vi.fn());
+const mockGetOAuthClient = vi.hoisted(() => vi.fn());
+const mockGenerateAuthorizationCode = vi.hoisted(() => vi.fn());
+const mockValidateCasTicket = vi.hoisted(() => vi.fn());
+const mockUpsertUserFromCas = vi.hoisted(() => vi.fn());
+const mockIssueSession = vi.hoisted(() => vi.fn());
+
+vi.mock("~/lib/oauth", () => ({
+  getOAuthSession: mockGetOAuthSession,
+  getOAuthClient: mockGetOAuthClient,
+  generateAuthorizationCode: mockGenerateAuthorizationCode,
+}));
+
+vi.mock("~/lib/auth", () => ({
+  validateCasTicket: mockValidateCasTicket,
+}));
+
+vi.mock("~/lib/user-provisioning", () => ({
+  upsertUserFromCas: mockUpsertUserFromCas,
+}));
+
+vi.mock("~/lib/session", () => ({
+  issueSession: mockIssueSession,
+}));
+
+vi.mock("~/lib/db", () => ({
+  prisma: {
+    oAuthGrant: { findUnique: vi.fn().mockResolvedValue(null) },
+    oAuthSession: { update: vi.fn().mockResolvedValue({}) },
+  },
+}));
+
+import { loader } from "~/routes/oauth.callback.cas";
+
+function makeRequest(sessionId: string, ticket = "cas-ticket") {
+  const params = new URLSearchParams({ ticket, session_id: sessionId });
+  return new Request(`http://localhost/oauth/callback/cas?${params}`, {
+    headers: { "user-agent": "test-agent", "X-Forwarded-For": "9.8.7.6" },
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.FRONTEND_URL = "http://localhost:5173";
+  process.env.API_BASE_URL = "http://localhost:3001";
+
+  mockGetOAuthSession.mockResolvedValue({
+    id: "sess-1",
+    state: "client-state",
+    redirectUri: "http://127.0.0.1:51999/callback",
+    expiresAt: new Date(Date.now() + 60_000),
+    exchanged: false,
+    accountType: "member",
+    clientId: "client-1",
+    scopes: ["mcp:read"],
+    linkUserId: null,
+  });
+  mockValidateCasTicket.mockResolvedValue({
+    netId: "abc123",
+  });
+  mockUpsertUserFromCas.mockResolvedValue({
+    user: { id: "user-1", netId: "abc123" },
+  });
+  mockIssueSession.mockResolvedValue({
+    rawId: "raw-session-id",
+    expiresAt: new Date(Date.now() + 1_000_000),
+    absoluteExpiresAt: new Date(Date.now() + 1_000_000),
+  });
+});
+
+describe("GET /oauth/callback/cas sets __dali_sid cookie", () => {
+  it("issues cookie session when redirecting to consent screen", async () => {
+    mockGetOAuthClient.mockResolvedValue({
+      clientId: "client-1",
+      name: "Some App",
+      isFirstParty: false,
+    });
+
+    const res = await loader({ request: makeRequest("sess-1") } as any);
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe(
+      "/oauth/consent?session_id=sess-1",
+    );
+
+    const setCookie = res.headers.get("Set-Cookie") ?? "";
+    expect(setCookie).toContain("__dali_sid=raw-session-id");
+    expect(setCookie).toContain("HttpOnly");
+    expect(setCookie).toContain("SameSite=Lax");
+
+    expect(mockIssueSession).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: "user-1", ip: "9.8.7.6" }),
+    );
+    expect(mockIssueSession).toHaveBeenCalledWith(
+      expect.not.objectContaining({ grantId: expect.anything() }),
+    );
+  });
+
+  it("issues cookie session on direct loopback redirect (first-party client)", async () => {
+    mockGetOAuthClient.mockResolvedValue({
+      clientId: "client-1",
+      name: "Some App",
+      isFirstParty: true,
+    });
+    mockGenerateAuthorizationCode.mockResolvedValue("auth-code-xyz");
+
+    const res = await loader({ request: makeRequest("sess-1") } as any);
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toContain(
+      "http://127.0.0.1:51999/callback",
+    );
+    expect(res.headers.get("Location")).toContain("code=auth-code-xyz");
+
+    const setCookie = res.headers.get("Set-Cookie") ?? "";
+    expect(setCookie).toContain("__dali_sid=raw-session-id");
+  });
+});

--- a/dali-api/app/routes/__tests__/oauth.callback.google.test.ts
+++ b/dali-api/app/routes/__tests__/oauth.callback.google.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const mockGetOAuthSession = vi.hoisted(() => vi.fn());
+const mockGetOAuthClient = vi.hoisted(() => vi.fn());
+const mockGenerateAuthorizationCode = vi.hoisted(() => vi.fn());
+const mockExchangeGoogleCode = vi.hoisted(() => vi.fn());
+const mockUpsertUserFromGoogle = vi.hoisted(() => vi.fn());
+const mockIssueSession = vi.hoisted(() => vi.fn());
+
+vi.mock("~/lib/oauth", () => ({
+  getOAuthSession: mockGetOAuthSession,
+  getOAuthClient: mockGetOAuthClient,
+  generateAuthorizationCode: mockGenerateAuthorizationCode,
+  exchangeGoogleCode: mockExchangeGoogleCode,
+}));
+
+vi.mock("~/lib/user-provisioning", () => ({
+  upsertUserFromGoogle: mockUpsertUserFromGoogle,
+}));
+
+vi.mock("~/lib/session", () => ({
+  issueSession: mockIssueSession,
+}));
+
+vi.mock("~/lib/db", () => ({
+  prisma: {
+    dALIMember: { findUnique: vi.fn() },
+    oAuthGrant: { findUnique: vi.fn().mockResolvedValue(null) },
+    oAuthSession: { update: vi.fn().mockResolvedValue({}) },
+  },
+}));
+
+import { loader } from "~/routes/oauth.callback.google";
+
+function makeRequest(sessionId: string, code = "google-code") {
+  const params = new URLSearchParams({ code, state: sessionId });
+  return new Request(`http://localhost/oauth/callback/google?${params}`, {
+    headers: { "user-agent": "test-agent", "X-Forwarded-For": "9.8.7.6" },
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.FRONTEND_URL = "http://localhost:5173";
+  process.env.API_BASE_URL = "http://localhost:3001";
+
+  mockGetOAuthSession.mockResolvedValue({
+    id: "sess-1",
+    state: "client-state",
+    redirectUri: "http://127.0.0.1:51999/callback",
+    expiresAt: new Date(Date.now() + 60_000),
+    exchanged: false,
+    accountType: "member",
+    clientId: "client-1",
+    scopes: ["mcp:read"],
+    linkUserId: null,
+  });
+  mockExchangeGoogleCode.mockResolvedValue({
+    email: "user@dali.dartmouth.edu",
+    sub: "g-123",
+    givenName: "Test",
+    familyName: "User",
+  });
+  mockUpsertUserFromGoogle.mockResolvedValue({
+    user: { id: "user-1", netId: "abc123" },
+  });
+  mockIssueSession.mockResolvedValue({
+    rawId: "raw-session-id",
+    expiresAt: new Date(Date.now() + 1_000_000),
+    absoluteExpiresAt: new Date(Date.now() + 1_000_000),
+  });
+});
+
+describe("GET /oauth/callback/google sets __dali_sid cookie", () => {
+  it("issues cookie session when redirecting to consent screen", async () => {
+    mockGetOAuthClient.mockResolvedValue({
+      clientId: "client-1",
+      name: "Some App",
+      isFirstParty: false,
+      requireMembership: false,
+    });
+
+    const res = await loader({ request: makeRequest("sess-1") } as any);
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe(
+      "/oauth/consent?session_id=sess-1",
+    );
+
+    const setCookie = res.headers.get("Set-Cookie") ?? "";
+    expect(setCookie).toContain("__dali_sid=raw-session-id");
+    expect(setCookie).toContain("HttpOnly");
+    expect(setCookie).toContain("SameSite=Lax");
+
+    expect(mockIssueSession).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: "user-1", ip: "9.8.7.6" }),
+    );
+    expect(mockIssueSession).toHaveBeenCalledWith(
+      expect.not.objectContaining({ grantId: expect.anything() }),
+    );
+  });
+
+  it("issues cookie session on direct loopback redirect (first-party client)", async () => {
+    mockGetOAuthClient.mockResolvedValue({
+      clientId: "client-1",
+      name: "Some App",
+      isFirstParty: true,
+      requireMembership: false,
+    });
+    mockGenerateAuthorizationCode.mockResolvedValue("auth-code-xyz");
+
+    const res = await loader({ request: makeRequest("sess-1") } as any);
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toContain(
+      "http://127.0.0.1:51999/callback",
+    );
+    expect(res.headers.get("Location")).toContain("code=auth-code-xyz");
+
+    const setCookie = res.headers.get("Set-Cookie") ?? "";
+    expect(setCookie).toContain("__dali_sid=raw-session-id");
+  });
+});

--- a/dali-api/app/routes/oauth.callback.cas.ts
+++ b/dali-api/app/routes/oauth.callback.cas.ts
@@ -7,6 +7,9 @@ import {
 } from "~/lib/oauth";
 import { upsertUserFromCas } from "~/lib/user-provisioning";
 import { prisma } from "~/lib/db";
+import { issueSession } from "~/lib/session";
+import { setSessionCookie } from "~/lib/cookies";
+import { getClientIp } from "~/lib/request-meta";
 
 export async function action() {
   return new Response("Method not allowed", { status: 405 });
@@ -87,23 +90,31 @@ export async function loader({ request }: Route.LoaderArgs) {
     }
   }
 
+  // Issue a first-party cookie session so the consent screen (and any
+  // subsequent first-party page load) can verify the user is signed in.
+  // This is the same cookie shape `/auth/callback/cas` issues; the MCP
+  // grant-bound session is separate and gets minted at /oauth/token.
+  const cookieSession = await issueSession({
+    userId: finalUser.id,
+    userAgent: request.headers.get("user-agent") ?? undefined,
+    ip: getClientIp(request),
+  });
+
   if (isFirstParty || matchingGrant || !client) {
     const code = await generateAuthorizationCode(session.id, finalUser.id);
     const params = new URLSearchParams({ code, state: session.state });
-    return new Response(null, {
-      status: 302,
-      headers: { Location: `${session.redirectUri}?${params}` },
-    });
+    const headers = new Headers();
+    setSessionCookie(headers, cookieSession.rawId);
+    headers.set("Location", `${session.redirectUri}?${params}`);
+    return new Response(null, { status: 302, headers });
   }
 
   await prisma.oAuthSession.update({
     where: { id: session.id },
     data: { userId: finalUser.id },
   });
-  return new Response(null, {
-    status: 302,
-    headers: {
-      Location: `/oauth/consent?session_id=${session.id}`,
-    },
-  });
+  const headers = new Headers();
+  setSessionCookie(headers, cookieSession.rawId);
+  headers.set("Location", `/oauth/consent?session_id=${session.id}`);
+  return new Response(null, { status: 302, headers });
 }

--- a/dali-api/app/routes/oauth.callback.google.ts
+++ b/dali-api/app/routes/oauth.callback.google.ts
@@ -7,6 +7,9 @@ import {
   exchangeGoogleCode,
 } from "~/lib/oauth";
 import { upsertUserFromGoogle } from "~/lib/user-provisioning";
+import { issueSession } from "~/lib/session";
+import { setSessionCookie } from "~/lib/cookies";
+import { getClientIp } from "~/lib/request-meta";
 
 export async function action() {
   return new Response("Method not allowed", { status: 405 });
@@ -129,13 +132,23 @@ export async function loader({ request }: Route.LoaderArgs) {
     }
   }
 
+  // Issue a first-party cookie session so the consent screen (and any
+  // subsequent first-party page load) can verify the user is signed in.
+  // This is the same cookie shape `/auth/callback/google` issues; the MCP
+  // grant-bound session is separate and gets minted at /oauth/token.
+  const cookieSession = await issueSession({
+    userId: user.id,
+    userAgent: request.headers.get("user-agent") ?? undefined,
+    ip: getClientIp(request),
+  });
+
   if (isFirstParty || matchingGrant || !client) {
     const code = await generateAuthorizationCode(session.id, user.id);
     const params = new URLSearchParams({ code, state: session.state });
-    return new Response(null, {
-      status: 302,
-      headers: { Location: `${session.redirectUri}?${params}` },
-    });
+    const headers = new Headers();
+    setSessionCookie(headers, cookieSession.rawId);
+    headers.set("Location", `${session.redirectUri}?${params}`);
+    return new Response(null, { status: 302, headers });
   }
 
   // Pre-set userId so the consent screen can render the client + scopes
@@ -144,10 +157,8 @@ export async function loader({ request }: Route.LoaderArgs) {
     where: { id: session.id },
     data: { userId: user.id },
   });
-  return new Response(null, {
-    status: 302,
-    headers: {
-      Location: `/oauth/consent?session_id=${session.id}`,
-    },
-  });
+  const headers = new Headers();
+  setSessionCookie(headers, cookieSession.rawId);
+  headers.set("Location", `/oauth/consent?session_id=${session.id}`);
+  return new Response(null, { status: 302, headers });
 }


### PR DESCRIPTION
## Bug from the field

After #538 + #541 + #544, real Claude Code clients running `claude mcp add` → `/mcp` complete Google sign-in successfully, but `/oauth/consent` rejects them with "Authorization unavailable / You must be signed in to authorize this app."

## Root cause

`/oauth/callback/google` (the OAuth-provider one) authenticates the user via Google and binds `OAuthSession.userId`, but **never issues a `__dali_sid` cookie session**. When the browser then loads `/oauth/consent?session_id=...`, the consent loader calls `parseSessionId(request)` → `lookupSession(...)` to verify the browser owns the OAuthSession and finds nothing — so it returns `"You must be signed in to authorize this app"`.

Same gap existed in `/oauth/callback/cas`.

The first-party `/auth/callback/{google,cas}` routes already do this correctly; the two flows already share `upsertUserFromGoogle` / `upsertUserFromCas`, but only the first-party one was issuing the cookie.

## Fix

After `upsertUserFromGoogle` / `upsertUserFromCas` returns the user, but **before** any redirect to `/oauth/consent` or the loopback `redirect_uri`, issue a first-party cookie session:

- `issueSession({ userId, userAgent, ip })` — **no `grantId`**, this is a first-party cookie session, not an MCP grant session.
- `setSessionCookie(headers, rawId)` — attach to the redirect.
- `getClientIp(request)` for the IP.

Mirrors `/auth/callback/google` / `/auth/callback/cas` exactly.

## Deliberately unchanged

- `/auth/callback/*` (first-party — already correct).
- `lib/user-provisioning.ts`.
- `/oauth/token` — still issues the MCP-grant session (with `grantId`) at code-exchange time. The cookie this PR adds is the first-party browser session; they coexist on the user.
- Consent screen logic — we fix the cause, not the check.
- The CAS-chain branch in `/oauth/callback/google` (member without netId) does not issue a cookie. The user finishes auth at `/oauth/callback/cas`, which now issues it.

## Tests

- Added `app/routes/__tests__/oauth.callback.google.test.ts` and `app/routes/__tests__/oauth.callback.cas.test.ts`. Each asserts the loader response sets `__dali_sid` (HttpOnly, SameSite=Lax) on both branches (redirect to consent screen, and direct redirect to loopback when client is first-party). Per the issue: this is the integration-style "fake Google has returned" coverage of cookie issuance — stubbing the real Google bounce in Playwright was impractical.
- Full vitest suite still green locally (727/727).

## Context

Builds on #538 / #541 / #544.