### PR TITLE
Add MCP schedule_meeting tool + RFC 9728 protected resource metadata

### DIFF
--- a/dali-api/app/calendar/routes/api.scheduled-meetings.ts
+++ b/dali-api/app/calendar/routes/api.scheduled-meetings.ts
@@ -1,11 +1,12 @@
 import type { Route } from "./+types/api.scheduled-meetings";
 import { z } from "zod";
-import { prisma } from "~/lib/db";
 import { requireAuth } from "~/lib/auth";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { parseJson } from "~/lib/validate";
-import { resolveGroupMembers } from "~/lib/groups";
-import { createGoogleCalendarEvent, type GoogleAttendee } from "~/lib/google-calendar";
+import {
+  createScheduledMeeting,
+  type ScheduledMeetingScope,
+} from "~/lib/scheduled-meeting";
 
 const Base = {
   title: z.string().trim().min(1).max(200),
@@ -41,119 +42,40 @@ export async function action({ request }: Route.ActionArgs) {
   const body = await parseJson(request, CreateSchema);
   if (body instanceof Response) return withCors(request, body);
 
-  // Resolve participants by scope.
-  let participantUserIds: string[] = [];
-  let scopeId: string | null = null;
+  let scope: ScheduledMeetingScope;
   if (body.scopeType === "Group") {
-    participantUserIds = await resolveGroupMembers(body.groupId);
-    scopeId = body.groupId;
+    scope = { type: "Group", groupId: body.groupId };
   } else if (body.scopeType === "UserList") {
-    participantUserIds = Array.from(new Set(body.participantUserIds));
+    scope = { type: "UserList", participantUserIds: body.participantUserIds };
+  } else {
+    scope = { type: "None" };
   }
 
-  const startDate = body.startTime ? new Date(body.startTime) : null;
-
-  // If the user picked a linked Google calendar, validate ownership before
-  // we trust it as the invite source.
-  let organizerLink: { id: string; userId: string; externalEmail: string; enabled: boolean } | null = null;
-  if (body.organizerCalendarLinkId) {
-    organizerLink = await prisma.userCalendarLink.findUnique({
-      where: { id: body.organizerCalendarLinkId },
-      select: { id: true, userId: true, externalEmail: true, enabled: true },
-    });
-    if (!organizerLink || organizerLink.userId !== auth.user.sub) {
-      return withCors(request, Response.json({ error: "Invalid calendar link" }, { status: 400 }));
-    }
-  }
-
-  const meeting = await prisma.scheduledMeeting.create({
-    data: {
-      organizerId: auth.user.sub,
-      title: body.title,
-      durationMinutes: body.durationMinutes,
-      scopeType: body.scopeType,
-      scopeId,
-      participantUserIds,
-      recurrenceRule: body.recurrenceRule ?? null,
-      selectedAt: startDate,
-      status: startDate ? "Confirmed" : "Searching",
-      ownerCalendarEmail: organizerLink?.externalEmail ?? auth.user.email,
-      organizerCalendarLinkId: organizerLink?.id ?? null,
-    },
+  const result = await createScheduledMeeting({
+    organizerId: auth.user.sub,
+    organizerEmail: auth.user.email,
+    title: body.title,
+    durationMinutes: body.durationMinutes,
+    scope,
+    startTime: body.startTime,
+    recurrenceRule: body.recurrenceRule,
+    organizerCalendarLinkId: body.organizerCalendarLinkId,
   });
 
-  // Push to Google Calendar (and let Google send Gmail invites) when we have
-  // a linked calendar, a confirmed start time, and at least one participant.
-  let externalEventId: string | null = null;
-  let gcalError: string | null = null;
-  if (organizerLink && organizerLink.enabled && startDate && participantUserIds.length > 0) {
-    // Resolve attendees' email addresses, prefer daliEmail → dartmouthEmail.
-    const attendeeUsers = await prisma.user.findMany({
-      where: { id: { in: participantUserIds } },
-      select: { id: true, firstName: true, lastName: true, daliEmail: true, dartmouthEmail: true },
-    });
-    const attendees: GoogleAttendee[] = [];
-    for (const u of attendeeUsers) {
-      const email = u.daliEmail ?? u.dartmouthEmail;
-      if (!email) continue;
-      attendees.push({
-        email,
-        displayName: `${u.firstName} ${u.lastName}`.trim() || email,
-      });
-    }
-    if (attendees.length > 0) {
-      const endDate = new Date(startDate.getTime() + body.durationMinutes * 60_000);
-      try {
-        const result = await createGoogleCalendarEvent({
-          linkId: organizerLink.id,
-          summary: body.title,
-          startIso: startDate.toISOString(),
-          endIso: endDate.toISOString(),
-          recurrenceRule: body.recurrenceRule ?? null,
-          attendees,
-        });
-        externalEventId = result.eventId;
-        await prisma.scheduledMeeting.update({
-          where: { id: meeting.id },
-          data: { externalEventId },
-        });
-      } catch (err) {
-        gcalError = err instanceof Error ? err.message : "Google Calendar push failed";
-      }
-    }
-  }
-
-  // Fan-out MeetingInvite notifications to participants (excluding the organizer themself).
-  const notifyIds = participantUserIds.filter((id) => id !== auth.user.sub);
-  let notifiedCount = 0;
-  if (notifyIds.length > 0) {
-    const linkUrl = `/calendar?meeting=${meeting.id}`;
-    const notifBody = startDate ? `Starts ${startDate.toISOString()}` : null;
-    const result = await prisma.notification.createMany({
-      data: notifyIds.map((rid) => ({
-        recipientUserId: rid,
-        createdByUserId: auth.user.sub,
-        kind: "MeetingInvite" as const,
-        title: `Meeting invite: ${body.title}`,
-        body: notifBody,
-        link: linkUrl,
-        sourceGroupId: scopeId,
-        scheduledMeetingId: meeting.id,
-      })),
-    });
-    notifiedCount = result.count;
+  if (!result.ok) {
+    return withCors(request, Response.json({ error: result.error }, { status: 400 }));
   }
 
   return withCors(
-      request,
-      Response.json(
-        {
-          ok: true,
-          meeting: { ...meeting, externalEventId },
-          notifiedCount,
-          gcalError,
-        },
-        { status: 201 },
-      ),
-    );
+    request,
+    Response.json(
+      {
+        ok: true,
+        meeting: result.meeting,
+        notifiedCount: result.notifiedCount,
+        gcalError: result.gcalError,
+      },
+      { status: 201 },
+    ),
+  );
 }

--- a/dali-api/app/lib/mcp-auth.ts
+++ b/dali-api/app/lib/mcp-auth.ts
@@ -30,12 +30,16 @@ export type McpAuthFailure = {
 export type McpAuthResult = McpAuthSuccess | McpAuthFailure;
 
 function unauthorized(reason: string): Response {
+  const issuer = process.env.API_BASE_URL;
+  const resourceMetadata = issuer
+    ? `, resource_metadata="${issuer}/.well-known/oauth-protected-resource/mcp"`
+    : "";
   return Response.json(
     { jsonrpc: "2.0", error: { code: -32001, message: `Unauthorized: ${reason}` }, id: null },
     {
       status: 401,
       headers: {
-        "WWW-Authenticate": `Bearer realm="dali-os-mcp", error="${reason}"`,
+        "WWW-Authenticate": `Bearer realm="dali-os-mcp", error="${reason}"${resourceMetadata}`,
       },
     },
   );

--- a/dali-api/app/lib/scheduled-meeting.ts
+++ b/dali-api/app/lib/scheduled-meeting.ts
@@ -1,0 +1,152 @@
+// Shared helper for creating a ScheduledMeeting. Called by the web API
+// (app/calendar/routes/api.scheduled-meetings.ts) and the MCP schedule_meeting
+// tool. Handles scope resolution, optional Google Calendar push, and
+// participant notification fan-out.
+
+import { prisma } from "~/lib/db";
+import { resolveGroupMembers } from "~/lib/groups";
+import { createGoogleCalendarEvent, type GoogleAttendee } from "~/lib/google-calendar";
+import type { ScheduledMeeting } from "~/generated/prisma/client";
+
+export type ScheduledMeetingScope =
+  | { type: "None" }
+  | { type: "Group"; groupId: string }
+  | { type: "UserList"; participantUserIds: string[] };
+
+export type CreateScheduledMeetingInput = {
+  organizerId: string;
+  organizerEmail: string;
+  title: string;
+  durationMinutes: number;
+  scope: ScheduledMeetingScope;
+  startTime?: string | null;
+  recurrenceRule?: string | null;
+  organizerCalendarLinkId?: string | null;
+};
+
+export type CreateScheduledMeetingResult =
+  | {
+      ok: true;
+      meeting: ScheduledMeeting & { externalEventId: string | null };
+      notifiedCount: number;
+      gcalError: string | null;
+    }
+  | { ok: false; error: string };
+
+export async function createScheduledMeeting(
+  input: CreateScheduledMeetingInput,
+): Promise<CreateScheduledMeetingResult> {
+  let participantUserIds: string[] = [];
+  let scopeId: string | null = null;
+  if (input.scope.type === "Group") {
+    participantUserIds = await resolveGroupMembers(input.scope.groupId);
+    scopeId = input.scope.groupId;
+  } else if (input.scope.type === "UserList") {
+    participantUserIds = Array.from(new Set(input.scope.participantUserIds));
+  }
+
+  const startDate = input.startTime ? new Date(input.startTime) : null;
+
+  let organizerLink: {
+    id: string;
+    userId: string;
+    externalEmail: string;
+    enabled: boolean;
+  } | null = null;
+  if (input.organizerCalendarLinkId) {
+    organizerLink = await prisma.userCalendarLink.findUnique({
+      where: { id: input.organizerCalendarLinkId },
+      select: { id: true, userId: true, externalEmail: true, enabled: true },
+    });
+    if (!organizerLink || organizerLink.userId !== input.organizerId) {
+      return { ok: false, error: "Invalid calendar link" };
+    }
+  }
+
+  const meeting = await prisma.scheduledMeeting.create({
+    data: {
+      organizerId: input.organizerId,
+      title: input.title,
+      durationMinutes: input.durationMinutes,
+      scopeType: input.scope.type,
+      scopeId,
+      participantUserIds,
+      recurrenceRule: input.recurrenceRule ?? null,
+      selectedAt: startDate,
+      status: startDate ? "Confirmed" : "Searching",
+      ownerCalendarEmail: organizerLink?.externalEmail ?? input.organizerEmail,
+      organizerCalendarLinkId: organizerLink?.id ?? null,
+    },
+  });
+
+  let externalEventId: string | null = null;
+  let gcalError: string | null = null;
+  if (organizerLink && organizerLink.enabled && startDate && participantUserIds.length > 0) {
+    const attendeeUsers = await prisma.user.findMany({
+      where: { id: { in: participantUserIds } },
+      select: {
+        id: true,
+        firstName: true,
+        lastName: true,
+        daliEmail: true,
+        dartmouthEmail: true,
+      },
+    });
+    const attendees: GoogleAttendee[] = [];
+    for (const u of attendeeUsers) {
+      const email = u.daliEmail ?? u.dartmouthEmail;
+      if (!email) continue;
+      attendees.push({
+        email,
+        displayName: `${u.firstName} ${u.lastName}`.trim() || email,
+      });
+    }
+    if (attendees.length > 0) {
+      const endDate = new Date(startDate.getTime() + input.durationMinutes * 60_000);
+      try {
+        const result = await createGoogleCalendarEvent({
+          linkId: organizerLink.id,
+          summary: input.title,
+          startIso: startDate.toISOString(),
+          endIso: endDate.toISOString(),
+          recurrenceRule: input.recurrenceRule ?? null,
+          attendees,
+        });
+        externalEventId = result.eventId;
+        await prisma.scheduledMeeting.update({
+          where: { id: meeting.id },
+          data: { externalEventId },
+        });
+      } catch (err) {
+        gcalError = err instanceof Error ? err.message : "Google Calendar push failed";
+      }
+    }
+  }
+
+  const notifyIds = participantUserIds.filter((id) => id !== input.organizerId);
+  let notifiedCount = 0;
+  if (notifyIds.length > 0) {
+    const linkUrl = `/calendar?meeting=${meeting.id}`;
+    const notifBody = startDate ? `Starts ${startDate.toISOString()}` : null;
+    const result = await prisma.notification.createMany({
+      data: notifyIds.map((rid) => ({
+        recipientUserId: rid,
+        createdByUserId: input.organizerId,
+        kind: "MeetingInvite" as const,
+        title: `Meeting invite: ${input.title}`,
+        body: notifBody,
+        link: linkUrl,
+        sourceGroupId: scopeId,
+        scheduledMeetingId: meeting.id,
+      })),
+    });
+    notifiedCount = result.count;
+  }
+
+  return {
+    ok: true,
+    meeting: { ...meeting, externalEventId },
+    notifiedCount,
+    gcalError,
+  };
+}

--- a/dali-api/app/mcp/tools/schedule-meeting.ts
+++ b/dali-api/app/mcp/tools/schedule-meeting.ts
@@ -1,0 +1,111 @@
+// MCP `schedule_meeting` — create a ScheduledMeeting on behalf of the
+// authenticated user with an explicit participant list. Mirrors the Calendar
+// "Schedule Meeting" button. Requires the `mcp:write` scope.
+//
+// Group and "None" (org-wide) scopes are deliberately not exposed via MCP —
+// pair this with `search_directory` to resolve participant userIds.
+
+import { createScheduledMeeting } from "~/lib/scheduled-meeting";
+
+export const SCHEDULE_MEETING_TOOL = {
+  name: "schedule_meeting",
+  description:
+    "Create a meeting with an explicit list of DALI member participants. Optionally schedule it for a specific start time; otherwise the meeting is created in 'Searching' state. Sends in-app MeetingInvite notifications to participants, and pushes to Google Calendar when the organizer has a linked calendar.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      title: {
+        type: "string",
+        minLength: 1,
+        maxLength: 200,
+        description: "Meeting title (1–200 chars).",
+      },
+      durationMinutes: {
+        type: "integer",
+        minimum: 5,
+        maximum: 480,
+        description: "Duration in minutes (5–480).",
+      },
+      participantUserIds: {
+        type: "array",
+        items: { type: "string", minLength: 1 },
+        minItems: 1,
+        description:
+          "DALI member User IDs to invite. Use `search_directory` to look up IDs by name.",
+      },
+      startTime: {
+        type: "string",
+        format: "date-time",
+        description:
+          "Optional ISO 8601 start time. If omitted, the meeting is created in 'Searching' state with no confirmed time.",
+      },
+      recurrenceRule: {
+        type: "string",
+        maxLength: 500,
+        description: "Optional RFC 5545 RRULE for recurring meetings.",
+      },
+      organizerCalendarLinkId: {
+        type: "string",
+        minLength: 1,
+        description:
+          "Optional UserCalendarLink ID. When provided (and enabled), the meeting is pushed to Google Calendar and Gmail invites are sent.",
+      },
+    },
+    required: ["title", "durationMinutes", "participantUserIds"],
+    additionalProperties: false,
+  },
+  requiredScope: "mcp:write" as const,
+};
+
+type Input = {
+  title: string;
+  durationMinutes: number;
+  participantUserIds: string[];
+  startTime?: string;
+  recurrenceRule?: string;
+  organizerCalendarLinkId?: string;
+};
+
+export class ScheduleMeetingError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ScheduleMeetingError";
+  }
+}
+
+export async function runScheduleMeeting(
+  user: { id: string; daliEmail: string | null; dartmouthEmail: string | null },
+  input: Input,
+) {
+  const organizerEmail = user.daliEmail ?? user.dartmouthEmail;
+  if (!organizerEmail) {
+    throw new ScheduleMeetingError("Organizer has no daliEmail or dartmouthEmail on file");
+  }
+
+  const result = await createScheduledMeeting({
+    organizerId: user.id,
+    organizerEmail,
+    title: input.title,
+    durationMinutes: input.durationMinutes,
+    scope: { type: "UserList", participantUserIds: input.participantUserIds },
+    startTime: input.startTime,
+    recurrenceRule: input.recurrenceRule,
+    organizerCalendarLinkId: input.organizerCalendarLinkId,
+  });
+
+  if (!result.ok) {
+    throw new ScheduleMeetingError(result.error);
+  }
+
+  return {
+    meetingId: result.meeting.id,
+    title: result.meeting.title,
+    status: result.meeting.status,
+    startsAt: result.meeting.selectedAt?.toISOString() ?? null,
+    durationMinutes: result.meeting.durationMinutes,
+    participantUserIds: result.meeting.participantUserIds,
+    externalEventId: result.meeting.externalEventId,
+    notifiedCount: result.notifiedCount,
+    gcalError: result.gcalError,
+  };
+}

