### PR TITLE
Rename InternToFull UI to Fellowship + add info-text blocks (#569)

### DIFF
--- a/dali-api/app/hiring/components/ApplicationViewer.tsx
+++ b/dali-api/app/hiring/components/ApplicationViewer.tsx
@@ -397,7 +397,7 @@ export function ApplicationViewer({ application, questionLabels, initialAnnotati
             <div key={dapp.id} className="bg-card rounded-xl border border-border shadow-sm overflow-hidden">
               <div className="px-6 py-4 border-b border-border bg-muted/50">
                 <h2 className="text-lg font-semibold text-foreground">{domainName}</h2>
-                <p className="text-xs text-muted-foreground mt-1">Target domain selected (no challenge for intern conversions).</p>
+                <p className="text-xs text-muted-foreground mt-1">Target domain selected (no challenge for fellowship applications).</p>
               </div>
             </div>
           )

--- a/dali-api/app/hiring/components/CycleSelector.tsx
+++ b/dali-api/app/hiring/components/CycleSelector.tsx
@@ -2,7 +2,7 @@ import { useSearchParams } from "react-router";
 
 export const CYCLE_TYPE_LABELS: Record<string, string> = {
   Standard: "Standard hire",
-  InternToFull: "Intern → Full-time",
+  InternToFull: "Fellowship",
 };
 
 export function CycleSelector({

--- a/dali-api/app/hiring/routes/api.cycles.$cycleId.status.ts
+++ b/dali-api/app/hiring/routes/api.cycles.$cycleId.status.ts
@@ -174,8 +174,8 @@ export async function action({ request, params }: Route.ActionArgs) {
         : "";
       fanOutPlan = {
         userIds,
-        title: "Intern → Full-time application is open",
-        body: `${cycle.name} is accepting conversion applications.${closeText}`,
+        title: "Fellowship application is open",
+        body: `${cycle.name} is accepting fellowship applications.${closeText}`,
       };
     }
   }

--- a/dali-api/app/hiring/routes/lead.intern-to-full-cycle.$id.tsx
+++ b/dali-api/app/hiring/routes/lead.intern-to-full-cycle.$id.tsx
@@ -9,7 +9,7 @@ import type { Prisma } from "~/generated/prisma/client";
 import { CycleSetupSection as Section } from "~/hiring/components/CycleSetupSection";
 
 export const meta: Route.MetaFunction = () => [
-  { title: "Intern → Full-time cycle · DALI OS" },
+  { title: "Fellowship cycle · DALI OS" },
 ];
 
 const MIN_POOL_SIZE = 2;
@@ -322,7 +322,7 @@ export default function InternToFullCycleSetup() {
           </Link>
           <h1 className="font-heading text-2xl font-bold text-dark-blue mt-1">{cycle.name}</h1>
           <p className="text-xs text-muted-foreground mt-1">
-            Intern → Full-time conversion cycle · {cycle.status}
+            Fellowship cycle · {cycle.status}
           </p>
         </div>
         <StatusButton cycleId={cycle.id} currentStatus={cycle.status} />
@@ -411,7 +411,13 @@ function FormVersionSection({
       {current ? (
         <div className="mb-3">
           <p className="text-sm font-medium text-dark-blue">
-            v{current.version} ({current.questions.length} question{current.questions.length === 1 ? "" : "s"})
+            {(() => {
+              const qCount = current.questions.filter((q) => q.type !== "info").length;
+              const iCount = current.questions.length - qCount;
+              const parts = [`${qCount} question${qCount === 1 ? "" : "s"}`];
+              if (iCount > 0) parts.push(`${iCount} info block${iCount === 1 ? "" : "s"}`);
+              return `v${current.version} (${parts.join(", ")})`;
+            })()}
           </p>
         </div>
       ) : (
@@ -475,8 +481,23 @@ function CreateFormVersionModal({
   function addQ() {
     setQs((prev) => [...prev, { key: crypto.randomUUID(), type: "textarea", required: false, data: { label: "" } }]);
   }
+  function addInfo() {
+    setQs((prev) => [
+      ...prev,
+      { key: crypto.randomUUID(), type: "info", required: false, data: { label: "", body: "" } },
+    ]);
+  }
   function removeQ(idx: number) {
     setQs((prev) => prev.filter((_, i) => i !== idx));
+  }
+  function move(idx: number, dir: -1 | 1) {
+    setQs((prev) => {
+      const target = idx + dir;
+      if (target < 0 || target >= prev.length) return prev;
+      const next = [...prev];
+      [next[idx], next[target]] = [next[target], next[idx]];
+      return next;
+    });
   }
   function update(
     idx: number,
@@ -499,53 +520,93 @@ function CreateFormVersionModal({
           <button onClick={onClose} className="text-muted-foreground/70">✕</button>
         </div>
         <div className="space-y-3">
-          {qs.map((q, idx) => (
-            <div key={q.key} className="border border-border rounded-md p-3 space-y-2">
-              <div className="flex items-center justify-between gap-2">
-                <span className="text-xs text-muted-foreground">Question {idx + 1}</span>
-                <button onClick={() => removeQ(idx)} className="text-xs text-red-600 hover:underline">
-                  Remove
-                </button>
-              </div>
-              <input
-                value={q.data.label}
-                onChange={(e) => update(idx, { data: { label: e.target.value } })}
-                placeholder="Question prompt"
-                className="w-full px-2 py-1.5 text-sm border border-border rounded-md"
-              />
-              <input
-                value={q.data.description ?? ""}
-                onChange={(e) => update(idx, { data: { description: e.target.value } })}
-                placeholder="Description (optional, e.g. 'Keep it under 200 words.')"
-                className="w-full px-2 py-1.5 text-xs border border-border rounded-md text-muted-foreground"
-              />
-              <div className="flex items-center gap-4 text-xs">
-                <label className="flex items-center gap-1">
-                  <input
-                    type="checkbox"
-                    checked={q.required}
-                    onChange={(e) => update(idx, { required: e.target.checked })}
+          {qs.map((q, idx) => {
+            const isInfo = q.type === "info";
+            return (
+              <div key={q.key} className="border border-border rounded-md p-3 space-y-2">
+                <div className="flex items-center justify-between gap-2">
+                  <span className="text-xs text-muted-foreground">
+                    {isInfo ? "Info text" : "Question"} {idx + 1}
+                  </span>
+                  <div className="flex items-center gap-2">
+                    <button
+                      onClick={() => move(idx, -1)}
+                      disabled={idx === 0}
+                      className="text-xs text-muted-foreground hover:text-foreground disabled:opacity-30"
+                      title="Move up"
+                    >
+                      ↑
+                    </button>
+                    <button
+                      onClick={() => move(idx, 1)}
+                      disabled={idx === qs.length - 1}
+                      className="text-xs text-muted-foreground hover:text-foreground disabled:opacity-30"
+                      title="Move down"
+                    >
+                      ↓
+                    </button>
+                    <button onClick={() => removeQ(idx)} className="text-xs text-red-600 hover:underline">
+                      Remove
+                    </button>
+                  </div>
+                </div>
+                {isInfo ? (
+                  <textarea
+                    value={q.data.body ?? ""}
+                    onChange={(e) => update(idx, { data: { body: e.target.value } })}
+                    placeholder="Free-form text shown to the applicant (e.g. instructions or context)."
+                    rows={4}
+                    className="w-full px-2 py-1.5 text-sm border border-border rounded-md"
                   />
-                  Required
-                </label>
-                <label className="flex items-center gap-1">
-                  Type:
-                  <select
-                    value={q.type}
-                    onChange={(e) => update(idx, { type: e.target.value as Question["type"] })}
-                    className="px-2 py-0.5 border border-border rounded"
-                  >
-                    <option value="textarea">Long answer</option>
-                    <option value="text">Short answer</option>
-                  </select>
-                </label>
+                ) : (
+                  <>
+                    <input
+                      value={q.data.label}
+                      onChange={(e) => update(idx, { data: { label: e.target.value } })}
+                      placeholder="Question prompt"
+                      className="w-full px-2 py-1.5 text-sm border border-border rounded-md"
+                    />
+                    <input
+                      value={q.data.description ?? ""}
+                      onChange={(e) => update(idx, { data: { description: e.target.value } })}
+                      placeholder="Description (optional, e.g. 'Keep it under 200 words.')"
+                      className="w-full px-2 py-1.5 text-xs border border-border rounded-md text-muted-foreground"
+                    />
+                    <div className="flex items-center gap-4 text-xs">
+                      <label className="flex items-center gap-1">
+                        <input
+                          type="checkbox"
+                          checked={q.required}
+                          onChange={(e) => update(idx, { required: e.target.checked })}
+                        />
+                        Required
+                      </label>
+                      <label className="flex items-center gap-1">
+                        Type:
+                        <select
+                          value={q.type}
+                          onChange={(e) => update(idx, { type: e.target.value as Question["type"] })}
+                          className="px-2 py-0.5 border border-border rounded"
+                        >
+                          <option value="textarea">Long answer</option>
+                          <option value="text">Short answer</option>
+                        </select>
+                      </label>
+                    </div>
+                  </>
+                )}
               </div>
-            </div>
-          ))}
+            );
+          })}
         </div>
-        <button onClick={addQ} className="text-sm text-blue-700 hover:underline">
-          + Add question
-        </button>
+        <div className="flex items-center gap-4">
+          <button onClick={addQ} className="text-sm text-blue-700 hover:underline">
+            + Add question
+          </button>
+          <button onClick={addInfo} className="text-sm text-blue-700 hover:underline">
+            + Add info text
+          </button>
+        </div>
         <div className="flex justify-end gap-2 pt-3 border-t border-border">
           <button
             onClick={onClose}
@@ -555,7 +616,9 @@ function CreateFormVersionModal({
           </button>
           <button
             onClick={() => {
-              const cleaned = qs.filter((q) => q.data.label.trim());
+              const cleaned = qs.filter((q) =>
+                q.type === "info" ? (q.data.body ?? "").trim() : q.data.label.trim(),
+              );
               if (cleaned.length === 0) return;
               onSubmit(cleaned);
             }}

--- a/dali-api/app/hiring/routes/lead.tsx
+++ b/dali-api/app/hiring/routes/lead.tsx
@@ -120,10 +120,10 @@ export default function HiringLeadDashboard() {
                     className="w-full px-3 py-2 text-sm text-foreground border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
                   >
                     <option value="Standard">Standard hire</option>
-                    <option value="InternToFull">Intern → Full-time conversion</option>
+                    <option value="InternToFull">Fellowship</option>
                   </select>
                   <p className="text-xs text-muted-foreground mt-1">
-                    InternToFull cycles use a shortform (no challenge) and skip interviews.
+                    Fellowship cycles use a shortform (no challenge) and skip interviews.
                   </p>
                 </div>
                 <div className="flex justify-end gap-2">
@@ -156,7 +156,7 @@ export default function HiringLeadDashboard() {
 
 const CYCLE_TYPE_LABELS: Record<string, string> = {
   Standard: "Standard hire",
-  InternToFull: "Intern → Full-time",
+  InternToFull: "Fellowship",
 };
 
 function heroLinkFor(cycle: any): string {

--- a/dali-api/app/routes/intern-to-full.tsx
+++ b/dali-api/app/routes/intern-to-full.tsx
@@ -14,7 +14,7 @@ import type { Question } from "~/types";
 import { ChallengeQuestionField } from "~/hiring/components/ChallengeQuestionField";
 
 export const meta: Route.MetaFunction = () => [
-  { title: "Intern → Full-time · DALI OS" },
+  { title: "Fellowship · DALI OS" },
 ];
 
 // This route is the *internal* applicant portal for InternToFull cycles. It
@@ -135,7 +135,7 @@ export async function action({ request }: Route.ActionArgs) {
 
     if (intent === "submit") {
       const missing = questions
-        .filter((q) => q.required && !isAnswered(answers[q.key]))
+        .filter((q) => q.type !== "info" && q.required && !isAnswered(answers[q.key]))
         .map((q) => q.data.label || q.key);
       if (missing.length > 0) {
         return Response.json(
@@ -237,15 +237,15 @@ export default function InternToFullRoute() {
   if (data.reason === "not-eligible") {
     return (
       <Message title="Not eligible">
-        Conversion applications are only open to members currently in an intern-program
+        Fellowship applications are only open to members currently in an intern-program
         domain (ERAS, EEJUST, WISP) during an active term.
       </Message>
     );
   }
   if (data.reason === "no-active-cycle") {
     return (
-      <Message title="No open conversion cycle">
-        There's no intern-to-full-time application cycle open right now. The hiring
+      <Message title="No open fellowship cycle">
+        There's no fellowship application cycle open right now. The hiring
         leads will let interns know when one opens.
       </Message>
     );
@@ -259,7 +259,7 @@ export default function InternToFullRoute() {
     <div className="max-w-3xl mx-auto py-10 px-6">
       <header className="mb-8">
         <h1 className="font-heading text-2xl font-bold text-dark-blue mb-1">
-          Intern → Full-time Application
+          Fellowship Application
         </h1>
         <p className="text-sm text-muted-foreground">
           {cycle.name}
@@ -286,7 +286,7 @@ export default function InternToFullRoute() {
 
       {withdrawn ? (
         <Message title="Application withdrawn">
-          You withdrew this conversion application. Contact the hiring lead if you
+          You withdrew this fellowship application. Contact the hiring lead if you
           want to reopen it.
         </Message>
       ) : submitted ? (
@@ -397,22 +397,34 @@ function FormView({
           Questions
         </h2>
         <div className="space-y-5">
-          {cycle.questions.map((q) => (
-            <div key={q.key}>
-              <label className="block text-sm font-semibold text-dark-blue mb-1">
-                {q.data.label}
-                {q.required && <span className="text-accent-coral ml-0.5">*</span>}
-              </label>
-              {q.data.description && (
-                <p className="text-xs text-muted-foreground mb-1">{q.data.description}</p>
-              )}
-              <ChallengeQuestionField
-                question={q}
-                value={answers[q.key] ?? ""}
-                onChange={(v) => setAnswers((prev) => ({ ...prev, [q.key]: v }))}
-              />
-            </div>
-          ))}
+          {cycle.questions.map((q) => {
+            if (q.type === "info") {
+              return (
+                <div
+                  key={q.key}
+                  className="rounded-lg border border-border bg-muted/30 px-4 py-3 text-sm text-muted-foreground whitespace-pre-wrap"
+                >
+                  {q.data.body ?? ""}
+                </div>
+              );
+            }
+            return (
+              <div key={q.key}>
+                <label className="block text-sm font-semibold text-dark-blue mb-1">
+                  {q.data.label}
+                  {q.required && <span className="text-accent-coral ml-0.5">*</span>}
+                </label>
+                {q.data.description && (
+                  <p className="text-xs text-muted-foreground mb-1">{q.data.description}</p>
+                )}
+                <ChallengeQuestionField
+                  question={q}
+                  value={answers[q.key] ?? ""}
+                  onChange={(v) => setAnswers((prev) => ({ ...prev, [q.key]: v }))}
+                />
+              </div>
+            );
+          })}
         </div>
       </section>
 
@@ -460,7 +472,7 @@ function SubmittedView({ draftId }: { draftId?: string } = {}) {
           Submitted
         </h2>
         <p className="text-sm text-muted-foreground">
-          Your conversion application is in. Hiring leads will review it and reach out
+          Your fellowship application is in. Hiring leads will review it and reach out
           with a decision.
         </p>
       </div>

--- a/dali-api/app/types.ts
+++ b/dali-api/app/types.ts
@@ -94,7 +94,7 @@ export interface Rubric {
 
 export interface Question {
   key: string
-  type: 'text' | 'textarea' | 'select' | 'github_url' | 'figma_url' | 'drive_url' | 'file' | 'skills_rating'
+  type: 'text' | 'textarea' | 'select' | 'github_url' | 'figma_url' | 'drive_url' | 'file' | 'skills_rating' | 'info'
   required: boolean
   data: {
     label: string
@@ -103,6 +103,9 @@ export interface Question {
     afterDomains?: boolean
     accept?: string
     maxWords?: number
+    // For type === 'info': free-form prose rendered as a non-question text
+    // block in the form. Plain text; line breaks preserved.
+    body?: string
   }
 }
 


### PR DESCRIPTION
Lets hiring leads drop free-form prose anywhere in the fellowship shortform (intro instructions, end-of-form notes, etc.) via a new "info" item type, and surfaces the cycle as "Fellowship" across applicant-, lead-, and reviewer-facing UI. Internal enum, routes, and file names are unchanged to avoid a migration.