### PR TITLE
Add 5 Tier 1 MCP read tools (notifications, meetings, freebusy, directory, profile)

### DIFF
--- a/dali-api/app/calendar/routes/api.calendar.group-availability.ts
+++ b/dali-api/app/calendar/routes/api.calendar.group-availability.ts
@@ -1,11 +1,13 @@
 import type { Route } from "./+types/api.calendar.group-availability";
 import { z } from "zod";
-import { prisma } from "~/lib/db";
 import { requireAuth } from "~/lib/auth";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { parseJson } from "~/lib/validate";
-import { computeFreeIntervals, type Interval, type WorkingHoursDayInput } from "~/lib/availability";
-import { fetchBusyEvents } from "~/lib/google-calendar";
+import {
+  computeUserFreeBusy,
+  intersectFreeIntervals,
+  type Interval,
+} from "~/lib/availability";
 import { getZonedYMD } from "~/lib/timezone";
 
 const Schema = z.object({
@@ -16,19 +18,6 @@ const Schema = z.object({
   timezone: z.string().min(1),
 });
 
-const DEFAULT_BUFFER_MIN = 15;
-const DEFAULT_WORK_START_MIN = 9 * 60;
-const DEFAULT_WORK_END_MIN = 17 * 60;
-
-function defaultWorkingHours(): WorkingHoursDayInput[] {
-  return Array.from({ length: 7 }).map((_, dow) => ({
-    dayOfWeek: dow,
-    enabled: dow >= 1 && dow <= 5,
-    startMinute: DEFAULT_WORK_START_MIN,
-    endMinute: DEFAULT_WORK_END_MIN,
-  }));
-}
-
 type DayBucket = {
   // Sun=0 .. Sat=6 in the requesting user's timezone.
   dayOfWeek: number;
@@ -37,30 +26,6 @@ type DayBucket = {
   matches: { startHour: number; durationHours: number }[];
   busy: { startHour: number; durationHours: number }[];
 };
-
-function intersectMany(sets: Interval[][]): Interval[] {
-  if (sets.length === 0) return [];
-  let acc = sets[0];
-  for (let i = 1; i < sets.length; i++) {
-    acc = intersectTwo(acc, sets[i]);
-    if (acc.length === 0) return [];
-  }
-  return acc;
-}
-
-function intersectTwo(a: Interval[], b: Interval[]): Interval[] {
-  const out: Interval[] = [];
-  let i = 0;
-  let j = 0;
-  while (i < a.length && j < b.length) {
-    const start = Math.max(a[i].start.getTime(), b[j].start.getTime());
-    const end = Math.min(a[i].end.getTime(), b[j].end.getTime());
-    if (start < end) out.push({ start: new Date(start), end: new Date(end) });
-    if (a[i].end.getTime() < b[j].end.getTime()) i++;
-    else j++;
-  }
-  return out;
-}
 
 function unionMany(sets: Interval[][]): Interval[] {
   const all: Interval[] = sets.flat().sort((x, y) => x.start.getTime() - y.start.getTime());
@@ -173,53 +138,12 @@ export async function action({ request }: Route.ActionArgs) {
 
   // Per-user: load availability inputs and compute busy/free.
   const perUser = await Promise.all(
-    userIds.map(async (uid) => {
-      const [settings, whRows, blocks, busyRaw] = await Promise.all([
-        prisma.userAvailabilitySettings.findUnique({ where: { userId: uid } }),
-        prisma.workingHoursDay.findMany({ where: { userId: uid } }),
-        prisma.manualBlock.findMany({ where: { userId: uid }, take: 500 }),
-        fetchBusyEvents(uid, windowStart, windowEnd).catch(() => [] as { start: string; end: string }[]),
-      ]);
-
-      // Multiple segments per dow are allowed — expand each persisted row as
-      // its own working-hours entry. Days with no persisted rows fall back to
-      // the Mon–Fri 9–5 default.
-      const persistedDows = new Set(whRows.map((r) => r.dayOfWeek));
-      const workingHours: WorkingHoursDayInput[] = [
-        ...whRows.map((r) => ({
-          dayOfWeek: r.dayOfWeek,
-          enabled: r.enabled,
-          startMinute: r.startMinute,
-          endMinute: r.endMinute,
-        })),
-        ...defaultWorkingHours().filter((d) => !persistedDows.has(d.dayOfWeek)),
-      ];
-
-      const externalBusy: Interval[] = busyRaw.map((b) => ({
-        start: new Date(b.start),
-        end: new Date(b.end),
-      }));
-
-      const { free, busy } = computeFreeIntervals({
-        windowStart,
-        windowEnd,
-        workingHours,
-        manualBlocks: blocks.map((b) => ({
-          startTime: b.startTime,
-          endTime: b.endTime,
-          recurrenceRule: b.recurrenceRule,
-        })),
-        externalBusy,
-        bufferMin: settings?.defaultEventBufferMin ?? DEFAULT_BUFFER_MIN,
-        timezone: settings?.timezone ?? body.timezone,
-      });
-      return { userId: uid, free, busy };
-    }),
+    userIds.map((uid) => computeUserFreeBusy(uid, windowStart, windowEnd, body.timezone)),
   );
 
   // Intersect all users' free intervals → match windows. Keep only those ≥ duration.
   const minDurationMs = body.durationMinutes * 60_000;
-  const matches = intersectMany(perUser.map((u) => u.free)).filter(
+  const matches = intersectFreeIntervals(perUser.map((u) => u.free)).filter(
     (iv) => iv.end.getTime() - iv.start.getTime() >= minDurationMs,
   );
 

--- a/dali-api/app/lib/__mocks__/db.ts
+++ b/dali-api/app/lib/__mocks__/db.ts
@@ -33,6 +33,7 @@ export const prisma = {
   interview: {
     create: vi.fn(),
     update: vi.fn(),
+    findMany: vi.fn().mockResolvedValue([]),
   },
   application: {
     findUnique: vi.fn(),
@@ -60,6 +61,45 @@ export const prisma = {
   },
   dALIMember: {
     findUnique: vi.fn(),
+  },
+  notification: {
+    findMany: vi.fn().mockResolvedValue([]),
+    count: vi.fn().mockResolvedValue(0),
+    create: vi.fn(),
+    createMany: vi.fn(),
+    update: vi.fn(),
+    updateMany: vi.fn(),
+  },
+  scheduledMeeting: {
+    findMany: vi.fn().mockResolvedValue([]),
+    create: vi.fn(),
+    update: vi.fn(),
+  },
+  userAvailabilitySettings: {
+    findUnique: vi.fn().mockResolvedValue(null),
+  },
+  workingHoursDay: {
+    findMany: vi.fn().mockResolvedValue([]),
+  },
+  manualBlock: {
+    findMany: vi.fn().mockResolvedValue([]),
+  },
+  userCalendarLink: {
+    findMany: vi.fn().mockResolvedValue([]),
+    findUnique: vi.fn(),
+    update: vi.fn(),
+  },
+  term: {
+    findFirst: vi.fn().mockResolvedValue(null),
+  },
+  adminMembership: {
+    findUnique: vi.fn(),
+  },
+  coreAssignment: {
+    findFirst: vi.fn(),
+  },
+  domainLeadAssignment: {
+    findFirst: vi.fn(),
   },
   $transaction: vi.fn(),
 };

--- a/dali-api/app/lib/__tests__/availability.test.ts
+++ b/dali-api/app/lib/__tests__/availability.test.ts
@@ -1,4 +1,8 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("~/lib/db");
+vi.mock("~/lib/google-calendar");
+
 import { computeFreeIntervals, type ComputeInput, type Interval } from "~/lib/availability";
 
 // Helpers ------------------------------------------------------------------

--- a/dali-api/app/lib/__tests__/mcp-input.test.ts
+++ b/dali-api/app/lib/__tests__/mcp-input.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { validateInput, type JsonSchema } from "~/lib/mcp-input";
+
+describe("validateInput", () => {
+  it("accepts an empty object when no required fields", () => {
+    const r = validateInput(undefined, {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    });
+    expect(r.ok).toBe(true);
+  });
+
+  it("rejects unexpected properties when additionalProperties is false", () => {
+    const r = validateInput(
+      { foo: 1 },
+      { type: "object", properties: {}, additionalProperties: false },
+    );
+    expect(r.ok).toBe(false);
+  });
+
+  it("enforces integer minimum/maximum", () => {
+    const schema: JsonSchema = {
+      type: "object",
+      properties: { n: { type: "integer", minimum: 1, maximum: 5 } },
+      additionalProperties: false,
+    };
+    expect(validateInput({ n: 0 }, schema).ok).toBe(false);
+    expect(validateInput({ n: 6 }, schema).ok).toBe(false);
+    expect(validateInput({ n: 3 }, schema).ok).toBe(true);
+  });
+
+  it("enforces required fields", () => {
+    const r = validateInput(
+      {},
+      { type: "object", required: ["x"], properties: { x: { type: "string" } } },
+    );
+    expect(r.ok).toBe(false);
+  });
+
+  it("enforces array maxItems and item type", () => {
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        ids: { type: "array", items: { type: "string" }, maxItems: 2 },
+      },
+    };
+    expect(validateInput({ ids: ["a", "b", "c"] }, schema).ok).toBe(false);
+    expect(validateInput({ ids: ["a", 1] }, schema).ok).toBe(false);
+    expect(validateInput({ ids: ["a"] }, schema).ok).toBe(true);
+  });
+
+  it("enforces enum", () => {
+    const schema: JsonSchema = {
+      type: "object",
+      properties: { mode: { type: "integer", enum: [15, 30, 45, 60] } },
+    };
+    expect(validateInput({ mode: 7 }, schema).ok).toBe(false);
+    expect(validateInput({ mode: 30 }, schema).ok).toBe(true);
+  });
+
+  it("enforces string length bounds", () => {
+    const schema: JsonSchema = {
+      type: "object",
+      properties: { q: { type: "string", minLength: 1, maxLength: 5 } },
+    };
+    expect(validateInput({ q: "" }, schema).ok).toBe(false);
+    expect(validateInput({ q: "abcdef" }, schema).ok).toBe(false);
+    expect(validateInput({ q: "abc" }, schema).ok).toBe(true);
+  });
+});

--- a/dali-api/app/lib/availability.ts
+++ b/dali-api/app/lib/availability.ts
@@ -1,5 +1,7 @@
 import rrulePkg from "rrule";
 import type { RRule as RRuleType } from "rrule";
+import { prisma } from "~/lib/db";
+import { fetchBusyEvents } from "~/lib/google-calendar";
 import { getZonedYMD, zonedDayStartUtc } from "~/lib/timezone";
 
 const { RRule, rrulestr } = rrulePkg as unknown as {
@@ -229,5 +231,128 @@ function formatDtstart(d: Date): string {
   return (
     `${d.getUTCFullYear()}${pad(d.getUTCMonth() + 1)}${pad(d.getUTCDate())}` +
     `T${pad(d.getUTCHours())}${pad(d.getUTCMinutes())}${pad(d.getUTCSeconds())}Z`
+  );
+}
+
+// ─── Multi-user mutual-availability helpers ─────────────────────────────────
+//
+// These power the in-app meeting scheduler (api.calendar.group-availability)
+// and the MCP `find_mutual_freebusy` tool. The route still owns its own
+// per-day grid bucketing; this module owns the cross-user math.
+
+const DEFAULT_BUFFER_MIN = 15;
+const DEFAULT_WORK_START_MIN = 9 * 60;
+const DEFAULT_WORK_END_MIN = 17 * 60;
+const DEFAULT_TIMEZONE = "America/New_York";
+
+function defaultWorkingHoursForDow(): WorkingHoursDayInput[] {
+  return Array.from({ length: 7 }).map((_, dow) => ({
+    dayOfWeek: dow,
+    enabled: dow >= 1 && dow <= 5,
+    startMinute: DEFAULT_WORK_START_MIN,
+    endMinute: DEFAULT_WORK_END_MIN,
+  }));
+}
+
+/**
+ * Load + compute free/busy for a single user across the given window.
+ * Pulls UserAvailabilitySettings, WorkingHoursDay segments, ManualBlock rows
+ * (incl. RRULE expansion), and external Google Calendar busy events.
+ *
+ * `fallbackTimezone` is used only if the user has no UserAvailabilitySettings row.
+ */
+export async function computeUserFreeBusy(
+  userId: string,
+  windowStart: Date,
+  windowEnd: Date,
+  fallbackTimezone: string = DEFAULT_TIMEZONE,
+): Promise<{ userId: string; free: Interval[]; busy: Interval[] }> {
+  const [settings, whRows, blocks, busyRaw] = await Promise.all([
+    prisma.userAvailabilitySettings.findUnique({ where: { userId } }),
+    prisma.workingHoursDay.findMany({ where: { userId } }),
+    prisma.manualBlock.findMany({ where: { userId }, take: 500 }),
+    fetchBusyEvents(userId, windowStart, windowEnd).catch(
+      () => [] as { start: string; end: string }[],
+    ),
+  ]);
+
+  const persistedDows = new Set(whRows.map((r) => r.dayOfWeek));
+  const workingHours: WorkingHoursDayInput[] = [
+    ...whRows.map((r) => ({
+      dayOfWeek: r.dayOfWeek,
+      enabled: r.enabled,
+      startMinute: r.startMinute,
+      endMinute: r.endMinute,
+    })),
+    ...defaultWorkingHoursForDow().filter((d) => !persistedDows.has(d.dayOfWeek)),
+  ];
+
+  const externalBusy: Interval[] = busyRaw.map((b) => ({
+    start: new Date(b.start),
+    end: new Date(b.end),
+  }));
+
+  const { free, busy } = computeFreeIntervals({
+    windowStart,
+    windowEnd,
+    workingHours,
+    manualBlocks: blocks.map((b) => ({
+      startTime: b.startTime,
+      endTime: b.endTime,
+      recurrenceRule: b.recurrenceRule,
+    })),
+    externalBusy,
+    bufferMin: settings?.defaultEventBufferMin ?? DEFAULT_BUFFER_MIN,
+    timezone: settings?.timezone ?? fallbackTimezone,
+  });
+  return { userId, free, busy };
+}
+
+/**
+ * Intersect a set of per-user free interval lists. Returns intervals where
+ * every participant is free. Each input list must be sorted by start.
+ */
+export function intersectFreeIntervals(sets: Interval[][]): Interval[] {
+  if (sets.length === 0) return [];
+  let acc = sets[0];
+  for (let i = 1; i < sets.length; i++) {
+    acc = intersectTwo(acc, sets[i]);
+    if (acc.length === 0) return [];
+  }
+  return acc;
+}
+
+function intersectTwo(a: Interval[], b: Interval[]): Interval[] {
+  const out: Interval[] = [];
+  let i = 0;
+  let j = 0;
+  while (i < a.length && j < b.length) {
+    const start = Math.max(a[i].start.getTime(), b[j].start.getTime());
+    const end = Math.min(a[i].end.getTime(), b[j].end.getTime());
+    if (start < end) out.push({ start: new Date(start), end: new Date(end) });
+    if (a[i].end.getTime() < b[j].end.getTime()) i++;
+    else j++;
+  }
+  return out;
+}
+
+/**
+ * For a list of users, find every contiguous slot of at least `slotMinutes`
+ * where all participants are mutually free.
+ */
+export async function findMutualFreeSlots(
+  participantUserIds: string[],
+  windowStart: Date,
+  windowEnd: Date,
+  slotMinutes: number,
+): Promise<Interval[]> {
+  if (participantUserIds.length === 0) return [];
+  const uniq = Array.from(new Set(participantUserIds));
+  const perUser = await Promise.all(
+    uniq.map((uid) => computeUserFreeBusy(uid, windowStart, windowEnd)),
+  );
+  const minMs = Math.max(1, slotMinutes) * 60_000;
+  return intersectFreeIntervals(perUser.map((u) => u.free)).filter(
+    (iv) => iv.end.getTime() - iv.start.getTime() >= minMs,
   );
 }

--- a/dali-api/app/lib/mcp-input.ts
+++ b/dali-api/app/lib/mcp-input.ts
@@ -1,0 +1,118 @@
+// Minimal, dependency-free JSON Schema validator for MCP tool inputs.
+//
+// Covers the subset our tool schemas actually use: type, properties, required,
+// additionalProperties, items, enum, minimum, maximum, minLength, maxLength,
+// minItems, maxItems. Anything outside that subset is silently ignored.
+
+export type JsonSchema = {
+  type?: string;
+  properties?: Record<string, JsonSchema>;
+  required?: string[];
+  additionalProperties?: boolean;
+  items?: JsonSchema;
+  enum?: unknown[];
+  minimum?: number;
+  maximum?: number;
+  minLength?: number;
+  maxLength?: number;
+  minItems?: number;
+  maxItems?: number;
+};
+
+export type ValidationResult =
+  | { ok: true; value: unknown }
+  | { ok: false; error: string };
+
+function typeOf(v: unknown): string {
+  if (v === null) return "null";
+  if (Array.isArray(v)) return "array";
+  if (Number.isInteger(v)) return "integer";
+  return typeof v;
+}
+
+function validate(value: unknown, schema: JsonSchema, path: string): string | null {
+  if (schema.type) {
+    const t = typeOf(value);
+    const expected = schema.type;
+    const ok =
+      t === expected ||
+      (expected === "number" && t === "integer") ||
+      (expected === "integer" && t === "integer");
+    if (!ok) {
+      return `${path || "value"}: expected ${expected}, got ${t}`;
+    }
+  }
+
+  if (schema.enum && !schema.enum.includes(value as never)) {
+    return `${path || "value"}: must be one of ${JSON.stringify(schema.enum)}`;
+  }
+
+  if (typeof value === "string") {
+    if (schema.minLength !== undefined && value.length < schema.minLength) {
+      return `${path}: shorter than minLength ${schema.minLength}`;
+    }
+    if (schema.maxLength !== undefined && value.length > schema.maxLength) {
+      return `${path}: longer than maxLength ${schema.maxLength}`;
+    }
+  }
+
+  if (typeof value === "number") {
+    if (schema.minimum !== undefined && value < schema.minimum) {
+      return `${path}: below minimum ${schema.minimum}`;
+    }
+    if (schema.maximum !== undefined && value > schema.maximum) {
+      return `${path}: above maximum ${schema.maximum}`;
+    }
+  }
+
+  if (Array.isArray(value)) {
+    if (schema.minItems !== undefined && value.length < schema.minItems) {
+      return `${path}: fewer than minItems ${schema.minItems}`;
+    }
+    if (schema.maxItems !== undefined && value.length > schema.maxItems) {
+      return `${path}: more than maxItems ${schema.maxItems}`;
+    }
+    if (schema.items) {
+      for (let i = 0; i < value.length; i++) {
+        const err = validate(value[i], schema.items, `${path}[${i}]`);
+        if (err) return err;
+      }
+    }
+  }
+
+  if (
+    schema.type === "object" ||
+    (value !== null && typeof value === "object" && !Array.isArray(value))
+  ) {
+    const obj = value as Record<string, unknown>;
+    if (schema.required) {
+      for (const k of schema.required) {
+        if (!(k in obj)) return `${path}${path ? "." : ""}${k}: missing required field`;
+      }
+    }
+    if (schema.properties) {
+      for (const [k, sub] of Object.entries(schema.properties)) {
+        if (k in obj) {
+          const err = validate(obj[k], sub, `${path}${path ? "." : ""}${k}`);
+          if (err) return err;
+        }
+      }
+    }
+    if (schema.additionalProperties === false && schema.properties) {
+      const allowed = new Set(Object.keys(schema.properties));
+      for (const k of Object.keys(obj)) {
+        if (!allowed.has(k)) return `${path}${path ? "." : ""}${k}: unexpected property`;
+      }
+    }
+  }
+
+  return null;
+}
+
+export function validateInput(value: unknown, schema: JsonSchema): ValidationResult {
+  // Default empty input to {} so tools with no required fields accept undefined.
+  const v = value === undefined ? {} : value;
+  const err = validate(v, schema, "");
+  if (err) return { ok: false, error: err };
+  return { ok: true, value: v };
+}

--- a/dali-api/app/lib/notifications.ts
+++ b/dali-api/app/lib/notifications.ts
@@ -1,0 +1,45 @@
+// Shared notification-fetch helpers. The in-app inbox route (`api.notifications.ts`)
+// and the MCP `list_my_notifications` tool both call into this module so the
+// "what counts as a recent notification" policy lives in one place.
+
+import { prisma } from "~/lib/db";
+
+export interface ListNotificationsOptions {
+  /** Hard cap on rows returned. */
+  limit?: number;
+  /** When true, only return notifications with readAt = null. */
+  onlyUnread?: boolean;
+}
+
+export interface NotificationListResult {
+  items: Awaited<ReturnType<typeof prisma.notification.findMany>>;
+  unreadCount: number;
+}
+
+/**
+ * Load the inbox view for a user: a slice of recent notifications plus the
+ * total unread count. Default slice mirrors the in-app inbox (last 50,
+ * newest first).
+ */
+export async function listMyNotifications(
+  userId: string,
+  opts: ListNotificationsOptions = {},
+): Promise<NotificationListResult> {
+  const limit = Math.max(1, Math.min(opts.limit ?? 50, 50));
+  const where = opts.onlyUnread
+    ? { recipientUserId: userId, readAt: null }
+    : { recipientUserId: userId };
+
+  const [items, unreadCount] = await Promise.all([
+    prisma.notification.findMany({
+      where,
+      orderBy: { createdAt: "desc" },
+      take: limit,
+    }),
+    prisma.notification.count({
+      where: { recipientUserId: userId, readAt: null },
+    }),
+  ]);
+
+  return { items, unreadCount };
+}

--- a/dali-api/app/mcp/tools/__tests__/find-mutual-freebusy.test.ts
+++ b/dali-api/app/mcp/tools/__tests__/find-mutual-freebusy.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("~/lib/db");
+vi.mock("~/lib/google-calendar", () => ({
+  fetchBusyEvents: vi.fn().mockResolvedValue([]),
+}));
+
+import { prisma } from "~/lib/db";
+import {
+  runFindMutualFreebusy,
+  FIND_MUTUAL_FREEBUSY_TOOL,
+} from "~/mcp/tools/find-mutual-freebusy";
+import { validateInput, type JsonSchema } from "~/lib/mcp-input";
+
+const mockPrisma = prisma as unknown as {
+  userAvailabilitySettings: { findUnique: ReturnType<typeof vi.fn> };
+  workingHoursDay: { findMany: ReturnType<typeof vi.fn> };
+  manualBlock: { findMany: ReturnType<typeof vi.fn> };
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Default: every user has a 9-5 weekday Mon-Fri working-hours schedule.
+  mockPrisma.userAvailabilitySettings.findUnique.mockResolvedValue({
+    timezone: "America/New_York",
+    defaultEventBufferMin: 0,
+  });
+  mockPrisma.workingHoursDay.findMany.mockResolvedValue([]);
+  mockPrisma.manualBlock.findMany.mockResolvedValue([]);
+});
+
+describe("find_mutual_freebusy", () => {
+  it("requires mcp:read", () => {
+    expect(FIND_MUTUAL_FREEBUSY_TOOL.requiredScope).toBe("mcp:read");
+  });
+
+  it("rejects windows > 7 days", async () => {
+    await expect(
+      runFindMutualFreebusy("user-1", {
+        participantUserIds: ["user-2"],
+        windowStart: "2026-05-14T00:00:00Z",
+        windowEnd: "2026-05-25T00:00:00Z",
+      }),
+    ).rejects.toThrow(/7 days/);
+  });
+
+  it("rejects invalid slotMinutes", async () => {
+    await expect(
+      runFindMutualFreebusy("user-1", {
+        participantUserIds: ["user-2"],
+        windowStart: "2026-05-14T00:00:00Z",
+        windowEnd: "2026-05-15T00:00:00Z",
+        slotMinutes: 7,
+      }),
+    ).rejects.toThrow(/slotMinutes/);
+  });
+
+  it("rejects > 8 participants including caller", async () => {
+    await expect(
+      runFindMutualFreebusy("user-1", {
+        participantUserIds: [
+          "u2",
+          "u3",
+          "u4",
+          "u5",
+          "u6",
+          "u7",
+          "u8",
+          "u9",
+        ],
+        windowStart: "2026-05-14T00:00:00Z",
+        windowEnd: "2026-05-15T00:00:00Z",
+      }),
+    ).rejects.toThrow(/Max 8 participants/);
+  });
+
+  it("returns mutual free slots in a single-weekday window", async () => {
+    // Wed 2026-05-13 09:00 ET → 17:00 ET (default working hours).
+    const out = await runFindMutualFreebusy("user-1", {
+      participantUserIds: ["user-2"],
+      windowStart: "2026-05-13T13:00:00Z", // 09:00 ET
+      windowEnd: "2026-05-13T21:00:00Z", // 17:00 ET
+      slotMinutes: 30,
+    });
+    expect(out.slots.length).toBeGreaterThan(0);
+    expect(out.slots[0]).toMatchObject({
+      start: "2026-05-13T13:00:00.000Z",
+      end: "2026-05-13T21:00:00.000Z",
+    });
+  });
+
+  it("rejects scope mismatch via dispatcher (shape check)", () => {
+    // Validate the schema rejects bad payloads at validation time.
+    const r = validateInput(
+      { participantUserIds: "not-an-array" },
+      FIND_MUTUAL_FREEBUSY_TOOL.inputSchema as JsonSchema,
+    );
+    expect(r.ok).toBe(false);
+  });
+});

--- a/dali-api/app/mcp/tools/__tests__/get-member-profile.test.ts
+++ b/dali-api/app/mcp/tools/__tests__/get-member-profile.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("~/lib/db");
+
+import { prisma } from "~/lib/db";
+import {
+  runGetMemberProfile,
+  GET_MEMBER_PROFILE_TOOL,
+  MemberNotFoundError,
+} from "~/mcp/tools/get-member-profile";
+import { validateInput, type JsonSchema } from "~/lib/mcp-input";
+
+const mockPrisma = prisma as unknown as {
+  user: { findUnique: ReturnType<typeof vi.fn> };
+  term: { findFirst: ReturnType<typeof vi.fn> };
+};
+
+const FULL_USER = {
+  id: "u-target",
+  firstName: "Grace",
+  lastName: "Hopper",
+  daliEmail: "grace@dali.dartmouth.edu",
+  dartmouthEmail: "grace@dartmouth.edu",
+  netId: "f099xyz",
+  personalEmail: "grace@personal.com",
+  classYear: 2027,
+  bioDocId: null,
+  pronouns: "she/her",
+  major: "CS",
+  hometown: "NYC",
+  linkedinUrl: null,
+  githubUrl: null,
+  personalSite: null,
+  daliMember: { id: "dm-1", createdAt: new Date("2025-09-01T00:00:00Z") },
+  adminMembership: null,
+  coreAssignments: [],
+  domainLeadAssignmentsAsUser: [],
+  domainEligibilities: [
+    { level: "P2", domain: { id: "d1", displayName: "Fullstack Dev" } },
+  ],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockPrisma.term.findFirst.mockResolvedValue({ id: "term-1", code: "26S" });
+});
+
+describe("get_member_profile", () => {
+  it("requires mcp:read", () => {
+    expect(GET_MEMBER_PROFILE_TOOL.requiredScope).toBe("mcp:read");
+  });
+
+  it("includes personalEmail when caller is the same as memberId", async () => {
+    mockPrisma.user.findUnique.mockResolvedValue(FULL_USER);
+    const out = await runGetMemberProfile("u-target", { memberId: "u-target" });
+    expect(out.personalEmail).toBe("grace@personal.com");
+    expect(out.tier).toBe("member");
+    expect(out.domains[0]).toMatchObject({ name: "Fullstack Dev", eligibility: "P2" });
+  });
+
+  it("hides personalEmail when caller ≠ memberId (privacy gate)", async () => {
+    mockPrisma.user.findUnique.mockResolvedValue(FULL_USER);
+    const out = await runGetMemberProfile("u-other", { memberId: "u-target" });
+    expect(out.personalEmail).toBeNull();
+    expect(out.daliEmail).toBe("grace@dali.dartmouth.edu");
+  });
+
+  it("throws MemberNotFoundError when no DALIMember row exists", async () => {
+    mockPrisma.user.findUnique.mockResolvedValue({
+      ...FULL_USER,
+      daliMember: null,
+    });
+    await expect(
+      runGetMemberProfile("u-other", { memberId: "u-target" }),
+    ).rejects.toBeInstanceOf(MemberNotFoundError);
+  });
+
+  it("throws MemberNotFoundError when user does not exist", async () => {
+    mockPrisma.user.findUnique.mockResolvedValue(null);
+    await expect(
+      runGetMemberProfile("u-other", { memberId: "missing" }),
+    ).rejects.toBeInstanceOf(MemberNotFoundError);
+  });
+
+  it("rejects missing memberId via the schema validator", () => {
+    const r = validateInput({}, GET_MEMBER_PROFILE_TOOL.inputSchema as JsonSchema);
+    expect(r.ok).toBe(false);
+  });
+});

--- a/dali-api/app/mcp/tools/__tests__/list-my-notifications.test.ts
+++ b/dali-api/app/mcp/tools/__tests__/list-my-notifications.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("~/lib/db");
+
+import { prisma } from "~/lib/db";
+import { runListMyNotifications } from "~/mcp/tools/list-my-notifications";
+import { validateInput, type JsonSchema } from "~/lib/mcp-input";
+import { LIST_MY_NOTIFICATIONS_TOOL } from "~/mcp/tools/list-my-notifications";
+
+const mockPrisma = prisma as unknown as {
+  notification: {
+    findMany: ReturnType<typeof vi.fn>;
+    count: ReturnType<typeof vi.fn>;
+  };
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("list_my_notifications", () => {
+  it("requires the mcp:read scope", () => {
+    expect(LIST_MY_NOTIFICATIONS_TOOL.requiredScope).toBe("mcp:read");
+  });
+
+  it("returns shaped notifications and unread count (happy path)", async () => {
+    mockPrisma.notification.findMany.mockResolvedValue([
+      {
+        id: "n1",
+        kind: "MeetingInvite",
+        title: "Invite",
+        body: "Now",
+        link: "/calendar?meeting=m1",
+        readAt: null,
+        createdAt: new Date("2026-05-14T10:00:00Z"),
+        scheduledMeetingId: "m1",
+        rsvp: null,
+      },
+    ]);
+    mockPrisma.notification.count.mockResolvedValue(3);
+
+    const out = await runListMyNotifications("user-1", {});
+    expect(out.unreadCount).toBe(3);
+    expect(out.notifications).toHaveLength(1);
+    expect(out.notifications[0]).toMatchObject({
+      id: "n1",
+      kind: "MeetingInvite",
+      readAt: null,
+      createdAt: "2026-05-14T10:00:00.000Z",
+    });
+  });
+
+  it("respects onlyUnread", async () => {
+    mockPrisma.notification.findMany.mockResolvedValue([]);
+    mockPrisma.notification.count.mockResolvedValue(0);
+
+    await runListMyNotifications("user-1", { onlyUnread: true });
+    expect(mockPrisma.notification.findMany).toHaveBeenCalledWith({
+      where: { recipientUserId: "user-1", readAt: null },
+      orderBy: { createdAt: "desc" },
+      take: 20,
+    });
+  });
+
+  it("rejects invalid input via the dispatcher validator", () => {
+    const result = validateInput(
+      { limit: 9999 },
+      LIST_MY_NOTIFICATIONS_TOOL.inputSchema as JsonSchema,
+    );
+    expect(result.ok).toBe(false);
+  });
+
+  it("returns empty list when user has no notifications", async () => {
+    mockPrisma.notification.findMany.mockResolvedValue([]);
+    mockPrisma.notification.count.mockResolvedValue(0);
+
+    const out = await runListMyNotifications("user-1", {});
+    expect(out.notifications).toEqual([]);
+    expect(out.unreadCount).toBe(0);
+  });
+});

--- a/dali-api/app/mcp/tools/__tests__/list-my-upcoming-meetings.test.ts
+++ b/dali-api/app/mcp/tools/__tests__/list-my-upcoming-meetings.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("~/lib/db");
+
+import { prisma } from "~/lib/db";
+import {
+  runListMyUpcomingMeetings,
+  LIST_MY_UPCOMING_MEETINGS_TOOL,
+} from "~/mcp/tools/list-my-upcoming-meetings";
+import { validateInput, type JsonSchema } from "~/lib/mcp-input";
+
+const mockPrisma = prisma as unknown as {
+  scheduledMeeting: { findMany: ReturnType<typeof vi.fn> };
+  interview: { findMany: ReturnType<typeof vi.fn> };
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-05-14T12:00:00Z"));
+});
+
+describe("list_my_upcoming_meetings", () => {
+  it("requires mcp:read", () => {
+    expect(LIST_MY_UPCOMING_MEETINGS_TOOL.requiredScope).toBe("mcp:read");
+  });
+
+  it("returns scheduled meetings + interviews sorted by start", async () => {
+    mockPrisma.scheduledMeeting.findMany.mockResolvedValue([
+      {
+        id: "m1",
+        organizerId: "user-1",
+        title: "Sync",
+        durationMinutes: 30,
+        selectedAt: new Date("2026-05-15T14:00:00Z"),
+        recurrenceRule: null,
+        participantUserIds: ["user-1", "user-2"],
+        status: "Confirmed",
+        exceptions: [],
+      },
+    ]);
+    mockPrisma.interview.findMany.mockResolvedValue([
+      {
+        id: "iv1",
+        startTime: new Date("2026-05-14T15:00:00Z"),
+        endTime: new Date("2026-05-14T15:30:00Z"),
+        location: "PodAppa",
+        assignments: [{ id: "a1" }, { id: "a2" }],
+      },
+    ]);
+
+    const out = await runListMyUpcomingMeetings("user-1", { daysAhead: 7 });
+    expect(out.meetings).toHaveLength(2);
+    expect(out.meetings[0].id).toBe("iv1");
+    expect(out.meetings[0].source).toBe("interview");
+    expect(out.meetings[1].id).toBe("m1");
+    expect(out.meetings[1].source).toBe("dali");
+    expect(out.meetings[1].attendeeCount).toBe(2);
+  });
+
+  it("excludes past events and cancelled exceptions", async () => {
+    mockPrisma.scheduledMeeting.findMany.mockResolvedValue([
+      {
+        id: "m-past",
+        organizerId: "user-1",
+        title: "Old",
+        durationMinutes: 30,
+        selectedAt: new Date("2026-05-10T12:00:00Z"),
+        recurrenceRule: null,
+        participantUserIds: ["user-1"],
+        status: "Confirmed",
+        exceptions: [],
+      },
+      {
+        id: "m-cancelled",
+        organizerId: "user-1",
+        title: "Cancelled by exception",
+        durationMinutes: 30,
+        selectedAt: new Date("2026-05-15T14:00:00Z"),
+        recurrenceRule: null,
+        participantUserIds: ["user-1"],
+        status: "Confirmed",
+        exceptions: [
+          {
+            originalStart: new Date("2026-05-15T14:00:00Z"),
+            cancelled: true,
+            overrideStart: null,
+            overrideDurationMin: null,
+            overrideTitle: null,
+          },
+        ],
+      },
+    ]);
+    mockPrisma.interview.findMany.mockResolvedValue([]);
+
+    const out = await runListMyUpcomingMeetings("user-1", {});
+    expect(out.meetings).toEqual([]);
+  });
+
+  it("rejects daysAhead > 30 via the input validator", () => {
+    const r = validateInput(
+      { daysAhead: 99 },
+      LIST_MY_UPCOMING_MEETINGS_TOOL.inputSchema as JsonSchema,
+    );
+    expect(r.ok).toBe(false);
+  });
+
+  it("returns empty when there are no meetings or interviews", async () => {
+    mockPrisma.scheduledMeeting.findMany.mockResolvedValue([]);
+    mockPrisma.interview.findMany.mockResolvedValue([]);
+    const out = await runListMyUpcomingMeetings("user-1", {});
+    expect(out.meetings).toEqual([]);
+  });
+});

--- a/dali-api/app/mcp/tools/__tests__/search-directory.test.ts
+++ b/dali-api/app/mcp/tools/__tests__/search-directory.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("~/lib/db");
+
+import { prisma } from "~/lib/db";
+import {
+  runSearchDirectory,
+  SEARCH_DIRECTORY_TOOL,
+} from "~/mcp/tools/search-directory";
+import { validateInput, type JsonSchema } from "~/lib/mcp-input";
+
+const mockPrisma = prisma as unknown as {
+  user: { findMany: ReturnType<typeof vi.fn> };
+  term: { findFirst: ReturnType<typeof vi.fn> };
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockPrisma.term.findFirst.mockResolvedValue({ id: "term-1", code: "26S" });
+});
+
+describe("search_directory", () => {
+  it("requires mcp:read", () => {
+    expect(SEARCH_DIRECTORY_TOOL.requiredScope).toBe("mcp:read");
+  });
+
+  it("returns directory rows with computed tier + domains", async () => {
+    mockPrisma.user.findMany.mockResolvedValue([
+      {
+        id: "u1",
+        firstName: "Ada",
+        lastName: "Lovelace",
+        daliEmail: "ada@dali.dartmouth.edu",
+        netId: "f001abc",
+        adminMembership: null,
+        coreAssignments: [{ leadTitle: "Hiring Lead" }],
+        domainLeadAssignmentsAsUser: [],
+        domainEligibilities: [{ domain: { displayName: "Fullstack Dev" } }],
+      },
+    ]);
+
+    const out = await runSearchDirectory({ query: "ada" });
+    expect(out.results).toHaveLength(1);
+    expect(out.results[0]).toMatchObject({
+      id: "u1",
+      tier: "core",
+      domains: ["Fullstack Dev"],
+      currentTermRoles: ["Hiring Lead"],
+    });
+  });
+
+  it("rejects empty query at the schema layer", () => {
+    const r = validateInput(
+      { query: "" },
+      SEARCH_DIRECTORY_TOOL.inputSchema as JsonSchema,
+    );
+    expect(r.ok).toBe(false);
+  });
+
+  it("rejects query > 100 chars at the schema layer", () => {
+    const r = validateInput(
+      { query: "x".repeat(101) },
+      SEARCH_DIRECTORY_TOOL.inputSchema as JsonSchema,
+    );
+    expect(r.ok).toBe(false);
+  });
+
+  it("returns empty results when no rows match", async () => {
+    mockPrisma.user.findMany.mockResolvedValue([]);
+    const out = await runSearchDirectory({ query: "noone" });
+    expect(out.results).toEqual([]);
+  });
+
+  it("scopes user.findMany to DALIMember rows only (privacy)", async () => {
+    mockPrisma.user.findMany.mockResolvedValue([]);
+    await runSearchDirectory({ query: "x" });
+    const call = mockPrisma.user.findMany.mock.calls[0][0];
+    expect(call.where.daliMember).toEqual({ isNot: null });
+  });
+});

--- a/dali-api/app/mcp/tools/find-mutual-freebusy.ts
+++ b/dali-api/app/mcp/tools/find-mutual-freebusy.ts
@@ -1,0 +1,90 @@
+// MCP `find_mutual_freebusy` — free-time intersection across multiple users.
+// Wraps the shared `findMutualFreeSlots` helper that powers the in-app group
+// availability scheduler. The caller's userId is implicitly added to the
+// participant list. Requires the `mcp:read` scope.
+
+import { findMutualFreeSlots } from "~/lib/availability";
+
+export const FIND_MUTUAL_FREEBUSY_TOOL = {
+  name: "find_mutual_freebusy",
+  description:
+    "Find time slots where all listed participants are mutually free. The authenticated caller is implicitly included.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      participantUserIds: {
+        type: "array",
+        items: { type: "string", minLength: 1 },
+        maxItems: 8,
+        description:
+          "User IDs of other participants. Caller is added if not already present. Max 8 total.",
+      },
+      windowStart: {
+        type: "string",
+        description: "ISO 8601 window start (e.g. 2026-05-14T13:00:00Z).",
+      },
+      windowEnd: {
+        type: "string",
+        description: "ISO 8601 window end. Span must be ≤ 7 days.",
+      },
+      slotMinutes: {
+        type: "integer",
+        enum: [15, 30, 45, 60],
+        description: "Minimum slot length in minutes (default 30).",
+      },
+    },
+    required: ["participantUserIds", "windowStart", "windowEnd"],
+    additionalProperties: false,
+  },
+  requiredScope: "mcp:read" as const,
+};
+
+type Input = {
+  participantUserIds: string[];
+  windowStart: string;
+  windowEnd: string;
+  slotMinutes?: number;
+};
+
+const MAX_PARTICIPANTS = 8;
+const MAX_SPAN_MS = 7 * 24 * 60 * 60 * 1000;
+
+export async function runFindMutualFreebusy(callerId: string, input: Input) {
+  const windowStart = new Date(input.windowStart);
+  const windowEnd = new Date(input.windowEnd);
+  if (isNaN(windowStart.getTime()) || isNaN(windowEnd.getTime())) {
+    throw new Error("windowStart/windowEnd must be ISO 8601 timestamps");
+  }
+  if (windowEnd <= windowStart) {
+    throw new Error("windowEnd must be after windowStart");
+  }
+  if (windowEnd.getTime() - windowStart.getTime() > MAX_SPAN_MS) {
+    throw new Error("Window span must be ≤ 7 days");
+  }
+
+  const slotMinutes = input.slotMinutes ?? 30;
+  if (![15, 30, 45, 60].includes(slotMinutes)) {
+    throw new Error("slotMinutes must be one of 15, 30, 45, 60");
+  }
+
+  const participants = Array.from(
+    new Set([callerId, ...input.participantUserIds]),
+  );
+  if (participants.length > MAX_PARTICIPANTS) {
+    throw new Error(`Max ${MAX_PARTICIPANTS} participants (including caller)`);
+  }
+
+  const slots = await findMutualFreeSlots(
+    participants,
+    windowStart,
+    windowEnd,
+    slotMinutes,
+  );
+
+  return {
+    slots: slots.map((s) => ({
+      start: s.start.toISOString(),
+      end: s.end.toISOString(),
+    })),
+  };
+}

