### PR TITLE
Fix #572: label Internal Feedback / Rejection Rationale in delibs mod…

### DIFF
--- a/dali-api/app/hiring/components/delibs/ApplicantContextModal.tsx
+++ b/dali-api/app/hiring/components/delibs/ApplicantContextModal.tsx
@@ -271,7 +271,7 @@ function ReviewAnnotations({
   );
 }
 
-function ReviewsSection({
+export function ReviewsSection({
   reviews,
   criteria,
   fieldContext,
@@ -343,17 +343,34 @@ function ReviewsSection({
                   </div>
                 )}
 
-                {review.feedback && (
-                  <p className="mt-2 text-xs text-muted-foreground bg-muted/50 rounded p-2 whitespace-pre-wrap">
-                    {review.feedback}
-                  </p>
-                )}
-                {review.rejectionRationale && (
-                  <p className="mt-2 text-xs text-red-600 bg-red-50 rounded p-2 whitespace-pre-wrap">
-                    <span className="font-medium">Rejection rationale:</span>{" "}
-                    {review.rejectionRationale}
-                  </p>
-                )}
+                <div className="mt-2">
+                  <div className="text-[10px] uppercase tracking-wide font-semibold text-muted-foreground/70 mb-1">
+                    Internal Feedback
+                  </div>
+                  {review.feedback ? (
+                    <p className="text-xs text-muted-foreground bg-muted/50 rounded p-2 whitespace-pre-wrap">
+                      {review.feedback}
+                    </p>
+                  ) : (
+                    <p className="text-xs text-muted-foreground/70 italic">
+                      No internal feedback provided
+                    </p>
+                  )}
+                </div>
+                <div className="mt-2">
+                  <div className="text-[10px] uppercase tracking-wide font-semibold text-muted-foreground/70 mb-1">
+                    Rejection Rationale
+                  </div>
+                  {review.rejectionRationale ? (
+                    <p className="text-xs text-red-600 bg-red-50 rounded p-2 whitespace-pre-wrap">
+                      {review.rejectionRationale}
+                    </p>
+                  ) : (
+                    <p className="text-xs text-muted-foreground/70 italic">
+                      No rejection rationale provided
+                    </p>
+                  )}
+                </div>
                 <ReviewAnnotations
                   annotations={Array.isArray(review.annotations) ? review.annotations : []}
                   fieldContext={fieldContext}

--- a/dali-api/app/hiring/components/delibs/__tests__/ApplicantContextModal.test.tsx
+++ b/dali-api/app/hiring/components/delibs/__tests__/ApplicantContextModal.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { ReviewsSection } from "../ApplicantContextModal";
+
+function render(reviews: any[]) {
+  return renderToStaticMarkup(
+    createElement(ReviewsSection, {
+      reviews,
+      criteria: [],
+      fieldContext: {},
+    }),
+  );
+}
+
+describe("ReviewsSection — Internal Feedback / Rejection Rationale", () => {
+  it("renders labeled feedback and rationale with the reviewer's content", () => {
+    const html = render([
+      {
+        id: "rev-1",
+        scores: {},
+        feedback: "Strong communicator, weak on systems design.",
+        rejectionRationale: "Did not meet the bar for the backend role.",
+        overallRecommendation: "Lean No Hire",
+        submittedAt: new Date("2026-04-01T00:00:00Z"),
+        cycleReviewer: { user: { firstName: "Rev", lastName: "Iewer" } },
+      },
+    ]);
+
+    expect(html).toContain("Internal Feedback");
+    expect(html).toContain("Rejection Rationale");
+    expect(html).toContain("Strong communicator, weak on systems design.");
+    expect(html).toContain("Did not meet the bar for the backend role.");
+    expect(html).not.toContain("No internal feedback provided");
+    expect(html).not.toContain("No rejection rationale provided");
+  });
+
+  it("renders both labeled blocks with placeholders when the fields are empty", () => {
+    const html = render([
+      {
+        id: "rev-1",
+        scores: {},
+        feedback: "",
+        rejectionRationale: "",
+        overallRecommendation: "Hire",
+        submittedAt: new Date("2026-04-01T00:00:00Z"),
+        cycleReviewer: { user: { firstName: "Rev", lastName: "Iewer" } },
+      },
+    ]);
+
+    // Labels are always present so a lead can scan for them.
+    expect(html).toContain("Internal Feedback");
+    expect(html).toContain("Rejection Rationale");
+    // Empty fields fall back to a muted placeholder instead of being omitted.
+    expect(html).toContain("No internal feedback provided");
+    expect(html).toContain("No rejection rationale provided");
+  });
+
+  it("shows the empty state when no reviewers are assigned", () => {
+    const html = render([]);
+    expect(html).toContain("No reviewers assigned yet.");
+  });
+});

--- a/dali-api/app/hiring/routes/__tests__/api.domain-applications.full-context.test.ts
+++ b/dali-api/app/hiring/routes/__tests__/api.domain-applications.full-context.test.ts
@@ -110,6 +110,8 @@ describe("GET /api/hiring/domain-applications/:id/full-context", () => {
     ]);
     expect(json.reviews).toHaveLength(1);
     expect(json.reviews[0].overallRecommendation).toBe("Hire");
+    expect(json.reviews[0].feedback).toBe("good");
+    expect(json.reviews[0].rejectionRationale).toBe("");
     expect(json.decisions).toHaveLength(1);
     expect(json.decisions[0].notes).toBe("moved from Initial delibs");
     expect(json.rubric.generalCriteria).toEqual([{ key: "g1c", label: "General", maxScore: 5 }]);


### PR DESCRIPTION
…al (#573)

Domain leads couldn't see reviewers' Internal Feedback or Rejection Rationale in the deliberations applicant modal: the fields were rendered as bare text with no heading, and omitted entirely when blank, so a lead scanning for them found nothing.

ReviewsSection now always renders labeled "Internal Feedback" and "Rejection Rationale" blocks per reviewer (matching the reviewer-form wording), with muted placeholders when a field is empty. Existing box styling is preserved.

Tests: extend the full-context loader test to assert feedback / rejectionRationale are returned; add a ReviewsSection render test covering populated and empty-state output.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/574"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->