### PR TITLE
Surface interviewer availability + lab-wide coverage heatmap

### DIFF
--- a/dali-api/app/hiring/routes/api.cycles.$cycleId.coverage.ts
+++ b/dali-api/app/hiring/routes/api.cycles.$cycleId.coverage.ts
@@ -1,0 +1,95 @@
+import type { Route } from "./+types/api.cycles.$cycleId.coverage";
+import { prisma } from "~/lib/db";
+import { requireAuth } from "~/lib/auth";
+import { hasCycleAccess } from "~/lib/roles";
+import { generateCandidateSlots, isInterviewerFree } from "~/hiring/lib/scheduling";
+
+export async function loader({ request, params }: Route.LoaderArgs) {
+  const auth = await requireAuth(request);
+  if (!auth.ok) return auth.response;
+
+  if (!(await hasCycleAccess(auth.user.sub, params.cycleId!)))
+    return Response.json({ error: "Forbidden" }, { status: 403 });
+
+  const config = await prisma.interviewConfig.findUnique({
+    where: { applicationCycleId: params.cycleId },
+  });
+  if (!config) {
+    return Response.json({
+      configured: false,
+      slots: [],
+      slotDurationMinutes: 30,
+      timezone: "America/New_York",
+    });
+  }
+
+  const interviewers = await prisma.cycleInterviewer.findMany({
+    where: { applicationCycleId: params.cycleId },
+    include: {
+      availabilityBlocks: { select: { startTime: true, endTime: true } },
+      interviewAssignments: {
+        where: { status: "Active", interview: { status: "Scheduled" } },
+        include: { interview: { select: { startTime: true, endTime: true } } },
+      },
+    },
+  });
+
+  // Per-member booked intervals (with buffer) — a member cross-listed on two
+  // CycleInterviewer rows shares one booked set.
+  const memberIntervals = new Map<string, { start: Date; end: Date }[]>();
+  for (const r of interviewers) {
+    const intervals = r.interviewAssignments.map((a) => ({
+      start: new Date(a.interview.startTime.getTime() - config.bufferMinutes * 60_000),
+      end: new Date(a.interview.endTime.getTime() + config.bufferMinutes * 60_000),
+    }));
+    memberIntervals.set(r.userId, (memberIntervals.get(r.userId) ?? []).concat(intervals));
+  }
+
+  const checks = interviewers.map((r) => ({
+    cycleInterviewerId: r.id,
+    userId: r.userId,
+    domainId: r.domainId,
+    availability: r.availabilityBlocks,
+    bookedIntervals: memberIntervals.get(r.userId) ?? [],
+  }));
+
+  const candidates = generateCandidateSlots(
+    config.interviewStartDate,
+    config.interviewEndDate,
+    config.dayStartHour,
+    config.dayEndHour,
+    config.slotDurationMinutes,
+    config.timezone,
+  );
+
+  // Booked interviews in this cycle for the "● booked" overlay.
+  const interviews = await prisma.interview.findMany({
+    where: { applicationCycleId: params.cycleId, status: "Scheduled" },
+    select: { startTime: true, endTime: true },
+  });
+
+  const slots = candidates.map((slotStart) => {
+    const slotEnd = new Date(slotStart.getTime() + config.slotDurationMinutes * 60_000);
+    const freeMembers = new Set<string>();
+    for (const r of checks) {
+      if (isInterviewerFree(r, slotStart, slotEnd)) freeMembers.add(r.userId);
+    }
+    const bookedCount = interviews.filter(
+      (i) => i.startTime < slotEnd && i.endTime > slotStart,
+    ).length;
+    return {
+      startTime: slotStart.toISOString(),
+      endTime: slotEnd.toISOString(),
+      freeInterviewerCount: freeMembers.size,
+      bookedInterviewCount: bookedCount,
+    };
+  });
+
+  return Response.json({
+    configured: true,
+    slots,
+    slotDurationMinutes: config.slotDurationMinutes,
+    timezone: config.timezone,
+    totalInterviewers: interviewers.length,
+  });
+}

--- a/dali-api/app/hiring/routes/api.cycles.$cycleId.interviewers.ts
+++ b/dali-api/app/hiring/routes/api.cycles.$cycleId.interviewers.ts
@@ -26,11 +26,28 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     include: {
       user: { select: { firstName: true, lastName: true, daliEmail: true } },
       domain: { select: { id: true, name: true } },
+      availabilityBlocks: { select: { startTime: true, endTime: true } },
     },
     orderBy: { createdAt: "asc" },
   });
 