--- a/dali-api/app/mcp/tools/get-member-profile.ts
+++ b/dali-api/app/mcp/tools/get-member-profile.ts
@@ -1,0 +1,153 @@
+// MCP `get_member_profile` — single-member drill-down. Returns identity,
+// domain eligibility, current-term roles, and basic profile fields. Personal
+// (non-Dartmouth) email is exposed ONLY when the caller is requesting their
+// own profile. Requires the `mcp:read` scope.
+
+import { prisma } from "~/lib/db";
+import { currentTerm } from "~/lib/roles";
+
+export const GET_MEMBER_PROFILE_TOOL = {
+  name: "get_member_profile",
+  description:
+    "Get a single member's profile. personalEmail is included only when the caller asks for their own profile.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      memberId: {
+        type: "string",
+        minLength: 1,
+        description: "The User.id of the member to look up.",
+      },
+    },
+    required: ["memberId"],
+    additionalProperties: false,
+  },
+  requiredScope: "mcp:read" as const,
+};
+
+type Input = { memberId: string };
+
+export class MemberNotFoundError extends Error {
+  constructor(memberId: string) {
+    super(`No DALI member found with id ${memberId}`);
+    this.name = "MemberNotFoundError";
+  }
+}
+
+export async function runGetMemberProfile(callerId: string, input: Input) {
+  const term = await currentTerm();
+  const termId = term?.id ?? null;
+  const isSelf = input.memberId === callerId;
+
+  const user = await prisma.user.findUnique({
+    where: { id: input.memberId },
+    select: {
+      id: true,
+      firstName: true,
+      lastName: true,
+      daliEmail: true,
+      dartmouthEmail: true,
+      netId: true,
+      personalEmail: true,
+      classYear: true,
+      bioDocId: true,
+      pronouns: true,
+      major: true,
+      hometown: true,
+      linkedinUrl: true,
+      githubUrl: true,
+      personalSite: true,
+      daliMember: { select: { id: true, createdAt: true } },
+      adminMembership: { select: { id: true } },
+      coreAssignments: termId
+        ? { where: { termId }, select: { leadTitle: true, termId: true } }
+        : { select: { leadTitle: true, termId: true } },
+      domainLeadAssignmentsAsUser: termId
+        ? {
+            where: { termId },
+            select: {
+              termId: true,
+              domain: { select: { id: true, displayName: true } },
+            },
+          }
+        : {
+            select: {
+              termId: true,
+              domain: { select: { id: true, displayName: true } },
+            },
+          },
+      domainEligibilities: {
+        select: {
+          level: true,
+          domain: { select: { id: true, displayName: true } },
+        },
+      },
+    },
+  });
+
+  if (!user || !user.daliMember) {
+    throw new MemberNotFoundError(input.memberId);
+  }
+
+  const isAdminUser = user.adminMembership !== null;
+  const isCoreUser = user.coreAssignments.length > 0;
+  const isDomainLeadUser = user.domainLeadAssignmentsAsUser.length > 0;
+  const tier: "admin" | "core" | "domain-lead" | "member" = isAdminUser
+    ? "admin"
+    : isCoreUser
+      ? "core"
+      : isDomainLeadUser
+        ? "domain-lead"
+        : "member";
+
+  const currentTermRoles: Array<{
+    roleType: "Core" | "DomainLead" | "Admin";
+    scopeName?: string;
+    termCode?: string;
+  }> = [];
+
+  if (isAdminUser) {
+    currentTermRoles.push({ roleType: "Admin" });
+  }
+  for (const c of user.coreAssignments) {
+    currentTermRoles.push({
+      roleType: "Core",
+      scopeName: c.leadTitle ?? undefined,
+      termCode: term?.code,
+    });
+  }
+  for (const dl of user.domainLeadAssignmentsAsUser) {
+    currentTermRoles.push({
+      roleType: "DomainLead",
+      scopeName: dl.domain.displayName,
+      termCode: term?.code,
+    });
+  }
+
+  return {
+    id: user.id,
+    firstName: user.firstName,
+    lastName: user.lastName,
+    daliEmail: user.daliEmail,
+    netId: user.netId,
+    dartmouthEmail: user.dartmouthEmail,
+    // Privacy: personalEmail only returned to the user themselves.
+    personalEmail: isSelf ? user.personalEmail : null,
+    tier,
+    domains: user.domainEligibilities.map((e) => ({
+      id: e.domain.id,
+      name: e.domain.displayName,
+      eligibility: e.level,
+    })),
+    currentTermRoles,
+    bioDocId: user.bioDocId,
+    classYear: user.classYear,
+    pronouns: user.pronouns,
+    major: user.major,
+    hometown: user.hometown,
+    linkedinUrl: user.linkedinUrl,
+    githubUrl: user.githubUrl,
+    personalSite: user.personalSite,
+    joinedAt: user.daliMember.createdAt.toISOString(),
+  };
+}

