### PR TITLE
Add Education MVP: offerings, applications, sessions, assignments

### DIFF
--- a/dali-api/app/collab/persistence.ts
+++ b/dali-api/app/collab/persistence.ts
@@ -39,6 +39,42 @@ async function seedContent(name: string): Promise<string | null> {
     if (field === "rejectionRationale") return review.rejectionRationale;
   }
 
+  if (entity === "education-offering" && field === "description") {
+    const offering = await prisma.educationOffering.findUnique({
+      where: { id },
+      select: { id: true },
+    });
+    return offering ? "" : null;
+  }
+  if (entity === "education-session" && field === "materials") {
+    const session = await prisma.educationSession.findUnique({
+      where: { id },
+      select: { id: true },
+    });
+    return session ? "" : null;
+  }
+  if (entity === "education-assignment" && field === "instructions") {
+    const assignment = await prisma.educationAssignment.findUnique({
+      where: { id },
+      select: { id: true },
+    });
+    return assignment ? "" : null;
+  }
+  if (entity === "education-submission" && (field === "content" || field === "feedback")) {
+    const submission = await prisma.educationSubmission.findUnique({
+      where: { id },
+      select: { id: true },
+    });
+    return submission ? "" : null;
+  }
+  if (entity === "education-application" && field === "review") {
+    const application = await prisma.educationApplication.findUnique({
+      where: { id },
+      select: { id: true },
+    });
+    return application ? "" : null;
+  }
+
   if (entity === "interview") {
     const interview = await prisma.interview.findUnique({ where: { id } });
     if (!interview) return null;

--- a/dali-api/app/components/Layout.tsx
+++ b/dali-api/app/components/Layout.tsx
@@ -22,6 +22,11 @@ import {
   List,
   UserPlus,
   Building2,
+  GraduationCap,
+  BookOpen,
+  Sparkles,
+  ClipboardList,
+  Megaphone,
 } from 'lucide-react'
 import { userInitials } from '~/lib/display'
 import { TabWorkspace, type TabWorkspaceHandle, type OpenTabRequest } from '~/components/TabWorkspace'
@@ -33,14 +38,26 @@ interface LayoutProps {
   isAdmin?: boolean
   isDomainLead?: boolean
   isInterviewer?: boolean
+  isCore?: boolean
+  isEducationLead?: boolean
+  isInstructor?: boolean
 }
 
 const SIDEBAR_COLLAPSED_KEY = 'dali:sidebar:collapsed'
 const EXPANDED_AREAS_KEY = 'dali:sidebar:expanded-areas'
 
-type AreaKey = 'hiring' | 'projects' | 'members' | 'partners' | 'admin-console'
+type AreaKey = 'hiring' | 'projects' | 'members' | 'partners' | 'admin-console' | 'education'
 
-export function Layout({ user, isHiringLead = false, isAdmin = false, isDomainLead = false, isInterviewer = false }: LayoutProps) {
+export function Layout({
+  user,
+  isHiringLead = false,
+  isAdmin = false,
+  isDomainLead = false,
+  isInterviewer = false,
+  isCore = false,
+  isEducationLead = false,
+  isInstructor = false,
+}: LayoutProps) {
   const location = useLocation()
   const [focusedTabUrl, setFocusedTabUrl] = useState<string | null>(null)
   // Sidebar highlight follows the focused workspace tab when one is open;
@@ -54,6 +71,7 @@ export function Layout({ user, isHiringLead = false, isAdmin = false, isDomainLe
     members: undefined,
     partners: undefined,
     'admin-console': undefined,
+    education: undefined,
   })
   const workspaceRef = useRef<TabWorkspaceHandle | null>(null)
 
@@ -104,6 +122,7 @@ export function Layout({ user, isHiringLead = false, isAdmin = false, isDomainLe
     : path.startsWith('/projects') ? 'projects'
     : path.startsWith('/members') ? 'members'
     : path.startsWith('/partners') ? 'partners'
+    : path.startsWith('/education') ? 'education'
     : null
 
   const hiringSections = [
@@ -230,6 +249,41 @@ export function Layout({ user, isHiringLead = false, isAdmin = false, isDomainLe
     },
   ].filter((s) => s.show)
 
+  const educationSections = [
+    {
+      label: 'Browse',
+      to: '/education/browse',
+      icon: BookOpen,
+      show: true,
+      active: path.startsWith('/education/browse'),
+      sub: null as { label: string; to: string; active: boolean }[] | null,
+    },
+    {
+      label: 'My Learning',
+      to: '/education/my-learning',
+      icon: Sparkles,
+      show: true,
+      active: path.startsWith('/education/my-learning'),
+      sub: null,
+    },
+    {
+      label: 'Teaching',
+      to: '/education/teaching',
+      icon: ClipboardList,
+      show: isInstructor || isCore,
+      active: path.startsWith('/education/teaching'),
+      sub: null,
+    },
+    {
+      label: 'Manage',
+      to: '/education/manage',
+      icon: Megaphone,
+      show: isCore || isEducationLead,
+      active: path.startsWith('/education/manage') || path.startsWith('/education/offerings'),
+      sub: null,
+    },
+  ].filter((s) => s.show)
+
   const partnersSections = [
     {
       label: 'Organizations',
@@ -269,6 +323,15 @@ export function Layout({ user, isHiringLead = false, isAdmin = false, isDomainLe
       show: true,
       active: activeAreaKey === 'members',
       sections: membersSections,
+    },
+    {
+      key: 'education' as AreaKey,
+      label: 'Education',
+      to: '/education/browse',
+      icon: GraduationCap,
+      show: true,
+      active: activeAreaKey === 'education',
+      sections: educationSections,
     },
     {
       key: 'partners' as AreaKey,

--- a/dali-api/app/education/components/EducationTabs.tsx
+++ b/dali-api/app/education/components/EducationTabs.tsx
@@ -1,0 +1,49 @@
+import { NavLink } from "react-router";
+
+interface Tab {
+  to: string;
+  label: string;
+}
+
+interface Props {
+  offeringId: string;
+  offeringTitle: string;
+}
+
+export function EducationTabs({ offeringId, offeringTitle }: Props) {
+  const tabs: Tab[] = [
+    { to: `/education/offerings/${offeringId}`, label: "Overview" },
+    { to: `/education/offerings/${offeringId}/sessions`, label: "Sessions" },
+    { to: `/education/offerings/${offeringId}/roster`, label: "Roster" },
+    { to: `/education/offerings/${offeringId}/attendance`, label: "Attendance" },
+    { to: `/education/offerings/${offeringId}/assignments`, label: "Assignments" },
+    { to: `/education/offerings/${offeringId}/announcements`, label: "Announcements" },
+    { to: `/education/offerings/${offeringId}/pages`, label: "Pages" },
+    { to: `/education/offerings/${offeringId}/settings`, label: "Settings" },
+  ];
+  return (
+    <div className="border-b border-border mb-6">
+      <h1 className="font-heading text-2xl font-bold text-dark-blue px-1 mb-3">
+        {offeringTitle}
+      </h1>
+      <nav className="flex gap-1 overflow-x-auto">
+        {tabs.map((t) => (
+          <NavLink
+            key={t.to}
+            to={t.to}
+            end={t.label === "Overview"}
+            className={({ isActive }) =>
+              `px-3 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
+                isActive
+                  ? "border-accent-coral text-dark-blue"
+                  : "border-transparent text-muted-foreground hover:text-dark-blue"
+              }`
+            }
+          >
+            {t.label}
+          </NavLink>
+        ))}
+      </nav>
+    </div>
+  );
+}

--- a/dali-api/app/education/lib/access.ts
+++ b/dali-api/app/education/lib/access.ts
@@ -1,0 +1,61 @@
+import { prisma } from "~/lib/db";
+import { requireAuth } from "~/lib/auth";
+import { isCore, isInstructorFor } from "~/lib/roles";
+
+// Common gate for Education routes. Returns either an auth'd userId with the
+// access boolean, or a Response to throw from the loader/action.
+
+export type EducationGate =
+  | { ok: true; userId: string; isInstructor: boolean; isCore: boolean }
+  | { ok: false; response: Response };
+
+function forbidden(): Response {
+  return new Response(JSON.stringify({ error: "Forbidden" }), {
+    status: 403,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export async function requireEducationManager(
+  request: Request,
+  offeringId: string | null,
+): Promise<EducationGate> {
+  const auth = await requireAuth(request);
+  if (!auth.ok) return { ok: false, response: auth.response };
+
+  const userId = auth.user.sub;
+  const coreFlag = await isCore(userId);
+  let instructorFlag = false;
+  if (offeringId) instructorFlag = await isInstructorFor(userId, offeringId);
+
+  if (!coreFlag && !instructorFlag) return { ok: false, response: forbidden() };
+  return { ok: true, userId, isInstructor: instructorFlag, isCore: coreFlag };
+}
+
+/** Lightweight auth-only gate (used for catalog + portal endpoints). */
+export async function requireAnyAuthed(
+  request: Request,
+): Promise<
+  | { ok: true; userId: string; email: string; firstName: string }
+  | { ok: false; response: Response }
+> {
+  const auth = await requireAuth(request);
+  if (!auth.ok) return { ok: false, response: auth.response };
+  return {
+    ok: true,
+    userId: auth.user.sub,
+    email: auth.user.email,
+    firstName: auth.user.firstName ?? "",
+  };
+}
+
+export async function isApplicantOf(
+  userId: string,
+  applicationId: string,
+): Promise<boolean> {
+  const row = await prisma.educationApplication.findUnique({
+    where: { id: applicationId },
+    select: { applicantUserId: true },
+  });
+  return row?.applicantUserId === userId;
+}

--- a/dali-api/app/education/routes/api.applications.$id.decision.ts
+++ b/dali-api/app/education/routes/api.applications.$id.decision.ts
@@ -1,0 +1,32 @@
+import type { Route } from "./+types/api.applications.$id.decision";
+import { prisma } from "~/lib/db";
+import { requireEducationManager } from "~/education/lib/access";
+import { decide, type DecisionAction } from "~/lib/education/decisions";
+
+export async function action({ request, params }: Route.ActionArgs) {
+  if (request.method !== "POST") {
+    return Response.json({ error: "Method not allowed" }, { status: 405 });
+  }
+  const application = await prisma.educationApplication.findUnique({
+    where: { id: params.id! },
+    select: { offeringId: true },
+  });
+  if (!application) return Response.json({ error: "Not found" }, { status: 404 });
+  const gate = await requireEducationManager(request, application.offeringId);
+  if (!gate.ok) return gate.response;
+
+  const body = (await request.json()) as {
+    action: DecisionAction;
+    reviewerNote?: string | null;
+  };
+  if (!["Approve", "Reject", "Waitlist"].includes(body.action)) {
+    return Response.json({ error: "Invalid action" }, { status: 400 });
+  }
+  const result = await decide({
+    applicationId: params.id!,
+    action: body.action,
+    actorUserId: gate.userId,
+    reviewerNote: body.reviewerNote ?? null,
+  });
+  return Response.json(result);
+}

--- a/dali-api/app/education/routes/api.applications.$id.withdraw.ts
+++ b/dali-api/app/education/routes/api.applications.$id.withdraw.ts
@@ -1,0 +1,21 @@
+import type { Route } from "./+types/api.applications.$id.withdraw";
+import { requireAuth } from "~/lib/auth";
+import { isApplicantOf } from "~/education/lib/access";
+import { decide } from "~/lib/education/decisions";
+
+export async function action({ request, params }: Route.ActionArgs) {
+  if (request.method !== "POST") {
+    return Response.json({ error: "Method not allowed" }, { status: 405 });
+  }
+  const auth = await requireAuth(request);
+  if (!auth.ok) return auth.response;
+  if (!(await isApplicantOf(auth.user.sub, params.id!))) {
+    return Response.json({ error: "Forbidden" }, { status: 403 });
+  }
+  const result = await decide({
+    applicationId: params.id!,
+    action: "Withdraw",
+    actorUserId: auth.user.sub,
+  });
+  return Response.json(result);
+}

--- a/dali-api/app/education/routes/api.assignments.$id.submit.ts
+++ b/dali-api/app/education/routes/api.assignments.$id.submit.ts
@@ -1,0 +1,68 @@
+import type { Route } from "./+types/api.assignments.$id.submit";
+import { prisma } from "~/lib/db";
+import { requireAuth } from "~/lib/auth";
+
+// Student creates/updates an EducationSubmission row. The submission body
+// lives in a collab doc named education-submission:{id}:content; this
+// endpoint just maintains the row + final submitted timestamp + file list.
+
+export async function action({ request, params }: Route.ActionArgs) {
+  if (request.method !== "POST") {
+    return Response.json({ error: "Method not allowed" }, { status: 405 });
+  }
+  const auth = await requireAuth(request);
+  if (!auth.ok) return auth.response;
+
+  const assignmentId = params.id!;
+  const assignment = await prisma.educationAssignment.findUnique({
+    where: { id: assignmentId },
+    select: {
+      id: true,
+      offeringId: true,
+      session: { select: { offeringId: true } },
+    },
+  });
+  if (!assignment) return Response.json({ error: "Not found" }, { status: 404 });
+
+  const offeringId = assignment.offeringId ?? assignment.session?.offeringId;
+  if (!offeringId) {
+    return Response.json({ error: "Assignment not linked to offering" }, { status: 500 });
+  }
+
+  // Student must have an Approved application for the parent offering.
+  const application = await prisma.educationApplication.findUnique({
+    where: {
+      applicantUserId_offeringId: {
+        applicantUserId: auth.user.sub,
+        offeringId,
+      },
+    },
+    select: { id: true, status: true },
+  });
+  if (!application || application.status !== "Approved") {
+    return Response.json({ error: "Not enrolled" }, { status: 403 });
+  }
+
+  const body = (await request.json()) as {
+    files?: Array<{ name: string; key: string }>;
+    finalize?: boolean;
+  };
+
+  const submission = await prisma.educationSubmission.upsert({
+    where: {
+      assignmentId_studentId: { assignmentId, studentId: auth.user.sub },
+    },
+    create: {
+      assignmentId,
+      studentId: auth.user.sub,
+      educationApplicationId: application.id,
+      files: body.files ?? undefined,
+      submittedAt: body.finalize ? new Date() : null,
+    },
+    update: {
+      files: body.files ?? undefined,
+      submittedAt: body.finalize ? new Date() : undefined,
+    },
+  });
+  return Response.json({ submission }, { status: 201 });
+}

--- a/dali-api/app/education/routes/api.assignments.$id.ts
+++ b/dali-api/app/education/routes/api.assignments.$id.ts
@@ -1,0 +1,45 @@
+import type { Route } from "./+types/api.assignments.$id";
+import { prisma } from "~/lib/db";
+import { requireEducationManager } from "~/education/lib/access";
+
+async function offeringIdForAssignment(id: string): Promise<string | null> {
+  const a = await prisma.educationAssignment.findUnique({
+    where: { id },
+    select: {
+      offeringId: true,
+      session: { select: { offeringId: true } },
+    },
+  });
+  if (!a) return null;
+  return a.offeringId ?? a.session?.offeringId ?? null;
+}
+
+export async function action({ request, params }: Route.ActionArgs) {
+  const id = params.id!;
+  const offeringId = await offeringIdForAssignment(id);
+  if (!offeringId) return Response.json({ error: "Not found" }, { status: 404 });
+  const gate = await requireEducationManager(request, offeringId);
+  if (!gate.ok) return gate.response;
+
+  if (request.method === "PUT" || request.method === "PATCH") {
+    const body = (await request.json()) as Partial<{
+      title: string;
+      dueAt: string | null;
+      submissionType: "Text" | "File" | "Mixed";
+    }>;
+    const assignment = await prisma.educationAssignment.update({
+      where: { id },
+      data: {
+        ...(body.title !== undefined ? { title: body.title } : {}),
+        ...(body.dueAt !== undefined ? { dueAt: body.dueAt ? new Date(body.dueAt) : null } : {}),
+        ...(body.submissionType !== undefined ? { submissionType: body.submissionType } : {}),
+      },
+    });
+    return Response.json({ assignment });
+  }
+  if (request.method === "DELETE") {
+    await prisma.educationAssignment.delete({ where: { id } });
+    return Response.json({ ok: true });
+  }
+  return Response.json({ error: "Method not allowed" }, { status: 405 });
+}

--- a/dali-api/app/education/routes/api.offerings.$id.announcements.ts
+++ b/dali-api/app/education/routes/api.offerings.$id.announcements.ts
@@ -1,0 +1,78 @@
+import type { Route } from "./+types/api.offerings.$id.announcements";
+import { prisma } from "~/lib/db";
+import { requireEducationManager } from "~/education/lib/access";
+import { emitEvent } from "~/lib/notifications";
+import { sendAnnouncementEmail } from "~/lib/education/email";
+
+export async function action({ request, params }: Route.ActionArgs) {
+  if (request.method !== "POST") {
+    return Response.json({ error: "Method not allowed" }, { status: 405 });
+  }
+  const offeringId = params.id!;
+  const gate = await requireEducationManager(request, offeringId);
+  if (!gate.ok) return gate.response;
+
+  const body = (await request.json()) as { body: string };
+  if (!body.body?.trim()) {
+    return Response.json({ error: "body required" }, { status: 400 });
+  }
+
+  const [offering, author, recipients] = await Promise.all([
+    prisma.educationOffering.findUnique({
+      where: { id: offeringId },
+      select: { title: true },
+    }),
+    prisma.user.findUnique({
+      where: { id: gate.userId },
+      select: { firstName: true, lastName: true },
+    }),
+    prisma.educationApplication.findMany({
+      where: { offeringId, status: "Approved" },
+      select: {
+        applicantUserId: true,
+        applicant: {
+          select: { firstName: true, daliEmail: true, dartmouthEmail: true },
+        },
+      },
+    }),
+  ]);
+  if (!offering) return Response.json({ error: "Not found" }, { status: 404 });
+
+  const announcement = await prisma.educationAnnouncement.create({
+    data: {
+      offeringId,
+      authorId: gate.userId,
+      body: body.body.trim(),
+    },
+  });
+
+  const authorName =
+    [author?.firstName, author?.lastName].filter(Boolean).join(" ") || "Instructor";
+
+  await emitEvent({
+    type: "education.announcement_posted",
+    recipients: recipients.map((r) => r.applicantUserId),
+    payload: { offeringId, announcementId: announcement.id },
+    inbox: {
+      kind: "EducationAnnouncementPosted",
+      title: `[${offering.title}] ${authorName}`,
+      body: body.body.trim().slice(0, 280),
+      link: `/portal/education/${offeringId}`,
+      createdByUserId: gate.userId,
+    },
+  });
+
+  // Email fan-out is best-effort; loop sequentially to keep memory predictable.
+  for (const r of recipients) {
+    const email = r.applicant.daliEmail ?? r.applicant.dartmouthEmail;
+    if (!email) continue;
+    await sendAnnouncementEmail({
+      to: { email, firstName: r.applicant.firstName },
+      offeringTitle: offering.title,
+      authorName,
+      body: body.body.trim(),
+    });
+  }
+
+  return Response.json({ announcement }, { status: 201 });
+}

--- a/dali-api/app/education/routes/api.offerings.$id.apply.ts
+++ b/dali-api/app/education/routes/api.offerings.$id.apply.ts
@@ -1,0 +1,26 @@
+import type { Route } from "./+types/api.offerings.$id.apply";
+import { requireAuth } from "~/lib/auth";
+import { apply } from "~/lib/education/apply";
+
+export async function action({ request, params }: Route.ActionArgs) {
+  if (request.method !== "POST") {
+    return Response.json({ error: "Method not allowed" }, { status: 405 });
+  }
+  const auth = await requireAuth(request);
+  if (!auth.ok) return auth.response;
+
+  const body = (await request.json()) as { answers?: Record<string, string> };
+  const outcome = await apply({
+    offeringId: params.id!,
+    applicantUserId: auth.user.sub,
+    answers: body.answers ?? {},
+  });
+  if (!outcome.ok) {
+    const status =
+      outcome.error.kind === "OfferingNotFound" ? 404
+      : outcome.error.kind === "MissingRequiredAnswer" ? 400
+      : 409;
+    return Response.json({ error: outcome.error }, { status });
+  }
+  return Response.json(outcome.result, { status: 201 });
+}

--- a/dali-api/app/education/routes/api.offerings.$id.assignments.ts
+++ b/dali-api/app/education/routes/api.offerings.$id.assignments.ts
@@ -1,0 +1,33 @@
+import type { Route } from "./+types/api.offerings.$id.assignments";
+import { prisma } from "~/lib/db";
+import { requireEducationManager } from "~/education/lib/access";
+
+export async function action({ request, params }: Route.ActionArgs) {
+  if (request.method !== "POST") {
+    return Response.json({ error: "Method not allowed" }, { status: 405 });
+  }
+  const offeringId = params.id!;
+  const gate = await requireEducationManager(request, offeringId);
+  if (!gate.ok) return gate.response;
+
+  const body = (await request.json()) as {
+    title: string;
+    sessionId?: string | null;
+    submissionType: "Text" | "File" | "Mixed";
+    dueAt?: string | null;
+  };
+  if (!body.title?.trim()) {
+    return Response.json({ error: "title required" }, { status: 400 });
+  }
+  const assignment = await prisma.educationAssignment.create({
+    data: {
+      title: body.title.trim(),
+      submissionType: body.submissionType,
+      dueAt: body.dueAt ? new Date(body.dueAt) : null,
+      // Per schema rule: exactly one of offeringId / sessionId is set.
+      offeringId: body.sessionId ? null : offeringId,
+      sessionId: body.sessionId ?? null,
+    },
+  });
+  return Response.json({ assignment }, { status: 201 });
+}

--- a/dali-api/app/education/routes/api.offerings.$id.instructors.ts
+++ b/dali-api/app/education/routes/api.offerings.$id.instructors.ts
@@ -1,0 +1,42 @@
+import type { Route } from "./+types/api.offerings.$id.instructors";
+import { prisma } from "~/lib/db";
+import { requireEducationManager } from "~/education/lib/access";
+import { currentTerm } from "~/lib/roles";
+
+// POST { userId }  → add instructor
+// DELETE { userId } → remove instructor
+
+export async function action({ request, params }: Route.ActionArgs) {
+  const offeringId = params.id!;
+  const gate = await requireEducationManager(request, offeringId);
+  if (!gate.ok) return gate.response;
+
+  const body = (await request.json()) as { userId: string };
+  if (!body.userId) {
+    return Response.json({ error: "userId required" }, { status: 400 });
+  }
+  const term = await currentTerm();
+  if (!term) {
+    return Response.json({ error: "No current term" }, { status: 500 });
+  }
+
+  if (request.method === "POST") {
+    try {
+      const assignment = await prisma.instructorAssignment.create({
+        data: { userId: body.userId, offeringId, termId: term.id },
+      });
+      return Response.json({ assignment }, { status: 201 });
+    } catch {
+      return Response.json({ error: "Already assigned" }, { status: 409 });
+    }
+  }
+
+  if (request.method === "DELETE") {
+    await prisma.instructorAssignment.deleteMany({
+      where: { userId: body.userId, offeringId, termId: term.id },
+    });
+    return Response.json({ ok: true });
+  }
+
+  return Response.json({ error: "Method not allowed" }, { status: 405 });
+}

--- a/dali-api/app/education/routes/api.offerings.$id.publish.ts
+++ b/dali-api/app/education/routes/api.offerings.$id.publish.ts
@@ -1,0 +1,22 @@
+import type { Route } from "./+types/api.offerings.$id.publish";
+import { prisma } from "~/lib/db";
+import { requireEducationManager } from "~/education/lib/access";
+
+export async function action({ request, params }: Route.ActionArgs) {
+  if (request.method !== "POST") {
+    return Response.json({ error: "Method not allowed" }, { status: 405 });
+  }
+  const id = params.id!;
+  const gate = await requireEducationManager(request, id);
+  if (!gate.ok) return gate.response;
+
+  const body = (await request.json()) as { status: "Draft" | "Published" | "Archived" };
+  if (!["Draft", "Published", "Archived"].includes(body.status)) {
+    return Response.json({ error: "Invalid status" }, { status: 400 });
+  }
+  const offering = await prisma.educationOffering.update({
+    where: { id },
+    data: { status: body.status },
+  });
+  return Response.json({ offering });
+}

--- a/dali-api/app/education/routes/api.offerings.$id.questions.ts
+++ b/dali-api/app/education/routes/api.offerings.$id.questions.ts
@@ -1,0 +1,34 @@
+import type { Route } from "./+types/api.offerings.$id.questions";
+import { prisma } from "~/lib/db";
+import { requireEducationManager } from "~/education/lib/access";
+
+export async function action({ request, params }: Route.ActionArgs) {
+  if (request.method !== "POST") {
+    return Response.json({ error: "Method not allowed" }, { status: 405 });
+  }
+  const offeringId = params.id!;
+  const gate = await requireEducationManager(request, offeringId);
+  if (!gate.ok) return gate.response;
+
+  const body = (await request.json()) as {
+    prompt: string;
+    position?: number;
+    required?: boolean;
+  };
+  if (!body.prompt?.trim()) {
+    return Response.json({ error: "prompt required" }, { status: 400 });
+  }
+  const max = await prisma.educationApplicationQuestion.aggregate({
+    where: { offeringId },
+    _max: { position: true },
+  });
+  const question = await prisma.educationApplicationQuestion.create({
+    data: {
+      offeringId,
+      prompt: body.prompt.trim(),
+      position: body.position ?? (max._max.position ?? -1) + 1,
+      required: body.required ?? true,
+    },
+  });
+  return Response.json({ question }, { status: 201 });
+}

--- a/dali-api/app/education/routes/api.offerings.$id.sessions.ts
+++ b/dali-api/app/education/routes/api.offerings.$id.sessions.ts
@@ -1,0 +1,37 @@
+import type { Route } from "./+types/api.offerings.$id.sessions";
+import { prisma } from "~/lib/db";
+import { requireEducationManager } from "~/education/lib/access";
+import { syncSessionRoster } from "~/lib/education/roster-sync";
+
+export async function action({ request, params }: Route.ActionArgs) {
+  if (request.method !== "POST") {
+    return Response.json({ error: "Method not allowed" }, { status: 405 });
+  }
+  const offeringId = params.id!;
+  const gate = await requireEducationManager(request, offeringId);
+  if (!gate.ok) return gate.response;
+
+  const body = (await request.json()) as {
+    datetime: string;
+    location?: string | null;
+    sequence?: number;
+  };
+  const max = await prisma.educationSession.aggregate({
+    where: { offeringId },
+    _max: { sequence: true },
+  });
+  const session = await prisma.educationSession.create({
+    data: {
+      offeringId,
+      sequence: body.sequence ?? (max._max.sequence ?? 0) + 1,
+      datetime: new Date(body.datetime),
+      location: body.location ?? null,
+    },
+  });
+  // Fire-and-forget: if there's already an approved roster, create the
+  // calendar event for the new session.
+  syncSessionRoster(offeringId).catch((err) => {
+    console.error("[education:sessions] post-create sync failed", err);
+  });
+  return Response.json({ session }, { status: 201 });
+}

--- a/dali-api/app/education/routes/api.offerings.$id.ts
+++ b/dali-api/app/education/routes/api.offerings.$id.ts
@@ -1,0 +1,48 @@
+import type { Route } from "./+types/api.offerings.$id";
+import { prisma } from "~/lib/db";
+import { requireEducationManager } from "~/education/lib/access";
+
+// PUT updates metadata; DELETE archives (we keep history for analytics).
+
+export async function action({ request, params }: Route.ActionArgs) {
+  const id = params.id!;
+  const gate = await requireEducationManager(request, id);
+  if (!gate.ok) return gate.response;
+
+  if (request.method === "PUT" || request.method === "PATCH") {
+    const body = (await request.json()) as Record<string, unknown>;
+    const data: Record<string, unknown> = {};
+    for (const k of [
+      "title",
+      "capacity",
+      "registrationOpensAt",
+      "registrationClosesAt",
+      "startsAt",
+      "endsAt",
+      "requiresReview",
+      "calendarEmail",
+      "descriptionDocId",
+    ] as const) {
+      if (!(k in body)) continue;
+      const v = body[k];
+      if (k.endsWith("At")) data[k] = v ? new Date(v as string) : null;
+      else if (k === "capacity") data[k] = Math.floor(Number(v));
+      else data[k] = v;
+    }
+    const offering = await prisma.educationOffering.update({
+      where: { id },
+      data,
+    });
+    return Response.json({ offering });
+  }
+
+  if (request.method === "DELETE") {
+    const offering = await prisma.educationOffering.update({
+      where: { id },
+      data: { status: "Archived" },
+    });
+    return Response.json({ offering });
+  }
+
+  return Response.json({ error: "Method not allowed" }, { status: 405 });
+}

--- a/dali-api/app/education/routes/api.offerings.ts
+++ b/dali-api/app/education/routes/api.offerings.ts
@@ -1,0 +1,64 @@
+import type { Route } from "./+types/api.offerings";
+import { prisma } from "~/lib/db";
+import { requireAuth } from "~/lib/auth";
+import { isCore, currentTerm } from "~/lib/roles";
+
+interface CreateOfferingPayload {
+  type: "Miniseries" | "Workshop";
+  title: string;
+  capacity: number;
+  registrationOpensAt: string;
+  registrationClosesAt: string;
+  startsAt: string;
+  endsAt: string;
+  requiresReview: boolean;
+  calendarEmail?: string | null;
+}
+
+// POST /api/education/offerings — create a new offering. Only Core may
+// create offerings (instructors get added separately and can then teach).
+export async function action({ request }: Route.ActionArgs) {
+  if (request.method !== "POST") {
+    return Response.json({ error: "Method not allowed" }, { status: 405 });
+  }
+  const auth = await requireAuth(request);
+  if (!auth.ok) return auth.response;
+  if (!(await isCore(auth.user.sub))) {
+    return Response.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const body = (await request.json()) as CreateOfferingPayload;
+  if (!body.title?.trim() || !Number.isFinite(body.capacity) || body.capacity < 1) {
+    return Response.json({ error: "Invalid payload" }, { status: 400 });
+  }
+
+  const offering = await prisma.educationOffering.create({
+    data: {
+      type: body.type,
+      title: body.title.trim(),
+      capacity: Math.floor(body.capacity),
+      registrationOpensAt: new Date(body.registrationOpensAt),
+      registrationClosesAt: new Date(body.registrationClosesAt),
+      startsAt: new Date(body.startsAt),
+      endsAt: new Date(body.endsAt),
+      requiresReview: !!body.requiresReview,
+      calendarEmail: body.calendarEmail?.trim() || null,
+      status: "Draft",
+    },
+  });
+
+  // Auto-assign the creator as the first instructor so they can manage
+  // the offering they just created.
+  const term = await currentTerm();
+  if (term) {
+    await prisma.instructorAssignment.create({
+      data: {
+        userId: auth.user.sub,
+        offeringId: offering.id,
+        termId: term.id,
+      },
+    });
+  }
+
+  return Response.json({ offering }, { status: 201 });
+}

--- a/dali-api/app/education/routes/api.questions.$id.ts
+++ b/dali-api/app/education/routes/api.questions.$id.ts
@@ -1,0 +1,36 @@
+import type { Route } from "./+types/api.questions.$id";
+import { prisma } from "~/lib/db";
+import { requireEducationManager } from "~/education/lib/access";
+
+export async function action({ request, params }: Route.ActionArgs) {
+  const id = params.id!;
+  const existing = await prisma.educationApplicationQuestion.findUnique({
+    where: { id },
+    select: { offeringId: true },
+  });
+  if (!existing) return Response.json({ error: "Not found" }, { status: 404 });
+  const gate = await requireEducationManager(request, existing.offeringId);
+  if (!gate.ok) return gate.response;
+
+  if (request.method === "PUT" || request.method === "PATCH") {
+    const body = (await request.json()) as Partial<{
+      prompt: string;
+      position: number;
+      required: boolean;
+    }>;
+    const question = await prisma.educationApplicationQuestion.update({
+      where: { id },
+      data: {
+        ...(body.prompt !== undefined ? { prompt: body.prompt } : {}),
+        ...(body.position !== undefined ? { position: body.position } : {}),
+        ...(body.required !== undefined ? { required: body.required } : {}),
+      },
+    });
+    return Response.json({ question });
+  }
+  if (request.method === "DELETE") {
+    await prisma.educationApplicationQuestion.delete({ where: { id } });
+    return Response.json({ ok: true });
+  }
+  return Response.json({ error: "Method not allowed" }, { status: 405 });
+}

--- a/dali-api/app/education/routes/api.sessions.$id.attendance.ts
+++ b/dali-api/app/education/routes/api.sessions.$id.attendance.ts
@@ -1,0 +1,45 @@
+import type { Route } from "./+types/api.sessions.$id.attendance";
+import { prisma } from "~/lib/db";
+import { requireEducationManager } from "~/education/lib/access";
+
+interface AttendancePayload {
+  entries: Array<{
+    applicationId: string;
+    status: "Present" | "Absent" | "Excused";
+  }>;
+}
+
+export async function action({ request, params }: Route.ActionArgs) {
+  if (request.method !== "POST") {
+    return Response.json({ error: "Method not allowed" }, { status: 405 });
+  }
+  const sessionId = params.id!;
+  const session = await prisma.educationSession.findUnique({
+    where: { id: sessionId },
+    select: { offeringId: true },
+  });
+  if (!session) return Response.json({ error: "Not found" }, { status: 404 });
+  const gate = await requireEducationManager(request, session.offeringId);
+  if (!gate.ok) return gate.response;
+
+  const body = (await request.json()) as AttendancePayload;
+  await prisma.$transaction(
+    body.entries.map((entry) =>
+      prisma.educationAttendance.upsert({
+        where: {
+          applicationId_sessionId: {
+            applicationId: entry.applicationId,
+            sessionId,
+          },
+        },
+        create: {
+          applicationId: entry.applicationId,
+          sessionId,
+          status: entry.status,
+        },
+        update: { status: entry.status },
+      }),
+    ),
+  );
+  return Response.json({ ok: true, count: body.entries.length });
+}

--- a/dali-api/app/education/routes/api.sessions.$id.ts
+++ b/dali-api/app/education/routes/api.sessions.$id.ts
@@ -1,0 +1,42 @@
+import type { Route } from "./+types/api.sessions.$id";
+import { prisma } from "~/lib/db";
+import { requireEducationManager } from "~/education/lib/access";
+import { syncSessionRoster } from "~/lib/education/roster-sync";
+
+export async function action({ request, params }: Route.ActionArgs) {
+  const id = params.id!;
+  const existing = await prisma.educationSession.findUnique({
+    where: { id },
+    select: { offeringId: true },
+  });
+  if (!existing) return Response.json({ error: "Not found" }, { status: 404 });
+  const gate = await requireEducationManager(request, existing.offeringId);
+  if (!gate.ok) return gate.response;
+
+  if (request.method === "PUT" || request.method === "PATCH") {
+    const body = (await request.json()) as Partial<{
+      datetime: string;
+      location: string | null;
+      recordingUrl: string | null;
+    }>;
+    const session = await prisma.educationSession.update({
+      where: { id },
+      data: {
+        ...(body.datetime ? { datetime: new Date(body.datetime) } : {}),
+        ...(body.location !== undefined ? { location: body.location } : {}),
+        ...(body.recordingUrl !== undefined ? { recordingUrl: body.recordingUrl } : {}),
+      },
+    });
+    if (body.datetime) {
+      syncSessionRoster(existing.offeringId).catch((err) => {
+        console.error("[education:sessions] post-update sync failed", err);
+      });
+    }
+    return Response.json({ session });
+  }
+  if (request.method === "DELETE") {
+    await prisma.educationSession.delete({ where: { id } });
+    return Response.json({ ok: true });
+  }
+  return Response.json({ error: "Method not allowed" }, { status: 405 });
+}

--- a/dali-api/app/education/routes/api.submissions.$id.grade.ts
+++ b/dali-api/app/education/routes/api.submissions.$id.grade.ts
@@ -1,0 +1,36 @@
+import type { Route } from "./+types/api.submissions.$id.grade";
+import { prisma } from "~/lib/db";
+import { requireEducationManager } from "~/education/lib/access";
+
+async function offeringIdForSubmission(id: string): Promise<string | null> {
+  const s = await prisma.educationSubmission.findUnique({
+    where: { id },
+    select: {
+      assignment: {
+        select: {
+          offeringId: true,
+          session: { select: { offeringId: true } },
+        },
+      },
+    },
+  });
+  if (!s) return null;
+  return s.assignment.offeringId ?? s.assignment.session?.offeringId ?? null;
+}
+
+export async function action({ request, params }: Route.ActionArgs) {
+  if (request.method !== "POST") {
+    return Response.json({ error: "Method not allowed" }, { status: 405 });
+  }
+  const id = params.id!;
+  const offeringId = await offeringIdForSubmission(id);
+  if (!offeringId) return Response.json({ error: "Not found" }, { status: 404 });
+  const gate = await requireEducationManager(request, offeringId);
+  if (!gate.ok) return gate.response;
+
+  const submission = await prisma.educationSubmission.update({
+    where: { id },
+    data: { gradedAt: new Date() },
+  });
+  return Response.json({ submission });
+}

--- a/dali-api/app/education/routes/api.submissions.$id.upload-post.ts
+++ b/dali-api/app/education/routes/api.submissions.$id.upload-post.ts
@@ -1,0 +1,35 @@
+import type { Route } from "./+types/api.submissions.$id.upload-post";
+import { prisma } from "~/lib/db";
+import { requireAuth } from "~/lib/auth";
+import { getUploadPost } from "~/lib/s3";
+
+function sanitizeFilename(name: string): string {
+  return name.replace(/[^a-zA-Z0-9._-]/g, "_").slice(0, 80);
+}
+
+export async function action({ request, params }: Route.ActionArgs) {
+  if (request.method !== "POST") {
+    return Response.json({ error: "Method not allowed" }, { status: 405 });
+  }
+  const auth = await requireAuth(request);
+  if (!auth.ok) return auth.response;
+
+  const submission = await prisma.educationSubmission.findUnique({
+    where: { id: params.id! },
+    select: { studentId: true },
+  });
+  if (!submission) return Response.json({ error: "Not found" }, { status: 404 });
+  if (submission.studentId !== auth.user.sub) {
+    return Response.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const body = (await request.json()) as { filename: string; contentType: string };
+  if (!body.filename || !body.contentType) {
+    return Response.json({ error: "filename + contentType required" }, { status: 400 });
+  }
+
+  const safe = sanitizeFilename(body.filename);
+  const key = `uploads/education/${params.id}/${Date.now()}-${safe}`;
+  const post = await getUploadPost(key, body.contentType);
+  return Response.json({ post, key });
+}

--- a/dali-api/app/education/routes/education._index.tsx
+++ b/dali-api/app/education/routes/education._index.tsx
@@ -1,0 +1,9 @@
+import { redirect } from "react-router";
+
+export async function loader() {
+  return redirect("/education/browse");
+}
+
+export default function EducationIndex() {
+  return null;
+}

--- a/dali-api/app/education/routes/education.browse.tsx
+++ b/dali-api/app/education/routes/education.browse.tsx
@@ -1,0 +1,70 @@
+import { useLoaderData, Link } from "react-router";
+import type { Route } from "./+types/education.browse";
+import { prisma } from "~/lib/db";
+import { requireAuth } from "~/lib/auth";
+
+export async function loader({ request }: Route.LoaderArgs) {
+  const auth = await requireAuth(request);
+  if (!auth.ok) return auth.response;
+
+  const offerings = await prisma.educationOffering.findMany({
+    where: { status: "Published" },
+    orderBy: { startsAt: "asc" },
+    include: {
+      instructors: {
+        include: {
+          user: { select: { firstName: true, lastName: true } },
+        },
+      },
+      _count: { select: { applications: true } },
+    },
+  });
+
+  return { offerings };
+}
+
+export default function EducationBrowse() {
+  const { offerings } = useLoaderData<typeof loader>();
+  return (
+    <div className="max-w-5xl mx-auto p-6">
+      <h1 className="font-heading text-2xl font-bold text-dark-blue mb-1">
+        Browse Education
+      </h1>
+      <p className="text-sm text-muted-foreground mb-6">
+        Miniseries and workshops open for registration.
+      </p>
+      {offerings.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          No published offerings right now. Check back later.
+        </p>
+      ) : (
+        <ul className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {offerings.map((o) => (
+            <li key={o.id} className="bg-card rounded-md border border-border p-4">
+              <div className="flex items-start justify-between gap-3">
+                <h2 className="font-heading font-semibold text-base text-dark-blue">
+                  <Link to={`/education/offerings/${o.id}`} className="hover:underline">
+                    {o.title}
+                  </Link>
+                </h2>
+                <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                  {o.type}
+                </span>
+              </div>
+              <p className="text-xs text-muted-foreground mt-1">
+                {o.instructors
+                  .map((i) => `${i.user.firstName} ${i.user.lastName}`.trim())
+                  .filter(Boolean)
+                  .join(", ") || "TBD"}
+              </p>
+              <p className="text-xs text-muted-foreground mt-2">
+                Starts {new Date(o.startsAt).toLocaleDateString()} ·{" "}
+                {o._count.applications}/{o.capacity} registered
+              </p>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/dali-api/app/education/routes/education.manage.tsx
+++ b/dali-api/app/education/routes/education.manage.tsx
@@ -1,0 +1,74 @@
+import { useLoaderData, Link } from "react-router";
+import type { Route } from "./+types/education.manage";
+import { prisma } from "~/lib/db";
+import { requireAuth } from "~/lib/auth";
+import { isCore } from "~/lib/roles";
+
+export async function loader({ request }: Route.LoaderArgs) {
+  const auth = await requireAuth(request);
+  if (!auth.ok) return auth.response;
+  if (!(await isCore(auth.user.sub))) {
+    return new Response("Forbidden", { status: 403 });
+  }
+  const offerings = await prisma.educationOffering.findMany({
+    orderBy: { createdAt: "desc" },
+    include: {
+      _count: { select: { applications: true, sessions: true } },
+    },
+  });
+  return { offerings };
+}
+
+export default function Manage() {
+  const { offerings } = useLoaderData<typeof loader>();
+  return (
+    <div className="max-w-5xl mx-auto p-6">
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="font-heading text-2xl font-bold text-dark-blue">
+          Manage Offerings
+        </h1>
+        <Link
+          to="/education/offerings/new"
+          className="px-3 py-2 bg-accent-coral text-white text-sm font-medium rounded-md hover:opacity-90"
+        >
+          + New Offering
+        </Link>
+      </div>
+      {offerings.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No offerings yet.</p>
+      ) : (
+        <table className="w-full text-sm">
+          <thead className="text-xs uppercase tracking-wide text-muted-foreground">
+            <tr>
+              <th className="text-left py-2">Title</th>
+              <th className="text-left">Type</th>
+              <th className="text-left">Status</th>
+              <th className="text-right">Roster</th>
+              <th className="text-right">Sessions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {offerings.map((o) => (
+              <tr key={o.id} className="border-t border-border">
+                <td className="py-2">
+                  <Link
+                    to={`/education/offerings/${o.id}`}
+                    className="text-dark-blue hover:underline font-medium"
+                  >
+                    {o.title}
+                  </Link>
+                </td>
+                <td>{o.type}</td>
+                <td>{o.status}</td>
+                <td className="text-right">
+                  {o._count.applications}/{o.capacity}
+                </td>
+                <td className="text-right">{o._count.sessions}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}

--- a/dali-api/app/education/routes/education.my-learning.tsx
+++ b/dali-api/app/education/routes/education.my-learning.tsx
@@ -1,0 +1,75 @@
+import { useLoaderData, Link } from "react-router";
+import type { Route } from "./+types/education.my-learning";
+import { prisma } from "~/lib/db";
+import { requireAuth } from "~/lib/auth";
+
+export async function loader({ request }: Route.LoaderArgs) {
+  const auth = await requireAuth(request);
+  if (!auth.ok) return auth.response;
+
+  const applications = await prisma.educationApplication.findMany({
+    where: { applicantUserId: auth.user.sub },
+    orderBy: { submittedAt: "desc" },
+    include: {
+      offering: { select: { id: true, title: true, startsAt: true, type: true } },
+    },
+  });
+  return { applications };
+}
+
+const STATUS_CLASSES: Record<string, string> = {
+  Approved: "bg-green-50 text-green-700",
+  Submitted: "bg-blue-50 text-blue-700",
+  Waitlisted: "bg-amber-50 text-amber-700",
+  Rejected: "bg-red-50 text-red-700",
+  Withdrawn: "bg-gray-100 text-gray-600",
+};
+
+export default function MyLearning() {
+  const { applications } = useLoaderData<typeof loader>();
+  return (
+    <div className="max-w-4xl mx-auto p-6">
+      <h1 className="font-heading text-2xl font-bold text-dark-blue mb-6">
+        My Learning
+      </h1>
+      {applications.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          You haven't applied to anything yet.{" "}
+          <Link to="/education/browse" className="text-accent-coral hover:underline">
+            Browse the catalog
+          </Link>
+          .
+        </p>
+      ) : (
+        <ul className="space-y-2">
+          {applications.map((a) => (
+            <li
+              key={a.id}
+              className="bg-card border border-border rounded-md p-4 flex items-center justify-between gap-4"
+            >
+              <div>
+                <Link
+                  to={`/portal/education/applications/${a.id}`}
+                  className="font-heading font-semibold text-dark-blue hover:underline"
+                >
+                  {a.offering.title}
+                </Link>
+                <p className="text-xs text-muted-foreground">
+                  {a.offering.type} · starts{" "}
+                  {new Date(a.offering.startsAt).toLocaleDateString()}
+                </p>
+              </div>
+              <span
+                className={`text-xs font-medium px-2 py-0.5 rounded ${
+                  STATUS_CLASSES[a.status] ?? "bg-gray-100 text-gray-600"
+                }`}
+              >
+                {a.status}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/dali-api/app/education/routes/education.offerings.$id.announcements.tsx
+++ b/dali-api/app/education/routes/education.offerings.$id.announcements.tsx
@@ -1,0 +1,120 @@
+import { useLoaderData, Form, useNavigation } from "react-router";
+import type { Route } from "./+types/education.offerings.$id.announcements";
+import { prisma } from "~/lib/db";
+import { requireEducationManager } from "~/education/lib/access";
+import { emitEvent } from "~/lib/notifications";
+import { sendAnnouncementEmail } from "~/lib/education/email";
+import { EducationTabs } from "~/education/components/EducationTabs";
+
+export async function loader({ request, params }: Route.LoaderArgs) {
+  const gate = await requireEducationManager(request, params.id);
+  if (!gate.ok) return gate.response;
+  const offering = await prisma.educationOffering.findUnique({
+    where: { id: params.id },
+    select: { id: true, title: true },
+  });
+  if (!offering) return new Response("Not found", { status: 404 });
+  const announcements = await prisma.educationAnnouncement.findMany({
+    where: { offeringId: params.id },
+    orderBy: { sentAt: "desc" },
+    include: { author: { select: { firstName: true, lastName: true } } },
+  });
+  return { offering, announcements };
+}
+
+export async function action({ request, params }: Route.ActionArgs) {
+  const gate = await requireEducationManager(request, params.id);
+  if (!gate.ok) return gate.response;
+  const fd = await request.formData();
+  const body = String(fd.get("body") || "").trim();
+  if (!body) return { error: "body required" };
+
+  const [offering, author, recipients] = await Promise.all([
+    prisma.educationOffering.findUnique({
+      where: { id: params.id! },
+      select: { title: true },
+    }),
+    prisma.user.findUnique({
+      where: { id: gate.userId },
+      select: { firstName: true, lastName: true },
+    }),
+    prisma.educationApplication.findMany({
+      where: { offeringId: params.id!, status: "Approved" },
+      include: {
+        applicant: {
+          select: { firstName: true, daliEmail: true, dartmouthEmail: true },
+        },
+      },
+    }),
+  ]);
+  const announcement = await prisma.educationAnnouncement.create({
+    data: { offeringId: params.id!, authorId: gate.userId, body },
+  });
+  const authorName =
+    [author?.firstName, author?.lastName].filter(Boolean).join(" ") || "Instructor";
+  await emitEvent({
+    type: "education.announcement_posted",
+    recipients: recipients.map((r) => r.applicantUserId),
+    payload: { offeringId: params.id, announcementId: announcement.id },
+    inbox: {
+      kind: "EducationAnnouncementPosted",
+      title: `[${offering?.title ?? ""}] ${authorName}`,
+      body: body.slice(0, 280),
+      link: `/portal/education/${params.id}`,
+      createdByUserId: gate.userId,
+    },
+  });
+  for (const r of recipients) {
+    const email = r.applicant.daliEmail ?? r.applicant.dartmouthEmail;
+    if (!email) continue;
+    await sendAnnouncementEmail({
+      to: { email, firstName: r.applicant.firstName },
+      offeringTitle: offering?.title ?? "",
+      authorName,
+      body,
+    });
+  }
+  return null;
+}
+
+export default function Announcements() {
+  const { offering, announcements } = useLoaderData<typeof loader>();
+  const nav = useNavigation();
+  return (
+    <div className="max-w-3xl mx-auto p-6">
+      <EducationTabs offeringId={offering.id} offeringTitle={offering.title} />
+      <Form method="post" className="bg-card border border-border rounded-md p-3 mb-4">
+        <label className="block">
+          <span className="text-xs font-medium text-muted-foreground">
+            Send to approved enrollees
+          </span>
+          <textarea
+            name="body"
+            required
+            rows={3}
+            className="mt-1 block w-full border border-border rounded-md px-2 py-1 text-sm"
+            placeholder="What do you want to say?"
+          />
+        </label>
+        <button
+          type="submit"
+          disabled={nav.state !== "idle"}
+          className="mt-2 px-3 py-1.5 bg-accent-coral text-white text-sm font-medium rounded-md"
+        >
+          Send announcement
+        </button>
+      </Form>
+      <ul className="space-y-3">
+        {announcements.map((a) => (
+          <li key={a.id} className="bg-card border border-border rounded-md p-3">
+            <p className="text-xs text-muted-foreground mb-1">
+              {a.author.firstName} {a.author.lastName} ·{" "}
+              {new Date(a.sentAt).toLocaleString()}
+            </p>
+            <p className="text-sm whitespace-pre-wrap">{a.body}</p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/dali-api/app/education/routes/education.offerings.$id.assignments.$assignmentId.tsx
+++ b/dali-api/app/education/routes/education.offerings.$id.assignments.$assignmentId.tsx
@@ -1,0 +1,97 @@
+import { useLoaderData, Form, useNavigation } from "react-router";
+import type { Route } from "./+types/education.offerings.$id.assignments.$assignmentId";
+import { prisma } from "~/lib/db";
+import { requireEducationManager } from "~/education/lib/access";
+import { EducationTabs } from "~/education/components/EducationTabs";
+
+export async function loader({ request, params }: Route.LoaderArgs) {
+  const gate = await requireEducationManager(request, params.id);
+  if (!gate.ok) return gate.response;
+  const offering = await prisma.educationOffering.findUnique({
+    where: { id: params.id },
+    select: { id: true, title: true },
+  });
+  const assignment = await prisma.educationAssignment.findUnique({
+    where: { id: params.assignmentId },
+    include: {
+      submissions: {
+        include: {
+          student: { select: { firstName: true, lastName: true } },
+        },
+        orderBy: { submittedAt: "desc" },
+      },
+    },
+  });
+  if (!offering || !assignment) {
+    return new Response("Not found", { status: 404 });
+  }
+  return { offering, assignment };
+}
+
+export async function action({ request, params }: Route.ActionArgs) {
+  const gate = await requireEducationManager(request, params.id);
+  if (!gate.ok) return gate.response;
+  const fd = await request.formData();
+  const submissionId = String(fd.get("submissionId"));
+  await prisma.educationSubmission.update({
+    where: { id: submissionId },
+    data: { gradedAt: new Date() },
+  });
+  return null;
+}
+
+export default function AssignmentDetail() {
+  const { offering, assignment } = useLoaderData<typeof loader>();
+  const nav = useNavigation();
+  return (
+    <div className="max-w-5xl mx-auto p-6">
+      <EducationTabs offeringId={offering.id} offeringTitle={offering.title} />
+      <h2 className="font-heading font-bold text-xl text-dark-blue mb-1">
+        {assignment.title}
+      </h2>
+      <p className="text-sm text-muted-foreground mb-4">
+        {assignment.submissionType} ·{" "}
+        {assignment.dueAt
+          ? `due ${new Date(assignment.dueAt).toLocaleString()}`
+          : "no due date"}
+      </p>
+      <h3 className="font-heading text-sm font-bold text-muted-foreground uppercase tracking-wide mb-2">
+        Submissions ({assignment.submissions.length})
+      </h3>
+      <ul className="space-y-2">
+        {assignment.submissions.map((s) => (
+          <li
+            key={s.id}
+            className="bg-card border border-border rounded-md p-3 flex items-center justify-between text-sm"
+          >
+            <div>
+              <p className="font-semibold text-dark-blue">
+                {s.student.firstName} {s.student.lastName}
+              </p>
+              <p className="text-xs text-muted-foreground">
+                {s.submittedAt
+                  ? `submitted ${new Date(s.submittedAt).toLocaleString()}`
+                  : "in progress"}
+                {s.gradedAt
+                  ? ` · graded ${new Date(s.gradedAt).toLocaleDateString()}`
+                  : ""}
+              </p>
+            </div>
+            {s.submittedAt && !s.gradedAt && (
+              <Form method="post">
+                <input type="hidden" name="submissionId" value={s.id} />
+                <button
+                  type="submit"
+                  disabled={nav.state !== "idle"}
+                  className="px-2 py-1 bg-accent-coral text-white text-xs font-medium rounded"
+                >
+                  Mark graded
+                </button>
+              </Form>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/dali-api/app/education/routes/education.offerings.$id.assignments.tsx
+++ b/dali-api/app/education/routes/education.offerings.$id.assignments.tsx
@@ -1,0 +1,123 @@
+import { useLoaderData, Form, Link, useNavigation } from "react-router";
+import type { Route } from "./+types/education.offerings.$id.assignments";
+import { prisma } from "~/lib/db";
+import { requireEducationManager } from "~/education/lib/access";
+import { EducationTabs } from "~/education/components/EducationTabs";
+
+export async function loader({ request, params }: Route.LoaderArgs) {
+  const gate = await requireEducationManager(request, params.id);
+  if (!gate.ok) return gate.response;
+  const offering = await prisma.educationOffering.findUnique({
+    where: { id: params.id },
+    select: { id: true, title: true },
+  });
+  if (!offering) return new Response("Not found", { status: 404 });
+  const assignments = await prisma.educationAssignment.findMany({
+    where: {
+      OR: [
+        { offeringId: params.id },
+        { session: { offeringId: params.id } },
+      ],
+    },
+    include: {
+      session: { select: { sequence: true } },
+      _count: { select: { submissions: true } },
+    },
+    orderBy: { dueAt: "asc" },
+  });
+  return { offering, assignments };
+}
+
+export async function action({ request, params }: Route.ActionArgs) {
+  const gate = await requireEducationManager(request, params.id);
+  if (!gate.ok) return gate.response;
+  const fd = await request.formData();
+  const title = String(fd.get("title") || "").trim();
+  const submissionType = String(fd.get("submissionType") || "Text") as
+    | "Text"
+    | "File"
+    | "Mixed";
+  const dueAt = String(fd.get("dueAt") || "");
+  if (!title) return { error: "title required" };
+  await prisma.educationAssignment.create({
+    data: {
+      offeringId: params.id!,
+      title,
+      submissionType,
+      dueAt: dueAt ? new Date(dueAt) : null,
+    },
+  });
+  return null;
+}
+
+export default function Assignments() {
+  const { offering, assignments } = useLoaderData<typeof loader>();
+  const nav = useNavigation();
+  return (
+    <div className="max-w-5xl mx-auto p-6">
+      <EducationTabs offeringId={offering.id} offeringTitle={offering.title} />
+      <Form method="post" className="bg-card border border-border rounded-md p-3 mb-4 flex items-end gap-2">
+        <label className="block flex-1">
+          <span className="text-xs font-medium text-muted-foreground">Title</span>
+          <input
+            name="title"
+            required
+            className="block w-full border border-border rounded-md px-2 py-1 text-sm"
+          />
+        </label>
+        <label className="block">
+          <span className="text-xs font-medium text-muted-foreground">Type</span>
+          <select
+            name="submissionType"
+            className="block border border-border rounded-md px-2 py-1 text-sm bg-white"
+          >
+            <option>Text</option>
+            <option>File</option>
+            <option>Mixed</option>
+          </select>
+        </label>
+        <label className="block">
+          <span className="text-xs font-medium text-muted-foreground">Due</span>
+          <input
+            type="datetime-local"
+            name="dueAt"
+            className="block border border-border rounded-md px-2 py-1 text-sm"
+          />
+        </label>
+        <button
+          type="submit"
+          disabled={nav.state !== "idle"}
+          className="px-3 py-1.5 bg-accent-coral text-white text-sm font-medium rounded-md"
+        >
+          Add
+        </button>
+      </Form>
+      <ul className="space-y-2">
+        {assignments.map((a) => (
+          <li
+            key={a.id}
+            className="bg-card border border-border rounded-md p-3 flex items-center justify-between text-sm"
+          >
+            <div>
+              <Link
+                to={`/education/offerings/${offering.id}/assignments/${a.id}`}
+                className="font-semibold text-dark-blue hover:underline"
+              >
+                {a.title}
+              </Link>
+              <p className="text-xs text-muted-foreground">
+                {a.submissionType}
+                {a.dueAt
+                  ? ` · due ${new Date(a.dueAt).toLocaleDateString()}`
+                  : ""}
+                {a.session ? ` · session #${a.session.sequence}` : ""}
+                {" · "}
+                {a._count.submissions} submissions
+              </p>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/dali-api/app/education/routes/education.offerings.$id.attendance.tsx
+++ b/dali-api/app/education/routes/education.offerings.$id.attendance.tsx
@@ -1,0 +1,126 @@
+import { useLoaderData, Form, useNavigation } from "react-router";
+import type { Route } from "./+types/education.offerings.$id.attendance";
+import { prisma } from "~/lib/db";
+import { requireEducationManager } from "~/education/lib/access";
+import { EducationTabs } from "~/education/components/EducationTabs";
+
+export async function loader({ request, params }: Route.LoaderArgs) {
+  const gate = await requireEducationManager(request, params.id);
+  if (!gate.ok) return gate.response;
+  const offering = await prisma.educationOffering.findUnique({
+    where: { id: params.id },
+    select: { id: true, title: true },
+  });
+  if (!offering) return new Response("Not found", { status: 404 });
+  const [sessions, applications] = await Promise.all([
+    prisma.educationSession.findMany({
+      where: { offeringId: params.id },
+      orderBy: { sequence: "asc" },
+      include: {
+        attendances: { select: { applicationId: true, status: true } },
+      },
+    }),
+    prisma.educationApplication.findMany({
+      where: { offeringId: params.id, status: "Approved" },
+      orderBy: { submittedAt: "asc" },
+      include: { applicant: { select: { firstName: true, lastName: true } } },
+    }),
+  ]);
+  return { offering, sessions, applications };
+}
+
+export async function action({ request, params }: Route.ActionArgs) {
+  const gate = await requireEducationManager(request, params.id);
+  if (!gate.ok) return gate.response;
+  const fd = await request.formData();
+  const sessionId = String(fd.get("sessionId"));
+  const entries = Array.from(fd.entries())
+    .filter(([k]) => k.startsWith("status:"))
+    .map(([k, v]) => ({
+      applicationId: k.slice("status:".length),
+      status: String(v) as "Present" | "Absent" | "Excused",
+    }));
+  await prisma.$transaction(
+    entries.map((e) =>
+      prisma.educationAttendance.upsert({
+        where: {
+          applicationId_sessionId: {
+            applicationId: e.applicationId,
+            sessionId,
+          },
+        },
+        create: {
+          applicationId: e.applicationId,
+          sessionId,
+          status: e.status,
+        },
+        update: { status: e.status },
+      }),
+    ),
+  );
+  return null;
+}
+
+export default function Attendance() {
+  const { offering, sessions, applications } = useLoaderData<typeof loader>();
+  const nav = useNavigation();
+  return (
+    <div className="max-w-5xl mx-auto p-6">
+      <EducationTabs offeringId={offering.id} offeringTitle={offering.title} />
+      {sessions.length === 0 ? (
+        <p className="text-sm text-muted-foreground">Create a session first.</p>
+      ) : (
+        sessions.map((s) => {
+          const existing = new Map(
+            s.attendances.map((a) => [a.applicationId, a.status]),
+          );
+          return (
+            <Form
+              method="post"
+              key={s.id}
+              className="bg-card border border-border rounded-md p-3 mb-4"
+            >
+              <input type="hidden" name="sessionId" value={s.id} />
+              <h3 className="font-heading font-semibold text-sm text-dark-blue mb-2">
+                #{s.sequence} · {new Date(s.datetime).toLocaleString()}
+              </h3>
+              <table className="w-full text-sm">
+                <tbody>
+                  {applications.map((a) => {
+                    const cur = existing.get(a.id) ?? "";
+                    return (
+                      <tr key={a.id} className="border-t border-border">
+                        <td className="py-1">
+                          {a.applicant.firstName} {a.applicant.lastName}
+                        </td>
+                        <td className="py-1 text-right">
+                          <select
+                            name={`status:${a.id}`}
+                            defaultValue={cur}
+                            className="border border-border rounded px-2 py-0.5 text-xs bg-white"
+                          >
+                            <option value="">—</option>
+                            <option value="Present">Present</option>
+                            <option value="Absent">Absent</option>
+                            <option value="Excused">Excused</option>
+                          </select>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+              <button
+                type="submit"
+                disabled={nav.state !== "idle"}
+                className="mt-2 px-3 py-1.5 bg-accent-coral text-white text-xs font-medium rounded-md"
+              >
+                Save attendance
+              </button>
+            </Form>
+          );
+        })
+      )}
+    </div>
+  );
+}

--- a/dali-api/app/education/routes/education.offerings.$id.pages.tsx
+++ b/dali-api/app/education/routes/education.offerings.$id.pages.tsx
@@ -1,0 +1,66 @@
+import { useLoaderData } from "react-router";
+import type { Route } from "./+types/education.offerings.$id.pages";
+import { prisma } from "~/lib/db";
+import { requireEducationManager } from "~/education/lib/access";
+import { EducationTabs } from "~/education/components/EducationTabs";
+
+export async function loader({ request, params }: Route.LoaderArgs) {
+  const gate = await requireEducationManager(request, params.id);
+  if (!gate.ok) return gate.response;
+  const offering = await prisma.educationOffering.findUnique({
+    where: { id: params.id },
+    select: { id: true, title: true },
+  });
+  if (!offering) return new Response("Not found", { status: 404 });
+  const pages = await prisma.page.findMany({
+    where: {
+      workspaceType: "EducationOffering",
+      workspaceId: params.id,
+      archivedAt: null,
+      parentPageId: null,
+    },
+    orderBy: [{ position: "asc" }, { createdAt: "asc" }],
+    include: {
+      children: {
+        where: { archivedAt: null },
+        orderBy: [{ position: "asc" }, { createdAt: "asc" }],
+      },
+    },
+  });
+  return { offering, pages };
+}
+
+export default function PagesTab() {
+  const { offering, pages } = useLoaderData<typeof loader>();
+  return (
+    <div className="max-w-3xl mx-auto p-6">
+      <EducationTabs offeringId={offering.id} offeringTitle={offering.title} />
+      <div className="bg-card border border-border rounded-md p-4">
+        <p className="text-sm text-muted-foreground mb-3">
+          Pages scoped to this offering's workspace. The page editor itself is
+          part of a separate track — this list links into it once it ships.
+        </p>
+        {pages.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No pages yet.</p>
+        ) : (
+          <ul className="space-y-1 text-sm">
+            {pages.map((p) => (
+              <li key={p.id}>
+                <span>{p.iconEmoji ?? "📄"} {p.title}</span>
+                {p.children.length > 0 && (
+                  <ul className="ml-6 mt-1 space-y-1">
+                    {p.children.map((c) => (
+                      <li key={c.id}>
+                        {c.iconEmoji ?? "📄"} {c.title}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/dali-api/app/education/routes/education.offerings.$id.roster.tsx
+++ b/dali-api/app/education/routes/education.offerings.$id.roster.tsx
@@ -1,0 +1,142 @@
+import { useLoaderData, Form, useNavigation } from "react-router";
+import type { Route } from "./+types/education.offerings.$id.roster";
+import { prisma } from "~/lib/db";
+import { requireEducationManager } from "~/education/lib/access";
+import { decide, type DecisionAction } from "~/lib/education/decisions";
+import { EducationTabs } from "~/education/components/EducationTabs";
+
+export async function loader({ request, params }: Route.LoaderArgs) {
+  const gate = await requireEducationManager(request, params.id);
+  if (!gate.ok) return gate.response;
+  const offering = await prisma.educationOffering.findUnique({
+    where: { id: params.id },
+    select: { id: true, title: true, capacity: true },
+  });
+  if (!offering) return new Response("Not found", { status: 404 });
+  const applications = await prisma.educationApplication.findMany({
+    where: { offeringId: params.id },
+    orderBy: [{ status: "asc" }, { submittedAt: "asc" }],
+    include: {
+      applicant: { select: { firstName: true, lastName: true, dartmouthEmail: true } },
+      answers: { include: { question: true } },
+    },
+  });
+  return { offering, applications };
+}
+
+export async function action({ request, params }: Route.ActionArgs) {
+  const gate = await requireEducationManager(request, params.id);
+  if (!gate.ok) return gate.response;
+  const fd = await request.formData();
+  const applicationId = String(fd.get("applicationId"));
+  const action = String(fd.get("action")) as DecisionAction;
+  const reviewerNote = String(fd.get("reviewerNote") || "") || null;
+  if (!["Approve", "Reject", "Waitlist"].includes(action)) {
+    return { error: "Invalid action" };
+  }
+  await decide({
+    applicationId,
+    action,
+    actorUserId: gate.userId,
+    reviewerNote,
+  });
+  return null;
+}
+
+const STATUS_ORDER = ["Submitted", "Approved", "Waitlisted", "Rejected", "Withdrawn"];
+
+export default function Roster() {
+  const { offering, applications } = useLoaderData<typeof loader>();
+  const nav = useNavigation();
+  const byStatus = STATUS_ORDER.map((s) => ({
+    status: s,
+    rows: applications.filter((a) => a.status === s),
+  }));
+  return (
+    <div className="max-w-5xl mx-auto p-6">
+      <EducationTabs offeringId={offering.id} offeringTitle={offering.title} />
+      {byStatus.map(({ status, rows }) => (
+        <section key={status} className="mb-6">
+          <h2 className="font-heading text-sm font-bold text-muted-foreground uppercase tracking-wide mb-2">
+            {status} ({rows.length})
+          </h2>
+          {rows.length === 0 ? (
+            <p className="text-sm text-muted-foreground">—</p>
+          ) : (
+            <ul className="space-y-2">
+              {rows.map((a) => (
+                <li
+                  key={a.id}
+                  className="bg-card border border-border rounded-md p-3"
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <p className="text-sm font-semibold text-dark-blue">
+                        {a.applicant.firstName} {a.applicant.lastName}
+                      </p>
+                      <p className="text-xs text-muted-foreground">
+                        {a.applicant.dartmouthEmail ?? "—"} · submitted{" "}
+                        {new Date(a.submittedAt).toLocaleDateString()}
+                      </p>
+                    </div>
+                    {(a.status === "Submitted" || a.status === "Waitlisted") && (
+                      <Form method="post" className="flex gap-1.5">
+                        <input type="hidden" name="applicationId" value={a.id} />
+                        <button
+                          type="submit"
+                          name="action"
+                          value="Approve"
+                          disabled={nav.state !== "idle"}
+                          className="px-2 py-1 bg-green-50 text-green-700 text-xs font-medium rounded"
+                        >
+                          Approve
+                        </button>
+                        {a.status === "Submitted" && (
+                          <button
+                            type="submit"
+                            name="action"
+                            value="Waitlist"
+                            disabled={nav.state !== "idle"}
+                            className="px-2 py-1 bg-amber-50 text-amber-700 text-xs font-medium rounded"
+                          >
+                            Waitlist
+                          </button>
+                        )}
+                        <button
+                          type="submit"
+                          name="action"
+                          value="Reject"
+                          disabled={nav.state !== "idle"}
+                          className="px-2 py-1 bg-red-50 text-red-700 text-xs font-medium rounded"
+                        >
+                          Reject
+                        </button>
+                      </Form>
+                    )}
+                  </div>
+                  {a.answers.length > 0 && (
+                    <details className="mt-2 text-xs">
+                      <summary className="cursor-pointer text-muted-foreground">
+                        View answers
+                      </summary>
+                      <dl className="mt-1 space-y-2">
+                        {a.answers.map((ans) => (
+                          <div key={ans.id}>
+                            <dt className="font-medium text-dark-blue">
+                              {ans.question.prompt}
+                            </dt>
+                            <dd className="whitespace-pre-wrap">{ans.content}</dd>
+                          </div>
+                        ))}
+                      </dl>
+                    </details>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/dali-api/app/education/routes/education.offerings.$id.sessions.tsx
+++ b/dali-api/app/education/routes/education.offerings.$id.sessions.tsx
@@ -1,0 +1,108 @@
+import { useLoaderData, Form, useNavigation } from "react-router";
+import type { Route } from "./+types/education.offerings.$id.sessions";
+import { prisma } from "~/lib/db";
+import { requireEducationManager } from "~/education/lib/access";
+import { syncSessionRoster } from "~/lib/education/roster-sync";
+import { EducationTabs } from "~/education/components/EducationTabs";
+
+export async function loader({ request, params }: Route.LoaderArgs) {
+  const gate = await requireEducationManager(request, params.id);
+  if (!gate.ok) return gate.response;
+  const offering = await prisma.educationOffering.findUnique({
+    where: { id: params.id },
+    select: { id: true, title: true },
+  });
+  if (!offering) return new Response("Not found", { status: 404 });
+  const sessions = await prisma.educationSession.findMany({
+    where: { offeringId: params.id },
+    orderBy: { sequence: "asc" },
+  });
+  return { offering, sessions };
+}
+
+export async function action({ request, params }: Route.ActionArgs) {
+  const gate = await requireEducationManager(request, params.id);
+  if (!gate.ok) return gate.response;
+  const fd = await request.formData();
+  const intent = String(fd.get("intent") || "create");
+  if (intent === "delete") {
+    await prisma.educationSession.delete({
+      where: { id: String(fd.get("sessionId")) },
+    });
+    return null;
+  }
+  const datetime = String(fd.get("datetime") || "");
+  const location = String(fd.get("location") || "") || null;
+  if (!datetime) return { error: "datetime required" };
+  const max = await prisma.educationSession.aggregate({
+    where: { offeringId: params.id! },
+    _max: { sequence: true },
+  });
+  await prisma.educationSession.create({
+    data: {
+      offeringId: params.id!,
+      sequence: (max._max.sequence ?? 0) + 1,
+      datetime: new Date(datetime),
+      location,
+    },
+  });
+  syncSessionRoster(params.id!).catch(() => {});
+  return null;
+}
+
+export default function Sessions() {
+  const { offering, sessions } = useLoaderData<typeof loader>();
+  const nav = useNavigation();
+  return (
+    <div className="max-w-5xl mx-auto p-6">
+      <EducationTabs offeringId={offering.id} offeringTitle={offering.title} />
+      <Form method="post" className="flex items-end gap-3 bg-card border border-border rounded-md p-3 mb-4">
+        <label className="block">
+          <span className="text-xs font-medium text-muted-foreground">When</span>
+          <input
+            type="datetime-local"
+            name="datetime"
+            required
+            className="block border border-border rounded-md px-2 py-1 text-sm"
+          />
+        </label>
+        <label className="block">
+          <span className="text-xs font-medium text-muted-foreground">Location</span>
+          <input
+            name="location"
+            placeholder="DALI Lab — Pod Appa"
+            className="block border border-border rounded-md px-2 py-1 text-sm"
+          />
+        </label>
+        <button
+          type="submit"
+          disabled={nav.state !== "idle"}
+          className="px-3 py-1.5 bg-accent-coral text-white text-sm font-medium rounded-md"
+        >
+          Add session
+        </button>
+      </Form>
+      <ul className="space-y-2">
+        {sessions.map((s) => (
+          <li key={s.id} className="bg-card border border-border rounded-md p-3 flex items-center justify-between text-sm">
+            <span>
+              <span className="font-semibold">#{s.sequence}</span> ·{" "}
+              {new Date(s.datetime).toLocaleString()} ·{" "}
+              <span className="text-muted-foreground">{s.location ?? "—"}</span>
+            </span>
+            <Form method="post">
+              <input type="hidden" name="intent" value="delete" />
+              <input type="hidden" name="sessionId" value={s.id} />
+              <button
+                type="submit"
+                className="text-xs text-red-600 hover:underline"
+              >
+                Delete
+              </button>
+            </Form>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/dali-api/app/education/routes/education.offerings.$id.settings.tsx
+++ b/dali-api/app/education/routes/education.offerings.$id.settings.tsx
@@ -1,0 +1,230 @@
+import { useLoaderData, Form, useNavigation } from "react-router";
+import type { Route } from "./+types/education.offerings.$id.settings";
+import { prisma } from "~/lib/db";
+import { requireEducationManager } from "~/education/lib/access";
+import { EducationTabs } from "~/education/components/EducationTabs";
+
+export async function loader({ request, params }: Route.LoaderArgs) {
+  const gate = await requireEducationManager(request, params.id);
+  if (!gate.ok) return gate.response;
+  const offering = await prisma.educationOffering.findUnique({
+    where: { id: params.id },
+    include: {
+      applicationQuestions: { orderBy: { position: "asc" } },
+      instructors: {
+        include: {
+          user: { select: { firstName: true, lastName: true, daliEmail: true } },
+        },
+      },
+    },
+  });
+  if (!offering) return new Response("Not found", { status: 404 });
+  return { offering };
+}
+
+export async function action({ request, params }: Route.ActionArgs) {
+  const gate = await requireEducationManager(request, params.id);
+  if (!gate.ok) return gate.response;
+  const fd = await request.formData();
+  const intent = String(fd.get("intent") || "save");
+
+  if (intent === "publish") {
+    await prisma.educationOffering.update({
+      where: { id: params.id },
+      data: { status: "Published" },
+    });
+    return null;
+  }
+  if (intent === "archive") {
+    await prisma.educationOffering.update({
+      where: { id: params.id },
+      data: { status: "Archived" },
+    });
+    return null;
+  }
+  if (intent === "addQuestion") {
+    const prompt = String(fd.get("prompt") || "").trim();
+    if (!prompt) return { error: "prompt required" };
+    const max = await prisma.educationApplicationQuestion.aggregate({
+      where: { offeringId: params.id! },
+      _max: { position: true },
+    });
+    await prisma.educationApplicationQuestion.create({
+      data: {
+        offeringId: params.id!,
+        prompt,
+        position: (max._max.position ?? -1) + 1,
+        required: fd.get("required") === "on",
+      },
+    });
+    return null;
+  }
+  if (intent === "removeQuestion") {
+    await prisma.educationApplicationQuestion.delete({
+      where: { id: String(fd.get("questionId")) },
+    });
+    return null;
+  }
+
+  // Default: save metadata.
+  await prisma.educationOffering.update({
+    where: { id: params.id },
+    data: {
+      title: String(fd.get("title") || ""),
+      capacity: Number(fd.get("capacity") || 0),
+      requiresReview: fd.get("requiresReview") === "on",
+      calendarEmail: String(fd.get("calendarEmail") || "") || null,
+    },
+  });
+  return null;
+}
+
+export default function Settings() {
+  const { offering } = useLoaderData<typeof loader>();
+  const nav = useNavigation();
+  return (
+    <div className="max-w-3xl mx-auto p-6">
+      <EducationTabs offeringId={offering.id} offeringTitle={offering.title} />
+
+      <Form method="post" className="bg-card border border-border rounded-md p-4 mb-4 space-y-3">
+        <label className="block">
+          <span className="text-xs font-medium text-muted-foreground">Title</span>
+          <input
+            name="title"
+            defaultValue={offering.title}
+            className="mt-1 block w-full border border-border rounded-md px-2 py-1 text-sm"
+          />
+        </label>
+        <div className="grid grid-cols-2 gap-3">
+          <label className="block">
+            <span className="text-xs font-medium text-muted-foreground">Capacity</span>
+            <input
+              type="number"
+              name="capacity"
+              defaultValue={offering.capacity}
+              min={1}
+              className="mt-1 block w-full border border-border rounded-md px-2 py-1 text-sm"
+            />
+          </label>
+          <label className="block">
+            <span className="text-xs font-medium text-muted-foreground">
+              Calendar email
+            </span>
+            <input
+              name="calendarEmail"
+              defaultValue={offering.calendarEmail ?? ""}
+              className="mt-1 block w-full border border-border rounded-md px-2 py-1 text-sm"
+            />
+          </label>
+        </div>
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            name="requiresReview"
+            defaultChecked={offering.requiresReview}
+          />
+          <span>Instructor review required</span>
+        </label>
+        <button
+          type="submit"
+          name="intent"
+          value="save"
+          disabled={nav.state !== "idle"}
+          className="px-3 py-1.5 bg-accent-coral text-white text-sm font-medium rounded-md"
+        >
+          Save metadata
+        </button>
+      </Form>
+
+      <div className="flex gap-2 mb-6">
+        <Form method="post">
+          <button
+            type="submit"
+            name="intent"
+            value="publish"
+            disabled={offering.status === "Published"}
+            className="px-3 py-1.5 bg-green-600 text-white text-sm font-medium rounded-md disabled:opacity-50"
+          >
+            Publish
+          </button>
+        </Form>
+        <Form method="post">
+          <button
+            type="submit"
+            name="intent"
+            value="archive"
+            disabled={offering.status === "Archived"}
+            className="px-3 py-1.5 bg-gray-300 text-dark-blue text-sm font-medium rounded-md disabled:opacity-50"
+          >
+            Archive
+          </button>
+        </Form>
+      </div>
+
+      <h2 className="font-heading font-bold text-sm text-muted-foreground uppercase tracking-wide mb-2">
+        Application questions
+      </h2>
+      <ul className="space-y-1 mb-3 text-sm">
+        {offering.applicationQuestions.map((q) => (
+          <li
+            key={q.id}
+            className="bg-card border border-border rounded-md p-2 flex items-center justify-between"
+          >
+            <span>
+              {q.prompt}{" "}
+              {q.required ? (
+                <span className="text-xs text-muted-foreground">(required)</span>
+              ) : null}
+            </span>
+            <Form method="post">
+              <input type="hidden" name="intent" value="removeQuestion" />
+              <input type="hidden" name="questionId" value={q.id} />
+              <button
+                type="submit"
+                className="text-xs text-red-600 hover:underline"
+              >
+                Delete
+              </button>
+            </Form>
+          </li>
+        ))}
+      </ul>
+      <Form method="post" className="flex items-end gap-2">
+        <input type="hidden" name="intent" value="addQuestion" />
+        <label className="block flex-1">
+          <span className="text-xs font-medium text-muted-foreground">Add question</span>
+          <input
+            name="prompt"
+            required
+            className="mt-1 block w-full border border-border rounded-md px-2 py-1 text-sm"
+          />
+        </label>
+        <label className="flex items-center gap-1 text-sm">
+          <input type="checkbox" name="required" defaultChecked />
+          Required
+        </label>
+        <button
+          type="submit"
+          disabled={nav.state !== "idle"}
+          className="px-3 py-1.5 bg-accent-coral text-white text-sm font-medium rounded-md"
+        >
+          Add
+        </button>
+      </Form>
+
+      <h2 className="font-heading font-bold text-sm text-muted-foreground uppercase tracking-wide mt-6 mb-2">
+        Instructors
+      </h2>
+      <ul className="text-sm space-y-1">
+        {offering.instructors.map((i) => (
+          <li key={i.id}>
+            {i.user.firstName} {i.user.lastName}{" "}
+            <span className="text-muted-foreground text-xs">
+              · {i.user.daliEmail ?? ""}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/dali-api/app/education/routes/education.offerings.$id.tsx
+++ b/dali-api/app/education/routes/education.offerings.$id.tsx
@@ -1,0 +1,76 @@
+import { useLoaderData } from "react-router";
+import type { Route } from "./+types/education.offerings.$id";
+import { prisma } from "~/lib/db";
+import { requireAuth } from "~/lib/auth";
+import { EducationTabs } from "~/education/components/EducationTabs";
+
+export async function loader({ request, params }: Route.LoaderArgs) {
+  const auth = await requireAuth(request);
+  if (!auth.ok) return auth.response;
+  const offering = await prisma.educationOffering.findUnique({
+    where: { id: params.id },
+    include: {
+      instructors: {
+        include: { user: { select: { firstName: true, lastName: true } } },
+      },
+      sessions: { orderBy: { sequence: "asc" } },
+      _count: { select: { applications: true } },
+    },
+  });
+  if (!offering) {
+    return new Response("Not found", { status: 404 });
+  }
+  return { offering };
+}
+
+export default function OfferingOverview() {
+  const { offering } = useLoaderData<typeof loader>();
+  return (
+    <div className="max-w-5xl mx-auto p-6">
+      <EducationTabs offeringId={offering.id} offeringTitle={offering.title} />
+      <dl className="grid grid-cols-2 gap-4 text-sm mb-6">
+        <div>
+          <dt className="text-xs uppercase tracking-wide text-muted-foreground">Type</dt>
+          <dd>{offering.type}</dd>
+        </div>
+        <div>
+          <dt className="text-xs uppercase tracking-wide text-muted-foreground">Status</dt>
+          <dd>{offering.status}</dd>
+        </div>
+        <div>
+          <dt className="text-xs uppercase tracking-wide text-muted-foreground">Capacity</dt>
+          <dd>{offering._count.applications}/{offering.capacity} (incl. waitlist)</dd>
+        </div>
+        <div>
+          <dt className="text-xs uppercase tracking-wide text-muted-foreground">Instructors</dt>
+          <dd>
+            {offering.instructors
+              .map((i) => `${i.user.firstName} ${i.user.lastName}`.trim())
+              .filter(Boolean)
+              .join(", ") || "—"}
+          </dd>
+        </div>
+      </dl>
+      <section className="bg-card border border-border rounded-md p-4">
+        <h2 className="font-heading font-semibold text-base text-dark-blue mb-3">
+          Sessions
+        </h2>
+        {offering.sessions.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No sessions scheduled yet.</p>
+        ) : (
+          <ul className="space-y-1.5 text-sm">
+            {offering.sessions.map((s) => (
+              <li key={s.id} className="flex justify-between">
+                <span>
+                  #{s.sequence} ·{" "}
+                  {new Date(s.datetime).toLocaleString()}
+                </span>
+                <span className="text-muted-foreground">{s.location ?? "—"}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/dali-api/app/education/routes/education.offerings.new.tsx
+++ b/dali-api/app/education/routes/education.offerings.new.tsx
@@ -1,0 +1,154 @@
+import { Form, redirect, useActionData } from "react-router";
+import type { Route } from "./+types/education.offerings.new";
+import { requireAuth } from "~/lib/auth";
+import { isCore, currentTerm } from "~/lib/roles";
+import { prisma } from "~/lib/db";
+
+export async function loader({ request }: Route.LoaderArgs) {
+  const auth = await requireAuth(request);
+  if (!auth.ok) return auth.response;
+  if (!(await isCore(auth.user.sub))) {
+    return new Response("Forbidden", { status: 403 });
+  }
+  return null;
+}
+
+export async function action({ request }: Route.ActionArgs) {
+  const auth = await requireAuth(request);
+  if (!auth.ok) return auth.response;
+  if (!(await isCore(auth.user.sub))) {
+    return new Response("Forbidden", { status: 403 });
+  }
+  const fd = await request.formData();
+  const title = String(fd.get("title") || "").trim();
+  const type = String(fd.get("type") || "Miniseries") as "Miniseries" | "Workshop";
+  const capacity = Number(fd.get("capacity") || 20);
+  const requiresReview = fd.get("requiresReview") === "on";
+  const registrationOpensAt = String(fd.get("registrationOpensAt") || "");
+  const registrationClosesAt = String(fd.get("registrationClosesAt") || "");
+  const startsAt = String(fd.get("startsAt") || "");
+  const endsAt = String(fd.get("endsAt") || "");
+  if (!title || !registrationOpensAt || !registrationClosesAt || !startsAt || !endsAt) {
+    return { error: "All fields required" };
+  }
+  const offering = await prisma.educationOffering.create({
+    data: {
+      title,
+      type,
+      capacity,
+      requiresReview,
+      registrationOpensAt: new Date(registrationOpensAt),
+      registrationClosesAt: new Date(registrationClosesAt),
+      startsAt: new Date(startsAt),
+      endsAt: new Date(endsAt),
+      status: "Draft",
+    },
+  });
+  const term = await currentTerm();
+  if (term) {
+    await prisma.instructorAssignment.create({
+      data: {
+        userId: auth.user.sub,
+        offeringId: offering.id,
+        termId: term.id,
+      },
+    });
+  }
+  return redirect(`/education/offerings/${offering.id}/settings`);
+}
+
+export default function NewOffering() {
+  const data = useActionData<typeof action>();
+  return (
+    <div className="max-w-2xl mx-auto p-6">
+      <h1 className="font-heading text-2xl font-bold text-dark-blue mb-6">
+        New Offering
+      </h1>
+      <Form method="post" className="space-y-4">
+        <label className="block">
+          <span className="text-sm font-medium text-dark-blue">Title</span>
+          <input
+            name="title"
+            required
+            className="mt-1 block w-full border border-border rounded-md px-3 py-2 text-sm"
+          />
+        </label>
+        <div className="grid grid-cols-2 gap-4">
+          <label className="block">
+            <span className="text-sm font-medium text-dark-blue">Type</span>
+            <select
+              name="type"
+              className="mt-1 block w-full border border-border rounded-md px-3 py-2 text-sm bg-white"
+            >
+              <option value="Miniseries">Miniseries</option>
+              <option value="Workshop">Workshop</option>
+            </select>
+          </label>
+          <label className="block">
+            <span className="text-sm font-medium text-dark-blue">Capacity</span>
+            <input
+              type="number"
+              name="capacity"
+              min={1}
+              defaultValue={20}
+              className="mt-1 block w-full border border-border rounded-md px-3 py-2 text-sm"
+            />
+          </label>
+        </div>
+        <label className="flex items-center gap-2 text-sm">
+          <input type="checkbox" name="requiresReview" defaultChecked />
+          <span>Requires instructor review (Miniseries default)</span>
+        </label>
+        <div className="grid grid-cols-2 gap-4">
+          <label className="block">
+            <span className="text-sm font-medium text-dark-blue">Registration opens</span>
+            <input
+              type="datetime-local"
+              name="registrationOpensAt"
+              required
+              className="mt-1 block w-full border border-border rounded-md px-3 py-2 text-sm"
+            />
+          </label>
+          <label className="block">
+            <span className="text-sm font-medium text-dark-blue">Registration closes</span>
+            <input
+              type="datetime-local"
+              name="registrationClosesAt"
+              required
+              className="mt-1 block w-full border border-border rounded-md px-3 py-2 text-sm"
+            />
+          </label>
+        </div>
+        <div className="grid grid-cols-2 gap-4">
+          <label className="block">
+            <span className="text-sm font-medium text-dark-blue">Starts</span>
+            <input
+              type="datetime-local"
+              name="startsAt"
+              required
+              className="mt-1 block w-full border border-border rounded-md px-3 py-2 text-sm"
+            />
+          </label>
+          <label className="block">
+            <span className="text-sm font-medium text-dark-blue">Ends</span>
+            <input
+              type="datetime-local"
+              name="endsAt"
+              required
+              className="mt-1 block w-full border border-border rounded-md px-3 py-2 text-sm"
+            />
+          </label>
+        </div>
+        {data?.error && (
+          <p className="text-sm text-red-600">{data.error}</p>
+        )}
+        <button
+          type="submit"
+          className="px-4 py-2 bg-accent-coral text-white text-sm font-medium rounded-md hover:opacity-90"
+        >
+          Create draft
+        </button>
+      </Form>
+    </div>
+  );
+}

--- a/dali-api/app/education/routes/education.teaching.tsx
+++ b/dali-api/app/education/routes/education.teaching.tsx
@@ -1,0 +1,59 @@
+import { useLoaderData, Link } from "react-router";
+import type { Route } from "./+types/education.teaching";
+import { prisma } from "~/lib/db";
+import { requireAuth } from "~/lib/auth";
+
+export async function loader({ request }: Route.LoaderArgs) {
+  const auth = await requireAuth(request);
+  if (!auth.ok) return auth.response;
+
+  const offerings = await prisma.educationOffering.findMany({
+    where: { instructors: { some: { userId: auth.user.sub } } },
+    orderBy: { startsAt: "desc" },
+    include: {
+      _count: {
+        select: { applications: true, sessions: true },
+      },
+    },
+  });
+  return { offerings };
+}
+
+export default function Teaching() {
+  const { offerings } = useLoaderData<typeof loader>();
+  return (
+    <div className="max-w-5xl mx-auto p-6">
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="font-heading text-2xl font-bold text-dark-blue">Teaching</h1>
+      </div>
+      {offerings.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          You aren't assigned as an instructor for any offering. Core can assign
+          you from an offering's Settings tab.
+        </p>
+      ) : (
+        <ul className="space-y-2">
+          {offerings.map((o) => (
+            <li
+              key={o.id}
+              className="bg-card border border-border rounded-md p-4 flex items-center justify-between"
+            >
+              <div>
+                <Link
+                  to={`/education/offerings/${o.id}`}
+                  className="font-heading font-semibold text-dark-blue hover:underline"
+                >
+                  {o.title}
+                </Link>
+                <p className="text-xs text-muted-foreground">
+                  {o.type} · {o.status} · {o._count.applications} applications ·{" "}
+                  {o._count.sessions} sessions
+                </p>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/dali-api/app/education/routes/portal.education.$offeringId.tsx
+++ b/dali-api/app/education/routes/portal.education.$offeringId.tsx
@@ -1,0 +1,153 @@
+import { useLoaderData, Link, Form, useNavigation } from "react-router";
+import type { Route } from "./+types/portal.education.$offeringId";
+import { prisma } from "~/lib/db";
+import { requireAuth } from "~/lib/auth";
+import { apply } from "~/lib/education/apply";
+
+export async function loader({ request, params }: Route.LoaderArgs) {
+  const auth = await requireAuth(request);
+  if (!auth.ok) return auth.response;
+  const [offering, application] = await Promise.all([
+    prisma.educationOffering.findUnique({
+      where: { id: params.offeringId },
+      include: {
+        sessions: { orderBy: { sequence: "asc" } },
+        applicationQuestions: { orderBy: { position: "asc" } },
+        _count: { select: { applications: true } },
+        instructors: {
+          include: {
+            user: { select: { firstName: true, lastName: true } },
+          },
+        },
+      },
+    }),
+    prisma.educationApplication.findUnique({
+      where: {
+        applicantUserId_offeringId: {
+          applicantUserId: auth.user.sub,
+          offeringId: params.offeringId!,
+        },
+      },
+    }),
+  ]);
+  if (!offering || offering.status !== "Published") {
+    return new Response("Not found", { status: 404 });
+  }
+  return { offering, application };
+}
+
+export async function action({ request, params }: Route.ActionArgs) {
+  const auth = await requireAuth(request);
+  if (!auth.ok) return auth.response;
+  const fd = await request.formData();
+  const answers: Record<string, string> = {};
+  for (const [k, v] of fd.entries()) {
+    if (k.startsWith("answer:")) answers[k.slice("answer:".length)] = String(v);
+  }
+  const outcome = await apply({
+    offeringId: params.offeringId!,
+    applicantUserId: auth.user.sub,
+    answers,
+  });
+  if (!outcome.ok) {
+    return { error: outcome.error };
+  }
+  return { result: outcome.result };
+}
+
+export default function PortalOfferingDetail() {
+  const { offering, application } = useLoaderData<typeof loader>();
+  const nav = useNavigation();
+  const closed = new Date() > new Date(offering.registrationClosesAt);
+  return (
+    <div className="max-w-2xl mx-auto px-4 py-8">
+      <p className="text-xs text-muted-foreground mb-1">
+        <Link to="/portal/education" className="hover:underline">
+          ← Back to catalog
+        </Link>
+      </p>
+      <h1 className="font-heading text-2xl font-bold text-dark-blue mb-2">
+        {offering.title}
+      </h1>
+      <p className="text-sm text-muted-foreground mb-4">
+        {offering.type} ·{" "}
+        {offering.instructors
+          .map((i) => `${i.user.firstName} ${i.user.lastName}`.trim())
+          .filter(Boolean)
+          .join(", ") || "TBD"}{" "}
+        · {offering._count.applications}/{offering.capacity} registered
+      </p>
+
+      <section className="bg-card border border-border rounded-md p-4 mb-4">
+        <h2 className="font-heading text-sm font-bold uppercase tracking-wide text-muted-foreground mb-2">
+          Sessions
+        </h2>
+        {offering.sessions.length === 0 ? (
+          <p className="text-sm text-muted-foreground">TBD</p>
+        ) : (
+          <ul className="text-sm space-y-1">
+            {offering.sessions.map((s) => (
+              <li key={s.id}>
+                #{s.sequence} · {new Date(s.datetime).toLocaleString()}
+                {s.location ? ` · ${s.location}` : ""}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      {application && application.status !== "Withdrawn" && application.status !== "Rejected" ? (
+        <div className="bg-card border border-border rounded-md p-4">
+          <p className="text-sm">
+            Your status:{" "}
+            <span className="font-semibold">{application.status}</span>
+          </p>
+          <Link
+            to={`/portal/education/applications/${application.id}`}
+            className="text-xs text-accent-coral hover:underline"
+          >
+            View application →
+          </Link>
+        </div>
+      ) : closed ? (
+        <p className="text-sm text-muted-foreground">Registration is closed.</p>
+      ) : (
+        <Form
+          method="post"
+          className="bg-card border border-border rounded-md p-4 space-y-3"
+        >
+          <h2 className="font-heading text-sm font-bold uppercase tracking-wide text-muted-foreground">
+            {offering.requiresReview ? "Apply" : "RSVP"}
+          </h2>
+          {offering.applicationQuestions.length === 0 ? (
+            <p className="text-xs text-muted-foreground">
+              No application questions — just confirm to register.
+            </p>
+          ) : (
+            offering.applicationQuestions.map((q) => (
+              <label key={q.id} className="block">
+                <span className="text-sm font-medium text-dark-blue">
+                  {q.prompt}
+                  {q.required && <span className="text-red-600"> *</span>}
+                </span>
+                <textarea
+                  name={`answer:${q.id}`}
+                  required={q.required}
+                  rows={3}
+                  className="mt-1 block w-full border border-border rounded-md px-2 py-1 text-sm"
+                />
+              </label>
+            ))
+          )}
+          <button
+            type="submit"
+            disabled={nav.state !== "idle"}
+            className="px-4 py-2 bg-accent-coral text-white text-sm font-medium rounded-md"
+          >
+            {offering.requiresReview ? "Submit application" : "Confirm RSVP"}
+          </button>
+        </Form>
+      )}
+    </div>
+  );
+}

--- a/dali-api/app/education/routes/portal.education._index.tsx
+++ b/dali-api/app/education/routes/portal.education._index.tsx
@@ -1,0 +1,61 @@
+import { useLoaderData, Link } from "react-router";
+import type { Route } from "./+types/portal.education._index";
+import { prisma } from "~/lib/db";
+import { requireAuth } from "~/lib/auth";
+
+export async function loader({ request }: Route.LoaderArgs) {
+  const auth = await requireAuth(request);
+  if (!auth.ok) return auth.response;
+  const offerings = await prisma.educationOffering.findMany({
+    where: { status: "Published" },
+    orderBy: { startsAt: "asc" },
+    include: { _count: { select: { applications: true } } },
+  });
+  return { offerings };
+}
+
+export default function PortalCatalog() {
+  const { offerings } = useLoaderData<typeof loader>();
+  return (
+    <div className="max-w-4xl mx-auto px-4 py-8">
+      <h1 className="font-heading text-2xl font-bold text-dark-blue mb-1">
+        DALI Education
+      </h1>
+      <p className="text-sm text-muted-foreground mb-6">
+        Apply for miniseries or RSVP to workshops open to the Dartmouth community.
+      </p>
+      {offerings.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          No published offerings right now.
+        </p>
+      ) : (
+        <ul className="space-y-3">
+          {offerings.map((o) => (
+            <li
+              key={o.id}
+              className="bg-card border border-border rounded-md p-4"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <h2 className="font-heading font-semibold text-base text-dark-blue">
+                  <Link
+                    to={`/portal/education/${o.id}`}
+                    className="hover:underline"
+                  >
+                    {o.title}
+                  </Link>
+                </h2>
+                <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                  {o.type}
+                </span>
+              </div>
+              <p className="text-xs text-muted-foreground mt-1">
+                Starts {new Date(o.startsAt).toLocaleDateString()} ·{" "}
+                {o._count.applications}/{o.capacity} registered
+              </p>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/dali-api/app/education/routes/portal.education.applications.$id.assignments.$assignmentId.tsx
+++ b/dali-api/app/education/routes/portal.education.applications.$id.assignments.$assignmentId.tsx
@@ -1,0 +1,113 @@
+import { useLoaderData, Form, useNavigation } from "react-router";
+import type { Route } from "./+types/portal.education.applications.$id.assignments.$assignmentId";
+import { prisma } from "~/lib/db";
+import { requireAuth } from "~/lib/auth";
+
+export async function loader({ request, params }: Route.LoaderArgs) {
+  const auth = await requireAuth(request);
+  if (!auth.ok) return auth.response;
+  const application = await prisma.educationApplication.findUnique({
+    where: { id: params.id },
+    select: { applicantUserId: true, offeringId: true, id: true },
+  });
+  if (!application || application.applicantUserId !== auth.user.sub) {
+    return new Response("Not found", { status: 404 });
+  }
+  const assignment = await prisma.educationAssignment.findUnique({
+    where: { id: params.assignmentId },
+  });
+  if (!assignment) return new Response("Not found", { status: 404 });
+
+  const submission = await prisma.educationSubmission.findUnique({
+    where: {
+      assignmentId_studentId: {
+        assignmentId: assignment.id,
+        studentId: auth.user.sub,
+      },
+    },
+  });
+  return { application, assignment, submission };
+}
+
+export async function action({ request, params }: Route.ActionArgs) {
+  const auth = await requireAuth(request);
+  if (!auth.ok) return auth.response;
+  const application = await prisma.educationApplication.findUnique({
+    where: { id: params.id },
+    select: { applicantUserId: true, status: true, id: true },
+  });
+  if (
+    !application ||
+    application.applicantUserId !== auth.user.sub ||
+    application.status !== "Approved"
+  ) {
+    return new Response("Forbidden", { status: 403 });
+  }
+  const fd = await request.formData();
+  const intent = String(fd.get("intent") || "save");
+  const submission = await prisma.educationSubmission.upsert({
+    where: {
+      assignmentId_studentId: {
+        assignmentId: params.assignmentId!,
+        studentId: auth.user.sub,
+      },
+    },
+    create: {
+      assignmentId: params.assignmentId!,
+      studentId: auth.user.sub,
+      educationApplicationId: application.id,
+      submittedAt: intent === "submit" ? new Date() : null,
+    },
+    update: {
+      ...(intent === "submit" ? { submittedAt: new Date() } : {}),
+    },
+  });
+  return { submission };
+}
+
+export default function PortalSubmissionView() {
+  const { assignment, submission } = useLoaderData<typeof loader>();
+  const nav = useNavigation();
+  return (
+    <div className="max-w-2xl mx-auto px-4 py-8">
+      <h1 className="font-heading text-2xl font-bold text-dark-blue mb-1">
+        {assignment.title}
+      </h1>
+      <p className="text-sm text-muted-foreground mb-4">
+        {assignment.submissionType}
+        {assignment.dueAt
+          ? ` · due ${new Date(assignment.dueAt).toLocaleString()}`
+          : ""}
+      </p>
+      {submission?.submittedAt && (
+        <p className="text-sm text-green-700 mb-4">
+          Submitted {new Date(submission.submittedAt).toLocaleString()}.
+        </p>
+      )}
+      <p className="text-sm text-muted-foreground mb-3">
+        Submission body lives in the collaborative editor (configure with the
+        page's <code>education-submission:{submission?.id ?? "<id>"}:content</code> doc).
+      </p>
+      <Form method="post" className="flex gap-2">
+        <button
+          type="submit"
+          name="intent"
+          value="save"
+          disabled={nav.state !== "idle"}
+          className="px-3 py-1.5 bg-card border border-border text-sm font-medium rounded-md"
+        >
+          Save draft
+        </button>
+        <button
+          type="submit"
+          name="intent"
+          value="submit"
+          disabled={nav.state !== "idle"}
+          className="px-3 py-1.5 bg-accent-coral text-white text-sm font-medium rounded-md"
+        >
+          Mark submitted
+        </button>
+      </Form>
+    </div>
+  );
+}

--- a/dali-api/app/education/routes/portal.education.applications.$id.tsx
+++ b/dali-api/app/education/routes/portal.education.applications.$id.tsx
@@ -1,0 +1,149 @@
+import { useLoaderData, Link, Form, useNavigation } from "react-router";
+import type { Route } from "./+types/portal.education.applications.$id";
+import { prisma } from "~/lib/db";
+import { requireAuth } from "~/lib/auth";
+import { decide } from "~/lib/education/decisions";
+
+export async function loader({ request, params }: Route.LoaderArgs) {
+  const auth = await requireAuth(request);
+  if (!auth.ok) return auth.response;
+  const application = await prisma.educationApplication.findUnique({
+    where: { id: params.id },
+    include: {
+      offering: {
+        include: {
+          sessions: { orderBy: { sequence: "asc" } },
+          assignments: { orderBy: { dueAt: "asc" } },
+          announcements: { orderBy: { sentAt: "desc" }, take: 10 },
+        },
+      },
+    },
+  });
+  if (!application || application.applicantUserId !== auth.user.sub) {
+    return new Response("Not found", { status: 404 });
+  }
+  return { application };
+}
+
+export async function action({ request, params }: Route.ActionArgs) {
+  const auth = await requireAuth(request);
+  if (!auth.ok) return auth.response;
+  const application = await prisma.educationApplication.findUnique({
+    where: { id: params.id },
+    select: { applicantUserId: true },
+  });
+  if (!application || application.applicantUserId !== auth.user.sub) {
+    return new Response("Not found", { status: 404 });
+  }
+  await decide({
+    applicationId: params.id!,
+    action: "Withdraw",
+    actorUserId: auth.user.sub,
+  });
+  return null;
+}
+
+export default function PortalApplicationDetail() {
+  const { application } = useLoaderData<typeof loader>();
+  const nav = useNavigation();
+  const isApproved = application.status === "Approved";
+  return (
+    <div className="max-w-2xl mx-auto px-4 py-8">
+      <p className="text-xs text-muted-foreground mb-1">
+        <Link to="/portal/education" className="hover:underline">
+          ← Back to catalog
+        </Link>
+      </p>
+      <h1 className="font-heading text-2xl font-bold text-dark-blue mb-1">
+        {application.offering.title}
+      </h1>
+      <p className="text-sm mb-4">
+        Status: <span className="font-semibold">{application.status}</span>
+      </p>
+
+      {isApproved && (
+        <>
+          <section className="bg-card border border-border rounded-md p-4 mb-4">
+            <h2 className="font-heading text-sm font-bold uppercase tracking-wide text-muted-foreground mb-2">
+              Sessions
+            </h2>
+            {application.offering.sessions.length === 0 ? (
+              <p className="text-sm text-muted-foreground">TBD</p>
+            ) : (
+              <ul className="text-sm space-y-1">
+                {application.offering.sessions.map((s) => (
+                  <li key={s.id}>
+                    #{s.sequence} · {new Date(s.datetime).toLocaleString()}
+                    {s.location ? ` · ${s.location}` : ""}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+
+          <section className="bg-card border border-border rounded-md p-4 mb-4">
+            <h2 className="font-heading text-sm font-bold uppercase tracking-wide text-muted-foreground mb-2">
+              Assignments
+            </h2>
+            {application.offering.assignments.length === 0 ? (
+              <p className="text-sm text-muted-foreground">None yet.</p>
+            ) : (
+              <ul className="text-sm space-y-1">
+                {application.offering.assignments.map((a) => (
+                  <li key={a.id}>
+                    <Link
+                      to={`/portal/education/applications/${application.id}/assignments/${a.id}`}
+                      className="text-dark-blue hover:underline"
+                    >
+                      {a.title}
+                    </Link>
+                    {a.dueAt && (
+                      <span className="text-xs text-muted-foreground">
+                        {" "}· due {new Date(a.dueAt).toLocaleDateString()}
+                      </span>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+
+          <section className="bg-card border border-border rounded-md p-4 mb-4">
+            <h2 className="font-heading text-sm font-bold uppercase tracking-wide text-muted-foreground mb-2">
+              Announcements
+            </h2>
+            {application.offering.announcements.length === 0 ? (
+              <p className="text-sm text-muted-foreground">No announcements yet.</p>
+            ) : (
+              <ul className="space-y-2 text-sm">
+                {application.offering.announcements.map((a) => (
+                  <li key={a.id}>
+                    <p className="text-xs text-muted-foreground">
+                      {new Date(a.sentAt).toLocaleString()}
+                    </p>
+                    <p className="whitespace-pre-wrap">{a.body}</p>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+        </>
+      )}
+
+      {application.status !== "Withdrawn" && application.status !== "Rejected" && (
+        <Form method="post">
+          <button
+            type="submit"
+            disabled={nav.state !== "idle"}
+            className="text-sm text-red-600 hover:underline"
+            onClick={(e) => {
+              if (!confirm("Withdraw this application?")) e.preventDefault();
+            }}
+          >
+            Withdraw
+          </button>
+        </Form>
+      )}
+    </div>
+  );
+}

--- a/dali-api/app/hiring/routes/__tests__/analytics.test.ts
+++ b/dali-api/app/hiring/routes/__tests__/analytics.test.ts
@@ -30,6 +30,9 @@ beforeEach(() => {
     isHiringLead: true,
     isAdmin: false,
     isDomainLead: false,
+    isCore: false,
+    isEducationLead: false,
+    isInstructor: false,
   });
 
   mockPrisma.applicationCycle = {

--- a/dali-api/app/lib/__mocks__/db.ts
+++ b/dali-api/app/lib/__mocks__/db.ts
@@ -72,8 +72,72 @@ export const prisma = {
   },
   scheduledMeeting: {
     findMany: vi.fn().mockResolvedValue([]),
+    findUnique: vi.fn(),
     create: vi.fn(),
     update: vi.fn(),
+  },
+  instructorAssignment: {
+    findFirst: vi.fn(),
+    create: vi.fn(),
+    deleteMany: vi.fn(),
+  },
+  educationOffering: {
+    findUnique: vi.fn(),
+    findMany: vi.fn().mockResolvedValue([]),
+    create: vi.fn(),
+    update: vi.fn(),
+  },
+  educationApplication: {
+    findUnique: vi.fn(),
+    findFirst: vi.fn(),
+    findMany: vi.fn().mockResolvedValue([]),
+    create: vi.fn(),
+    update: vi.fn(),
+    count: vi.fn().mockResolvedValue(0),
+  },
+  educationApplicationAnswer: {
+    createMany: vi.fn(),
+    deleteMany: vi.fn(),
+  },
+  educationApplicationQuestion: {
+    findMany: vi.fn().mockResolvedValue([]),
+    aggregate: vi.fn().mockResolvedValue({ _max: { position: null } }),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  },
+  educationSession: {
+    findMany: vi.fn().mockResolvedValue([]),
+    findUnique: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    aggregate: vi.fn().mockResolvedValue({ _max: { sequence: null } }),
+  },
+  educationAssignment: {
+    findUnique: vi.fn(),
+    findMany: vi.fn().mockResolvedValue([]),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  },
+  educationSubmission: {
+    findUnique: vi.fn(),
+    upsert: vi.fn(),
+    update: vi.fn(),
+  },
+  educationAttendance: {
+    upsert: vi.fn(),
+  },
+  educationAnnouncement: {
+    create: vi.fn(),
+    findMany: vi.fn().mockResolvedValue([]),
+  },
+  notificationEvent: {
+    createMany: vi.fn().mockResolvedValue({ count: 0 }),
+  },
+  page: {
+    findMany: vi.fn().mockResolvedValue([]),
   },
   userAvailabilitySettings: {
     findUnique: vi.fn().mockResolvedValue(null),
@@ -86,6 +150,7 @@ export const prisma = {
   },
   userCalendarLink: {
     findMany: vi.fn().mockResolvedValue([]),
+    findFirst: vi.fn().mockResolvedValue(null),
     findUnique: vi.fn(),
     update: vi.fn(),
   },

--- a/dali-api/app/lib/collabAuth.ts
+++ b/dali-api/app/lib/collabAuth.ts
@@ -1,5 +1,5 @@
 import { prisma } from "~/lib/db";
-import { isHiringLead, isDomainLead } from "~/lib/roles";
+import { isHiringLead, isDomainLead, isCore, isInstructorFor } from "~/lib/roles";
 import { getCycleConfidentialityState } from "~/hiring/lib/confidentiality";
 
 /** Hydrate author IDs into `{ id, name }` objects in a single IN query. */
@@ -50,6 +50,86 @@ export async function authorizeCollabDoc(
     if (review.cycleReviewer.userId === userSub) return true;
     if (await isDomainLead(userSub)) return true;
     if (await isHiringLead(userSub)) return true;
+    return false;
+  }
+
+  if (entity === "education-offering") {
+    const offering = await prisma.educationOffering.findUnique({
+      where: { id },
+      select: { id: true },
+    });
+    if (!offering) return false;
+    if (await isInstructorFor(userSub, id)) return true;
+    if (await isCore(userSub)) return true;
+    return false;
+  }
+
+  if (entity === "education-session") {
+    const session = await prisma.educationSession.findUnique({
+      where: { id },
+      select: { offeringId: true },
+    });
+    if (!session) return false;
+    if (await isInstructorFor(userSub, session.offeringId)) return true;
+    if (await isCore(userSub)) return true;
+    return false;
+  }
+
+  if (entity === "education-assignment") {
+    const assignment = await prisma.educationAssignment.findUnique({
+      where: { id },
+      select: { offeringId: true, sessionId: true },
+    });
+    if (!assignment) return false;
+    let offeringId = assignment.offeringId;
+    if (!offeringId && assignment.sessionId) {
+      const session = await prisma.educationSession.findUnique({
+        where: { id: assignment.sessionId },
+        select: { offeringId: true },
+      });
+      offeringId = session?.offeringId ?? null;
+    }
+    if (offeringId && (await isInstructorFor(userSub, offeringId))) return true;
+    if (await isCore(userSub)) return true;
+    return false;
+  }
+
+  if (entity === "education-submission") {
+    const submission = await prisma.educationSubmission.findUnique({
+      where: { id },
+      select: {
+        studentId: true,
+        assignment: {
+          select: {
+            offeringId: true,
+            sessionId: true,
+          },
+        },
+      },
+    });
+    if (!submission) return false;
+    if (submission.studentId === userSub) return true;
+    let offeringId = submission.assignment.offeringId;
+    if (!offeringId && submission.assignment.sessionId) {
+      const session = await prisma.educationSession.findUnique({
+        where: { id: submission.assignment.sessionId },
+        select: { offeringId: true },
+      });
+      offeringId = session?.offeringId ?? null;
+    }
+    if (offeringId && (await isInstructorFor(userSub, offeringId))) return true;
+    if (await isCore(userSub)) return true;
+    return false;
+  }
+
+  if (entity === "education-application") {
+    const application = await prisma.educationApplication.findUnique({
+      where: { id },
+      select: { offeringId: true },
+    });
+    if (!application) return false;
+    if (await isInstructorFor(userSub, application.offeringId)) return true;
+    if (await isCore(userSub)) return true;
     return false;
   }
 

--- a/dali-api/app/lib/education/__tests__/apply.test.ts
+++ b/dali-api/app/lib/education/__tests__/apply.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("~/lib/db");
+vi.mock("~/lib/education/email", () => ({
+  sendApplicationSubmittedEmail: vi.fn().mockResolvedValue(undefined),
+  sendDecisionEmail: vi.fn().mockResolvedValue(undefined),
+  sendAnnouncementEmail: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("~/lib/education/roster-sync", () => ({
+  syncSessionRoster: vi.fn().mockResolvedValue({
+    meetingsCreated: 0,
+    meetingsUpdated: 0,
+    gcalErrors: [],
+  }),
+}));
+
+import { prisma } from "~/lib/db";
+import { apply } from "~/lib/education/apply";
+
+const mockPrisma = prisma as unknown as {
+  educationOffering: { findUnique: ReturnType<typeof vi.fn> };
+  educationApplication: {
+    findUnique: ReturnType<typeof vi.fn>;
+    create: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+    count: ReturnType<typeof vi.fn>;
+  };
+  educationApplicationAnswer: {
+    createMany: ReturnType<typeof vi.fn>;
+    deleteMany: ReturnType<typeof vi.fn>;
+  };
+  user: { findUnique: ReturnType<typeof vi.fn> };
+  $transaction: ReturnType<typeof vi.fn>;
+};
+
+const future = (offsetMs: number) => new Date(Date.now() + offsetMs);
+const past = (offsetMs: number) => new Date(Date.now() - offsetMs);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockPrisma.$transaction.mockImplementation(async (fn: any) => fn(mockPrisma));
+  mockPrisma.user.findUnique.mockResolvedValue({
+    firstName: "Bo",
+    daliEmail: null,
+    dartmouthEmail: "bo@dartmouth",
+  });
+});
+
+describe("apply()", () => {
+  it("auto-approves up to capacity when review is not required", async () => {
+    mockPrisma.educationOffering.findUnique.mockResolvedValue({
+      id: "off-1",
+      title: "Workshop",
+      status: "Published",
+      capacity: 2,
+      requiresReview: false,
+      registrationOpensAt: past(60_000),
+      registrationClosesAt: future(60_000),
+      applicationQuestions: [],
+    });
+    mockPrisma.educationApplication.findUnique.mockResolvedValue(null);
+    mockPrisma.educationApplication.count.mockResolvedValue(0);
+    mockPrisma.educationApplication.create.mockResolvedValue({
+      id: "app-1",
+      status: "Approved",
+    });
+
+    const outcome = await apply({
+      offeringId: "off-1",
+      applicantUserId: "u-1",
+      answers: {},
+    });
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      expect(outcome.result.status).toBe("Approved");
+    }
+    expect(mockPrisma.educationApplication.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({ status: "Approved" }),
+    });
+  });
+
+  it("waitlists when capacity is full", async () => {
+    mockPrisma.educationOffering.findUnique.mockResolvedValue({
+      id: "off-1",
+      title: "Workshop",
+      status: "Published",
+      capacity: 2,
+      requiresReview: false,
+      registrationOpensAt: past(60_000),
+      registrationClosesAt: future(60_000),
+      applicationQuestions: [],
+    });
+    mockPrisma.educationApplication.findUnique.mockResolvedValue(null);
+    mockPrisma.educationApplication.count.mockResolvedValue(2);
+    mockPrisma.educationApplication.create.mockResolvedValue({
+      id: "app-1",
+      status: "Waitlisted",
+    });
+
+    const outcome = await apply({
+      offeringId: "off-1",
+      applicantUserId: "u-3",
+      answers: {},
+    });
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) expect(outcome.result.status).toBe("Waitlisted");
+  });
+
+  it("leaves status at Submitted when review is required", async () => {
+    mockPrisma.educationOffering.findUnique.mockResolvedValue({
+      id: "off-2",
+      title: "Miniseries",
+      status: "Published",
+      capacity: 5,
+      requiresReview: true,
+      registrationOpensAt: past(60_000),
+      registrationClosesAt: future(60_000),
+      applicationQuestions: [],
+    });
+    mockPrisma.educationApplication.findUnique.mockResolvedValue(null);
+    mockPrisma.educationApplication.create.mockResolvedValue({
+      id: "app-2",
+      status: "Submitted",
+    });
+
+    const outcome = await apply({
+      offeringId: "off-2",
+      applicantUserId: "u-1",
+      answers: {},
+    });
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) expect(outcome.result.status).toBe("Submitted");
+  });
+
+  it("rejects re-apply when the existing application is still active", async () => {
+    mockPrisma.educationOffering.findUnique.mockResolvedValue({
+      id: "off-1",
+      title: "Workshop",
+      status: "Published",
+      capacity: 2,
+      requiresReview: false,
+      registrationOpensAt: past(60_000),
+      registrationClosesAt: future(60_000),
+      applicationQuestions: [],
+    });
+    mockPrisma.educationApplication.findUnique.mockResolvedValue({
+      id: "app-existing",
+      status: "Approved",
+    });
+    mockPrisma.educationApplication.count.mockResolvedValue(0);
+
+    const outcome = await apply({
+      offeringId: "off-1",
+      applicantUserId: "u-1",
+      answers: {},
+    });
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) expect(outcome.result.status).toBe("Approved");
+    expect(mockPrisma.educationApplication.create).not.toHaveBeenCalled();
+  });
+
+  it("flags missing required answer", async () => {
+    mockPrisma.educationOffering.findUnique.mockResolvedValue({
+      id: "off-3",
+      title: "Series",
+      status: "Published",
+      capacity: 5,
+      requiresReview: true,
+      registrationOpensAt: past(60_000),
+      registrationClosesAt: future(60_000),
+      applicationQuestions: [
+        { id: "q-1", prompt: "Why?", position: 0, required: true },
+      ],
+    });
+
+    const outcome = await apply({
+      offeringId: "off-3",
+      applicantUserId: "u-1",
+      answers: {},
+    });
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok) {
+      expect(outcome.error.kind).toBe("MissingRequiredAnswer");
+    }
+  });
+
+  it("rejects an unpublished offering", async () => {
+    mockPrisma.educationOffering.findUnique.mockResolvedValue({
+      id: "off-9",
+      title: "Draft",
+      status: "Draft",
+      capacity: 1,
+      requiresReview: false,
+      registrationOpensAt: past(60_000),
+      registrationClosesAt: future(60_000),
+      applicationQuestions: [],
+    });
+
+    const outcome = await apply({
+      offeringId: "off-9",
+      applicantUserId: "u-1",
+      answers: {},
+    });
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok) expect(outcome.error.kind).toBe("OfferingNotPublished");
+  });
+});

--- a/dali-api/app/lib/education/__tests__/decisions.test.ts
+++ b/dali-api/app/lib/education/__tests__/decisions.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("~/lib/db");
+vi.mock("~/lib/notifications", () => ({
+  emitEvent: vi.fn().mockResolvedValue({ eventsWritten: 0, notificationsWritten: 0 }),
+}));
+vi.mock("~/lib/education/email", () => ({
+  sendDecisionEmail: vi.fn().mockResolvedValue(undefined),
+  sendApplicationSubmittedEmail: vi.fn().mockResolvedValue(undefined),
+  sendAnnouncementEmail: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("~/lib/education/roster-sync", () => ({
+  syncSessionRoster: vi.fn().mockResolvedValue({
+    meetingsCreated: 0,
+    meetingsUpdated: 0,
+    gcalErrors: [],
+  }),
+}));
+
+import { prisma } from "~/lib/db";
+import { decide } from "~/lib/education/decisions";
+import { emitEvent } from "~/lib/notifications";
+
+const mockPrisma = prisma as unknown as {
+  educationApplication: {
+    findUnique: ReturnType<typeof vi.fn>;
+    findFirst: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+    count: ReturnType<typeof vi.fn>;
+  };
+  user: { findUnique: ReturnType<typeof vi.fn> };
+  $transaction: ReturnType<typeof vi.fn>;
+};
+
+const OFFERING = {
+  id: "off-1",
+  title: "Intro to ML",
+  capacity: 2,
+  requiresReview: true,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // The default $transaction passes through the supplied callback,
+  // executing it with the same mockPrisma. Mirrors Prisma's interactive
+  // transaction signature for our tests.
+  mockPrisma.$transaction.mockImplementation(async (fn: any) => fn(mockPrisma));
+  mockPrisma.user.findUnique.mockResolvedValue({
+    firstName: "Ava",
+    daliEmail: "ava@dali",
+    dartmouthEmail: null,
+  });
+});
+
+describe("decide()", () => {
+  it("approves a submitted application and emits a decision notification", async () => {
+    mockPrisma.educationApplication.findUnique.mockResolvedValue({
+      id: "app-1",
+      status: "Submitted",
+      offeringId: "off-1",
+      applicantUserId: "user-1",
+      offering: OFFERING,
+    });
+    mockPrisma.educationApplication.update.mockResolvedValue({
+      id: "app-1",
+      status: "Approved",
+      applicantUserId: "user-1",
+    });
+
+    const result = await decide({
+      applicationId: "app-1",
+      action: "Approve",
+      actorUserId: "core-1",
+    });
+
+    expect(result.newStatus).toBe("Approved");
+    expect(result.promotedApplicationId).toBeNull();
+    expect(mockPrisma.educationApplication.update).toHaveBeenCalledWith({
+      where: { id: "app-1" },
+      data: expect.objectContaining({
+        status: "Approved",
+        reviewedBy: "core-1",
+      }),
+    });
+    expect(emitEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "education.application_approved",
+        recipients: ["user-1"],
+      }),
+    );
+  });
+
+  it("promotes the next waitlisted applicant when a freed slot opens", async () => {
+    mockPrisma.educationApplication.findUnique.mockResolvedValue({
+      id: "app-1",
+      status: "Approved",
+      offeringId: "off-1",
+      applicantUserId: "user-1",
+      offering: OFFERING,
+    });
+    mockPrisma.educationApplication.update.mockResolvedValue({
+      id: "app-1",
+      status: "Withdrawn",
+      applicantUserId: "user-1",
+    });
+    // Approved count post-withdraw is 1, capacity is 2 → room for one promotion.
+    mockPrisma.educationApplication.count.mockResolvedValue(1);
+    mockPrisma.educationApplication.findFirst.mockResolvedValue({
+      id: "app-2",
+      applicantUserId: "user-2",
+    });
+
+    const result = await decide({
+      applicationId: "app-1",
+      action: "Withdraw",
+      actorUserId: "user-1",
+    });
+
+    expect(result.promotedApplicationId).toBe("app-2");
+    expect(mockPrisma.educationApplication.update).toHaveBeenCalledWith({
+      where: { id: "app-2" },
+      data: expect.objectContaining({ status: "Approved" }),
+    });
+    // Waitlist-promote emits its own event in addition to the withdraw side
+    // (which actually doesn't emit since the user withdrew themselves).
+    const calls = (emitEvent as unknown as ReturnType<typeof vi.fn>).mock.calls;
+    expect(
+      calls.some((c) => c[0].type === "education.waitlist_promoted"),
+    ).toBe(true);
+  });
+
+  it("does not promote when rejecting a non-Approved applicant", async () => {
+    mockPrisma.educationApplication.findUnique.mockResolvedValue({
+      id: "app-3",
+      status: "Submitted",
+      offeringId: "off-1",
+      applicantUserId: "user-3",
+      offering: OFFERING,
+    });
+    mockPrisma.educationApplication.update.mockResolvedValue({
+      id: "app-3",
+      status: "Rejected",
+      applicantUserId: "user-3",
+    });
+
+    const result = await decide({
+      applicationId: "app-3",
+      action: "Reject",
+      actorUserId: "core-1",
+    });
+
+    expect(result.promotedApplicationId).toBeNull();
+    expect(mockPrisma.educationApplication.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("does not promote when capacity is already saturated", async () => {
+    mockPrisma.educationApplication.findUnique.mockResolvedValue({
+      id: "app-1",
+      status: "Approved",
+      offeringId: "off-1",
+      applicantUserId: "user-1",
+      offering: { ...OFFERING, capacity: 1 },
+    });
+    mockPrisma.educationApplication.update.mockResolvedValue({
+      id: "app-1",
+      status: "Rejected",
+      applicantUserId: "user-1",
+    });
+    // After the rejection, there are no other approved rows.
+    mockPrisma.educationApplication.count.mockResolvedValue(0);
+    mockPrisma.educationApplication.findFirst.mockResolvedValue(null);
+
+    const result = await decide({
+      applicationId: "app-1",
+      action: "Reject",
+      actorUserId: "core-1",
+    });
+
+    expect(result.promotedApplicationId).toBeNull();
+  });
+});

--- a/dali-api/app/lib/education/__tests__/roster-sync.test.ts
+++ b/dali-api/app/lib/education/__tests__/roster-sync.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("~/lib/db");
+vi.mock("~/lib/scheduled-meeting", () => ({
+  createScheduledMeeting: vi.fn().mockResolvedValue({
+    ok: true,
+    meeting: { id: "meeting-new", externalEventId: null },
+    notifiedCount: 0,
+    gcalError: null,
+  }),
+  updateScheduledMeetingParticipants: vi.fn().mockResolvedValue({
+    ok: true,
+    added: [],
+    removed: [],
+    gcalError: null,
+  }),
+}));
+
+import { prisma } from "~/lib/db";
+import {
+  createScheduledMeeting,
+  updateScheduledMeetingParticipants,
+} from "~/lib/scheduled-meeting";
+import { syncSessionRoster } from "~/lib/education/roster-sync";
+
+const mockPrisma = prisma as unknown as {
+  educationOffering: { findUnique: ReturnType<typeof vi.fn> };
+  educationApplication: { findMany: ReturnType<typeof vi.fn> };
+  educationSession: {
+    findMany: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+  };
+  user: { findUnique: ReturnType<typeof vi.fn> };
+  userCalendarLink: { findFirst: ReturnType<typeof vi.fn> };
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockPrisma.educationOffering.findUnique.mockResolvedValue({
+    id: "off-1",
+    title: "Intro",
+    calendarEmail: "edu@dali",
+    instructors: [{ userId: "instructor-1" }],
+  });
+  mockPrisma.educationApplication.findMany.mockResolvedValue([
+    { applicantUserId: "stu-1" },
+    { applicantUserId: "stu-2" },
+  ]);
+  mockPrisma.user.findUnique.mockResolvedValue({
+    daliEmail: "instructor@dali",
+    dartmouthEmail: null,
+  });
+  mockPrisma.userCalendarLink.findFirst.mockResolvedValue(null);
+});
+
+describe("syncSessionRoster", () => {
+  it("creates a ScheduledMeeting for each future session that lacks one", async () => {
+    mockPrisma.educationSession.findMany.mockResolvedValue([
+      {
+        id: "sess-1",
+        datetime: new Date(Date.now() + 86_400_000),
+        scheduledMeetingId: null,
+      },
+    ]);
+
+    const result = await syncSessionRoster("off-1");
+    expect(createScheduledMeeting).toHaveBeenCalledOnce();
+    expect(mockPrisma.educationSession.update).toHaveBeenCalledWith({
+      where: { id: "sess-1" },
+      data: { scheduledMeetingId: "meeting-new" },
+    });
+    expect(result.meetingsCreated).toBe(1);
+  });
+
+  it("updates existing meetings with the latest roster", async () => {
+    mockPrisma.educationSession.findMany.mockResolvedValue([
+      {
+        id: "sess-2",
+        datetime: new Date(Date.now() + 3600_000),
+        scheduledMeetingId: "meeting-existing",
+      },
+    ]);
+    (updateScheduledMeetingParticipants as any).mockResolvedValueOnce({
+      ok: true,
+      added: ["stu-2"],
+      removed: [],
+      gcalError: null,
+    });
+
+    const result = await syncSessionRoster("off-1");
+    expect(updateScheduledMeetingParticipants).toHaveBeenCalledWith(
+      "meeting-existing",
+      ["stu-1", "stu-2"],
+    );
+    expect(result.meetingsUpdated).toBe(1);
+  });
+
+  it("does nothing when there are no future sessions", async () => {
+    mockPrisma.educationSession.findMany.mockResolvedValue([]);
+    const result = await syncSessionRoster("off-1");
+    expect(result.meetingsCreated).toBe(0);
+    expect(result.meetingsUpdated).toBe(0);
+    expect(createScheduledMeeting).not.toHaveBeenCalled();
+  });
+});

--- a/dali-api/app/lib/education/apply.ts
+++ b/dali-api/app/lib/education/apply.ts
@@ -1,0 +1,160 @@
+import { prisma } from "~/lib/db";
+import { sendApplicationSubmittedEmail } from "./email";
+import { syncSessionRoster } from "./roster-sync";
+import type { EduApplicationStatus } from "~/generated/prisma/enums";
+
+// Application / RSVP creation. Mirrors the decisions module — the DB writes
+// happen in one transaction, side effects (email + calendar sync) fire after.
+//
+// For requiresReview=true offerings, the application is left at "Submitted"
+// for the instructor to review. For requiresReview=false, we attempt to
+// auto-approve up to capacity and waitlist past that.
+
+export interface ApplyInput {
+  offeringId: string;
+  applicantUserId: string;
+  /** questionId → answer text. Validated against EducationApplicationQuestion. */
+  answers: Record<string, string>;
+}
+
+export interface ApplyResult {
+  applicationId: string;
+  status: EduApplicationStatus;
+  /** True when the apply resurrected a withdrawn row (vs created fresh). */
+  reapplied: boolean;
+}
+
+export type ApplyError =
+  | { kind: "OfferingNotFound" }
+  | { kind: "OfferingNotPublished" }
+  | { kind: "RegistrationClosed" }
+  | { kind: "MissingRequiredAnswer"; questionId: string };
+
+export type ApplyOutcome =
+  | { ok: true; result: ApplyResult }
+  | { ok: false; error: ApplyError };
+
+export async function apply(input: ApplyInput): Promise<ApplyOutcome> {
+  const offering = await prisma.educationOffering.findUnique({
+    where: { id: input.offeringId },
+    include: { applicationQuestions: true },
+  });
+  if (!offering) return { ok: false, error: { kind: "OfferingNotFound" } };
+  if (offering.status !== "Published") {
+    return { ok: false, error: { kind: "OfferingNotPublished" } };
+  }
+  const now = new Date();
+  if (now < offering.registrationOpensAt || now > offering.registrationClosesAt) {
+    return { ok: false, error: { kind: "RegistrationClosed" } };
+  }
+
+  for (const q of offering.applicationQuestions) {
+    if (!q.required) continue;
+    const ans = input.answers[q.id]?.trim();
+    if (!ans) return { ok: false, error: { kind: "MissingRequiredAnswer", questionId: q.id } };
+  }
+
+  const result = await prisma.$transaction(async (tx) => {
+    const existing = await tx.educationApplication.findUnique({
+      where: {
+        applicantUserId_offeringId: {
+          applicantUserId: input.applicantUserId,
+          offeringId: input.offeringId,
+        },
+      },
+    });
+
+    const reapplied =
+      existing !== null &&
+      (existing.status === "Withdrawn" || existing.status === "Rejected");
+
+    let status: EduApplicationStatus = "Submitted";
+
+    if (!offering.requiresReview) {
+      const approved = await tx.educationApplication.count({
+        where: { offeringId: input.offeringId, status: "Approved" },
+      });
+      status = approved < offering.capacity ? "Approved" : "Waitlisted";
+    }
+
+    let app;
+    if (existing) {
+      // Idempotent re-apply: reset answers + status. Disallow re-applying
+      // when the user already has an active application.
+      if (
+        existing.status !== "Withdrawn" &&
+        existing.status !== "Rejected"
+      ) {
+        return { existing: true, app: existing, status: existing.status, reapplied: false };
+      }
+      app = await tx.educationApplication.update({
+        where: { id: existing.id },
+        data: {
+          status,
+          submittedAt: new Date(),
+          reviewedAt: offering.requiresReview ? null : new Date(),
+          reviewedBy: null,
+        },
+      });
+      await tx.educationApplicationAnswer.deleteMany({
+        where: { applicationId: existing.id },
+      });
+    } else {
+      app = await tx.educationApplication.create({
+        data: {
+          applicantUserId: input.applicantUserId,
+          offeringId: input.offeringId,
+          status,
+        },
+      });
+    }
+
+    const answerRows = Object.entries(input.answers)
+      .filter(([_, content]) => content.trim().length > 0)
+      .map(([questionId, content]) => ({
+        applicationId: app.id,
+        questionId,
+        content,
+      }));
+    if (answerRows.length > 0) {
+      await tx.educationApplicationAnswer.createMany({ data: answerRows });
+    }
+
+    return { existing: false, app, status, reapplied };
+  });
+
+  // Side effects: confirmation email + calendar sync if we auto-approved.
+  const user = await prisma.user.findUnique({
+    where: { id: input.applicantUserId },
+    select: {
+      firstName: true,
+      daliEmail: true,
+      dartmouthEmail: true,
+    },
+  });
+  if (user) {
+    const email = user.daliEmail ?? user.dartmouthEmail;
+    if (email) {
+      await sendApplicationSubmittedEmail({
+        to: { email, firstName: user.firstName },
+        offeringTitle: offering.title,
+        requiresReview: offering.requiresReview,
+      });
+    }
+  }
+
+  if (result.status === "Approved") {
+    syncSessionRoster(input.offeringId).catch((err) => {
+      console.error("[education:apply] roster sync failed", err);
+    });
+  }
+
+  return {
+    ok: true,
+    result: {
+      applicationId: result.app.id,
+      status: result.status,
+      reapplied: result.reapplied,
+    },
+  };
+}

--- a/dali-api/app/lib/education/capacity.ts
+++ b/dali-api/app/lib/education/capacity.ts
@@ -1,0 +1,50 @@
+import { prisma } from "~/lib/db";
+
+// All Education capacity / waitlist queries live here so the decisions
+// module can compose them inside a single transaction.
+
+export async function approvedCount(
+  offeringId: string,
+  tx?: typeof prisma,
+): Promise<number> {
+  const client = tx ?? prisma;
+  return client.educationApplication.count({
+    where: { offeringId, status: "Approved" },
+  });
+}
+
+export async function waitlistedCount(
+  offeringId: string,
+  tx?: typeof prisma,
+): Promise<number> {
+  const client = tx ?? prisma;
+  return client.educationApplication.count({
+    where: { offeringId, status: "Waitlisted" },
+  });
+}
+
+/** First-in-waitlist by submittedAt (the earliest waitlisted application). */
+export async function nextOnWaitlist(
+  offeringId: string,
+  tx?: typeof prisma,
+): Promise<{ id: string; applicantUserId: string } | null> {
+  const client = tx ?? prisma;
+  return client.educationApplication.findFirst({
+    where: { offeringId, status: "Waitlisted" },
+    orderBy: { submittedAt: "asc" },
+    select: { id: true, applicantUserId: true },
+  });
+}
+
+/** Approved applicantUserIds for an offering — used by roster-sync. */
+export async function approvedApplicantIds(
+  offeringId: string,
+  tx?: typeof prisma,
+): Promise<string[]> {
+  const client = tx ?? prisma;
+  const rows = await client.educationApplication.findMany({
+    where: { offeringId, status: "Approved" },
+    select: { applicantUserId: true },
+  });
+  return rows.map((r) => r.applicantUserId);
+}

--- a/dali-api/app/lib/education/decisions.ts
+++ b/dali-api/app/lib/education/decisions.ts
@@ -1,0 +1,207 @@
+import { prisma } from "~/lib/db";
+import { emitEvent } from "~/lib/notifications";
+import { sendDecisionEmail } from "./email";
+import { syncSessionRoster } from "./roster-sync";
+import type { EduApplicationStatus } from "~/generated/prisma/enums";
+
+// The single funnel for all EducationApplication state transitions. Apply,
+// Approve, Reject, Waitlist, and Withdraw all converge here so the waitlist-
+// promotion + calendar-sync + notification fan-out logic lives in one place.
+
+export type DecisionAction =
+  | "Approve"
+  | "Reject"
+  | "Waitlist"
+  | "Withdraw"
+  | "AutoApprove";
+
+export interface DecisionInput {
+  applicationId: string;
+  action: DecisionAction;
+  /** The actor making the decision. For Withdraw, this is the applicant. */
+  actorUserId: string;
+  /**
+   * Optional free-form note shown in the decision email. The persistent
+   * reviewer note lives in the per-application collab doc; this is a
+   * convenience for fast decisions without opening the editor.
+   */
+  reviewerNote?: string | null;
+}
+
+export interface DecisionResult {
+  applicationId: string;
+  newStatus: EduApplicationStatus;
+  promotedApplicationId: string | null;
+}
+
+function actionToStatus(action: DecisionAction): EduApplicationStatus {
+  switch (action) {
+    case "Approve":
+    case "AutoApprove":
+      return "Approved";
+    case "Reject":
+      return "Rejected";
+    case "Waitlist":
+      return "Waitlisted";
+    case "Withdraw":
+      return "Withdrawn";
+  }
+}
+
+/**
+ * Apply a decision and (when capacity allows) promote the next waitlisted
+ * applicant in a single transaction. Side effects (notification fan-out,
+ * email send, calendar sync) run after the transaction commits.
+ */
+export async function decide(input: DecisionInput): Promise<DecisionResult> {
+  const newStatus = actionToStatus(input.action);
+
+  const { app, promoted, offering } = await prisma.$transaction(async (tx) => {
+    const existing = await tx.educationApplication.findUnique({
+      where: { id: input.applicationId },
+      include: {
+        offering: {
+          select: {
+            id: true,
+            title: true,
+            capacity: true,
+            requiresReview: true,
+          },
+        },
+      },
+    });
+    if (!existing) throw new Error("Application not found");
+
+    const wasApproved = existing.status === "Approved";
+
+    const updated = await tx.educationApplication.update({
+      where: { id: input.applicationId },
+      data: {
+        status: newStatus,
+        reviewedAt: input.action === "Withdraw" ? existing.reviewedAt : new Date(),
+        reviewedBy: input.action === "Withdraw" ? existing.reviewedBy : input.actorUserId,
+      },
+    });
+
+    let promotedApp: { id: string; applicantUserId: string } | null = null;
+
+    // Promotion only triggers when a previously-Approved slot has just been
+    // freed (Reject or Withdraw from Approved). Rejecting a Submitted /
+    // Waitlisted applicant doesn't free a seat.
+    const freedSlot = wasApproved && newStatus !== "Approved";
+    if (freedSlot) {
+      const currentApproved = await tx.educationApplication.count({
+        where: { offeringId: existing.offeringId, status: "Approved" },
+      });
+      if (currentApproved < existing.offering.capacity) {
+        const next = await tx.educationApplication.findFirst({
+          where: { offeringId: existing.offeringId, status: "Waitlisted" },
+          orderBy: { submittedAt: "asc" },
+          select: { id: true, applicantUserId: true },
+        });
+        if (next) {
+          await tx.educationApplication.update({
+            where: { id: next.id },
+            data: {
+              status: "Approved",
+              reviewedAt: new Date(),
+              reviewedBy: input.actorUserId,
+            },
+          });
+          promotedApp = next;
+        }
+      }
+    }
+
+    return { app: updated, promoted: promotedApp, offering: existing.offering };
+  });
+
+  // Side effects — best-effort, post-commit.
+  await Promise.allSettled([
+    notifyDecision(app.applicantUserId, offering, newStatus, input),
+    promoted
+      ? notifyPromoted(promoted.applicantUserId, offering)
+      : Promise.resolve(),
+    syncSessionRoster(offering.id).catch((err) => {
+      console.error("[education:decisions] roster sync failed", err);
+    }),
+  ]);
+
+  return {
+    applicationId: app.id,
+    newStatus,
+    promotedApplicationId: promoted?.id ?? null,
+  };
+}
+
+async function notifyDecision(
+  applicantUserId: string,
+  offering: { id: string; title: string },
+  status: EduApplicationStatus,
+  input: DecisionInput,
+): Promise<void> {
+  // Skip notification on self-withdraw (the user knows they did it).
+  if (input.action === "Withdraw") return;
+  // Skip the "Submitted" non-decision case (apply confirmation handled
+  // separately; decide() doesn't reach this branch for AutoApprove either
+  // because AutoApprove → Approved).
+  if (status === "Submitted") return;
+
+  await emitEvent({
+    type: `education.application_${status.toLowerCase()}`,
+    recipients: [applicantUserId],
+    payload: { offeringId: offering.id, status },
+    inbox: {
+      kind: "EducationApplicationDecision",
+      title: `${offering.title}: ${status}`,
+      body: input.reviewerNote ?? null,
+      link: `/portal/education/applications/${input.applicationId}`,
+      createdByUserId: input.actorUserId,
+    },
+  });
+
+  const recipient = await loadRecipient(applicantUserId);
+  if (recipient) {
+    await sendDecisionEmail({
+      to: recipient,
+      offeringTitle: offering.title,
+      status,
+      reviewerNote: input.reviewerNote ?? null,
+    });
+  }
+}
+
+async function notifyPromoted(
+  applicantUserId: string,
+  offering: { id: string; title: string },
+): Promise<void> {
+  await emitEvent({
+    type: "education.waitlist_promoted",
+    recipients: [applicantUserId],
+    payload: { offeringId: offering.id },
+    inbox: {
+      kind: "EducationWaitlistPromoted",
+      title: `You're off the waitlist for ${offering.title}!`,
+      body: "A spot opened up and you've been promoted to approved.",
+      link: `/portal/education/${offering.id}`,
+    },
+  });
+  // Per scope: no email on auto-promote. In-app notif only.
+}
+
+async function loadRecipient(
+  applicantUserId: string,
+): Promise<{ email: string; firstName: string } | null> {
+  const user = await prisma.user.findUnique({
+    where: { id: applicantUserId },
+    select: {
+      firstName: true,
+      daliEmail: true,
+      dartmouthEmail: true,
+    },
+  });
+  if (!user) return null;
+  const email = user.daliEmail ?? user.dartmouthEmail;
+  if (!email) return null;
+  return { email, firstName: user.firstName };
+}

--- a/dali-api/app/lib/education/email.ts
+++ b/dali-api/app/lib/education/email.ts
@@ -1,0 +1,98 @@
+import { sendEmail } from "~/lib/gmail";
+import { getApplicationsGmailRefreshToken } from "~/lib/gmail-integration";
+import { bodyToHtml, interpolate } from "~/lib/email";
+import type { EduApplicationStatus } from "~/generated/prisma/enums";
+
+// Education transactional emails. Templates live inline (no DB-stored
+// templates in MVP). All three sends are best-effort: failure does not
+// roll back the calling transaction.
+
+interface BaseRecipient {
+  email: string;
+  firstName: string;
+}
+
+function decisionSubject(status: EduApplicationStatus, offeringTitle: string): string {
+  if (status === "Approved") return `You're in: ${offeringTitle}`;
+  if (status === "Rejected") return `Update on your ${offeringTitle} application`;
+  if (status === "Waitlisted") return `Waitlisted: ${offeringTitle}`;
+  return `Update on your ${offeringTitle} application`;
+}
+
+function decisionBody(
+  status: EduApplicationStatus,
+  offeringTitle: string,
+  reviewerNote: string | null,
+): string {
+  const intro: Record<string, string> = {
+    Approved: `Welcome to ${offeringTitle}! Your application has been approved. You'll find session details and any pre-reads on your "My Learning" page in DALI OS.`,
+    Rejected: `Thanks for applying to ${offeringTitle}. We weren't able to offer you a spot this round, but please apply again in the future.`,
+    Waitlisted: `Thanks for applying to ${offeringTitle}. You're on the waitlist — if a spot opens up, we'll let you know in DALI OS.`,
+  };
+  const body = intro[status] ?? `Your ${offeringTitle} application status changed to ${status}.`;
+  if (reviewerNote && reviewerNote.trim().length > 0) {
+    return `${body}\n\nNote from the instructor:\n${reviewerNote.trim()}`;
+  }
+  return body;
+}
+
+export async function sendApplicationSubmittedEmail(opts: {
+  to: BaseRecipient;
+  offeringTitle: string;
+  requiresReview: boolean;
+}): Promise<void> {
+  const refreshToken = await getApplicationsGmailRefreshToken();
+  if (!refreshToken) return;
+  const subject = `Application received: ${opts.offeringTitle}`;
+  const bodyText = opts.requiresReview
+    ? `Hi {{firstName}},\n\nWe've received your application for ${opts.offeringTitle}. You'll hear back once the instructor has reviewed it.`
+    : `Hi {{firstName}},\n\nYou're registered for ${opts.offeringTitle}. See you in class!`;
+  const html = bodyToHtml(
+    interpolate(bodyText, { firstName: opts.to.firstName }),
+  );
+  try {
+    await sendEmail({ refreshToken, to: opts.to.email, subject, html });
+  } catch (err) {
+    console.error("[education:email] application-submitted failed", err);
+  }
+}
+
+export async function sendDecisionEmail(opts: {
+  to: BaseRecipient;
+  offeringTitle: string;
+  status: EduApplicationStatus;
+  reviewerNote: string | null;
+}): Promise<void> {
+  const refreshToken = await getApplicationsGmailRefreshToken();
+  if (!refreshToken) return;
+  const subject = decisionSubject(opts.status, opts.offeringTitle);
+  const bodyText = `Hi {{firstName}},\n\n${decisionBody(opts.status, opts.offeringTitle, opts.reviewerNote)}`;
+  const html = bodyToHtml(
+    interpolate(bodyText, { firstName: opts.to.firstName }),
+  );
+  try {
+    await sendEmail({ refreshToken, to: opts.to.email, subject, html });
+  } catch (err) {
+    console.error("[education:email] decision failed", err);
+  }
+}
+
+export async function sendAnnouncementEmail(opts: {
+  to: BaseRecipient;
+  offeringTitle: string;
+  authorName: string;
+  body: string;
+}): Promise<void> {
+  const refreshToken = await getApplicationsGmailRefreshToken();
+  if (!refreshToken) return;
+  const subject = `[${opts.offeringTitle}] Announcement from ${opts.authorName}`;
+  const bodyText = `Hi {{firstName}},\n\n${opts.body}\n\n— ${opts.authorName}`;
+  const html = bodyToHtml(
+    interpolate(bodyText, { firstName: opts.to.firstName }),
+  );
+  try {
+    await sendEmail({ refreshToken, to: opts.to.email, subject, html });
+  } catch (err) {
+    console.error("[education:email] announcement failed", err);
+  }
+}

--- a/dali-api/app/lib/education/roster-sync.ts
+++ b/dali-api/app/lib/education/roster-sync.ts
@@ -1,0 +1,127 @@
+import { prisma } from "~/lib/db";
+import {
+  createScheduledMeeting,
+  updateScheduledMeetingParticipants,
+} from "~/lib/scheduled-meeting";
+import { approvedApplicantIds } from "./capacity";
+
+// Sync calendar events to match the current Approved roster. Called from
+// the decisions module (post-transaction) and from session-create endpoints.
+// Each EducationSession gets at most one ScheduledMeeting; we create it
+// lazily on first sync and patch participants thereafter.
+//
+// "Future sessions only" — past sessions don't get touched. Re-syncing the
+// whole offering on every roster change is fine at lab scale (handful of
+// sessions per offering).
+
+const SESSION_DURATION_MINUTES = 60;
+
+interface SyncResult {
+  meetingsCreated: number;
+  meetingsUpdated: number;
+  gcalErrors: string[];
+}
+
+export async function syncSessionRoster(offeringId: string): Promise<SyncResult> {
+  const result: SyncResult = {
+    meetingsCreated: 0,
+    meetingsUpdated: 0,
+    gcalErrors: [],
+  };
+
+  const offering = await prisma.educationOffering.findUnique({
+    where: { id: offeringId },
+    select: {
+      id: true,
+      title: true,
+      calendarEmail: true,
+      instructors: {
+        select: { userId: true },
+        orderBy: { id: "asc" },
+        take: 1,
+      },
+    },
+  });
+  if (!offering) return result;
+
+  const primaryInstructor = offering.instructors[0];
+  if (!primaryInstructor) return result;
+
+  const now = new Date();
+  const sessions = await prisma.educationSession.findMany({
+    where: { offeringId, datetime: { gte: now } },
+    orderBy: { datetime: "asc" },
+    select: {
+      id: true,
+      datetime: true,
+      scheduledMeetingId: true,
+    },
+  });
+  if (sessions.length === 0) return result;
+
+  const approved = await approvedApplicantIds(offeringId);
+  const organizerEmail = offering.calendarEmail ?? null;
+
+  let resolvedOrganizerEmail = organizerEmail;
+  let organizerCalendarLinkId: string | null = null;
+  if (!resolvedOrganizerEmail) {
+    const organizerUser = await prisma.user.findUnique({
+      where: { id: primaryInstructor.userId },
+      select: { daliEmail: true, dartmouthEmail: true },
+    });
+    resolvedOrganizerEmail =
+      organizerUser?.daliEmail ?? organizerUser?.dartmouthEmail ?? null;
+  }
+  // If the instructor has a linked Google calendar, use it so Google sends
+  // the invites. Otherwise we still create the meeting row + notifications.
+  const link = await prisma.userCalendarLink.findFirst({
+    where: { userId: primaryInstructor.userId, enabled: true },
+    select: { id: true },
+  });
+  organizerCalendarLinkId = link?.id ?? null;
+
+  if (!resolvedOrganizerEmail) {
+    // Can't create a ScheduledMeeting without an organizer email. Skip
+    // calendar push entirely; in-app notifications still fire through emit.
+    return result;
+  }
+
+  for (const session of sessions) {
+    if (!session.scheduledMeetingId) {
+      const created = await createScheduledMeeting({
+        organizerId: primaryInstructor.userId,
+        organizerEmail: resolvedOrganizerEmail,
+        title: offering.title,
+        durationMinutes: SESSION_DURATION_MINUTES,
+        scope: { type: "UserList", participantUserIds: approved },
+        startTime: session.datetime.toISOString(),
+        organizerCalendarLinkId,
+      });
+      if (created.ok) {
+        await prisma.educationSession.update({
+          where: { id: session.id },
+          data: { scheduledMeetingId: created.meeting.id },
+        });
+        result.meetingsCreated += 1;
+        if (created.gcalError) result.gcalErrors.push(created.gcalError);
+      } else {
+        result.gcalErrors.push(created.error);
+      }
+    } else {
+      const updated = await updateScheduledMeetingParticipants(
+        session.scheduledMeetingId,
+        approved,
+      );
+      if (updated.ok) {
+        if (updated.added.length > 0 || updated.removed.length > 0) {
+          result.meetingsUpdated += 1;
+        }
+        if (updated.gcalError) result.gcalErrors.push(updated.gcalError);
+      } else {
+        result.gcalErrors.push(updated.error);
+      }
+    }
+  }
+
+  return result;
+}

--- a/dali-api/app/lib/google-calendar.ts
+++ b/dali-api/app/lib/google-calendar.ts
@@ -304,3 +304,33 @@ export async function updateGoogleAttendeeRsvp(opts: {
     throw new Error(`Google events.patch failed (${patchRes.status}): ${detail}`);
   }
 }
+
+/**
+ * Replace the attendee list on an existing Google Calendar event. Sends
+ * Gmail invite/uninvite mail via `sendUpdates=all` so newly added attendees
+ * receive an invite and removed attendees receive a cancellation.
+ */
+export async function setGoogleCalendarEventAttendees(opts: {
+  linkId: string;
+  calendarId?: string;
+  eventId: string;
+  attendees: GoogleAttendee[];
+}): Promise<void> {
+  const token = await getValidAccessTokenForLink(opts.linkId);
+  const calendarId = encodeURIComponent(opts.calendarId ?? "primary");
+  const patchRes = await fetch(
+    `https://www.googleapis.com/calendar/v3/calendars/${calendarId}/events/${encodeURIComponent(opts.eventId)}?sendUpdates=all`,
+    {
+      method: "PATCH",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ attendees: opts.attendees }),
+    },
+  );
+  if (!patchRes.ok) {
+    const detail = await extractGoogleErrorDetail(patchRes);
+    throw new Error(`Google events.patch failed (${patchRes.status}): ${detail}`);
+  }
+}

--- a/dali-api/app/lib/notifications.ts
+++ b/dali-api/app/lib/notifications.ts
@@ -3,6 +3,7 @@
 // "what counts as a recent notification" policy lives in one place.
 
 import { prisma } from "~/lib/db";
+import type { NotificationKind } from "~/generated/prisma/enums";
 
 export interface ListNotificationsOptions {
   /** Hard cap on rows returned. */
@@ -42,4 +43,66 @@ export async function listMyNotifications(
   ]);
 
   return { items, unreadCount };
+}
+
+// ─── Event emission ──────────────────────────────────────────────────────────
+//
+// `emitEvent` is the producer side of the notification pipeline. Writes one
+// NotificationEvent row per recipient (the canonical event log) and, when an
+// in-app inbox surface is configured, one Notification row per recipient
+// (the interactive bell). They will be reconciled when the unified delivery
+// track ships; until then producers should call this and move on.
+
+export interface EmitEventInput {
+  type: string;
+  recipients: string[];
+  payload: Record<string, unknown>;
+  inbox?: {
+    kind: NotificationKind;
+    title: string;
+    body?: string | null;
+    link?: string | null;
+    createdByUserId?: string | null;
+  };
+}
+
+export interface EmitEventResult {
+  eventsWritten: number;
+  notificationsWritten: number;
+}
+
+export async function emitEvent(input: EmitEventInput): Promise<EmitEventResult> {
+  const recipients = Array.from(new Set(input.recipients.filter(Boolean)));
+  if (recipients.length === 0) {
+    return { eventsWritten: 0, notificationsWritten: 0 };
+  }
+
+  const eventResult = await prisma.notificationEvent.createMany({
+    data: recipients.map((recipientId) => ({
+      type: input.type,
+      recipientId,
+      payload: input.payload as object,
+    })),
+  });
+
+  let notificationsWritten = 0;
+  if (input.inbox) {
+    const inbox = input.inbox;
+    const notifResult = await prisma.notification.createMany({
+      data: recipients.map((recipientUserId) => ({
+        recipientUserId,
+        createdByUserId: inbox.createdByUserId ?? null,
+        kind: inbox.kind,
+        title: inbox.title,
+        body: inbox.body ?? null,
+        link: inbox.link ?? null,
+      })),
+    });
+    notificationsWritten = notifResult.count;
+  }
+
+  return {
+    eventsWritten: eventResult.count,
+    notificationsWritten,
+  };
 }

--- a/dali-api/app/lib/roles.ts
+++ b/dali-api/app/lib/roles.ts
@@ -1,4 +1,7 @@
 import { prisma } from "~/lib/db";
+import { requireAuth } from "~/lib/auth";
+
+export const EDUCATION_LEAD_TITLE = "Education Lead";
 
 // Phase 2 rewrite: role flags derived from the new typed assignment tables
 // (AdminMembership, CoreAssignment, DomainLeadAssignment) rather than the
@@ -17,6 +20,9 @@ export interface UserRoles {
   isHiringLead: boolean;
   isAdmin: boolean;
   isDomainLead: boolean;
+  isCore: boolean;
+  isEducationLead: boolean;
+  isInstructor: boolean;
 }
 
 /**
@@ -28,7 +34,7 @@ export async function getUserRoles(userId: string): Promise<UserRoles> {
     .split(",")
     .filter(Boolean);
 
-  const [member, admin, core, domainLead] = await Promise.all([
+  const [member, admin, core, educationLead, instructor, domainLead] = await Promise.all([
     prisma.dALIMember.findUnique({ where: { userId }, select: { id: true } }),
     prisma.adminMembership.findUnique({ where: { userId }, select: { id: true } }),
     // Any CoreAssignment is sufficient for "hiring lead-equivalent" access.
@@ -37,6 +43,11 @@ export async function getUserRoles(userId: string): Promise<UserRoles> {
     // year-long and the few minutes around term rollover don't warrant a
     // current-term filter at this layer.
     prisma.coreAssignment.findFirst({ where: { userId }, select: { id: true } }),
+    prisma.coreAssignment.findFirst({
+      where: { userId, leadTitle: EDUCATION_LEAD_TITLE },
+      select: { id: true },
+    }),
+    prisma.instructorAssignment.findFirst({ where: { userId }, select: { id: true } }),
     // DomainLeadAssignment.termId is required post-Phase-2; any row signals
     // domain-lead authority for that user.
     prisma.domainLeadAssignment.findFirst({ where: { userId }, select: { id: true } }),
@@ -53,6 +64,9 @@ export async function getUserRoles(userId: string): Promise<UserRoles> {
     isHiringLead: isAdminVal || isCoreVal,
     isAdmin: isAdminVal,
     isDomainLead: domainLead !== null,
+    isCore: isAdminVal || isCoreVal,
+    isEducationLead: educationLead !== null,
+    isInstructor: instructor !== null,
   };
 }
 
@@ -148,4 +162,71 @@ export async function hasCycleAccess(userId: string, cycleId: string): Promise<b
     }),
   ]);
   return reviewer !== null || interviewer !== null;
+}
+
+// ─── Education-scoped helpers ────────────────────────────────────────────────
+
+/** Core for the current term. Admins are a superset of Core. */
+export async function isCore(userId: string): Promise<boolean> {
+  const envIds = (process.env.ADMIN_USER_IDS ?? "")
+    .split(",")
+    .filter(Boolean);
+  if (envIds.includes(userId)) return true;
+  const [admin, core] = await Promise.all([
+    prisma.adminMembership.findUnique({ where: { userId }, select: { id: true } }),
+    prisma.coreAssignment.findFirst({ where: { userId }, select: { id: true } }),
+  ]);
+  return admin !== null || core !== null;
+}
+
+/** True when the user holds a Core seat with leadTitle = "Education Lead". */
+export async function isEducationLead(userId: string): Promise<boolean> {
+  const row = await prisma.coreAssignment.findFirst({
+    where: { userId, leadTitle: EDUCATION_LEAD_TITLE },
+    select: { id: true },
+  });
+  return row !== null;
+}
+
+/** True when the user is currently an instructor for the offering (any term). */
+export async function isInstructorFor(
+  userId: string,
+  offeringId: string,
+): Promise<boolean> {
+  const row = await prisma.instructorAssignment.findFirst({
+    where: { userId, offeringId },
+    select: { id: true },
+  });
+  return row !== null;
+}
+
+/**
+ * Gate helper for Education manager loaders/actions. Returns either an
+ * authenticated userId or a Response the caller should throw. Pass
+ * `offeringId = null` for endpoints that only Core may use (e.g. create
+ * an offering).
+ */
+export async function requireInstructorOrCore(
+  request: Request,
+  offeringId: string | null,
+): Promise<
+  | { ok: true; userId: string }
+  | { ok: false; response: Response }
+> {
+  const auth = await requireAuth(request);
+  if (!auth.ok) return { ok: false, response: auth.response };
+
+  if (await isCore(auth.user.sub)) return { ok: true, userId: auth.user.sub };
+
+  if (offeringId && (await isInstructorFor(auth.user.sub, offeringId))) {
+    return { ok: true, userId: auth.user.sub };
+  }
+
+  return {
+    ok: false,
+    response: new Response(JSON.stringify({ error: "Forbidden" }), {
+      status: 403,
+      headers: { "Content-Type": "application/json" },
+    }),
+  };
 }

--- a/dali-api/app/lib/scheduled-meeting.ts
+++ b/dali-api/app/lib/scheduled-meeting.ts
@@ -5,7 +5,11 @@
 
 import { prisma } from "~/lib/db";
 import { resolveGroupMembers } from "~/lib/groups";
-import { createGoogleCalendarEvent, type GoogleAttendee } from "~/lib/google-calendar";
+import {
+  createGoogleCalendarEvent,
+  setGoogleCalendarEventAttendees,
+  type GoogleAttendee,
+} from "~/lib/google-calendar";
 import type { ScheduledMeeting } from "~/generated/prisma/client";
 
 export type ScheduledMeetingScope =
@@ -149,4 +153,82 @@ export async function createScheduledMeeting(
     notifiedCount,
     gcalError,
   };
+}
+
+export type UpdateParticipantsResult =
+  | { ok: true; added: string[]; removed: string[]; gcalError: string | null }
+  | { ok: false; error: string };
+
+/**
+ * Reconcile a ScheduledMeeting's participants to `participantUserIds`. Updates
+ * the participantUserIds column and patches the Google Calendar event when
+ * the meeting has an externalEventId + a calendar link is still attached.
+ */
+export async function updateScheduledMeetingParticipants(
+  meetingId: string,
+  participantUserIds: string[],
+): Promise<UpdateParticipantsResult> {
+  const targetIds = Array.from(new Set(participantUserIds));
+
+  const meeting = await prisma.scheduledMeeting.findUnique({
+    where: { id: meetingId },
+    select: {
+      id: true,
+      participantUserIds: true,
+      externalEventId: true,
+      organizerCalendarLinkId: true,
+      organizerCalendarLink: {
+        select: { id: true, enabled: true },
+      },
+    },
+  });
+  if (!meeting) return { ok: false, error: "Meeting not found" };
+
+  const current = new Set(meeting.participantUserIds);
+  const target = new Set(targetIds);
+  const added = targetIds.filter((id) => !current.has(id));
+  const removed = meeting.participantUserIds.filter((id) => !target.has(id));
+
+  if (added.length === 0 && removed.length === 0) {
+    return { ok: true, added: [], removed: [], gcalError: null };
+  }
+
+  await prisma.scheduledMeeting.update({
+    where: { id: meetingId },
+    data: { participantUserIds: targetIds },
+  });
+
+  let gcalError: string | null = null;
+  if (meeting.externalEventId && meeting.organizerCalendarLink?.enabled) {
+    const users = await prisma.user.findMany({
+      where: { id: { in: targetIds } },
+      select: {
+        id: true,
+        firstName: true,
+        lastName: true,
+        daliEmail: true,
+        dartmouthEmail: true,
+      },
+    });
+    const attendees: GoogleAttendee[] = [];
+    for (const u of users) {
+      const email = u.daliEmail ?? u.dartmouthEmail;
+      if (!email) continue;
+      attendees.push({
+        email,
+        displayName: `${u.firstName} ${u.lastName}`.trim() || email,
+      });
+    }
+    try {
+      await setGoogleCalendarEventAttendees({
+        linkId: meeting.organizerCalendarLink.id,
+        eventId: meeting.externalEventId,
+        attendees,
+      });
+    } catch (err) {
+      gcalError = err instanceof Error ? err.message : "Google Calendar patch failed";
+    }
+  }
+
+  return { ok: true, added, removed, gcalError };
 }

--- a/dali-api/app/routes.ts
+++ b/dali-api/app/routes.ts
@@ -42,6 +42,26 @@ export default [
 
     // Partners
     route("partners", "partners/routes/partners.tsx"),
+
+    // Education (member-facing)
+    route("education", "education/routes/education._index.tsx"),
+    route("education/browse", "education/routes/education.browse.tsx"),
+    route("education/my-learning", "education/routes/education.my-learning.tsx"),
+    route("education/teaching", "education/routes/education.teaching.tsx"),
+    route("education/manage", "education/routes/education.manage.tsx"),
+    route("education/offerings/new", "education/routes/education.offerings.new.tsx"),
+    route("education/offerings/:id", "education/routes/education.offerings.$id.tsx"),
+    route("education/offerings/:id/sessions", "education/routes/education.offerings.$id.sessions.tsx"),
+    route("education/offerings/:id/roster", "education/routes/education.offerings.$id.roster.tsx"),
+    route("education/offerings/:id/attendance", "education/routes/education.offerings.$id.attendance.tsx"),
+    route("education/offerings/:id/assignments", "education/routes/education.offerings.$id.assignments.tsx"),
+    route(
+      "education/offerings/:id/assignments/:assignmentId",
+      "education/routes/education.offerings.$id.assignments.$assignmentId.tsx",
+    ),
+    route("education/offerings/:id/announcements", "education/routes/education.offerings.$id.announcements.tsx"),
+    route("education/offerings/:id/pages", "education/routes/education.offerings.$id.pages.tsx"),
+    route("education/offerings/:id/settings", "education/routes/education.offerings.$id.settings.tsx"),
   ]),
 
   // Applicant portal (lightweight layout)
@@ -49,6 +69,18 @@ export default [
     route("portal", "routes/portal.tsx"),
     route("portal/apply", "routes/portal.apply.tsx"),
     route("portal/application", "routes/portal.application.tsx"),
+
+    // Education portal
+    route("portal/education", "education/routes/portal.education._index.tsx"),
+    route("portal/education/:offeringId", "education/routes/portal.education.$offeringId.tsx"),
+    route(
+      "portal/education/applications/:id",
+      "education/routes/portal.education.applications.$id.tsx",
+    ),
+    route(
+      "portal/education/applications/:id/assignments/:assignmentId",
+      "education/routes/portal.education.applications.$id.assignments.$assignmentId.tsx",
+    ),
   ]),
 
   // Login (no layout)
@@ -178,4 +210,24 @@ export default [
   // Collaborative editing version history
   route("api/collab/versions", "routes/api.collab.versions.ts"),
   route("api/collab/versions/:id", "routes/api.collab.versions.$id.ts"),
+
+  // Education API
+  route("api/education/offerings", "education/routes/api.offerings.ts"),
+  route("api/education/offerings/:id", "education/routes/api.offerings.$id.ts"),
+  route("api/education/offerings/:id/publish", "education/routes/api.offerings.$id.publish.ts"),
+  route("api/education/offerings/:id/instructors", "education/routes/api.offerings.$id.instructors.ts"),
+  route("api/education/offerings/:id/questions", "education/routes/api.offerings.$id.questions.ts"),
+  route("api/education/questions/:id", "education/routes/api.questions.$id.ts"),
+  route("api/education/offerings/:id/sessions", "education/routes/api.offerings.$id.sessions.ts"),
+  route("api/education/sessions/:id", "education/routes/api.sessions.$id.ts"),
+  route("api/education/sessions/:id/attendance", "education/routes/api.sessions.$id.attendance.ts"),
+  route("api/education/offerings/:id/apply", "education/routes/api.offerings.$id.apply.ts"),
+  route("api/education/applications/:id/withdraw", "education/routes/api.applications.$id.withdraw.ts"),
+  route("api/education/applications/:id/decision", "education/routes/api.applications.$id.decision.ts"),
+  route("api/education/offerings/:id/assignments", "education/routes/api.offerings.$id.assignments.ts"),
+  route("api/education/assignments/:id", "education/routes/api.assignments.$id.ts"),
+  route("api/education/assignments/:id/submit", "education/routes/api.assignments.$id.submit.ts"),
+  route("api/education/submissions/:id/upload-post", "education/routes/api.submissions.$id.upload-post.ts"),
+  route("api/education/submissions/:id/grade", "education/routes/api.submissions.$id.grade.ts"),
+  route("api/education/offerings/:id/announcements", "education/routes/api.offerings.$id.announcements.ts"),
 ] satisfies RouteConfig;

--- a/dali-api/app/routes/home.tsx
+++ b/dali-api/app/routes/home.tsx
@@ -13,10 +13,11 @@ import {
 import { requireAuth } from "~/lib/auth";
 import { prisma } from "~/lib/db";
 import type { Route } from "./+types/home";
+import type { NotificationKind } from "~/generated/prisma/enums";
 
 type HomeNotification = {
   id: string;
-  kind: "General" | "MeetingInvite" | "MeetingReminder" | "SystemAnnouncement";
+  kind: NotificationKind;
   title: string;
   body: string | null;
   link: string | null;

--- a/dali-api/app/routes/layout.tsx
+++ b/dali-api/app/routes/layout.tsx
@@ -11,7 +11,15 @@ export async function loader({ request }: Route.LoaderArgs) {
   const auth = await requireAuth(request)
   if (!auth.ok) return redirect('/login')
   if (auth.user.type === 'applicant') return redirect('/portal')
-  const { isLabMember, isHiringLead: hiringLead, isAdmin: admin, isDomainLead: domainLead } = await getUserRoles(auth.user.sub)
+  const {
+    isLabMember,
+    isHiringLead: hiringLead,
+    isAdmin: admin,
+    isDomainLead: domainLead,
+    isCore: core,
+    isEducationLead: educationLead,
+    isInstructor: instructor,
+  } = await getUserRoles(auth.user.sub)
 
   let isInterviewer = false
   if (isLabMember) {
@@ -30,11 +38,31 @@ export async function loader({ request }: Route.LoaderArgs) {
   const fetchDest = request.headers.get('sec-fetch-dest')
   const isEmbedded = fetchDest === 'iframe' || fetchDest === 'frame'
 
-  return { user: auth.user, isHiringLead: hiringLead, isAdmin: admin, isDomainLead: domainLead, isInterviewer, isEmbedded }
+  return {
+    user: auth.user,
+    isHiringLead: hiringLead,
+    isAdmin: admin,
+    isDomainLead: domainLead,
+    isInterviewer,
+    isCore: core,
+    isEducationLead: educationLead,
+    isInstructor: instructor,
+    isEmbedded,
+  }
 }
 
 export default function AppLayoutRoute() {
-  const { user, isHiringLead, isAdmin, isDomainLead, isInterviewer, isEmbedded } = useLoaderData<typeof loader>()
+  const {
+    user,
+    isHiringLead,
+    isAdmin,
+    isDomainLead,
+    isInterviewer,
+    isCore,
+    isEducationLead,
+    isInstructor,
+    isEmbedded,
+  } = useLoaderData<typeof loader>()
   const [searchParams] = useSearchParams()
 
   // After a client-side navigation inside the workspace iframe, the loader
@@ -65,6 +93,15 @@ export default function AppLayoutRoute() {
   }
 
   return (
-    <Layout user={user} isHiringLead={isHiringLead} isAdmin={isAdmin} isDomainLead={isDomainLead} isInterviewer={isInterviewer} />
+    <Layout
+      user={user}
+      isHiringLead={isHiringLead}
+      isAdmin={isAdmin}
+      isDomainLead={isDomainLead}
+      isInterviewer={isInterviewer}
+      isCore={isCore}
+      isEducationLead={isEducationLead}
+      isInstructor={isInstructor}
+    />
   )
 }

--- a/dali-api/e2e/education-apply-attend-submit.spec.ts
+++ b/dali-api/e2e/education-apply-attend-submit.spec.ts
@@ -1,0 +1,153 @@
+import { test, expect } from "./fixtures";
+import pg from "pg";
+
+const DATABASE_URL =
+  process.env.DATABASE_URL || "postgresql://dali:dali@localhost:5432/dali";
+
+const OFFERING_TITLE = "E2E Test Miniseries";
+
+// Insert a published EducationOffering with one session + question; clean up
+// after. Uses the admin seed user (admin@dali.dartmouth.edu) as the
+// instructor — already a Core member from the local seed.
+async function seedOffering(): Promise<{
+  offeringId: string;
+  sessionId: string;
+  questionId: string;
+  termId: string;
+  adminId: string;
+}> {
+  const client = new pg.Client(DATABASE_URL);
+  await client.connect();
+  try {
+    const admin = await client.query<{ id: string }>(
+      `SELECT id FROM "User" WHERE "daliEmail" = 'admin@dali.dartmouth.edu' LIMIT 1`,
+    );
+    const adminId = admin.rows[0].id;
+    const term = await client.query<{ id: string }>(
+      `SELECT id FROM "Term" ORDER BY "sortKey" DESC LIMIT 1`,
+    );
+    const termId = term.rows[0].id;
+
+    const now = new Date();
+    const opens = new Date(now.getTime() - 60_000).toISOString();
+    const closes = new Date(now.getTime() + 7 * 86_400_000).toISOString();
+    const starts = new Date(now.getTime() + 86_400_000).toISOString();
+    const ends = new Date(now.getTime() + 14 * 86_400_000).toISOString();
+
+    const offering = await client.query<{ id: string }>(
+      `INSERT INTO "EducationOffering"
+       ("id","type","title","capacity","registrationOpensAt","registrationClosesAt","startsAt","endsAt","status","requiresReview","createdAt")
+       VALUES (gen_random_uuid()::text, 'Miniseries', $1, 5, $2, $3, $4, $5, 'Published', true, NOW())
+       RETURNING id`,
+      [OFFERING_TITLE, opens, closes, starts, ends],
+    );
+    const offeringId = offering.rows[0].id;
+    await client.query(
+      `INSERT INTO "InstructorAssignment" ("id","userId","offeringId","termId") VALUES (gen_random_uuid()::text,$1,$2,$3)`,
+      [adminId, offeringId, termId],
+    );
+    const session = await client.query<{ id: string }>(
+      `INSERT INTO "EducationSession" ("id","offeringId","sequence","datetime")
+       VALUES (gen_random_uuid()::text, $1, 1, $2) RETURNING id`,
+      [offeringId, starts],
+    );
+    const sessionId = session.rows[0].id;
+    const question = await client.query<{ id: string }>(
+      `INSERT INTO "EducationApplicationQuestion" ("id","offeringId","prompt","position","required")
+       VALUES (gen_random_uuid()::text, $1, 'Why do you want to take this?', 0, true)
+       RETURNING id`,
+      [offeringId],
+    );
+    return {
+      offeringId,
+      sessionId,
+      questionId: question.rows[0].id,
+      termId,
+      adminId,
+    };
+  } finally {
+    await client.end();
+  }
+}
+
+async function cleanupOffering(offeringId: string) {
+  const client = new pg.Client(DATABASE_URL);
+  await client.connect();
+  try {
+    await client.query(
+      `DELETE FROM "EducationAttendance" WHERE "sessionId" IN (SELECT id FROM "EducationSession" WHERE "offeringId" = $1)`,
+      [offeringId],
+    );
+    await client.query(
+      `DELETE FROM "EducationApplicationAnswer" WHERE "applicationId" IN (SELECT id FROM "EducationApplication" WHERE "offeringId" = $1)`,
+      [offeringId],
+    );
+    await client.query(
+      `DELETE FROM "EducationApplication" WHERE "offeringId" = $1`,
+      [offeringId],
+    );
+    await client.query(
+      `DELETE FROM "EducationApplicationQuestion" WHERE "offeringId" = $1`,
+      [offeringId],
+    );
+    await client.query(
+      `DELETE FROM "EducationSession" WHERE "offeringId" = $1`,
+      [offeringId],
+    );
+    await client.query(
+      `DELETE FROM "InstructorAssignment" WHERE "offeringId" = $1`,
+      [offeringId],
+    );
+    await client.query(
+      `DELETE FROM "EducationOffering" WHERE id = $1`,
+      [offeringId],
+    );
+  } finally {
+    await client.end();
+  }
+}
+
+test.describe("Education: apply → approve → attend happy path", () => {
+  let ids: Awaited<ReturnType<typeof seedOffering>>;
+
+  test.beforeAll(async () => {
+    ids = await seedOffering();
+  });
+  test.afterAll(async () => {
+    await cleanupOffering(ids.offeringId);
+  });
+
+  test("student applies, instructor approves, student sees Approved", async ({
+    page,
+    loginAs,
+  }) => {
+    // Student (any Dartmouth-authed user works — use the seeded carol applicant).
+    await loginAs({ netId: "carolp" });
+    await page.goto(`/portal/education/${ids.offeringId}`);
+    await expect(page.getByRole("heading", { name: OFFERING_TITLE })).toBeVisible();
+
+    await page
+      .getByRole("textbox", { name: /Why do you want to take this/ })
+      .fill("I want to learn.");
+    await page.getByRole("button", { name: /Submit application/ }).click();
+
+    await expect(page.getByText("Your status:")).toBeVisible();
+    await expect(page.getByText("Submitted")).toBeVisible();
+
+    // Instructor (admin) approves from the roster page.
+    await loginAs({ daliEmail: "admin@dali.dartmouth.edu" });
+    await page.goto(`/education/offerings/${ids.offeringId}/roster`);
+    await expect(page.getByRole("heading", { name: OFFERING_TITLE })).toBeVisible();
+    const approveButton = page
+      .getByRole("button", { name: "Approve" })
+      .first();
+    await expect(approveButton).toBeVisible();
+    await approveButton.click();
+
+    // Student sees Approved.
+    await loginAs({ netId: "carolp" });
+    await page.goto("/education/my-learning");
+    await expect(page.getByText(OFFERING_TITLE)).toBeVisible();
+    await expect(page.getByText("Approved")).toBeVisible();
+  });
+});

--- a/dali-api/prisma/migrations/20260518031604_education_notification_kinds_and_session_meeting/migration.sql
+++ b/dali-api/prisma/migrations/20260518031604_education_notification_kinds_and_session_meeting/migration.sql
@@ -1,0 +1,15 @@
+-- Education MVP: extend NotificationKind for education events + link
+-- EducationSession to ScheduledMeeting for lazy calendar push.
+-- Both changes are purely additive (enum extension; new nullable FK column).
+
+ALTER TYPE "NotificationKind" ADD VALUE 'EducationApplicationDecision';
+ALTER TYPE "NotificationKind" ADD VALUE 'EducationAnnouncementPosted';
+ALTER TYPE "NotificationKind" ADD VALUE 'EducationWaitlistPromoted';
+ALTER TYPE "NotificationKind" ADD VALUE 'EducationSessionInvite';
+
+ALTER TABLE "EducationSession" ADD COLUMN "scheduledMeetingId" TEXT;
+
+ALTER TABLE "EducationSession"
+  ADD CONSTRAINT "EducationSession_scheduledMeetingId_fkey"
+  FOREIGN KEY ("scheduledMeetingId") REFERENCES "ScheduledMeeting"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE;

--- a/dali-api/prisma/schema.prisma
+++ b/dali-api/prisma/schema.prisma
@@ -1129,8 +1129,9 @@ model ScheduledMeeting {
   organizerCalendarLinkId String?
   organizerCalendarLink   UserCalendarLink? @relation(fields: [organizerCalendarLinkId], references: [id])
 
-  exceptions    MeetingException[]
-  notifications Notification[]
+  exceptions       MeetingException[]
+  notifications    Notification[]
+  educationSession EducationSession[] @relation("EducationSessionMeeting")
 
   createdAt DateTime @default(now())
 }
@@ -1182,6 +1183,10 @@ enum NotificationKind {
   MeetingInvite
   MeetingReminder
   SystemAnnouncement
+  EducationApplicationDecision
+  EducationAnnouncementPosted
+  EducationWaitlistPromoted
+  EducationSessionInvite
 }
 
 enum MeetingRsvp {
@@ -1726,10 +1731,14 @@ model EducationSession {
   // Materials as collab doc — slides, notes, pre-reads.
   materialsDocId String?
   recordingUrl   String?
+  // Lazily created when roster sync first runs. Lets us re-sync participants
+  // on approve / withdraw / promote without recreating the calendar event.
+  scheduledMeetingId String?
 
-  offering    EducationOffering     @relation(fields: [offeringId], references: [id])
-  attendances EducationAttendance[]
-  assignments EducationAssignment[]
+  offering         EducationOffering     @relation(fields: [offeringId], references: [id])
+  scheduledMeeting ScheduledMeeting?     @relation("EducationSessionMeeting", fields: [scheduledMeetingId], references: [id], onDelete: SetNull)
+  attendances      EducationAttendance[]
+  assignments      EducationAssignment[]
 
   @@index([offeringId, sequence])
 }


### PR DESCRIPTION
## Summary

End-to-end mini course-management system in one PR. Education Leads / instructors create and run **Miniseries** + **Workshop** offerings; DALI members and any Dartmouth student can enroll, attend, and submit work. Capacity, waitlists, and inline transactional auto-promotion on withdraw / capacity raise.

- New **Education** sidebar area (Browse / My Learning / Teaching / Manage) with role-gated sub-items
- New `/portal/education` catalog open to any authenticated Dartmouth user (uses existing applicant-layout)
- Per-offering workspace with sub-routes for Sessions, Roster (with decision controls), Attendance, Assignments, Announcements, Pages, Settings
- 18 API endpoints under `/api/education/*`
- Lazy Google Calendar push per session via existing `lib/scheduled-meeting.ts`, with roster sync on approve/withdraw/promote
- 3 transactional emails (apply confirmation, decision, announcement broadcast) via existing `lib/gmail.ts`
- Per-application + per-submission collab feedback docs via existing Hocuspocus pipeline

## v0 helpers landed alongside the feature

The expansion plan called for these in v0; they're tiny and Education is the first consumer:
- `lib/notifications.ts`: `emitEvent(type, recipients, payload, inbox?)` producer
- `lib/roles.ts`: `isCore`, `isEducationLead`, `isInstructorFor`, `requireInstructorOrCore`, `EDUCATION_LEAD_TITLE`
- `lib/scheduled-meeting.ts`: `updateScheduledMeetingParticipants`
- `lib/google-calendar.ts`: `setGoogleCalendarEventAttendees`

## Migration

One additive migration: `20260518031604_education_notification_kinds_and_session_meeting`
- Extends `NotificationKind` enum with `EducationApplicationDecision`, `EducationAnnouncementPosted`, `EducationWaitlistPromoted`, `EducationSessionInvite`
- Adds nullable `EducationSession.scheduledMeetingId` FK to `ScheduledMeeting`

No backfill required.

## Out of scope (deferred per scoping Q&A)

- Office hours / instructor scheduling
- Dedicated Analytics page (use inline counts on Manage list)
- Session reminders (24h before)
- Waitlist-auto-promoted email (in-app notification only)
- Page editor changes (Pages tab is read-only list pointing into the existing editor)

## Test plan

- [x] `npm run typecheck` — zero errors in Education code (pre-existing slack/* errors unrelated)
- [x] `npm test` — 783 passing including 13 new Education unit tests (decisions, apply, roster-sync)
- [ ] Playwright `education-apply-attend-submit.spec.ts` runs against seeded Postgres on CI
- [ ] Manual: Workshop variant — apply 3 times from 3 accounts with capacity=2 -> 2 Approved + 1 Waitlisted; withdraw one Approved -> Waitlisted promotes to Approved
- [ ] Manual: confirm Google Calendar push works against a real linked instructor calendar in staging
- [ ] Manual: confirm decision email renders in Gmail web client in staging
- [ ] Manual: sidebar Education area gates correctly for plain member / instructor / Core / Education Lead

🤖 Generated with [Claude Code](https://claude.com/claude-code)