-  return Response.json(interviewers);
+  const withStats = interviewers.map((i) => {
+    const sorted = [...i.availabilityBlocks].sort(
+      (a, b) => a.startTime.getTime() - b.startTime.getTime(),
+    );
+    const totalMs = sorted.reduce(
+      (sum, b) => sum + (b.endTime.getTime() - b.startTime.getTime()),
+      0,
+    );
+    return {
+      ...i,
+      availabilityBlocks: sorted,
+      availabilityBlockCount: sorted.length,
+      availabilityHours: totalMs / (1000 * 60 * 60),
+    };
+  });
+
+  return Response.json(withStats);
 }
 
 export async function action({ request, params }: Route.ActionArgs) {

--- a/dali-api/app/hiring/routes/lead.cycle.$id.tsx
+++ b/dali-api/app/hiring/routes/lead.cycle.$id.tsx
@@ -16,7 +16,7 @@ import {
 } from "~/hiring/lib/email-variables";
 import { Modal } from "~/components/Modal";
 import { ChallengePreviewModal } from "~/hiring/components/ChallengePreviewModal";
-import { Settings, Users, Calendar, AlertTriangle, Trash2, Plus, CheckCircle, ArrowRight, Circle, ChevronRight, X, LayoutDashboard, Eye } from 'lucide-react'
+import { Settings, Users, Calendar, AlertTriangle, Trash2, Plus, CheckCircle, ArrowRight, Circle, ChevronRight, X, LayoutDashboard, Eye, Mail } from 'lucide-react'
 import { formatVersionLabel, buildVersionNumberMap } from "~/lib/formatVersion";
 import { getCycleConfidentialityState } from "~/hiring/lib/confidentiality";
 import { sendExtensionNoticeIfDue, resendExtensionNotice } from "~/hiring/lib/extension-notice";
@@ -846,6 +846,20 @@ function formatHour(h: number) {
   if (h < 12) return `${h} AM`
   if (h === 12) return '12 PM'
   return `${h - 12} PM`
+}
+
+// Inline marker for any control that sends an email when committed.
+// Hover the icon to see exactly who receives mail.
+function EmailMarker({ recipients, label = 'Sends email' }: { recipients: string; label?: string }) {
+  return (
+    <span
+      title={`${label} — ${recipients}`}
+      aria-label={`${label}: ${recipients}`}
+      className="inline-flex items-center justify-center align-middle text-blue-600/80 ml-1"
+    >
+      <Mail className="w-3.5 h-3.5" />
+    </span>
+  )
 }
 
 // ─── Coverage Heatmap ────────────────────────────────────────────────────────
@@ -2062,6 +2076,10 @@ export default function HiringLeadCycleDetails() {
         />
       ) : tab === 'dashboard' && (
         <div className="space-y-4">
+          <div className="rounded-lg border border-blue-200 bg-blue-50 px-4 py-2.5 text-xs text-blue-900 inline-flex items-center gap-2">
+            <Mail className="w-3.5 h-3.5 flex-shrink-0" aria-hidden />
+            <span>Controls marked with <Mail className="w-3 h-3 inline-block align-middle text-blue-600" /> send an email when committed. Hover the icon to see who receives it.</span>
+          </div>
           <CoverageHeatmap coverage={coverage} />
           <div className="bg-card rounded-xl border border-border shadow-sm overflow-hidden">
             <div className="hidden sm:block overflow-x-auto">
@@ -2106,32 +2124,35 @@ export default function HiringLeadCycleDetails() {
                       </td>
                       <td className="px-4 py-3">
                         {isFuture && interview.status === 'Scheduled' ? (
-                          <select
-                            value={interview.location}
-                            onChange={async (e) => {
-                              const newLocation = e.target.value
-                              const res = await fetch(`/api/hiring/interviews/${interview.id}/location`, {
-                                method: 'PATCH',
-                                credentials: 'include',
-                                headers: { 'Content-Type': 'application/json' },
-                                body: JSON.stringify({ location: newLocation }),
-                              })
-                              if (res.ok) {
-                                const updated = await res.json()
-                                setInterviews(prev => prev.map(i =>
-                                  i.id === interview.id ? { ...i, location: newLocation, zoomJoinUrl: updated.zoomJoinUrl ?? null } : i
-                                ))
-                              } else {
-                                const body = await res.json().catch(() => ({}))
-                                alert(body.error ?? 'Failed to update location')
-                              }
-                            }}
-                            className="text-xs border border-border rounded px-1.5 py-0.5 bg-card"
-                          >
-                            <option value="PodAppa">Pod Appa</option>
-                            <option value="PodMomo">Pod Momo</option>
-                            <option value="Online">Online</option>
-                          </select>
+                          <span className="inline-flex items-center gap-1">
+                            <select
+                              value={interview.location}
+                              onChange={async (e) => {
+                                const newLocation = e.target.value
+                                const res = await fetch(`/api/hiring/interviews/${interview.id}/location`, {
+                                  method: 'PATCH',
+                                  credentials: 'include',
+                                  headers: { 'Content-Type': 'application/json' },
+                                  body: JSON.stringify({ location: newLocation }),
+                                })
+                                if (res.ok) {
+                                  const updated = await res.json()
+                                  setInterviews(prev => prev.map(i =>
+                                    i.id === interview.id ? { ...i, location: newLocation, zoomJoinUrl: updated.zoomJoinUrl ?? null } : i
+                                  ))
+                                } else {
+                                  const body = await res.json().catch(() => ({}))
+                                  alert(body.error ?? 'Failed to update location')
+                                }
+                              }}
+                              className="text-xs border border-border rounded px-1.5 py-0.5 bg-card"
+                            >
+                              <option value="PodAppa">Pod Appa</option>
+                              <option value="PodMomo">Pod Momo</option>
+                              <option value="Online">Online</option>
+                            </select>
+                            <EmailMarker recipients="applicant + both interviewers" label="Changing fires location-change email" />
+                          </span>
                         ) : (
                           <span className="text-xs text-muted-foreground">
                             {interview.location === 'PodAppa' ? 'Pod Appa' :
@@ -2141,7 +2162,8 @@ export default function HiringLeadCycleDetails() {
                         {interview.location === 'Online' && isFuture && interview.status === 'Scheduled' && (
                           <input
                             type="url"
-                            placeholder="Paste meeting link"
+                            placeholder="Paste meeting link (emails on save)"
+                            title="Sends location-change email to applicant + both interviewers when you tab away"
                             defaultValue={interview.zoomJoinUrl ?? ''}
                             onBlur={async (e) => {
                               let meetingUrl = e.target.value.trim()
@@ -2210,6 +2232,9 @@ export default function HiringLeadCycleDetails() {
                                         return <option key={i.id} value={i.id}>{iName}</option>
                                       })}
                                   </select>
+                                )}
+                                {isFuture && interview.status === 'Scheduled' && (
+                                  <EmailMarker recipients="removed + replacement interviewer" label="Reassigning fires emails" />
                                 )}
                               </div>
                             )
@@ -2364,6 +2389,9 @@ export default function HiringLeadCycleDetails() {
                                       })}
                                   </select>
                                 )}
+                                {editable && (
+                                  <EmailMarker recipients="removed + replacement interviewer" label="Reassigning fires emails" />
+                                )}
                               </div>
                             )
                           })}