--- a/dali-api/app/mcp/tools/list-my-notifications.ts
+++ b/dali-api/app/mcp/tools/list-my-notifications.ts
@@ -1,0 +1,57 @@
+// MCP `list_my_notifications` — returns the authenticated user's recent in-app
+// notifications. Reuses the same fetch logic as the inbox endpoint at
+// `api.notifications.ts`. Requires the `mcp:read` scope.
+
+import { listMyNotifications } from "~/lib/notifications";
+
+export const LIST_MY_NOTIFICATIONS_TOOL = {
+  name: "list_my_notifications",
+  description:
+    "Return the authenticated DALI OS member's recent in-app notifications, with a total unread count.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      limit: {
+        type: "integer",
+        minimum: 1,
+        maximum: 50,
+        description: "Maximum number of notifications to return (default 30, max 50).",
+      },
+      onlyUnread: {
+        type: "boolean",
+        description: "If true, only return notifications that have not been read.",
+      },
+    },
+    additionalProperties: false,
+  },
+  requiredScope: "mcp:read" as const,
+};
+
+type Input = { limit?: number; onlyUnread?: boolean };
+
+export async function runListMyNotifications(
+  userId: string,
+  input: Input,
+) {
+  // Default to "20 unread + 10 read" semantics by fetching a slightly larger
+  // mixed slice. When onlyUnread=true, callers usually want a shorter view.
+  const limit = input.limit ?? (input.onlyUnread ? 20 : 30);
+  const { items, unreadCount } = await listMyNotifications(userId, {
+    limit,
+    onlyUnread: input.onlyUnread ?? false,
+  });
+  return {
+    unreadCount,
+    notifications: items.map((n) => ({
+      id: n.id,
+      kind: n.kind,
+      title: n.title,
+      body: n.body,
+      link: n.link,
+      readAt: n.readAt ? n.readAt.toISOString() : null,
+      createdAt: n.createdAt.toISOString(),
+      scheduledMeetingId: n.scheduledMeetingId,
+      rsvp: n.rsvp,
+    })),
+  };
+}