--- a/dali-api/app/routes.ts
+++ b/dali-api/app/routes.ts
@@ -72,6 +72,16 @@ export default [
 
   // MCP foundation (no layout)
   route(".well-known/oauth-authorization-server", "routes/well-known.oauth-authorization-server.ts"),
+  route(
+    ".well-known/oauth-protected-resource",
+    "routes/well-known.oauth-protected-resource.ts",
+    { id: "well-known.oauth-protected-resource" },
+  ),
+  route(
+    ".well-known/oauth-protected-resource/mcp",
+    "routes/well-known.oauth-protected-resource.ts",
+    { id: "well-known.oauth-protected-resource.mcp" },
+  ),
   route("mcp", "routes/mcp.ts"),
   route("help/mcp", "routes/help.mcp.tsx"),
   route("settings/connected-apps", "routes/settings.connected-apps.tsx"),

--- a/dali-api/app/routes/mcp.ts
+++ b/dali-api/app/routes/mcp.ts
@@ -31,6 +31,11 @@ import {
   runGetMemberProfile,
   MemberNotFoundError,
 } from "~/mcp/tools/get-member-profile";
+import {
+  SCHEDULE_MEETING_TOOL,
+  runScheduleMeeting,
+  ScheduleMeetingError,
+} from "~/mcp/tools/schedule-meeting";
 
 const PROTOCOL_VERSION = "2024-11-05";
 const SERVER_INFO = { name: "dali-os", version: "1.0.0" };
@@ -45,6 +50,7 @@ const TOOLS = [
   FIND_MUTUAL_FREEBUSY_TOOL,
   SEARCH_DIRECTORY_TOOL,
   GET_MEMBER_PROFILE_TOOL,
+  SCHEDULE_MEETING_TOOL,
 ] as const;
 
 type JsonRpcRequest = {
@@ -175,6 +181,12 @@ export async function action({ request }: Route.ActionArgs) {
               args as Parameters<typeof runGetMemberProfile>[1],
             );
             break;
+          case "schedule_meeting":
+            payload = await runScheduleMeeting(
+              auth.user,
+              args as Parameters<typeof runScheduleMeeting>[1],
+            );
+            break;
           default:
             return rpcError(body.id, -32601, "Tool not implemented");
         }
@@ -198,6 +210,9 @@ export async function action({ request }: Route.ActionArgs) {
       } catch (err) {
         if (err instanceof MemberNotFoundError) {
           return rpcError(body.id, -32004, err.message);
+        }
+        if (err instanceof ScheduleMeetingError) {
+          return rpcError(body.id, -32602, err.message);
         }
         const message = err instanceof Error ? err.message : "Tool execution failed";
         return rpcError(body.id, -32000, message);

--- a/dali-api/app/routes/well-known.oauth-protected-resource.ts
+++ b/dali-api/app/routes/well-known.oauth-protected-resource.ts
@@ -1,0 +1,30 @@
+// RFC 9728 OAuth 2.0 Protected Resource Metadata for the MCP endpoint.
+// Served at both /.well-known/oauth-protected-resource and
+// /.well-known/oauth-protected-resource/mcp — MCP clients probe both
+// before falling back to AS metadata.
+
+import type { Route } from "./+types/well-known.oauth-protected-resource";
+
+export async function action() {
+  return new Response("Method not allowed", { status: 405 });
+}
+
+export async function loader({ request }: Route.LoaderArgs) {
+  const url = new URL(request.url);
+  const issuer = process.env.API_BASE_URL ?? `${url.protocol}//${url.host}`;
+
+  return Response.json(
+    {
+      resource: `${issuer}/mcp`,
+      authorization_servers: [issuer],
+      scopes_supported: ["mcp:read", "mcp:write"],
+      bearer_methods_supported: ["header"],
+      resource_documentation: `${issuer}/help/mcp`,
+    },
+    {
+      headers: {
+        "Cache-Control": "public, max-age=300",
+      },
+    },
+  );
+}


### PR DESCRIPTION
## Summary

- **New MCP tool: `schedule_meeting`** (scope `mcp:write`). Mirrors the Calendar "Schedule Meeting" button — takes `title`, `durationMinutes`, `participantUserIds` (required) plus optional `startTime`, `recurrenceRule`, and `organizerCalendarLinkId`. Group / org-wide scopes deliberately not exposed via MCP; pair with `search_directory` to resolve participants.
- **Shared helper** `app/lib/scheduled-meeting.ts` extracted from the existing `POST /api/scheduled-meetings` route. The web API and the MCP tool now share one code path for scope resolution, Google Calendar push, and notification fan-out. The route is now a thin zod-validation + CORS wrapper.
- **RFC 9728 Protected Resource Metadata** served at `/.well-known/oauth-protected-resource` and `/.well-known/oauth-protected-resource/mcp`. Current Claude / MCP clients probe these paths before falling back to AS metadata — serving them eliminates the 404 log noise and aligns with newer transport revs.
- **`WWW-Authenticate`** on MCP 401s now advertises `resource_metadata=...` so clients can find the PRM endpoint without guessing the well-known path.

## Test plan

- [ ] `npm run typecheck` is clean for changed files (`api.scheduled-meetings.ts`, `mcp-auth.ts`, `routes.ts`, `routes/mcp.ts`, the three new files).
- [ ] CI Vitest + Playwright still green.
- [ ] Manually call `schedule_meeting` over MCP with a valid `participantUserIds` array; confirm the ScheduledMeeting row is created and a MeetingInvite notification fans out to participants.
- [ ] Manually call `schedule_meeting` with a `startTime` and an `organizerCalendarLinkId` for a linked Google calendar; confirm `externalEventId` is set and the calendar event lands.
- [ ] Verify existing `POST /api/scheduled-meetings` from the Calendar UI still creates meetings end-to-end (behavior should be identical — same helper).
- [ ] `curl https://os.dali.dartmouth.edu/.well-known/oauth-protected-resource/mcp` returns the PRM JSON with `resource`, `authorization_servers`, `scopes_supported`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)