### PR TITLE
Fix delibs view: live updates, review notes, non-lead access (#556)

### DIFF
--- a/dali-api/app/hiring/components/delibs/ApplicantContextModal.tsx
+++ b/dali-api/app/hiring/components/delibs/ApplicantContextModal.tsx
@@ -124,6 +124,7 @@ export function ApplicantContextModal({
                   ...(data.rubric.generalCriteria ?? []),
                   ...(data.rubric.domainCriteria ?? []),
                 ]}
+                fieldContext={buildFieldContext(data)}
               />
               <DecisionsSection decisions={data.decisions ?? []} />
             </>
@@ -186,7 +187,99 @@ function AnswerSection({
   );
 }
 
-function ReviewsSection({ reviews, criteria }: { reviews: any[]; criteria: any[] }) {
+type FieldContext = Record<string, { label: string; answer: string }>;
+
+function buildFieldContext(data: any): FieldContext {
+  const ctx: FieldContext = {};
+  const generalQs = Array.isArray(data?.application?.generalQuestions)
+    ? data.application.generalQuestions
+    : [];
+  const generalAns = (data?.application?.answers && typeof data.application.answers === "object")
+    ? (data.application.answers as Record<string, unknown>)
+    : {};
+  const domainQs = Array.isArray(data?.domainApplication?.challengeQuestions)
+    ? data.domainApplication.challengeQuestions
+    : [];
+  const domainAns = (data?.domainApplication?.answers && typeof data.domainApplication.answers === "object")
+    ? (data.domainApplication.answers as Record<string, unknown>)
+    : {};
+  for (const q of generalQs) {
+    ctx[q.key] = {
+      label: q.data?.label ?? q.key,
+      answer: typeof generalAns[q.key] === "string" ? (generalAns[q.key] as string) : "",
+    };
+  }
+  for (const q of domainQs) {
+    ctx[q.key] = {
+      label: q.data?.label ?? q.key,
+      answer: typeof domainAns[q.key] === "string" ? (domainAns[q.key] as string) : "",
+    };
+  }
+  return ctx;
+}
+
+function ReviewAnnotations({
+  annotations,
+  fieldContext,
+}: {
+  annotations: Array<{ id: string; fieldKey: string; start: number; end: number; comment: string }>;
+  fieldContext: FieldContext;
+}) {
+  if (!annotations.length) return null;
+  // Group annotations by field so each section reads cleanly.
+  const byField = new Map<string, typeof annotations>();
+  for (const a of annotations) {
+    const list = byField.get(a.fieldKey) ?? [];
+    list.push(a);
+    byField.set(a.fieldKey, list);
+  }
+  return (
+    <div className="mt-2 space-y-2">
+      <div className="text-[10px] uppercase tracking-wide font-semibold text-muted-foreground/70">
+        Notes
+      </div>
+      {Array.from(byField.entries()).map(([fieldKey, anns]) => {
+        const ctx = fieldContext[fieldKey];
+        const label = ctx?.label ?? fieldKey;
+        const answer = ctx?.answer ?? "";
+        return (
+          <div key={fieldKey} className="text-xs">
+            <div className="font-medium text-foreground/80 mb-1">{label}</div>
+            <ul className="space-y-1.5">
+              {anns.map((a) => {
+                const excerpt = answer
+                  ? answer.slice(Math.max(0, a.start), Math.max(a.start, a.end))
+                  : "";
+                return (
+                  <li key={a.id} className="bg-yellow-50 border-l-2 border-yellow-300 rounded-r p-2">
+                    {excerpt && (
+                      <div className="italic text-muted-foreground mb-1 whitespace-pre-wrap">
+                        “{excerpt}”
+                      </div>
+                    )}
+                    {a.comment && (
+                      <div className="text-foreground whitespace-pre-wrap">{a.comment}</div>
+                    )}
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function ReviewsSection({
+  reviews,
+  criteria,
+  fieldContext,
+}: {
+  reviews: any[];
+  criteria: any[];
+  fieldContext: FieldContext;
+}) {
   return (
     <section className="bg-card border border-border rounded-lg overflow-hidden">
       <div className="px-4 py-2 bg-muted/50 border-b border-border">
@@ -261,6 +354,10 @@ function ReviewsSection({ reviews, criteria }: { reviews: any[]; criteria: any[]
                     {review.rejectionRationale}
                   </p>
                 )}
+                <ReviewAnnotations
+                  annotations={Array.isArray(review.annotations) ? review.annotations : []}
+                  fieldContext={fieldContext}
+                />
               </div>
             );
           })}

--- a/dali-api/app/hiring/routes/domain-lead.delibs.$id.tsx
+++ b/dali-api/app/hiring/routes/domain-lead.delibs.$id.tsx
@@ -1,5 +1,5 @@
-import { useState, useCallback, useRef } from "react";
-import { redirect, useLoaderData, useNavigate } from "react-router";
+import { useState, useCallback, useRef, useEffect } from "react";
+import { redirect, useLoaderData, useNavigate, useRevalidator } from "react-router";
 import type { Route } from "./+types/domain-lead.delibs.$id";
 import { prisma } from "~/lib/db";
 import { requireAuth } from "~/lib/auth";
@@ -142,6 +142,34 @@ export default function DelibsKanban() {
   // HTML5 drag-and-drop fires a stray `click` after `dragend` on some browsers;
   // suppress the modal-open click that immediately follows a drag.
   const wasDragging = useRef(false);
+
+  // Resync local columnOrder from the loader after a revalidation, so concurrent
+  // moves by other leads (or newly qualifying apps) show up without a reload.
+  // Skip while the user is mid-drag or while a move POST is in flight — the
+  // optimistic local state is authoritative until the server response lands.
+  const dragItemRef = useRef(dragItem);
+  const savingRef = useRef(saving);
+  dragItemRef.current = dragItem;
+  savingRef.current = saving;
+  useEffect(() => {
+    if (dragItemRef.current || savingRef.current) return;
+    setColumnOrder(initialOrder);
+    // initialOrder is recomputed every render from loader data + columns;
+    // depending on its JSON form keeps the effect tied to actual data changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [JSON.stringify(initialOrder)]);
+
+  // Poll the loader every 5s while the session is active so other leads' moves
+  // and newly qualifying applications surface without a manual refresh.
+  const revalidator = useRevalidator();
+  useEffect(() => {
+    if (session.status !== "Active") return;
+    const t = setInterval(() => {
+      if (dragItemRef.current || savingRef.current) return;
+      if (revalidator.state === "idle") revalidator.revalidate();
+    }, 5000);
+    return () => clearInterval(t);
+  }, [session.status, revalidator]);
 
   const sendMove = useCallback(
     async (cardId: string, toColumn: string) => {

--- a/dali-api/app/hiring/routes/reviewer.tsx
+++ b/dali-api/app/hiring/routes/reviewer.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react'
-import { Link, useLoaderData } from 'react-router'
+import { Link, useLoaderData, useRevalidator } from 'react-router'
 import {
   ChevronRight,
   ChevronDown,
@@ -15,6 +15,7 @@ import { getActiveCycle, cycleStatusToStage, inferUnderReviewStage } from '~/hir
 import { getCycleConfidentialityState } from '~/hiring/lib/confidentiality'
 import { ConfidentialityGate } from '~/hiring/components/ConfidentialityGate'
 import { INITIAL_COLUMNS, FINAL_COLUMNS } from '~/hiring/lib/delibs'
+import { ApplicantContextModal } from '~/hiring/components/delibs/ApplicantContextModal'
 import CalendarGrid from '~/hiring/components/CalendarGrid'
 import { getZonedYMD } from '~/lib/timezone'
 
@@ -260,6 +261,24 @@ export default function ReviewerDashboard() {
   const submittedReviews = reviews.filter(r => getReviewStatus(r) === 'submitted')
   const inProgressReviews = reviews.filter(r => getReviewStatus(r) === 'inProgress')
   const pendingReviews = reviews.filter(r => getReviewStatus(r) === 'notStarted')
+
+  // Poll the loader every 5s while any delibs session is visible, so column
+  // moves made by the domain lead surface in this mirror view without a manual
+  // refresh.
+  const revalidator = useRevalidator()
+  const hasActiveDelibs = (delibsSessions?.length ?? 0) > 0
+  useEffect(() => {
+    if (!hasActiveDelibs) return
+    const t = setInterval(() => {
+      if (revalidator.state === 'idle') revalidator.revalidate()
+    }, 5000)
+    return () => clearInterval(t)
+  }, [hasActiveDelibs, revalidator])
+
+  // Selected delibs card → opens the same applicant-context modal the domain
+  // lead uses. /full-context permits any reviewer with cycle access, so this
+  // gives non-leads visibility into all reviews on apps in their domain.
+  const [selectedDelibsDaId, setSelectedDelibsDaId] = useState<string | null>(null)
 
   // Lookup table of every domainApplication referenced in an active delibs
   // session, so we can render per-column cards from columnOrder.
@@ -654,11 +673,19 @@ export default function ReviewerDashboard() {
                 key={session.id}
                 session={session}
                 appMap={delibsAppMap}
+                onSelect={(daId) => setSelectedDelibsDaId(daId)}
               />
             ))}
           </div>
         )}
       </Section>
+
+      {selectedDelibsDaId && (
+        <ApplicantContextModal
+          domainApplicationId={selectedDelibsDaId}
+          onClose={() => setSelectedDelibsDaId(null)}
+        />
+      )}
     </div>
   )
 }
@@ -738,9 +765,11 @@ const FINAL_COLUMN_STYLES: Record<string, { label: string; classes: string; head
 function DelibsSessionView({
   session,
   appMap,
+  onSelect,
 }: {
   session: any
   appMap: Map<string, any>
+  onSelect: (domainApplicationId: string) => void
 }) {
   const isInitial = session.type === 'Initial'
   const columnOrder = (session.columnOrder ?? {}) as Record<string, string[]>
@@ -774,15 +803,17 @@ function DelibsSessionView({
                   const user = da?.application?.user
                   const label = user ? `${user.firstName} ${user.lastName}` : 'Applicant'
                   return (
-                    <div
+                    <button
                       key={id}
-                      className="bg-white p-3 rounded-md border border-gray-200 shadow-sm flex items-center gap-2"
+                      type="button"
+                      onClick={() => onSelect(id)}
+                      className="w-full text-left bg-white p-3 rounded-md border border-gray-200 shadow-sm flex items-center gap-2 hover:shadow-md hover:border-blue-300 transition cursor-pointer"
                     >
                       {!isInitial && col === 'Waitlist' && (
                         <span className="text-gray-400 font-bold text-xs w-4">{i + 1}.</span>
                       )}
                       <span className="font-medium text-gray-900 text-sm">{label}</span>
-                    </div>
+                    </button>
                   )
                 })}
                 {ids.length === 0 && (


### PR DESCRIPTION
Auto-revalidate delibs kanban every 5s on both the domain-lead view and the reviewer mirror view, so concurrent moves and newly qualifying apps surface without a manual refresh. The domain-lead kanban now resyncs its local columnOrder from the loader after each revalidation, skipping the sync while a drag or save is in flight so optimistic state isn't clobbered.

Render ApplicationReview.annotations in the applicant-context modal, grouped by field with the quoted excerpt and the reviewer's comment, so delibs participants see the per-field notes that reviewers leave on applications.

Make delibs cards clickable in the reviewer mirror view, opening the same ApplicantContextModal the domain lead uses. /full-context is already gated by hasCycleAccess so any cycle reviewer can read it.