--- a/dali-api/app/mcp/tools/list-my-upcoming-meetings.ts
+++ b/dali-api/app/mcp/tools/list-my-upcoming-meetings.ts
@@ -1,0 +1,165 @@
+// MCP `list_my_upcoming_meetings` — returns ScheduledMeeting + Interview
+// occurrences the authenticated user is involved in within the next N days.
+// Reads directly from the calendar/hiring tables — no helper exists in the app
+// today because the calendar UI is per-week-grid, not "next-N-days inbox".
+// Requires the `mcp:read` scope.
+
+import { prisma } from "~/lib/db";
+import rrulePkg from "rrule";
+import type { RRule as RRuleType } from "rrule";
+
+const { RRule, rrulestr } = rrulePkg as unknown as {
+  RRule: typeof import("rrule").RRule;
+  rrulestr: typeof import("rrule").rrulestr;
+};
+
+export const LIST_MY_UPCOMING_MEETINGS_TOOL = {
+  name: "list_my_upcoming_meetings",
+  description:
+    "Return meetings the authenticated DALI OS member is invited to or attending in a forward window. Includes scheduled meetings and assigned interviews.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      daysAhead: {
+        type: "integer",
+        minimum: 1,
+        maximum: 30,
+        description: "How many days into the future to scan (default 7, max 30).",
+      },
+    },
+    additionalProperties: false,
+  },
+  requiredScope: "mcp:read" as const,
+};
+
+type Input = { daysAhead?: number };
+
+type MeetingOut = {
+  id: string;
+  title: string;
+  startsAt: string;
+  endsAt: string;
+  location: string | null;
+  attendeeCount: number;
+  source: "dali" | "interview";
+};
+
+function buildRule(rule: string, dtstart: Date): RRuleType | null {
+  try {
+    const trimmed = rule.trim();
+    const rrulePart = trimmed.toUpperCase().startsWith("RRULE:") ? trimmed : `RRULE:${trimmed}`;
+    const pad = (n: number) => String(n).padStart(2, "0");
+    const dt =
+      `${dtstart.getUTCFullYear()}${pad(dtstart.getUTCMonth() + 1)}${pad(dtstart.getUTCDate())}` +
+      `T${pad(dtstart.getUTCHours())}${pad(dtstart.getUTCMinutes())}${pad(dtstart.getUTCSeconds())}Z`;
+    const parsed = rrulestr(`DTSTART:${dt}\n${rrulePart}`);
+    return parsed instanceof RRule ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function runListMyUpcomingMeetings(userId: string, input: Input) {
+  const daysAhead = Math.min(Math.max(input.daysAhead ?? 7, 1), 30);
+  const now = new Date();
+  const windowEnd = new Date(now.getTime() + daysAhead * 24 * 60 * 60 * 1000);
+
+  // (1) ScheduledMeeting — user is organizer OR in participantUserIds.
+  const meetings = await prisma.scheduledMeeting.findMany({
+    where: {
+      status: { not: "Cancelled" },
+      OR: [
+        { organizerId: userId },
+        { participantUserIds: { has: userId } },
+      ],
+    },
+    include: { exceptions: true },
+    take: 200,
+  });
+
+  const out: MeetingOut[] = [];
+
+  for (const m of meetings) {
+    const attendeeCount = new Set([m.organizerId, ...m.participantUserIds]).size;
+    if (!m.selectedAt) continue; // still in Searching state with no start time
+
+    const baseEnd = new Date(m.selectedAt.getTime() + m.durationMinutes * 60_000);
+    const exceptionsByStart = new Map<number, (typeof m.exceptions)[number]>();
+    for (const ex of m.exceptions) {
+      exceptionsByStart.set(ex.originalStart.getTime(), ex);
+    }
+
+    const candidates: { start: Date; end: Date }[] = [];
+    if (m.recurrenceRule) {
+      const rule = buildRule(m.recurrenceRule, m.selectedAt);
+      if (rule) {
+        const occurrences = rule.between(now, windowEnd, true);
+        for (const occStart of occurrences) {
+          const ex = exceptionsByStart.get(occStart.getTime());
+          if (ex?.cancelled) continue;
+          const start = ex?.overrideStart ?? occStart;
+          const dur = ex?.overrideDurationMin ?? m.durationMinutes;
+          candidates.push({ start, end: new Date(start.getTime() + dur * 60_000) });
+        }
+      }
+    } else {
+      if (m.selectedAt < windowEnd && baseEnd > now) {
+        const ex = exceptionsByStart.get(m.selectedAt.getTime());
+        if (!ex?.cancelled) {
+          const start = ex?.overrideStart ?? m.selectedAt;
+          const dur = ex?.overrideDurationMin ?? m.durationMinutes;
+          candidates.push({ start, end: new Date(start.getTime() + dur * 60_000) });
+        }
+      }
+    }
+
+    for (const c of candidates) {
+      if (c.end <= now || c.start >= windowEnd) continue;
+      out.push({
+        id: m.id,
+        title: m.title,
+        startsAt: c.start.toISOString(),
+        endsAt: c.end.toISOString(),
+        location: null,
+        attendeeCount,
+        source: "dali",
+      });
+    }
+  }
+
+  // (2) Interview — user is assigned as a CycleInterviewer.
+  const interviews = await prisma.interview.findMany({
+    where: {
+      status: "Scheduled",
+      startTime: { gte: now, lte: windowEnd },
+      assignments: {
+        some: {
+          status: "Active",
+          cycleInterviewer: { userId },
+        },
+      },
+    },
+    include: {
+      assignments: {
+        where: { status: "Active" },
+        select: { id: true },
+      },
+    },
+    take: 100,
+  });
+
+  for (const iv of interviews) {
+    out.push({
+      id: iv.id,
+      title: "Interview",
+      startsAt: iv.startTime.toISOString(),
+      endsAt: iv.endTime.toISOString(),
+      location: iv.location,
+      attendeeCount: iv.assignments.length + 1, // interviewers + applicant
+      source: "interview",
+    });
+  }
+
+  out.sort((a, b) => a.startsAt.localeCompare(b.startsAt));
+  return { meetings: out };
+}

--- a/dali-api/app/mcp/tools/search-directory.ts
+++ b/dali-api/app/mcp/tools/search-directory.ts
@@ -1,0 +1,139 @@
+// MCP `search_directory` — substring search over lab members (User rows with a
+// linked DALIMember marker). Matches against names, daliEmail, netId, domain
+// names, and current-term role titles. Requires the `mcp:read` scope.
+
+import { prisma } from "~/lib/db";
+import { currentTerm } from "~/lib/roles";
+
+export const SEARCH_DIRECTORY_TOOL = {
+  name: "search_directory",
+  description:
+    "Search the DALI member directory. Matches against name fragments, daliEmail, netId, domain names, and role titles. Only returns lab members.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      query: {
+        type: "string",
+        minLength: 1,
+        maxLength: 100,
+        description: "Search query (≤ 100 chars). Case-insensitive substring match.",
+      },
+      limit: {
+        type: "integer",
+        minimum: 1,
+        maximum: 50,
+        description: "Maximum results to return (default 20, max 50).",
+      },
+    },
+    required: ["query"],
+    additionalProperties: false,
+  },
+  requiredScope: "mcp:read" as const,
+};
+
+type Input = { query: string; limit?: number };
+
+type DirectoryRow = {
+  id: string;
+  firstName: string;
+  lastName: string;
+  daliEmail: string | null;
+  netId: string | null;
+  tier: "admin" | "core" | "domain-lead" | "member";
+  domains: string[];
+  currentTermRoles: string[];
+};
+
+export async function runSearchDirectory(input: Input): Promise<{ results: DirectoryRow[] }> {
+  const q = input.query.trim();
+  if (q.length === 0) return { results: [] };
+  const limit = Math.max(1, Math.min(input.limit ?? 20, 50));
+
+  const term = await currentTerm();
+  const termId = term?.id ?? null;
+
+  const users = await prisma.user.findMany({
+    where: {
+      daliMember: { isNot: null },
+      OR: [
+        { firstName: { contains: q, mode: "insensitive" } },
+        { lastName: { contains: q, mode: "insensitive" } },
+        { daliEmail: { contains: q, mode: "insensitive" } },
+        { netId: { contains: q, mode: "insensitive" } },
+        {
+          domainEligibilities: {
+            some: {
+              domain: {
+                OR: [
+                  { displayName: { contains: q, mode: "insensitive" } },
+                  { code: { contains: q, mode: "insensitive" } },
+                ],
+              },
+            },
+          },
+        },
+        {
+          coreAssignments: {
+            some: { leadTitle: { contains: q, mode: "insensitive" } },
+          },
+        },
+      ],
+    },
+    orderBy: [{ lastName: "asc" }, { firstName: "asc" }],
+    take: limit,
+    select: {
+      id: true,
+      firstName: true,
+      lastName: true,
+      daliEmail: true,
+      netId: true,
+      adminMembership: { select: { id: true } },
+      coreAssignments: termId
+        ? { where: { termId }, select: { leadTitle: true } }
+        : { select: { leadTitle: true } },
+      domainLeadAssignmentsAsUser: termId
+        ? {
+            where: { termId },
+            select: { domain: { select: { displayName: true } } },
+          }
+        : { select: { domain: { select: { displayName: true } } } },
+      domainEligibilities: {
+        select: { domain: { select: { displayName: true } } },
+      },
+    },
+  });
+
+  const results: DirectoryRow[] = users.map((u) => {
+    const isAdminUser = u.adminMembership !== null;
+    const isCoreUser = u.coreAssignments.length > 0;
+    const isDomainLeadUser = u.domainLeadAssignmentsAsUser.length > 0;
+    const tier: DirectoryRow["tier"] = isAdminUser
+      ? "admin"
+      : isCoreUser
+        ? "core"
+        : isDomainLeadUser
+          ? "domain-lead"
+          : "member";
+
+    const currentTermRoles: string[] = [];
+    for (const c of u.coreAssignments) {
+      if (c.leadTitle) currentTermRoles.push(c.leadTitle);
+    }
+    for (const dl of u.domainLeadAssignmentsAsUser) {
+      currentTermRoles.push(`${dl.domain.displayName} Lead`);
+    }
+
+    return {
+      id: u.id,
+      firstName: u.firstName,
+      lastName: u.lastName,
+      daliEmail: u.daliEmail,
+      netId: u.netId,
+      tier,
+      domains: u.domainEligibilities.map((e) => e.domain.displayName),
+      currentTermRoles,
+    };
+  });
+
+  return { results };
+}

