### PR TITLE
Polish MCP consent + auth-success screen styling

### DIFF
--- a/dali-api/app/routes/oauth.consent.tsx
+++ b/dali-api/app/routes/oauth.consent.tsx
@@ -148,35 +148,35 @@ export async function action({ request }: Route.ActionArgs) {
 export default function ConsentScreen({ loaderData }: Route.ComponentProps) {
   if (!loaderData.ok) {
     return (
-      <main className="mx-auto max-w-md p-8">
+      <main className="mx-auto max-w-md p-8 text-foreground">
         <h1 className="text-xl font-semibold">Authorization unavailable</h1>
-        <p className="mt-2 text-sm text-zinc-600">{loaderData.error}</p>
+        <p className="mt-2 text-sm text-muted-foreground">{loaderData.error}</p>
       </main>
     );
   }
   const { sessionId, clientName, scopes, userEmail } = loaderData;
   return (
-    <main className="mx-auto max-w-md p-8">
+    <main className="mx-auto max-w-md p-8 text-foreground">
       <h1 className="text-xl font-semibold">
         Authorize {clientName}?
       </h1>
-      <p className="mt-2 text-sm text-zinc-600">
-        Signed in as <strong>{userEmail}</strong>.
+      <p className="mt-2 text-sm text-muted-foreground">
+        Signed in as <strong className="text-foreground">{userEmail}</strong>.
       </p>
-      <p className="mt-4 text-sm text-zinc-700">
+      <p className="mt-4 text-sm text-foreground/90">
         <strong>{clientName}</strong> is requesting:
       </p>
       <ul className="mt-3 space-y-2">
         {scopes.length === 0 ? (
-          <li className="text-sm text-zinc-500">Basic profile (no scopes requested)</li>
+          <li className="text-sm text-muted-foreground">Basic profile (no scopes requested)</li>
         ) : (
           scopes.map((s) => (
             <li
               key={s}
-              className="rounded border border-zinc-200 bg-zinc-50 px-3 py-2 text-sm"
+              className="rounded border border-border bg-card px-3 py-2 text-sm"
             >
-              <code className="font-mono text-xs">{s}</code>
-              <div className="text-xs text-zinc-600">
+              <code className="font-mono text-xs text-foreground">{s}</code>
+              <div className="text-xs text-muted-foreground">
                 {SCOPE_DESCRIPTIONS[s] ?? "Custom scope"}
               </div>
             </li>
@@ -189,7 +189,7 @@ export default function ConsentScreen({ loaderData }: Route.ComponentProps) {
           type="submit"
           name="decision"
           value="approve"
-          className="flex-1 rounded bg-zinc-900 px-4 py-2 text-sm text-white hover:bg-zinc-700"
+          className="flex-1 rounded bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90"
         >
           Authorize
         </button>
@@ -197,7 +197,7 @@ export default function ConsentScreen({ loaderData }: Route.ComponentProps) {
           type="submit"
           name="decision"
           value="deny"
-          className="flex-1 rounded border border-zinc-300 px-4 py-2 text-sm text-zinc-700 hover:bg-zinc-100"
+          className="flex-1 rounded border border-border bg-card px-4 py-2 text-sm font-medium text-foreground hover:bg-muted"
         >
           Cancel
         </button>


### PR DESCRIPTION
## Summary

- Fixes the **`/oauth/consent`** contrast bug. The screen was using `text-zinc-*` / `bg-zinc-*` / `border-zinc-*` classes, which have no dark-mode remap in `app/app.css` (only `gray-*` does). On a dark page background the "Signed in as ...", "Claude Code (dali-os-dev) is requesting:", `mcp:read` / `mcp:write` scope labels, and the **Cancel** button all rendered as very-light-gray-on-dark and were effectively invisible.
- Swapped those classes for the app's semantic tokens (`text-foreground`, `text-muted-foreground`, `border-border`, `bg-card`, `bg-primary` / `text-primary-foreground`) so the screen reads correctly in both light and dark mode. Layout untouched.

## Auth-success page

Grepped `dali-api/app/` for "Authentication Successful", "close this window", and "Return to Claude Code" — **no matches**. That page is rendered by Claude Code's local loopback listener, not by this app. Out of scope; not touched.

## Test plan

- [x] `npm run typecheck` — no new errors introduced (pre-existing Prisma-generated-client errors unrelated).
- [x] `npm test` — 723/723 passing.
- [ ] Manual: load `/oauth/consent?session_id=...` in dark mode, verify all text and both buttons are legible.
- [ ] Manual: same in light mode — no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)