@@ -2389,6 +2417,10 @@ export default function HiringLeadCycleDetails() {
         />
       ) : tab === 'decisions' && (
         <div className="space-y-4">
+          <div className="rounded-lg border border-blue-200 bg-blue-50 px-4 py-2.5 text-xs text-blue-900 inline-flex items-center gap-2">
+            <Mail className="w-3.5 h-3.5 flex-shrink-0" aria-hidden />
+            <span><span className="font-semibold">Release</span> emails the applicant the decision (using the bound template). It cannot be undone.</span>
+          </div>
           <div className="bg-card rounded-xl border border-border shadow-sm overflow-hidden">
             <div className="px-4 sm:px-6 py-3 sm:py-4 border-b border-border bg-muted/50 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
               <h3 className="font-bold text-foreground">Final Decisions Ready for Release</h3>
@@ -2412,8 +2444,9 @@ export default function HiringLeadCycleDetails() {
                         ? `${skipped} decision${skipped === 1 ? '' : 's'} skipped — no email template bound on the Setup tab`
                         : undefined
                     }
-                    className="px-3 py-1.5 text-sm font-medium rounded-lg bg-green-600 hover:bg-green-700 text-white transition self-start sm:self-auto disabled:opacity-50 disabled:cursor-not-allowed"
+                    className="px-3 py-1.5 text-sm font-medium rounded-lg bg-green-600 hover:bg-green-700 text-white transition self-start sm:self-auto disabled:opacity-50 disabled:cursor-not-allowed inline-flex items-center gap-1"
                   >
+                    <Mail className="w-3.5 h-3.5" aria-hidden />
                     Release All ({releasable.length})
                     {skipped > 0 && ` — ${skipped} skipped, no template bound`}
                   </button>
@@ -2477,8 +2510,9 @@ export default function HiringLeadCycleDetails() {
                               ? `No email template bound to ${d.type} in this cycle. Bind one on the Setup tab → Decision Emails before releasing.`
                               : undefined
                           }
-                          className="px-3 py-1 text-sm font-medium rounded-lg bg-green-600 hover:bg-green-700 text-white transition disabled:opacity-50 disabled:cursor-not-allowed"
+                          className="px-3 py-1 text-sm font-medium rounded-lg bg-green-600 hover:bg-green-700 text-white transition disabled:opacity-50 disabled:cursor-not-allowed inline-flex items-center gap-1"
                         >
+                          <Mail className="w-3.5 h-3.5" aria-hidden />
                           {releasing === d.id ? 'Releasing...' : 'Release'}
                         </button>
                       </div>
@@ -2543,8 +2577,9 @@ export default function HiringLeadCycleDetails() {
                             ? `No email template bound to ${d.type} in this cycle. Bind one on the Setup tab → Decision Emails before releasing.`
                             : undefined
                         }
-                        className="px-3 py-1.5 text-sm font-medium rounded-lg bg-green-600 hover:bg-green-700 text-white transition disabled:opacity-50 disabled:cursor-not-allowed"
+                        className="px-3 py-1.5 text-sm font-medium rounded-lg bg-green-600 hover:bg-green-700 text-white transition disabled:opacity-50 disabled:cursor-not-allowed inline-flex items-center gap-1"
                       >
+                        <Mail className="w-3.5 h-3.5" aria-hidden />
                         {releasing === d.id ? 'Releasing...' : 'Release'}
                       </button>
                     </div>

--- a/dali-api/app/hiring/routes/lead.cycle.$id.tsx
+++ b/dali-api/app/hiring/routes/lead.cycle.$id.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from 'react'
+import { useState, useEffect, useCallback, useRef, Fragment } from 'react'
 import { Form, Link, useParams, useLoaderData, redirect } from 'react-router'
 import type { Route } from "./+types/lead.cycle.$id";
 import { prisma } from "~/lib/db";
@@ -848,6 +848,172 @@ function formatHour(h: number) {
   return `${h - 12} PM`
 }
 
+// ─── Coverage Heatmap ────────────────────────────────────────────────────────
+
+type CoverageData = {
+  configured: boolean
+  slots: { startTime: string; endTime: string; freeInterviewerCount: number; bookedInterviewCount: number }[]
+  slotDurationMinutes: number
+  timezone: string
+  totalInterviewers?: number
+}
+
+function CoverageHeatmap({ coverage }: { coverage: CoverageData | null }) {
+  if (!coverage) {
+    return (
+      <div className="bg-card rounded-xl border border-border shadow-sm p-6 text-sm text-muted-foreground">
+        Loading availability coverage…
+      </div>
+    )
+  }
+  if (!coverage.configured) {
+    return (
+      <div className="bg-amber-50 border border-amber-200 rounded-xl p-4 text-sm text-amber-900">
+        Set an interview window and slot length in <span className="font-semibold">Interview Config</span> to see availability coverage.
+      </div>
+    )
+  }
+  if (coverage.slots.length === 0) {
+    return (
+      <div className="bg-muted/30 border border-border rounded-xl p-4 text-sm text-muted-foreground">
+        No future slots fall inside the configured interview window.
+      </div>
+    )
+  }
+
+  const tz = coverage.timezone
+  // Group slots by local date (YYYY-MM-DD in cycle timezone).
+  const byDay = new Map<string, typeof coverage.slots>()
+  const timeKeys = new Set<string>()
+  for (const slot of coverage.slots) {
+    const d = new Date(slot.startTime)
+    const dayKey = d.toLocaleDateString('en-CA', { timeZone: tz }) // YYYY-MM-DD
+    const timeKey = d.toLocaleTimeString('en-US', { timeZone: tz, hour: '2-digit', minute: '2-digit', hour12: false })
+    timeKeys.add(timeKey)
+    if (!byDay.has(dayKey)) byDay.set(dayKey, [])
+    byDay.get(dayKey)!.push(slot)
+  }
+  const days = Array.from(byDay.keys()).sort()
+  const times = Array.from(timeKeys).sort()
+
+  // Lookup: (dayKey, timeKey) -> slot
+  const lookup = new Map<string, typeof coverage.slots[number]>()
+  for (const slot of coverage.slots) {
+    const d = new Date(slot.startTime)
+    const dayKey = d.toLocaleDateString('en-CA', { timeZone: tz })
+    const timeKey = d.toLocaleTimeString('en-US', { timeZone: tz, hour: '2-digit', minute: '2-digit', hour12: false })
+    lookup.set(`${dayKey}|${timeKey}`, slot)
+  }
+
+  // Totals
+  const totalFreeHours = coverage.slots.reduce((sum, s) => sum + (s.freeInterviewerCount * coverage.slotDurationMinutes) / 60, 0)
+  const totalBooked = coverage.slots.reduce((sum, s) => sum + s.bookedInterviewCount, 0)
+  const slotHours = coverage.slotDurationMinutes / 60
+
+  function cellColor(freeCount: number) {
+    if (freeCount === 0) return 'bg-muted/40 text-muted-foreground/60'
+    if (freeCount <= 2) return 'bg-amber-100 text-amber-900'
+    if (freeCount <= 4) return 'bg-emerald-100 text-emerald-900'
+    if (freeCount <= 6) return 'bg-emerald-200 text-emerald-900'
+    return 'bg-emerald-300 text-emerald-950'
+  }
+
+  function formatTime(timeKey: string) {
+    const [hh, mm] = timeKey.split(':').map(Number)
+    const period = hh >= 12 ? 'p' : 'a'
+    const h12 = hh % 12 === 0 ? 12 : hh % 12
+    return mm === 0 ? `${h12}${period}` : `${h12}:${String(mm).padStart(2, '0')}${period}`
+  }
+
+  function formatDay(dayKey: string) {
+    // dayKey is YYYY-MM-DD; parse as UTC noon to avoid TZ drift then format.
+    const d = new Date(`${dayKey}T12:00:00Z`)
+    return d.toLocaleDateString('en-US', { weekday: 'short', month: 'numeric', day: 'numeric', timeZone: tz })
+  }
+
+  return (
+    <div className="bg-card rounded-xl border border-border shadow-sm p-4 sm:p-6 space-y-4">
+      <div className="flex flex-wrap items-baseline gap-x-6 gap-y-2">
+        <h3 className="text-sm font-bold text-foreground/80">Lab-wide availability coverage</h3>
+        <div className="text-xs text-muted-foreground">
+          <span className="font-semibold text-foreground">{totalFreeHours.toFixed(0)}</span> interviewer-hours offered ·{' '}
+          <span className="font-semibold text-foreground">{totalBooked}</span> interview{totalBooked === 1 ? '' : 's'} booked ·{' '}
+          <span className="font-semibold text-foreground">{coverage.totalInterviewers ?? 0}</span> interviewer{coverage.totalInterviewers === 1 ? '' : 's'} ·{' '}
+          {slotHours < 1 ? `${coverage.slotDurationMinutes} min` : `${slotHours} h`} slots
+        </div>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="text-xs border-separate border-spacing-0.5">
+          <thead>
+            <tr>
+              <th className="text-left px-2 py-1 text-muted-foreground font-medium sticky left-0 bg-card z-10">Time</th>
+              {days.map((day) => (
+                <th key={day} className="px-2 py-1 text-center font-semibold text-foreground/80 whitespace-nowrap">
+                  {formatDay(day)}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {times.map((time) => (
+              <tr key={time}>
+                <td className="px-2 py-1 text-right text-muted-foreground font-medium sticky left-0 bg-card whitespace-nowrap">
+                  {formatTime(time)}
+                </td>
+                {days.map((day) => {
+                  const slot = lookup.get(`${day}|${time}`)
+                  if (!slot) {
+                    return <td key={`${day}-${time}`} className="px-2 py-1 bg-transparent" />
+                  }
+                  const free = slot.freeInterviewerCount
+                  const booked = slot.bookedInterviewCount
+                  return (
+                    <td
+                      key={`${day}-${time}`}
+                      title={`${free} interviewer${free === 1 ? '' : 's'} free${booked > 0 ? ` · ${booked} booked` : ''}`}
+                      className={`px-2 py-1 text-center font-semibold rounded ${cellColor(free)} relative min-w-[44px]`}
+                    >
+                      {free}
+                      {booked > 0 && (
+                        <span className="absolute top-0.5 right-0.5 flex gap-0.5">
+                          {Array.from({ length: Math.min(booked, 3) }).map((_, i) => (
+                            <span key={i} className="w-1.5 h-1.5 rounded-full bg-blue-600" />
+                          ))}
+                          {booked > 3 && <span className="text-[9px] text-blue-700 font-bold leading-none">+</span>}
+                        </span>
+                      )}
+                    </td>
+                  )
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-[11px] text-muted-foreground">
+        <span className="inline-flex items-center gap-1.5">
+          <span className="w-3 h-3 rounded bg-muted/40 border border-border" />0
+        </span>
+        <span className="inline-flex items-center gap-1.5">
+          <span className="w-3 h-3 rounded bg-amber-100" />1–2 thin
+        </span>
+        <span className="inline-flex items-center gap-1.5">
+          <span className="w-3 h-3 rounded bg-emerald-100" />3–4
+        </span>
+        <span className="inline-flex items-center gap-1.5">
+          <span className="w-3 h-3 rounded bg-emerald-200" />5–6
+        </span>
+        <span className="inline-flex items-center gap-1.5">
+          <span className="w-3 h-3 rounded bg-emerald-300" />7+
+        </span>
+        <span className="inline-flex items-center gap-1.5 ml-2">
+          <span className="w-1.5 h-1.5 rounded-full bg-blue-600" />booked
+        </span>
+      </div>
+    </div>
+  )
+}
+
 // ─── Component ───────────────────────────────────────────────────────────────
 
 export default function HiringLeadCycleDetails() {
@@ -881,9 +1047,19 @@ export default function HiringLeadCycleDetails() {
   const [interviewers, setInterviewers] = useState<any[]>([])
   const [newInterviewerMemberId, setNewInterviewerMemberId] = useState('')
   const [newInterviewerDomainId, setNewInterviewerDomainId] = useState('')
+  const [expandedInterviewers, setExpandedInterviewers] = useState<Set<string>>(new Set())
 
   // ── Interviews state ──
   const [interviews, setInterviews] = useState<InterviewRow[]>([])
+
+  // ── Coverage heatmap state ──
+  const [coverage, setCoverage] = useState<{
+    configured: boolean
+    slots: { startTime: string; endTime: string; freeInterviewerCount: number; bookedInterviewCount: number }[]
+    slotDurationMinutes: number
+    timezone: string
+    totalInterviewers?: number
+  } | null>(null)
 
   // ── Cycle status ──
   const [cycleStatus, setCycleStatus] = useState<string>('Draft')
@@ -974,6 +1150,14 @@ export default function HiringLeadCycleDetails() {
     } catch {}
   }, [cycleId])
 
+  const loadCoverage = useCallback(async () => {
+    if (!cycleId) return
+    try {
+      const r = await fetch(`/api/hiring/cycles/${cycleId}/coverage`, { credentials: 'include' })
+      setCoverage(r.ok ? await r.json() : null)
+    } catch {}
+  }, [cycleId])
+
   async function advanceStatus(force = false) {
     if (!cycleId) return
     const idx = STATUS_FLOW.indexOf(cycleStatus as any)
@@ -1015,7 +1199,8 @@ export default function HiringLeadCycleDetails() {
     loadDomains()
     loadInterviewers()
     loadInterviews()
-  }, [cycleId, loadStatus, loadConfig, loadReviewers, loadMembers, loadDomains, loadInterviewers, loadInterviews])
+    loadCoverage()
+  }, [cycleId, loadStatus, loadConfig, loadReviewers, loadMembers, loadDomains, loadInterviewers, loadInterviews, loadCoverage])
 
   // ── Handlers ──
 
@@ -1667,13 +1852,31 @@ export default function HiringLeadCycleDetails() {
           </div>
 
           {/* Interviewer roster table */}
+          {interviewers.length > 0 && (() => {
+            const submitted = interviewers.filter((i: any) => (i.availabilityBlockCount ?? 0) > 0).length
+            const total = interviewers.length
+            const allSubmitted = submitted === total
+            return (
+              <div className={`rounded-lg px-4 py-3 text-sm border ${
+                allSubmitted
+                  ? 'bg-green-50 border-green-200 text-green-900'
+                  : 'bg-amber-50 border-amber-200 text-amber-900'
+              }`}>
+                <span className="font-semibold">{submitted} of {total}</span> interviewer{total === 1 ? '' : 's'} ha{submitted === 1 ? 's' : 've'} submitted availability
+                {!allSubmitted && total - submitted > 0 && (
+                  <span className="text-amber-800/80"> · {total - submitted} pending</span>
+                )}
+              </div>
+            )
+          })()}
           <div className="bg-card rounded-xl border border-border shadow-sm overflow-hidden">
             <div className="hidden sm:block overflow-x-auto">
-            <table className="w-full text-sm min-w-[480px]">
+            <table className="w-full text-sm min-w-[640px]">
               <thead className="bg-muted/50 border-b border-border">
                 <tr>
                   <th className="text-left px-4 py-3 font-bold text-foreground/80">Interviewer</th>
                   <th className="text-left px-4 py-3 font-bold text-foreground/80">Domain</th>
+                  <th className="text-left px-4 py-3 font-bold text-foreground/80">Availability</th>
                   <th className="text-right px-4 py-3 font-bold text-foreground/80">Actions</th>
                 </tr>
               </thead>
@@ -1681,20 +1884,85 @@ export default function HiringLeadCycleDetails() {
                 {interviewers.map((i: any) => {
                   const m = i.user
                   const name = m?.firstName && m?.lastName ? `${m.firstName} ${m.lastName}` : m?.daliEmail ?? i.userId
+                  const hours = i.availabilityHours ?? 0
+                  const blocks = i.availabilityBlockCount ?? 0
+                  const hasAvail = blocks > 0
+                  const isExpanded = expandedInterviewers.has(i.id)
+                  const toggle = () => setExpandedInterviewers(prev => {
+                    const next = new Set(prev)
+                    if (next.has(i.id)) next.delete(i.id); else next.add(i.id)
+                    return next
+                  })
                   return (
-                    <tr key={i.id} className="hover:bg-muted/50 transition">
-                      <td className="px-4 py-3 font-medium text-foreground">{name}</td>
-                      <td className="px-4 py-3 text-muted-foreground">{i.domain?.name ?? ''}</td>
-                      <td className="px-4 py-3 text-right">
-                        <button onClick={() => removeInterviewer(i.id)} className="text-red-500 hover:text-red-700 transition">
-                          <Trash2 className="w-4 h-4" />
-                        </button>
-                      </td>
-                    </tr>
+                    <Fragment key={i.id}>
+                      <tr className="hover:bg-muted/50 transition">
+                        <td className="px-4 py-3 font-medium text-foreground">
+                          {hasAvail ? (
+                            <button onClick={toggle} className="inline-flex items-center gap-1.5 text-left hover:underline">
+                              <span className={`text-muted-foreground transition-transform inline-block ${isExpanded ? 'rotate-90' : ''}`}>▸</span>
+                              {name}
+                            </button>
+                          ) : (
+                            <span className="inline-flex items-center gap-1.5">
+                              <span className="w-2" />
+                              {name}
+                            </span>
+                          )}
+                        </td>
+                        <td className="px-4 py-3 text-muted-foreground">{i.domain?.name ?? ''}</td>
+                        <td className="px-4 py-3">
+                          {hasAvail ? (
+                            <span className="inline-flex items-center gap-1.5 text-green-700">
+                              <span className="w-1.5 h-1.5 rounded-full bg-green-500" />
+                              {hours.toFixed(1)}h <span className="text-muted-foreground">({blocks} block{blocks === 1 ? '' : 's'})</span>
+                            </span>
+                          ) : (
+                            <span className="inline-flex items-center gap-1.5 text-amber-700">
+                              <span className="w-1.5 h-1.5 rounded-full bg-amber-500" />
+                              Not submitted
+                            </span>
+                          )}
+                        </td>
+                        <td className="px-4 py-3 text-right">
+                          <button onClick={() => removeInterviewer(i.id)} className="text-red-500 hover:text-red-700 transition">
+                            <Trash2 className="w-4 h-4" />
+                          </button>
+                        </td>
+                      </tr>
+                      {isExpanded && hasAvail && (
+                        <tr className="bg-muted/20">
+                          <td colSpan={4} className="px-4 py-3">
+                            <div className="ml-6 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-x-6 gap-y-1.5 text-xs">
+                              {(i.availabilityBlocks ?? []).map((b: any, idx: number) => {
+                                const start = new Date(b.startTime)
+                                const end = new Date(b.endTime)
+                                const sameDay = start.toDateString() === end.toDateString()
+                                const dur = (end.getTime() - start.getTime()) / (1000 * 60 * 60)
+                                return (
+                                  <div key={idx} className="flex items-baseline gap-2">
+                                    <span className="font-medium text-foreground whitespace-nowrap">
+                                      {start.toLocaleDateString(undefined, { weekday: 'short', month: 'short', day: 'numeric' })}
+                                    </span>
+                                    <span className="text-muted-foreground">
+                                      {start.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })}
+                                      {' – '}
+                                      {sameDay
+                                        ? end.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })
+                                        : `${end.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })} ${end.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })}`}
+                                    </span>
+                                    <span className="text-muted-foreground/60">({dur.toFixed(1)}h)</span>
+                                  </div>
+                                )
+                              })}
+                            </div>
+                          </td>
+                        </tr>
+                      )}
+                    </Fragment>
                   )
                 })}
                 {interviewers.length === 0 && (
-                  <tr><td colSpan={3} className="px-4 py-8 text-center text-muted-foreground/70"><span className="sr-only">Table empty: </span>No interviewers assigned yet.</td></tr>
+                  <tr><td colSpan={4} className="px-4 py-8 text-center text-muted-foreground/70"><span className="sr-only">Table empty: </span>No interviewers assigned yet.</td></tr>
                 )}
               </tbody>
             </table>
@@ -1703,19 +1971,69 @@ export default function HiringLeadCycleDetails() {
               {interviewers.map((i: any) => {
                 const m = i.user
                 const name = m?.firstName && m?.lastName ? `${m.firstName} ${m.lastName}` : m?.daliEmail ?? i.userId
+                const hours = i.availabilityHours ?? 0
+                const blocks = i.availabilityBlockCount ?? 0
+                const hasAvail = blocks > 0
+                const isExpanded = expandedInterviewers.has(i.id)
+                const toggle = () => setExpandedInterviewers(prev => {
+                  const next = new Set(prev)
+                  if (next.has(i.id)) next.delete(i.id); else next.add(i.id)
+                  return next
+                })
                 return (
-                  <li key={i.id} className="px-4 py-3 flex items-start justify-between gap-3">
-                    <div className="min-w-0">
-                      <div className="font-medium text-foreground truncate">{name}</div>
-                      <div className="text-xs text-muted-foreground mt-0.5">{i.domain?.name ?? ''}</div>
+                  <li key={i.id} className="px-4 py-3">
+                    <div className="flex items-start justify-between gap-3">
+                      <button
+                        onClick={hasAvail ? toggle : undefined}
+                        className="min-w-0 text-left flex-1"
+                        disabled={!hasAvail}
+                      >
+                        <div className="font-medium text-foreground truncate flex items-center gap-1.5">
+                          {hasAvail && <span className={`text-muted-foreground transition-transform inline-block ${isExpanded ? 'rotate-90' : ''}`}>▸</span>}
+                          {name}
+                        </div>
+                        <div className="text-xs text-muted-foreground mt-0.5">{i.domain?.name ?? ''}</div>
+                        <div className="text-xs mt-1">
+                          {hasAvail ? (
+                            <span className="inline-flex items-center gap-1.5 text-green-700">
+                              <span className="w-1.5 h-1.5 rounded-full bg-green-500" />
+                              {hours.toFixed(1)}h · {blocks} block{blocks === 1 ? '' : 's'}
+                            </span>
+                          ) : (
+                            <span className="inline-flex items-center gap-1.5 text-amber-700">
+                              <span className="w-1.5 h-1.5 rounded-full bg-amber-500" />
+                              No availability yet
+                            </span>
+                          )}
+                        </div>
+                      </button>
+                      <button
+                        onClick={() => removeInterviewer(i.id)}
+                        aria-label="Remove interviewer"
+                        className="p-2 -m-2 text-red-500 hover:text-red-700 transition flex-shrink-0"
+                      >
+                        <Trash2 className="w-4 h-4" />
+                      </button>
                     </div>
-                    <button
-                      onClick={() => removeInterviewer(i.id)}
-                      aria-label="Remove interviewer"
-                      className="p-2 -m-2 text-red-500 hover:text-red-700 transition flex-shrink-0"
-                    >
-                      <Trash2 className="w-4 h-4" />
-                    </button>
+                    {isExpanded && hasAvail && (
+                      <div className="mt-2 pl-4 space-y-1 text-xs">
+                        {(i.availabilityBlocks ?? []).map((b: any, idx: number) => {
+                          const start = new Date(b.startTime)
+                          const end = new Date(b.endTime)
+                          const sameDay = start.toDateString() === end.toDateString()
+                          return (
+                            <div key={idx} className="text-muted-foreground">
+                              <span className="font-medium text-foreground">
+                                {start.toLocaleDateString(undefined, { weekday: 'short', month: 'short', day: 'numeric' })}
+                              </span>{' '}
+                              {start.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })} – {sameDay
+                                ? end.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })
+                                : `${end.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })} ${end.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })}`}
+                            </div>
+                          )
+                        })}
+                      </div>
+                    )}
                   </li>
                 )
               })}
@@ -1736,6 +2054,7 @@ export default function HiringLeadCycleDetails() {
         />
       ) : tab === 'dashboard' && (
         <div className="space-y-4">
+          <CoverageHeatmap coverage={coverage} />
           <div className="bg-card rounded-xl border border-border shadow-sm overflow-hidden">
             <div className="hidden sm:block overflow-x-auto">
             <table className="w-full text-sm min-w-[820px]">

--- a/dali-api/app/hiring/routes/lead.cycle.$id.tsx
+++ b/dali-api/app/hiring/routes/lead.cycle.$id.tsx
@@ -873,6 +873,7 @@ type CoverageData = {
 }
 
 function CoverageHeatmap({ coverage }: { coverage: CoverageData | null }) {
+  const [showEmpty, setShowEmpty] = useState(false)
   if (!coverage) {
     return (
       <div className="bg-card rounded-xl border border-border shadow-sm p-6 text-sm text-muted-foreground">
@@ -908,7 +909,7 @@ function CoverageHeatmap({ coverage }: { coverage: CoverageData | null }) {
     byDay.get(dayKey)!.push(slot)
   }
   const days = Array.from(byDay.keys()).sort()
-  const times = Array.from(timeKeys).sort()
+  const allTimes = Array.from(timeKeys).sort()
 
   // Lookup: (dayKey, timeKey) -> slot
   const lookup = new Map<string, typeof coverage.slots[number]>()
@@ -918,6 +919,17 @@ function CoverageHeatmap({ coverage }: { coverage: CoverageData | null }) {
     const timeKey = d.toLocaleTimeString('en-US', { timeZone: tz, hour: '2-digit', minute: '2-digit', hour12: false })
     lookup.set(`${dayKey}|${timeKey}`, slot)
   }
+
+  // Rows where at least one day has free interviewers or a booked interview.
+  // These are the "interesting" rows — most slots end up all-zero.
+  const activeTimes = allTimes.filter((time) =>
+    days.some((day) => {
+      const s = lookup.get(`${day}|${time}`)
+      return s && (s.freeInterviewerCount > 0 || s.bookedInterviewCount > 0)
+    }),
+  )
+  const hiddenCount = allTimes.length - activeTimes.length
+  const times = showEmpty ? allTimes : activeTimes
 
   // Totals
   const totalFreeHours = coverage.slots.reduce((sum, s) => sum + (s.freeInterviewerCount * coverage.slotDurationMinutes) / 60, 0)
@@ -949,20 +961,29 @@ function CoverageHeatmap({ coverage }: { coverage: CoverageData | null }) {
     <div className="bg-card rounded-xl border border-border shadow-sm p-4 sm:p-6 space-y-4">
       <div className="flex flex-wrap items-baseline gap-x-6 gap-y-2">
         <h3 className="text-sm font-bold text-foreground/80">Lab-wide availability coverage</h3>
-        <div className="text-xs text-muted-foreground">
+        <div className="text-xs text-muted-foreground flex-1">
           <span className="font-semibold text-foreground">{totalFreeHours.toFixed(0)}</span> interviewer-hours offered ·{' '}
           <span className="font-semibold text-foreground">{totalBooked}</span> interview{totalBooked === 1 ? '' : 's'} booked ·{' '}
           <span className="font-semibold text-foreground">{coverage.totalInterviewers ?? 0}</span> interviewer{coverage.totalInterviewers === 1 ? '' : 's'} ·{' '}
           {slotHours < 1 ? `${coverage.slotDurationMinutes} min` : `${slotHours} h`} slots
         </div>
+        {hiddenCount > 0 && (
+          <button
+            type="button"
+            onClick={() => setShowEmpty((v) => !v)}
+            className="text-xs text-blue-700 hover:text-blue-800 hover:underline"
+          >
+            {showEmpty ? `Hide ${hiddenCount} empty slot${hiddenCount === 1 ? '' : 's'}` : `Show ${hiddenCount} empty slot${hiddenCount === 1 ? '' : 's'}`}
+          </button>
+        )}
       </div>
       <div className="overflow-x-auto">
-        <table className="text-xs border-separate border-spacing-0.5">
+        <table className="text-[11px] border-separate border-spacing-[2px] leading-none">
           <thead>
             <tr>
-              <th className="text-left px-2 py-1 text-muted-foreground font-medium sticky left-0 bg-card z-10">Time</th>
+              <th className="text-left px-1.5 py-0.5 text-muted-foreground font-medium sticky left-0 bg-card z-10">Time</th>
               {days.map((day) => (
-                <th key={day} className="px-2 py-1 text-center font-semibold text-foreground/80 whitespace-nowrap">
+                <th key={day} className="px-1.5 py-0.5 text-center font-semibold text-foreground/80 whitespace-nowrap">
                   {formatDay(day)}
                 </th>
               ))}
@@ -971,13 +992,13 @@ function CoverageHeatmap({ coverage }: { coverage: CoverageData | null }) {
           <tbody>
             {times.map((time) => (
               <tr key={time}>
-                <td className="px-2 py-1 text-right text-muted-foreground font-medium sticky left-0 bg-card whitespace-nowrap">
+                <td className="px-1.5 py-0.5 text-right text-muted-foreground font-medium sticky left-0 bg-card whitespace-nowrap">
                   {formatTime(time)}
                 </td>
                 {days.map((day) => {
                   const slot = lookup.get(`${day}|${time}`)
                   if (!slot) {
-                    return <td key={`${day}-${time}`} className="px-2 py-1 bg-transparent" />
+                    return <td key={`${day}-${time}`} className="px-1.5 py-0.5 bg-transparent" />
                   }
                   const free = slot.freeInterviewerCount
                   const booked = slot.bookedInterviewCount
@@ -985,7 +1006,7 @@ function CoverageHeatmap({ coverage }: { coverage: CoverageData | null }) {
                     <td
                       key={`${day}-${time}`}
                       title={`${free} interviewer${free === 1 ? '' : 's'} free${booked > 0 ? ` · ${booked} booked` : ''}`}
-                      className={`px-2 py-1 text-center font-semibold rounded ${cellColor(free)} relative min-w-[44px]`}
+                      className={`px-1.5 py-0.5 text-center font-semibold rounded ${cellColor(free)} relative min-w-[36px]`}
                     >
                       {free}
                       {booked > 0 && (

--- a/dali-api/app/hiring/routes/lead.cycle.$id.tsx
+++ b/dali-api/app/hiring/routes/lead.cycle.$id.tsx
@@ -1804,7 +1804,15 @@ export default function HiringLeadCycleDetails() {
               )}
             </ul>
           </div>
+        </div>
+      )}
 
+      {/* ── Interviewers Roster (shown under Interview Setup) ── */}
+      {tab === 'config' && (
+        <div className="space-y-4 mt-4">
+          <h3 className="text-base font-bold text-foreground/90 flex items-center gap-2">
+            <Users className="w-4 h-4" /> Interviewers
+          </h3>
           {/* Add interviewer form */}
           <div className="bg-card rounded-xl border border-border shadow-sm p-4 sm:p-6">
             <h3 className="text-sm font-bold text-foreground/80 mb-4 flex items-center gap-2">

--- a/dali-api/app/routes.ts
+++ b/dali-api/app/routes.ts
@@ -131,6 +131,7 @@ export default [
   route("api/hiring/cycles/:cycleId/available-slots", "hiring/routes/api.cycles.$cycleId.available-slots.ts"),
   route("api/hiring/cycles/:cycleId/interviews", "hiring/routes/api.cycles.$cycleId.interviews.ts"),
   route("api/hiring/cycles/:cycleId/interviewers", "hiring/routes/api.cycles.$cycleId.interviewers.ts"),
+  route("api/hiring/cycles/:cycleId/coverage", "hiring/routes/api.cycles.$cycleId.coverage.ts"),
   route("api/hiring/cycles/:cycleId/delibs", "hiring/routes/api.cycles.$cycleId.delibs.ts"),
   route("api/hiring/cycles/:cycleId/domains/:domainId/auto-assign", "hiring/routes/api.cycles.$cycleId.domains.$domainId.auto-assign.ts"),
   route("api/hiring/cycles/:cycleId/confidentiality/sign", "hiring/routes/api.cycles.$cycleId.confidentiality.sign.ts"),


### PR DESCRIPTION
## Summary
- Hiring leads can now see, at a glance, **which interviewers have submitted availability** and **where the cycle has thin coverage** without dropping into Neon
- Cycle Setup → Interviewers gets a green/amber status column, "X of Y submitted" banner, and click-to-expand per-interviewer block detail
- Interview Dashboard gets a days × slots **coverage heatmap** (shaded by free-interviewer count, booked interviews shown as blue dots), slot-matched to `InterviewConfig.slotDurationMinutes`

## Changes
- `api.cycles.$cycleId.interviewers.ts` — loader returns `availabilityHours`, `availabilityBlockCount`, and sorted `availabilityBlocks[]`
- `api.cycles.$cycleId.coverage.ts` (new) — per-slot `freeInterviewerCount` + `bookedInterviewCount`. Reuses `generateCandidateSlots` and `isInterviewerFree` from `hiring/lib/scheduling.ts`; respects `bufferMinutes` for booked intervals
- `lead.cycle.$id.tsx` — `CoverageHeatmap` component on Dashboard tab; expanded roster table with per-interviewer block list
- `routes.ts` — registers `/api/hiring/cycles/:cycleId/coverage`

## Notes
- All routes gated by existing `hasCycleAccess` — no permission surface change
- No schema or migration changes
- Pre-existing typecheck errors in `reviewer.tsx` remain (untouched)

## Test plan
- [ ] On a cycle with no `InterviewConfig`, the heatmap shows "set a window…" hint instead of crashing
- [ ] Assign 2+ interviewers, submit availability on one → roster shows green hours for them and amber "Not submitted" for the other; banner reads "1 of 2"
- [ ] Click an interviewer with availability → row expands and lists each block formatted as "Mon Jun 16, 2:00 PM – 5:00 PM (3.0h)"
- [ ] Heatmap cells reflect interviewer count; book a test interview → see blue dot overlay on the matching cell
- [ ] Cycle Setup roster on mobile (<sm) expands the same way

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/577"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->