--- a/dali-api/app/routes/api.notifications.ts
+++ b/dali-api/app/routes/api.notifications.ts
@@ -2,6 +2,7 @@ import type { Route } from "./+types/api.notifications";
 import { prisma } from "~/lib/db";
 import { requireAuth } from "~/lib/auth";
 import { withCors, handlePreflight } from "~/lib/cors";
+import { listMyNotifications } from "~/lib/notifications";
 
 export async function loader({ request }: Route.LoaderArgs) {
   const preflight = handlePreflight(request);
@@ -10,18 +11,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   const auth = await requireAuth(request);
   if (!auth.ok) return withCors(request, auth.response);
 
-  const userId = auth.user.sub;
-  const [items, unreadCount] = await Promise.all([
-    prisma.notification.findMany({
-      where: { recipientUserId: userId },
-      orderBy: { createdAt: "desc" },
-      take: 50,
-    }),
-    prisma.notification.count({
-      where: { recipientUserId: userId, readAt: null },
-    }),
-  ]);
-
+  const { items, unreadCount } = await listMyNotifications(auth.user.sub);
   return withCors(request, Response.json({ items, unreadCount }));
 }
 

--- a/dali-api/app/routes/mcp.ts
+++ b/dali-api/app/routes/mcp.ts
@@ -1,14 +1,36 @@
 // MCP v1 transport. Hand-rolled JSON-RPC 2.0 over HTTP — no @modelcontextprotocol
