### PR TITLE
Add list_my_calendar_links MCP tool

### DIFF
--- a/dali-api/app/mcp/tools/list-my-calendar-links.ts
+++ b/dali-api/app/mcp/tools/list-my-calendar-links.ts
@@ -1,0 +1,62 @@
+// MCP `list_my_calendar_links` — list the authenticated user's linked external
+// calendars (Google, etc.). Provides the `id` needed for the
+// `organizerCalendarLinkId` parameter on `schedule_meeting`. Requires the
+// `mcp:read` scope.
+
+import { prisma } from "~/lib/db";
+
+export const LIST_MY_CALENDAR_LINKS_TOOL = {
+  name: "list_my_calendar_links",
+  description:
+    "List the authenticated user's linked external calendars. Use the returned `id` as `organizerCalendarLinkId` on `schedule_meeting` to push the meeting to that calendar (and send Gmail invites). Includes disabled / errored links so the agent can surface broken connections.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {},
+    additionalProperties: false,
+  },
+  requiredScope: "mcp:read" as const,
+};
+
+type CalendarLinkOut = {
+  id: string;
+  provider: string;
+  externalEmail: string;
+  displayName: string | null;
+  primary: boolean;
+  enabled: boolean;
+  hasSyncError: boolean;
+  linkedAt: string;
+  lastSyncedAt: string | null;
+};
+
+export async function runListMyCalendarLinks(userId: string) {
+  const links = await prisma.userCalendarLink.findMany({
+    where: { userId },
+    orderBy: { linkedAt: "asc" },
+    select: {
+      id: true,
+      provider: true,
+      externalEmail: true,
+      displayName: true,
+      primary: true,
+      enabled: true,
+      syncError: true,
+      linkedAt: true,
+      lastSyncedAt: true,
+    },
+  });
+
+  const out: CalendarLinkOut[] = links.map((l) => ({
+    id: l.id,
+    provider: l.provider,
+    externalEmail: l.externalEmail,
+    displayName: l.displayName,
+    primary: l.primary,
+    enabled: l.enabled,
+    hasSyncError: l.syncError !== null,
+    linkedAt: l.linkedAt.toISOString(),
+    lastSyncedAt: l.lastSyncedAt?.toISOString() ?? null,
+  }));
+
+  return { links: out };
+}

--- a/dali-api/app/mcp/tools/schedule-meeting.ts
+++ b/dali-api/app/mcp/tools/schedule-meeting.ts
@@ -48,7 +48,7 @@ export const SCHEDULE_MEETING_TOOL = {
         type: "string",
         minLength: 1,
         description:
-          "Optional UserCalendarLink ID. When provided (and enabled), the meeting is pushed to Google Calendar and Gmail invites are sent.",
+          "Optional UserCalendarLink ID. When provided (and enabled), the meeting is pushed to that external calendar and Gmail invites are sent. Use `list_my_calendar_links` to discover available IDs.",
       },
     },
     required: ["title", "durationMinutes", "participantUserIds"],

--- a/dali-api/app/routes/mcp.ts
+++ b/dali-api/app/routes/mcp.ts
@@ -36,6 +36,10 @@ import {
   runScheduleMeeting,
   ScheduleMeetingError,
 } from "~/mcp/tools/schedule-meeting";
+import {
+  LIST_MY_CALENDAR_LINKS_TOOL,
+  runListMyCalendarLinks,
+} from "~/mcp/tools/list-my-calendar-links";
 
 const PROTOCOL_VERSION = "2024-11-05";
 const SERVER_INFO = { name: "dali-os", version: "1.0.0" };
@@ -51,6 +55,7 @@ const TOOLS = [
   SEARCH_DIRECTORY_TOOL,
   GET_MEMBER_PROFILE_TOOL,
   SCHEDULE_MEETING_TOOL,
+  LIST_MY_CALENDAR_LINKS_TOOL,
 ] as const;
 
 type JsonRpcRequest = {
@@ -186,6 +191,9 @@ export async function action({ request }: Route.ActionArgs) {
               auth.user,
               args as Parameters<typeof runScheduleMeeting>[1],
             );
+            break;
+          case "list_my_calendar_links":
+            payload = await runListMyCalendarLinks(auth.user.id);
             break;
           default:
             return rpcError(body.id, -32601, "Tool not implemented");


### PR DESCRIPTION
## Summary

Follow-up to #550. Adds `list_my_calendar_links` (mcp:read) so MCP agents can discover the `UserCalendarLink` CUIDs they need to pass as `organizerCalendarLinkId` on `schedule_meeting`. Without this, the calendar-push path of `schedule_meeting` is effectively unreachable from MCP since the agent has no way to obtain a valid ID.

Returns each link's `id`, `provider`, `externalEmail`, `displayName`, `primary`, `enabled`, `hasSyncError`, `linkedAt`, `lastSyncedAt`.

Also tweaks the `schedule_meeting` tool description to point at `list_my_calendar_links` for ID discovery.

(This was originally part of #550 but landed after that PR was merged — splitting it out cleanly here.)

## Test plan

- [ ] `npm run typecheck` clean.
- [ ] Call `list_my_calendar_links` over MCP for a member with linked Google calendar(s); confirm rows returned with correct `enabled` / `hasSyncError` flags.
- [ ] Confirm a member with no links gets `{ links: [] }`.
- [ ] End-to-end: agent calls `list_my_calendar_links` → uses the returned `id` as `organizerCalendarLinkId` in `schedule_meeting` → meeting lands in Google Calendar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)