### PR TITLE
Share components across cycle types + single reviewer pool for InternToFull

### DIFF
--- a/dali-api/app/hiring/components/CycleSelector.tsx
+++ b/dali-api/app/hiring/components/CycleSelector.tsx
@@ -1,0 +1,43 @@
+import { useSearchParams } from "react-router";
+
+export const CYCLE_TYPE_LABELS: Record<string, string> = {
+  Standard: "Standard hire",
+  InternToFull: "Intern → Full-time",
+};
+
+export function CycleSelector({
+  cycles,
+  activeId,
+}: {
+  cycles: Array<{ id: string; name: string; cycleType: string }>;
+  activeId: string;
+}) {
+  const [searchParams, setSearchParams] = useSearchParams();
+  if (cycles.length < 2) return null;
+  return (
+    <div className="inline-flex rounded-md border border-border bg-card p-0.5 text-xs">
+      {cycles.map((c) => {
+        const isActive = c.id === activeId;
+        return (
+          <button
+            key={c.id}
+            type="button"
+            onClick={() => {
+              const next = new URLSearchParams(searchParams);
+              next.set("cycle", c.id);
+              setSearchParams(next, { replace: true });
+            }}
+            className={`px-3 py-1.5 rounded font-medium transition ${
+              isActive
+                ? "bg-blue-600 text-white"
+                : "text-muted-foreground hover:text-foreground"
+            }`}
+            title={c.name}
+          >
+            {CYCLE_TYPE_LABELS[c.cycleType] ?? c.cycleType}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/dali-api/app/hiring/components/CycleSetupSection.tsx
+++ b/dali-api/app/hiring/components/CycleSetupSection.tsx
@@ -1,0 +1,19 @@
+export function CycleSetupSection({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="rounded-2xl border border-border bg-card px-6 py-5">
+      <h2 className="font-heading text-sm font-bold uppercase tracking-wider text-dark-blue">
+        {title}
+      </h2>
+      {description && <p className="text-xs text-muted-foreground mt-1 mb-4">{description}</p>}
+      <div className={description ? "" : "mt-4"}>{children}</div>
+    </section>
+  );
+}

--- a/dali-api/app/hiring/lib/domain-application.ts
+++ b/dali-api/app/hiring/lib/domain-application.ts
@@ -1,0 +1,74 @@
+import { prisma } from "~/lib/db";
+
+/**
+ * Reconcile DomainApplication rows for an Application against a desired set of
+ * domains.
+ *
+ * - InternToFull cycles call with just `domainIds` — DAs hold a direct
+ *   domainId FK and no challenge version.
+ * - Standard cycles call with `challengeVersionByDomain` populated — DAs are
+ *   pinned to a per-domain ChallengeVersion; switching the CV wipes that
+ *   domain's answers (the question set is different).
+ *
+ * Semantics in both modes:
+ *   - Missing DA: create with selected=true (default).
+ *   - Existing DA not in desired set: mark selected=false (answers preserved
+ *     so the applicant can reselect without losing work).
+ *   - Existing DA in desired set: ensure selected=true. For Standard, also
+ *     swap CV + clear answers if the desired CV changed.
+ */
+export async function reconcileDomainApplications({
+  applicationId,
+  domainIds,
+  challengeVersionByDomain,
+}: {
+  applicationId: string;
+  domainIds: string[];
+  challengeVersionByDomain?: Map<string, string>;
+}): Promise<void> {
+  const existing = await prisma.domainApplication.findMany({
+    where: { applicationId },
+    select: { id: true, domainId: true, selected: true, challengeVersionId: true },
+  });
+  const byDomain = new Map(
+    existing.filter((da) => da.domainId).map((da) => [da.domainId!, da]),
+  );
+
+  for (const domainId of domainIds) {
+    const desiredCv = challengeVersionByDomain?.get(domainId);
+    const ex = byDomain.get(domainId);
+    if (!ex) {
+      await prisma.domainApplication.create({
+        data: {
+          applicationId,
+          domainId,
+          ...(desiredCv ? { challengeVersionId: desiredCv } : {}),
+          answers: {},
+        },
+      });
+      continue;
+    }
+    const updates: { selected?: boolean; challengeVersionId?: string; answers?: object } = {};
+    if (!ex.selected) updates.selected = true;
+    if (desiredCv && ex.challengeVersionId !== desiredCv) {
+      updates.challengeVersionId = desiredCv;
+      updates.answers = {};
+    }
+    if (Object.keys(updates).length > 0) {
+      await prisma.domainApplication.update({
+        where: { id: ex.id },
+        data: updates,
+      });
+    }
+  }
+
+  const toDeselect = existing
+    .filter((da) => da.domainId && !domainIds.includes(da.domainId) && da.selected)
+    .map((da) => da.id);
+  if (toDeselect.length > 0) {
+    await prisma.domainApplication.updateMany({
+      where: { id: { in: toDeselect } },
+      data: { selected: false },
+    });
+  }
+}

--- a/dali-api/app/hiring/routes/domain-lead.tsx
+++ b/dali-api/app/hiring/routes/domain-lead.tsx
@@ -13,6 +13,7 @@ import { ConfidentialityGate } from "~/hiring/components/ConfidentialityGate";
 import { RichTextViewer, isEmptyDoc } from "~/components/RichTextViewer";
 import { Modal } from "~/components/Modal";
 import { ChallengePreviewModal } from "~/hiring/components/ChallengePreviewModal";
+import { CycleSelector } from "~/hiring/components/CycleSelector";
 import {
   summarizeDecisionPills,
   synthesizePrePipelinePill,
@@ -45,48 +46,6 @@ const STATUS_MESSAGES: Record<string, string> = {
   UnderReview: "Submissions are closed. Review applications below.",
   Completed: "Decisions have been released to applicants.",
 };
-
-const CYCLE_TYPE_LABELS: Record<string, string> = {
-  Standard: "Standard hire",
-  InternToFull: "Intern → Full-time",
-};
-
-function CyclePicker({
-  cycles,
-  activeId,
-}: {
-  cycles: Array<{ id: string; name: string; cycleType: string }>;
-  activeId: string;
-}) {
-  const [searchParams, setSearchParams] = useSearchParams();
-  if (cycles.length < 2) return null;
-  return (
-    <div className="inline-flex rounded-md border border-border bg-card p-0.5 text-xs">
-      {cycles.map((c) => {
-        const isActive = c.id === activeId;
-        return (
-          <button
-            key={c.id}
-            type="button"
-            onClick={() => {
-              const next = new URLSearchParams(searchParams);
-              next.set("cycle", c.id);
-              setSearchParams(next, { replace: true });
-            }}
-            className={`px-3 py-1.5 rounded font-medium transition ${
-              isActive
-                ? "bg-blue-600 text-white"
-                : "text-muted-foreground hover:text-foreground"
-            }`}
-            title={c.name}
-          >
-            {CYCLE_TYPE_LABELS[c.cycleType] ?? c.cycleType}
-          </button>
-        );
-      })}
-    </div>
-  );
-}
 
 export const meta: Route.MetaFunction = () => [{ title: "Domain lead · DALI OS" }];
 
@@ -716,7 +675,7 @@ export default function DomainLeadDashboard() {
                           {STATUS_LABELS[currentStatus]}
                         </span>
                       )}
-                      <CyclePicker cycles={availableCycles ?? []} activeId={cycle.id} />
+                      <CycleSelector cycles={availableCycles ?? []} activeId={cycle.id} />
                     </div>
                     {currentStatus !== "Draft" && !confidentialityRequired && (
                       <div className="flex flex-wrap items-center gap-x-4 gap-y-1">

--- a/dali-api/app/hiring/routes/lead.intern-to-full-cycle.$id.tsx
+++ b/dali-api/app/hiring/routes/lead.intern-to-full-cycle.$id.tsx
@@ -6,12 +6,13 @@ import { requireAuth } from "~/lib/auth";
 import { isHiringLead } from "~/lib/roles";
 import type { Question } from "~/types";
 import type { Prisma } from "~/generated/prisma/client";
+import { CycleSetupSection as Section } from "~/hiring/components/CycleSetupSection";
 
 export const meta: Route.MetaFunction = () => [
   { title: "Intern → Full-time cycle · DALI OS" },
 ];
 
-const MIN_REVIEWERS_PER_DOMAIN = 2;
+const MIN_POOL_SIZE = 2;
 
 export async function loader({ request, params }: Route.LoaderArgs) {
   const auth = await requireAuth(request);
@@ -86,13 +87,24 @@ export async function loader({ request, params }: Route.LoaderArgs) {
           : null,
         isReady: d.isReady,
       })),
-      reviewers: cycle.cycleReviewers.map((r) => ({
-        id: r.id,
-        userId: r.userId,
-        domainId: r.domainId,
-        domainCode: r.domain.code,
-        displayName: [r.user.firstName, r.user.lastName].filter(Boolean).join(" ") || r.user.daliEmail || r.userId,
-      })),
+      // InternToFull uses a single reviewer pool: each member reads every DA
+      // across all target domains. The schema still stores one CycleReviewer
+      // row per (user, cycle, domain) so the existing fan-out (auto-assign,
+      // review submission) works unchanged — dedupe by userId for the UI.
+      reviewers: Array.from(
+        new Map(
+          cycle.cycleReviewers.map((r) => [
+            r.userId,
+            {
+              userId: r.userId,
+              displayName:
+                [r.user.firstName, r.user.lastName].filter(Boolean).join(" ") ||
+                r.user.daliEmail ||
+                r.userId,
+            },
+          ]),
+        ).values(),
+      ),
     },
     allDomains: allDomains.map((d) => ({ id: d.id, code: d.code, displayName: d.displayName })),
     allFormVersions: allFormVersions.map((fv) => ({
@@ -187,15 +199,49 @@ export async function action({ request, params }: Route.ActionArgs) {
           { status: 409 },
         );
       }
-      await prisma.domainApplicationCycle.deleteMany({
-        where: { applicationCycleId: cycleId, domainId: { in: toRemove } },
-      });
     }
-    if (toAdd.length > 0) {
-      await prisma.domainApplicationCycle.createMany({
-        data: toAdd.map((domainId) => ({ applicationCycleId: cycleId, domainId })),
-      });
-    }
+
+    // Pool members are stored as one CycleReviewer row per (user, cycle, domain);
+    // sync the rowset whenever the target-domain set changes so the pool
+    // invariant "every member is on every active domain" holds.
+    const poolUserIds = Array.from(
+      new Set(
+        (
+          await prisma.cycleReviewer.findMany({
+            where: { applicationCycleId: cycleId },
+            select: { userId: true },
+          })
+        ).map((r) => r.userId),
+      ),
+    );
+
+    await prisma.$transaction(async (tx) => {
+      if (toRemove.length > 0) {
+        await tx.cycleReviewer.deleteMany({
+          where: { applicationCycleId: cycleId, domainId: { in: toRemove } },
+        });
+        await tx.domainApplicationCycle.deleteMany({
+          where: { applicationCycleId: cycleId, domainId: { in: toRemove } },
+        });
+      }
+      if (toAdd.length > 0) {
+        await tx.domainApplicationCycle.createMany({
+          data: toAdd.map((domainId) => ({ applicationCycleId: cycleId, domainId })),
+        });
+        if (poolUserIds.length > 0) {
+          await tx.cycleReviewer.createMany({
+            data: toAdd.flatMap((domainId) =>
+              poolUserIds.map((userId) => ({
+                userId,
+                applicationCycleId: cycleId,
+                domainId,
+              })),
+            ),
+            skipDuplicates: true,
+          });
+        }
+      }
+    });
     return { ok: true };
   }
 
@@ -223,26 +269,37 @@ export async function action({ request, params }: Route.ActionArgs) {
     return { ok: true };
   }
 
-  if (intent === "add-reviewer") {
+  if (intent === "add-reviewer-pool") {
+    // InternToFull cycles use a single reviewer pool. Adding a pool member
+    // creates one CycleReviewer row per current target domain so the existing
+    // per-domain fan-out (auto-assign, review join keys) keeps working.
     const userId = formData.get("userId") as string;
-    const domainId = formData.get("domainId") as string;
-    await prisma.cycleReviewer.upsert({
-      where: {
-        userId_applicationCycleId_domainId: {
-          userId,
-          applicationCycleId: cycleId,
-          domainId,
-        },
-      },
-      update: {},
-      create: { userId, applicationCycleId: cycleId, domainId },
+    const targetDomains = await prisma.domainApplicationCycle.findMany({
+      where: { applicationCycleId: cycleId },
+      select: { domainId: true },
+    });
+    if (targetDomains.length === 0) {
+      return Response.json(
+        { error: "Pick at least one target domain before adding reviewers." },
+        { status: 409 },
+      );
+    }
+    await prisma.cycleReviewer.createMany({
+      data: targetDomains.map((d) => ({
+        userId,
+        applicationCycleId: cycleId,
+        domainId: d.domainId,
+      })),
+      skipDuplicates: true,
     });
     return { ok: true };
   }
 
-  if (intent === "remove-reviewer") {
-    const reviewerId = formData.get("reviewerId") as string;
-    await prisma.cycleReviewer.delete({ where: { id: reviewerId } });
+  if (intent === "remove-reviewer-pool") {
+    const userId = formData.get("userId") as string;
+    await prisma.cycleReviewer.deleteMany({
+      where: { userId, applicationCycleId: cycleId },
+    });
     return { ok: true };
   }
 
@@ -295,26 +352,6 @@ export default function InternToFullCycleSetup() {
         members={members}
       />
     </div>
-  );
-}
-
-function Section({
-  title,
-  description,
-  children,
-}: {
-  title: string;
-  description?: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <section className="rounded-2xl border border-border bg-card px-6 py-5">
-      <h2 className="font-heading text-sm font-bold uppercase tracking-wider text-dark-blue">
-        {title}
-      </h2>
-      {description && <p className="text-xs text-muted-foreground mt-1 mb-4">{description}</p>}
-      <div className={description ? "" : "mt-4"}>{children}</div>
-    </section>
   );
 }
 
@@ -441,8 +478,15 @@ function CreateFormVersionModal({
   function removeQ(idx: number) {
     setQs((prev) => prev.filter((_, i) => i !== idx));
   }
-  function update(idx: number, patch: Partial<Question>) {
-    setQs((prev) => prev.map((q, i) => (i === idx ? { ...q, ...patch, data: { ...q.data, ...(patch.data ?? {}) } } : q)));
+  function update(
+    idx: number,
+    patch: Partial<Omit<Question, "data">> & { data?: Partial<Question["data"]> },
+  ) {
+    setQs((prev) =>
+      prev.map((q, i) =>
+        i === idx ? { ...q, ...patch, data: { ...q.data, ...(patch.data ?? {}) } } : q,
+      ),
+    );
   }
   return (
     <div className="fixed inset-0 z-50 bg-black/40 flex items-center justify-center p-4" onClick={onClose}>
@@ -468,6 +512,12 @@ function CreateFormVersionModal({
                 onChange={(e) => update(idx, { data: { label: e.target.value } })}
                 placeholder="Question prompt"
                 className="w-full px-2 py-1.5 text-sm border border-border rounded-md"
+              />
+              <input
+                value={q.data.description ?? ""}
+                onChange={(e) => update(idx, { data: { description: e.target.value } })}
+                placeholder="Description (optional, e.g. 'Keep it under 200 words.')"
+                className="w-full px-2 py-1.5 text-xs border border-border rounded-md text-muted-foreground"
               />
               <div className="flex items-center gap-4 text-xs">
                 <label className="flex items-center gap-1">
@@ -675,89 +725,82 @@ function ReviewersSection({
   members,
 }: {
   cycleId: string;
-  reviewers: { id: string; userId: string; domainId: string; domainCode: string; displayName: string }[];
+  reviewers: { userId: string; displayName: string }[];
   targetDomains: { domainId: string; code: string; displayName: string }[];
   members: { userId: string; displayName: string }[];
 }) {
   const fetcher = useFetcher();
-  const byDomain = new Map<string, typeof reviewers>();
-  for (const d of targetDomains) byDomain.set(d.domainId, []);
-  for (const r of reviewers) {
-    const list = byDomain.get(r.domainId) ?? [];
-    list.push(r);
-    byDomain.set(r.domainId, list);
-  }
+  const assignedIds = new Set(reviewers.map((r) => r.userId));
+  const candidates = members.filter((m) => !assignedIds.has(m.userId));
+  const meetsMin = reviewers.length >= MIN_POOL_SIZE;
+  const error =
+    fetcher.data && typeof fetcher.data === "object" && "error" in fetcher.data
+      ? (fetcher.data.error as string)
+      : null;
 
   return (
     <Section
       title="Reviewers"
-      description={`Assign at least ${MIN_REVIEWERS_PER_DOMAIN} reviewers per target domain.`}
+      description={`Single reviewer pool — every reviewer reads every application across all target domains. Add at least ${MIN_POOL_SIZE}.`}
     >
       {targetDomains.length === 0 ? (
         <p className="text-sm text-muted-foreground">Pick target domains first.</p>
       ) : (
-        <div className="space-y-4">
-          {targetDomains.map((d) => {
-            const assigned = byDomain.get(d.domainId) ?? [];
-            const assignedIds = new Set(assigned.map((r) => r.userId));
-            const candidates = members.filter((m) => !assignedIds.has(m.userId));
-            const meetsMin = assigned.length >= MIN_REVIEWERS_PER_DOMAIN;
-            return (
-              <div key={d.domainId} className="border border-border rounded-md p-3">
-                <div className="flex items-center justify-between mb-2">
-                  <h3 className="text-sm font-semibold text-dark-blue">{d.displayName}</h3>
-                  <span
-                    className={`text-xs px-2 py-0.5 rounded-full ${
-                      meetsMin ? "bg-green-100 text-green-700" : "bg-yellow-100 text-yellow-800"
-                    }`}
-                  >
-                    {assigned.length} / {MIN_REVIEWERS_PER_DOMAIN}
-                  </span>
-                </div>
-                <ul className="space-y-1 mb-2">
-                  {assigned.map((r) => (
-                    <li key={r.id} className="flex items-center justify-between text-sm">
-                      <span>{r.displayName}</span>
-                      <button
-                        onClick={() =>
-                          fetcher.submit(
-                            { intent: "remove-reviewer", reviewerId: r.id },
-                            { method: "post" },
-                          )
-                        }
-                        className="text-xs text-red-600 hover:underline"
-                      >
-                        Remove
-                      </button>
-                    </li>
-                  ))}
-                  {assigned.length === 0 && (
-                    <li className="text-xs text-muted-foreground italic">No reviewers assigned yet.</li>
-                  )}
-                </ul>
-                <select
-                  defaultValue=""
-                  onChange={(e) => {
-                    const userId = e.target.value;
-                    if (!userId) return;
+        <div className="border border-border rounded-md p-3">
+          <div className="flex items-center justify-between mb-2">
+            <h3 className="text-sm font-semibold text-dark-blue">Reviewer pool</h3>
+            <span
+              className={`text-xs px-2 py-0.5 rounded-full ${
+                meetsMin ? "bg-green-100 text-green-700" : "bg-yellow-100 text-yellow-800"
+              }`}
+            >
+              {reviewers.length} / {MIN_POOL_SIZE}
+            </span>
+          </div>
+          <ul className="space-y-1 mb-2">
+            {reviewers.map((r) => (
+              <li key={r.userId} className="flex items-center justify-between text-sm">
+                <span>{r.displayName}</span>
+                <button
+                  onClick={() =>
                     fetcher.submit(
-                      { intent: "add-reviewer", userId, domainId: d.domainId },
+                      { intent: "remove-reviewer-pool", userId: r.userId },
                       { method: "post" },
-                    );
-                    e.currentTarget.value = "";
-                  }}
-                  className="text-sm px-2 py-1.5 border border-border rounded"
+                    )
+                  }
+                  className="text-xs text-red-600 hover:underline"
                 >
-                  <option value="">+ Add reviewer…</option>
-                  {candidates.map((m) => (
-                    <option key={m.userId} value={m.userId}>
-                      {m.displayName}
-                    </option>
-                  ))}
-                </select>
-              </div>
-            );
-          })}
+                  Remove
+                </button>
+              </li>
+            ))}
+            {reviewers.length === 0 && (
+              <li className="text-xs text-muted-foreground italic">No reviewers in the pool yet.</li>
+            )}
+          </ul>
+          <select
+            defaultValue=""
+            onChange={(e) => {
+              const userId = e.target.value;
+              if (!userId) return;
+              fetcher.submit(
+                { intent: "add-reviewer-pool", userId },
+                { method: "post" },
+              );
+              e.currentTarget.value = "";
+            }}
+            className="text-sm px-2 py-1.5 border border-border rounded"
+          >
+            <option value="">+ Add reviewer…</option>
+            {candidates.map((m) => (
+              <option key={m.userId} value={m.userId}>
+                {m.displayName}
+              </option>
+            ))}
+          </select>
+          {error && (
+            <p className="mt-2 text-xs text-red-600">{error}</p>
+          )}
         </div>
       )}
     </Section>

--- a/dali-api/app/hiring/routes/reviewer.tsx
+++ b/dali-api/app/hiring/routes/reviewer.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react'
-import { Link, useLoaderData, useRevalidator, useSearchParams } from 'react-router'
+import { Link, useLoaderData, useRevalidator } from 'react-router'
 import {
   ChevronRight,
   ChevronDown,
@@ -11,6 +11,7 @@ import {
   ListOrdered,
 } from 'lucide-react'
 import { getReviewStatus } from '~/hiring/lib/review-status'
+import { CycleSelector } from '~/hiring/components/CycleSelector'
 import { getActiveCycle, cycleStatusToStage, inferUnderReviewStage } from '~/hiring/lib/cycles'
 import { getCycleConfidentialityState } from '~/hiring/lib/confidentiality'
 import { ConfidentialityGate } from '~/hiring/components/ConfidentialityGate'
@@ -259,48 +260,6 @@ export async function loader({ request }: Route.LoaderArgs) {
     }
 }
 
-const CYCLE_TYPE_LABELS: Record<string, string> = {
-  Standard: "Standard hire",
-  InternToFull: "Intern → Full-time",
-}
-
-function CyclePicker({
-  cycles,
-  activeId,
-}: {
-  cycles: Array<{ id: string; name: string; cycleType: string }>
-  activeId: string
-}) {
-  const [searchParams, setSearchParams] = useSearchParams()
-  if (cycles.length < 2) return null
-  return (
-    <div className="inline-flex rounded-md border border-border bg-card p-0.5 text-xs">
-      {cycles.map((c) => {
-        const isActive = c.id === activeId
-        return (
-          <button
-            key={c.id}
-            type="button"
-            onClick={() => {
-              const next = new URLSearchParams(searchParams)
-              next.set("cycle", c.id)
-              setSearchParams(next, { replace: true })
-            }}
-            className={`px-3 py-1.5 rounded font-medium transition ${
-              isActive
-                ? "bg-blue-600 text-white"
-                : "text-muted-foreground hover:text-foreground"
-            }`}
-            title={c.name}
-          >
-            {CYCLE_TYPE_LABELS[c.cycleType] ?? c.cycleType}
-          </button>
-        )
-      })}
-    </div>
-  )
-}
-
 export default function ReviewerDashboard() {
   const {
     activeCycle,
@@ -495,7 +454,7 @@ export default function ReviewerDashboard() {
             Manage your hiring responsibilities.
           </p>
         </div>
-        <CyclePicker cycles={availableCycles} activeId={activeCycle.id} />
+        <CycleSelector cycles={availableCycles} activeId={activeCycle.id} />
       </div>
 
       <Section

--- a/dali-api/app/routes/intern-to-full.tsx
+++ b/dali-api/app/routes/intern-to-full.tsx
@@ -5,11 +5,13 @@ import { prisma } from "~/lib/db";
 import { requireAuth } from "~/lib/auth";
 import { requireMember } from "~/lib/roles";
 import { getActiveCycle } from "~/hiring/lib/cycles";
+import { reconcileDomainApplications } from "~/hiring/lib/domain-application";
 import {
   isInternToFullEligible,
   currentInternDomains,
 } from "~/hiring/lib/intern-eligibility";
 import type { Question } from "~/types";
+import { ChallengeQuestionField } from "~/hiring/components/ChallengeQuestionField";
 
 export const meta: Route.MetaFunction = () => [
   { title: "Intern → Full-time · DALI OS" },
@@ -172,40 +174,10 @@ export async function action({ request }: Route.ActionArgs) {
       },
     });
 
-    // Reconcile DomainApplication rows: create missing, reselect deselected,
-    // deselect (preserve row) any no-longer-picked.
-    const existing = await prisma.domainApplication.findMany({
-      where: { applicationId: application.id },
-      select: { id: true, domainId: true, selected: true },
+    await reconcileDomainApplications({
+      applicationId: application.id,
+      domainIds: selectedDomainIds,
     });
-    const byDomain = new Map(existing.filter((da) => da.domainId).map((da) => [da.domainId!, da]));
-
-    for (const domainId of selectedDomainIds) {
-      const ex = byDomain.get(domainId);
-      if (!ex) {
-        await prisma.domainApplication.create({
-          data: {
-            applicationId: application.id,
-            domainId,
-            answers: {},
-          },
-        });
-      } else if (!ex.selected) {
-        await prisma.domainApplication.update({
-          where: { id: ex.id },
-          data: { selected: true },
-        });
-      }
-    }
-    const toDeselect = existing
-      .filter((da) => da.domainId && !selectedDomainIds.includes(da.domainId) && da.selected)
-      .map((da) => da.id);
-    if (toDeselect.length > 0) {
-      await prisma.domainApplication.updateMany({
-        where: { id: { in: toDeselect } },
-        data: { selected: false },
-      });
-    }
 
     if (intent === "submit") {
       const alreadySubmitted = await prisma.applicationStatusUpdate.findFirst({
@@ -426,12 +398,20 @@ function FormView({
         </h2>
         <div className="space-y-5">
           {cycle.questions.map((q) => (
-            <QuestionField
-              key={q.key}
-              question={q}
-              value={answers[q.key] ?? ""}
-              onChange={(v) => setAnswers((prev) => ({ ...prev, [q.key]: v }))}
-            />
+            <div key={q.key}>
+              <label className="block text-sm font-semibold text-dark-blue mb-1">
+                {q.data.label}
+                {q.required && <span className="text-accent-coral ml-0.5">*</span>}
+              </label>
+              {q.data.description && (
+                <p className="text-xs text-muted-foreground mb-1">{q.data.description}</p>
+              )}
+              <ChallengeQuestionField
+                question={q}
+                value={answers[q.key] ?? ""}
+                onChange={(v) => setAnswers((prev) => ({ ...prev, [q.key]: v }))}
+              />
+            </div>
           ))}
         </div>
       </section>
@@ -465,50 +445,6 @@ function FormView({
           {busy && fetcher.formData?.get("intent") === "submit" ? "Submitting…" : "Submit"}
         </button>
       </div>
-    </div>
-  );
-}
-
-function QuestionField({
-  question,
-  value,
-  onChange,
-}: {
-  question: Question;
-  value: string;
-  onChange: (v: string) => void;
-}) {
-  const label = (
-    <div className="mb-1.5">
-      <span className="text-sm font-semibold text-dark-blue">{question.data.label}</span>
-      {question.required && <span className="text-red-500 ml-1">*</span>}
-      {question.data.description && (
-        <p className="text-xs text-muted-foreground mt-1">{question.data.description}</p>
-      )}
-    </div>
-  );
-  if (question.type === "textarea") {
-    return (
-      <div>
-        {label}
-        <textarea
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
-          rows={5}
-          className="w-full rounded-lg border border-border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-accent-coral/30 focus:border-accent-coral"
-        />
-      </div>
-    );
-  }
-  return (
-    <div>
-      {label}
-      <input
-        type="text"
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        className="w-full rounded-lg border border-border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-accent-coral/30 focus:border-accent-coral"
-      />
     </div>
   );
 }

--- a/dali-api/app/routes/portal.apply.tsx
+++ b/dali-api/app/routes/portal.apply.tsx
@@ -7,6 +7,7 @@ import { sendEmail } from "~/lib/gmail";
 import { getApplicationsGmailRefreshToken } from "~/lib/gmail-integration";
 import { renderForSlot, notificationSlot } from "~/hiring/lib/email-variables";
 import { getActiveCycle } from "~/hiring/lib/cycles";
+import { reconcileDomainApplications } from "~/hiring/lib/domain-application";
 import { checkGitHubUrl, checkFigmaUrl, checkDriveUrl } from "~/hiring/lib/submission-check";
 import type { SubmissionCheckResult } from "~/hiring/lib/submission-check";
 import { validateWordLimits } from "~/lib/word-count";
@@ -239,57 +240,11 @@ export async function action({ request }: Route.ActionArgs) {
     const newDomainIds = validSelections.map(s => s.domainId);
     const desiredCvByDomain = new Map(validSelections.map(s => [s.domainId, s.challengeVersionId]));
 
-    // Existing DAs for this application, keyed by domainId
-    const existing = await prisma.domainApplication.findMany({
-      where: { applicationId },
-      include: { challengeVersion: { select: { domainId: true } } },
+    await reconcileDomainApplications({
+      applicationId,
+      domainIds: newDomainIds,
+      challengeVersionByDomain: desiredCvByDomain,
     });
-    const existingByDomain = new Map<string, (typeof existing)[number]>();
-    for (const da of existing) {
-      const did = da.domainId;
-      if (did) existingByDomain.set(did, da);
-    }
-
-    // For each desired (domainId, cvId): create new DA, reselect, or switch CV.
-    for (const sel of validSelections) {
-      const ex = existingByDomain.get(sel.domainId);
-      if (!ex) {
-        await prisma.domainApplication.create({
-          data: {
-            applicationId,
-            domainId: sel.domainId,
-            challengeVersionId: sel.challengeVersionId,
-            answers: {},
-          },
-        });
-        continue;
-      }
-      const updates: { selected?: boolean; challengeVersionId?: string; answers?: any } = {};
-      if (!ex.selected) updates.selected = true;
-      if (ex.challengeVersionId !== sel.challengeVersionId) {
-        // Switching the picked challenge wipes that domain's answers — the
-        // question set is different. The applicant is warned client-side.
-        updates.challengeVersionId = sel.challengeVersionId;
-        updates.answers = {};
-      }
-      if (Object.keys(updates).length > 0) {
-        await prisma.domainApplication.update({
-          where: { id: ex.id },
-          data: updates,
-        });
-      }
-    }
-
-    // Domains the applicant deselected — preserve answers but mark unselected.
-    const toDeselectIds = existing
-      .filter(da => da.domainId && !newDomainIds.includes(da.domainId))
-      .map(da => da.id);
-    if (toDeselectIds.length > 0) {
-      await prisma.domainApplication.updateMany({
-        where: { id: { in: toDeselectIds } },
-        data: { selected: false },
-      });
-    }
 
     // Return full updated draft
     const updatedApp = await prisma.application.findUnique({


### PR DESCRIPTION
## Summary

Audit of #540 surfaced duplication between InternToFull and Standard cycle paths. This PR unifies the genuinely-shared pieces, leaves the intentionally-different UX alone, and converts InternToFull's per-domain reviewer panels into a single reviewer pool.

**Net diff:** 329 insertions / 341 deletions across 8 files.

### Shared

| File | Purpose |
|---|---|
| `app/hiring/components/CycleSelector.tsx` | `CYCLE_TYPE_LABELS` + picker. Was duplicated verbatim in `reviewer.tsx` and `domain-lead.tsx`. |
| `app/hiring/components/CycleSetupSection.tsx` | Card wrapper. Used by InternToFull lead route. |
| `app/hiring/lib/domain-application.ts` | `reconcileDomainApplications()` — collapses the create/reselect/deselect loop in `portal.apply.tsx` (with CV switching) and `intern-to-full.tsx` (without). |
| `intern-to-full.tsx` | Drops local `QuestionField` in favor of `ChallengeQuestionField`. Unlocks file uploads, URL checks, word counts, select, and skills_rating for any future shortform that uses them. |

### Question descriptions

`CreateFormVersionModal` in the InternToFull lead route now exposes `Question.data.description`, matching Standard's challenge builder. Already-rendered by `ChallengeQuestionField` after the reuse above.

### Single reviewer pool (InternToFull)

- One **Reviewer pool** list instead of per-domain panels (`MIN_POOL_SIZE = 2`).
- Loader dedupes `cycle.reviewers` by `userId`.
- New intents `add-reviewer-pool` / `remove-reviewer-pool` fan out / cascade across all target domains.
- `set-target-domains` is now transactional: adding a domain creates a `CycleReviewer` row for every existing pool member; removing one deletes the per-domain rows alongside the `DomainApplicationCycle` row.
- **No schema change** — `CycleReviewer.domainId` stays required. Downstream paths keep working as-is: `reviewer.application.$id.tsx` DA-scoping returns every DA the applicant selected (pool member is on every target domain); per-domain auto-assign continues to pick up each pool member naturally; per-domain rubric application is preserved (one ApplicationReview per (reviewer, DA)).

### Not shared (intentional UX divergence — verified)

- Standard's reviewer roster (flat table + separate Reviewer/Interviewer forms, fetch-based dispatch) vs InternToFull's grouped panels with `fetcher.submit` intents.
- Standard's `CloseDateCard` (extension subsystem, `Form` posts) vs InternToFull's `datetime-local` + fetcher button.
- Standard's in-page status state with `force` flag vs InternToFull's standalone Move-to button + reload.

## Test plan

- [x] `npm test` — 789/789 pass
- [x] `npm run typecheck` — no new errors (pre-existing `reviewer.tsx:94` fallback bug + untracked scripts unchanged)
- [ ] Manual: open a Standard cycle's reviewer dashboard, confirm picker still works
- [ ] Manual: open InternToFull lead setup, add ≥2 pool reviewers, verify they appear on every target domain in the DB
- [ ] Manual: with a pool in place, add a new target domain — confirm existing pool members get a CycleReviewer row for it
- [ ] Manual: remove a target domain (before any DAs exist) — confirm CycleReviewer rows for that domain are also deleted
- [ ] Manual: submit an InternToFull application targeting 2 domains, verify reviewer sees both DAs and the per-domain rubrics
- [ ] Manual: add a question description in the shortform editor, verify it renders under the label on the applicant form

🤖 Generated with [Claude Code](https://claude.com/claude-code)