-// /sdk dependency. Streamable-HTTP semantics not needed for a tool catalog
-// of one; this responds to POST with a JSON-RPC envelope and is sufficient
-// for Claude Desktop / Claude Code to call `whoami`.
+// /sdk dependency. Streamable-HTTP semantics not needed for a small tool
+// catalog; this responds to POST with a JSON-RPC envelope and is sufficient
+// for Claude Desktop / Claude Code to call our tools.
 
 import type { Route } from "./+types/mcp";
 import { authenticateMcpRequest } from "~/lib/mcp-auth";
 import { checkRateLimit } from "~/lib/rate-limit";
 import { logAuditEvent } from "~/lib/audit";
 import { safeJson } from "~/lib/safe-json";
+import { validateInput, type JsonSchema } from "~/lib/mcp-input";
 import { WHOAMI_TOOL, runWhoami } from "~/mcp/tools/whoami";
+import {
+  LIST_MY_NOTIFICATIONS_TOOL,
+  runListMyNotifications,
+} from "~/mcp/tools/list-my-notifications";
+import {
+  LIST_MY_UPCOMING_MEETINGS_TOOL,
+  runListMyUpcomingMeetings,
+} from "~/mcp/tools/list-my-upcoming-meetings";
+import {
+  FIND_MUTUAL_FREEBUSY_TOOL,
+  runFindMutualFreebusy,
+} from "~/mcp/tools/find-mutual-freebusy";
+import {
+  SEARCH_DIRECTORY_TOOL,
+  runSearchDirectory,
+} from "~/mcp/tools/search-directory";
+import {
+  GET_MEMBER_PROFILE_TOOL,
+  runGetMemberProfile,
+  MemberNotFoundError,
+} from "~/mcp/tools/get-member-profile";
 
 const PROTOCOL_VERSION = "2024-11-05";
 const SERVER_INFO = { name: "dali-os", version: "1.0.0" };
@@ -16,7 +38,14 @@ const SERVER_INFO = { name: "dali-os", version: "1.0.0" };
 const RATE_LIMIT_MAX = 120;
 const RATE_LIMIT_WINDOW_MS = 60_000;
 
-const TOOLS = [WHOAMI_TOOL] as const;
+const TOOLS = [
+  WHOAMI_TOOL,
+  LIST_MY_NOTIFICATIONS_TOOL,
+  LIST_MY_UPCOMING_MEETINGS_TOOL,
+  FIND_MUTUAL_FREEBUSY_TOOL,
+  SEARCH_DIRECTORY_TOOL,
+  GET_MEMBER_PROFILE_TOOL,
+] as const;
 
 type JsonRpcRequest = {
   jsonrpc: "2.0";
@@ -111,12 +140,43 @@ export async function action({ request }: Route.ActionArgs) {
         );
       }
 
+      const validated = validateInput(params?.arguments, tool.inputSchema as JsonSchema);
+      if (!validated.ok) {
+        return rpcError(body.id, -32602, `Invalid params: ${validated.error}`);
+      }
+      const args = validated.value as Record<string, unknown>;
+
       try {
         let payload: unknown;
-        if (tool.name === "whoami") {
-          payload = await runWhoami(auth.user);
-        } else {
-          return rpcError(body.id, -32601, "Tool not implemented");
+        switch (tool.name) {
+          case "whoami":
+            payload = await runWhoami(auth.user);
+            break;
+          case "list_my_notifications":
+            payload = await runListMyNotifications(auth.user.id, args);
+            break;
+          case "list_my_upcoming_meetings":
+            payload = await runListMyUpcomingMeetings(auth.user.id, args);
+            break;
+          case "find_mutual_freebusy":
+            payload = await runFindMutualFreebusy(
+              auth.user.id,
+              args as Parameters<typeof runFindMutualFreebusy>[1],
+            );
+            break;
+          case "search_directory":
+            payload = await runSearchDirectory(
+              args as Parameters<typeof runSearchDirectory>[0],
+            );
+            break;
+          case "get_member_profile":
+            payload = await runGetMemberProfile(
+              auth.user.id,
+              args as Parameters<typeof runGetMemberProfile>[1],
+            );
+            break;
+          default:
+            return rpcError(body.id, -32601, "Tool not implemented");
         }
 
         await logAuditEvent({
@@ -136,6 +196,9 @@ export async function action({ request }: Route.ActionArgs) {
           structuredContent: payload,
         });
       } catch (err) {
+        if (err instanceof MemberNotFoundError) {
+          return rpcError(body.id, -32004, err.message);
+        }
         const message = err instanceof Error ? err.message : "Tool execution failed";
         return rpcError(body.id, -32000, message);
       }

--- a/dali-api/e2e/mcp-tools.spec.ts
+++ b/dali-api/e2e/mcp-tools.spec.ts
@@ -1,0 +1,193 @@
+import { createHash, randomBytes } from 'node:crypto';
+import { test, expect } from './fixtures';
+
+// E2E coverage for the Tier 1 MCP read tools. Walks the existing OAuth flow
+// (registered client → /oauth/authorize → consent → token) once, then calls
+// every new tool over /mcp asserting response shape only (no data asserts).
+
+function base64UrlSha256(input: string): string {
+  return createHash('sha256').update(input).digest('base64url');
+}
+
+async function obtainBearer({
+  request,
+  page,
+  loginAs,
+}: {
+  request: import('@playwright/test').APIRequestContext;
+  page: import('@playwright/test').Page;
+  loginAs: (opts: { daliEmail?: string; netId?: string }) => Promise<void>;
+}): Promise<string> {
+  await loginAs({ daliEmail: 'admin@dali.dartmouth.edu' });
+
+  const redirectUri = 'http://127.0.0.1:51999/callback';
+  const regIp = `10.${Math.floor(Math.random() * 256)}.${Math.floor(
+    Math.random() * 256,
+  )}.${Math.floor(Math.random() * 256)}`;
+  const regRes = await request.post('/oauth/register', {
+    headers: { 'X-Forwarded-For': regIp },
+    data: { redirect_uris: [redirectUri], client_name: 'Claude Code E2E' },
+  });
+  expect(regRes.status()).toBe(200);
+  const clientId = (await regRes.json()).client_id as string;
+
+  const verifier = randomBytes(32).toString('base64url');
+  const challenge = base64UrlSha256(verifier);
+  const state = randomBytes(8).toString('hex');
+
+  await page.goto(
+    `/oauth/authorize?` +
+      new URLSearchParams({
+        response_type: 'code',
+        client_id: clientId,
+        redirect_uri: redirectUri,
+        state,
+        code_challenge: challenge,
+        code_challenge_method: 'S256',
+        provider: 'google',
+        scope: 'mcp:read',
+      }),
+  );
+  await expect(page).toHaveURL(/\/oauth\/consent\?session_id=/);
+
+  const sessionIdMatch = page.url().match(/session_id=([^&]+)/);
+  const oauthSessionId = sessionIdMatch![1];
+
+  const consentResponse = await page.request.post('/oauth/consent', {
+    form: { session_id: oauthSessionId, decision: 'approve' },
+    maxRedirects: 0,
+    failOnStatusCode: false,
+  });
+  const loc = consentResponse.headers()['location'];
+  const callbackUrl = new URL(loc);
+  const code = callbackUrl.searchParams.get('code')!;
+
+  const tokenRes = await request.post('/oauth/token', {
+    form: {
+      grant_type: 'authorization_code',
+      code,
+      code_verifier: verifier,
+      redirect_uri: redirectUri,
+      client_id: clientId,
+    },
+  });
+  return (await tokenRes.json()).access_token as string;
+}
+
+async function callTool(
+  request: import('@playwright/test').APIRequestContext,
+  bearer: string,
+  name: string,
+  args: Record<string, unknown>,
+) {
+  const res = await request.post('/mcp', {
+    headers: {
+      Authorization: `Bearer ${bearer}`,
+      'Content-Type': 'application/json',
+    },
+    data: {
+      jsonrpc: '2.0',
+      id: Math.floor(Math.random() * 1_000_000),
+      method: 'tools/call',
+      params: { name, arguments: args },
+    },
+  });
+  expect(res.ok()).toBe(true);
+  return res.json();
+}
+
+test.describe('MCP Tier 1 read tools', () => {
+  test('every tier-1 tool returns a well-formed response shape', async ({
+    page,
+    loginAs,
+    request,
+  }) => {
+    const bearer = await obtainBearer({ request, page, loginAs });
+
+    // tools/list — should list all six tools.
+    const listRes = await request.post('/mcp', {
+      headers: {
+        Authorization: `Bearer ${bearer}`,
+        'Content-Type': 'application/json',
+      },
+      data: { jsonrpc: '2.0', id: 0, method: 'tools/list' },
+    });
+    const listJson = await listRes.json();
+    const toolNames = listJson.result.tools.map((t: { name: string }) => t.name);
+    expect(toolNames).toEqual(
+      expect.arrayContaining([
+        'whoami',
+        'list_my_notifications',
+        'list_my_upcoming_meetings',
+        'find_mutual_freebusy',
+        'search_directory',
+        'get_member_profile',
+      ]),
+    );
+
+    // list_my_notifications
+    const notifs = await callTool(request, bearer, 'list_my_notifications', {});
+    expect(notifs.error).toBeUndefined();
+    expect(notifs.result.structuredContent).toHaveProperty('unreadCount');
+    expect(notifs.result.structuredContent).toHaveProperty('notifications');
+    expect(Array.isArray(notifs.result.structuredContent.notifications)).toBe(true);
+
+    // list_my_upcoming_meetings
+    const meetings = await callTool(request, bearer, 'list_my_upcoming_meetings', {
+      daysAhead: 14,
+    });
+    expect(meetings.error).toBeUndefined();
+    expect(Array.isArray(meetings.result.structuredContent.meetings)).toBe(true);
+
+    // find_mutual_freebusy — caller is implicit; no other participants needed.
+    const now = new Date();
+    const tomorrow = new Date(now.getTime() + 24 * 60 * 60 * 1000);
+    const freebusy = await callTool(request, bearer, 'find_mutual_freebusy', {
+      participantUserIds: [],
+      windowStart: now.toISOString(),
+      windowEnd: tomorrow.toISOString(),
+      slotMinutes: 30,
+    });
+    expect(freebusy.error).toBeUndefined();
+    expect(Array.isArray(freebusy.result.structuredContent.slots)).toBe(true);
+
+    // search_directory — query "a" hits most member names.
+    const search = await callTool(request, bearer, 'search_directory', {
+      query: 'a',
+      limit: 5,
+    });
+    expect(search.error).toBeUndefined();
+    expect(Array.isArray(search.result.structuredContent.results)).toBe(true);
+
+    // get_member_profile — call against the caller's own id (via whoami).
+    const whoami = await callTool(request, bearer, 'whoami', {});
+    const myId = whoami.result.structuredContent.id as string;
+    const profile = await callTool(request, bearer, 'get_member_profile', {
+      memberId: myId,
+    });
+    expect(profile.error).toBeUndefined();
+    expect(profile.result.structuredContent.id).toBe(myId);
+    // Self-profile path: personalEmail should be present (could be null if
+    // unset, but the key must exist).
+    expect(profile.result.structuredContent).toHaveProperty('personalEmail');
+  });
+
+  test('input validation rejects bad arguments', async ({ page, loginAs, request }) => {
+    const bearer = await obtainBearer({ request, page, loginAs });
+    const res = await request.post('/mcp', {
+      headers: {
+        Authorization: `Bearer ${bearer}`,
+        'Content-Type': 'application/json',
+      },
+      data: {
+        jsonrpc: '2.0',
+        id: 99,
+        method: 'tools/call',
+        params: { name: 'list_my_notifications', arguments: { limit: 9999 } },
+      },
+    });
+    const json = await res.json();
+    expect(json.error).toBeDefined();
+    expect(json.error.code).toBe(-32602);
+  });
+});


### PR DESCRIPTION
## Summary

Adds five MCP read tools that exercise live data, layered on top of the v1 `whoami`-only foundation from #538. All require the existing `mcp:read` scope; no new schema.

## Tools

- **`list_my_notifications`** — recent in-app notifications for the caller. Reuses the inbox query that backs `/api/notifications`.
- **`list_my_upcoming_meetings`** — forward window of `ScheduledMeeting` + interview attendance, merged and sorted.
- **`find_mutual_freebusy`** — free-time intersection for a set of participants over a window. Reuses the same availability computation the in-app scheduler uses.
- **`search_directory`** — name / email / netId / domain / role search against `DALIMember`-backed users only.
- **`get_member_profile`** — single-member drill-down. Hides `personalEmail` for non-self callers.

## Architecture

Each tool follows the `whoami` precedent: one file under `dali-api/app/mcp/tools/`, registered in the dispatcher at `dali-api/app/routes/mcp.ts`, audit-logged per call, scope-checked before the handler runs. Shared queries were extracted into helpers rather than duplicated (first commit on the branch).

## Test plan

- [ ] `npm run typecheck`
- [ ] `npm test` (Vitest — covers happy path, scope rejection, input validation, privacy gate, empty result for each tool)
- [ ] `npm run test:e2e` (Playwright — extends the existing MCP auth-flow spec to call each tool through `/mcp` and assert response shape)
- [ ] Manual smoke from Claude Code against the preview deploy

## Notes for review

- `find_mutual_freebusy` is the heaviest of the five; double-check it reuses the in-app helper rather than reimplementing.
- `get_member_profile` privacy gate: confirm `personalEmail` is correctly hidden for non-self callers and any other private fields follow existing patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)