### PR TITLE
Add public /privacy and /terms pages for Google OAuth verification

### DIFF
--- a/dali-api/app/routes.ts
+++ b/dali-api/app/routes.ts
@@ -57,6 +57,11 @@ export default [
     route("portal/application", "routes/portal.application.tsx"),
   ]),
 
+  // Public policy pages (no auth, no layout) — linked from the Google OAuth
+  // consent screen, so they must load for an unauthenticated reviewer.
+  route("privacy", "routes/privacy.tsx"),
+  route("terms", "routes/terms.tsx"),
+
   // Login (no layout)
   route("login", "routes/login.tsx"),
   route("dev-login", "routes/dev-login.ts"),

--- a/dali-api/app/routes/privacy.tsx
+++ b/dali-api/app/routes/privacy.tsx
@@ -1,0 +1,271 @@
+// Public privacy policy. Required for Google OAuth verification — Google's
+// reviewer loads this URL while validating the consent screen, so it must be
+// (a) reachable without authentication and (b) explicitly describe what the
+// app does with each requested Google scope. Keep the Google Calendar /
+// Gmail sections accurate against app/lib/google-calendar.ts and
+// app/lib/gmail.ts — if those change, update this page in the same PR.
+
+import type { Route } from "./+types/privacy";
+
+export const meta: Route.MetaFunction = () => [
+  { title: "Privacy Policy · DALI OS" },
+];
+
+const LAST_UPDATED = "May 20, 2026";
+
+export default function PrivacyPolicy() {
+  return (
+    <main className="mx-auto max-w-3xl px-6 py-12 text-foreground">
+      <h1 className="font-heading text-3xl font-bold">Privacy Policy</h1>
+      <p className="mt-1 text-sm text-muted-foreground">
+        Last updated: {LAST_UPDATED}
+      </p>
+
+      <Section title="Who this applies to">
+        <p>
+          DALI OS is an internal tool operated by the{" "}
+          <a
+            href="https://dali.dartmouth.edu"
+            className="text-accent-coral underline"
+          >
+            DALI Lab
+          </a>{" "}
+          at Dartmouth College. This policy covers the data the application
+          collects, stores, and transmits when you sign in or link a Google
+          account.
+        </p>
+      </Section>
+
+      <Section title="What we collect">
+        <ul className="list-disc pl-6 space-y-1.5">
+          <li>
+            <strong>Account profile</strong>: your name, Dartmouth or DALI
+            email address, and profile photo, used to identify you inside the
+            app.
+          </li>
+          <li>
+            <strong>Membership and role data</strong>: your team assignments,
+            domain eligibility, lab role, and project participation — managed
+            by DALI staff and used to scope what you can see and do in the
+            app.
+          </li>
+          <li>
+            <strong>Work content you create</strong>: forms, tasks, comments,
+            announcements, documents, and similar artifacts you author or
+            collaborate on within the app.
+          </li>
+          <li>
+            <strong>Google account data</strong> (only if you choose to link a
+            Google account — see the next section).
+          </li>
+        </ul>
+      </Section>
+
+      <Section title="Google account data (Calendar)">
+        <p>
+          You can optionally link a Google account so the app can read your
+          calendar availability and create meetings on your behalf. When you
+          authorize this, the application requests the OAuth scope{" "}
+          <code className="rounded bg-muted px-1.5 py-0.5 text-xs">
+            https://www.googleapis.com/auth/calendar
+          </code>{" "}
+          and uses it to:
+        </p>
+        <ul className="list-disc pl-6 space-y-1.5 mt-2">
+          <li>
+            <strong>Read your free/busy times</strong> across your linked
+            calendars to find mutual availability when scheduling meetings
+            with other lab members. The app reads busy time blocks only — it
+            does not read event titles, descriptions, attendee identities, or
+            attachments.
+          </li>
+          <li>
+            <strong>List your calendars</strong> (id and display name only) so
+            you can choose which calendar should receive new events the app
+            creates.
+          </li>
+          <li>
+            <strong>Create calendar events</strong> when you or another lab
+            member schedules a meeting through the app, and update those
+            events' attendee response status as members RSVP.
+          </li>
+        </ul>
+        <p className="mt-3">
+          The app does <strong>not</strong> read, modify, or delete calendar
+          events that it did not create. It does not access any other Google
+          service through your linked account beyond the scopes listed above.
+        </p>
+      </Section>
+
+      <Section title="Google account data (Gmail)">
+        <p>
+          A single shared lab account (
+          <code className="rounded bg-muted px-1.5 py-0.5 text-xs">
+            applications@dali.dartmouth.edu
+          </code>
+          ) is authorized with the scope{" "}
+          <code className="rounded bg-muted px-1.5 py-0.5 text-xs">
+            https://www.googleapis.com/auth/gmail.send
+          </code>{" "}
+          so the application can send transactional email — interview
+          invitations, decision notifications, and similar lab correspondence
+          — from that single address. The app does not read inboxes, list
+          messages, or access any user's personal Gmail.
+        </p>
+      </Section>
+
+      <Section title="How we store Google tokens">
+        <p>
+          OAuth access and refresh tokens issued to the application are
+          encrypted with AES-256-GCM before being written to the database. The
+          encryption key is held only in the deployment's runtime environment
+          and is not stored alongside the tokens. Tokens are scoped to your
+          user record and are deleted when you disconnect the integration or
+          when an administrator removes you from the lab.
+        </p>
+      </Section>
+
+      <Section title="How we use this data">
+        <ul className="list-disc pl-6 space-y-1.5">
+          <li>To authenticate you and authorize what you can do in the app.</li>
+          <li>
+            To display lab content (projects, tasks, applications, calendars,
+            announcements) to the people who should see it.
+          </li>
+          <li>
+            To schedule and update calendar events you participate in, when
+            you have opted in to the Google Calendar integration.
+          </li>
+          <li>
+            To send transactional email from the lab's shared account
+            (interview invitations, decisions, scheduling confirmations).
+          </li>
+        </ul>
+        <p className="mt-3">
+          We do <strong>not</strong> use your data for advertising, profiling,
+          training machine-learning models, or sale to third parties.
+        </p>
+      </Section>
+
+      <Section title="Who we share data with">
+        <p>
+          DALI OS data is not sold or shared with third parties for marketing.
+          The application relies on the following processors, each handling
+          only the data needed to perform its function:
+        </p>
+        <ul className="list-disc pl-6 space-y-1.5 mt-2">
+          <li>
+            <strong>Neon</strong> — managed PostgreSQL hosting (all
+            application data).
+          </li>
+          <li>
+            <strong>Fly.io</strong> — application hosting and request
+            handling.
+          </li>
+          <li>
+            <strong>Google</strong> — Calendar / Gmail APIs (only for accounts
+            you have linked or, in the case of Gmail, the shared lab account).
+          </li>
+          <li>
+            <strong>AWS S3</strong> — file uploads attached to forms and
+            applications.
+          </li>
+          <li>
+            <strong>Slack</strong> — optional notifications routed to a
+            member's Slack DM, if a Slack user id is on file.
+          </li>
+        </ul>
+      </Section>
+
+      <Section title="How to revoke access">
+        <p>
+          You can disconnect your linked Google account at any time from{" "}
+          <a href="/settings/connected-apps" className="text-accent-coral underline">
+            Settings → Connected Apps
+          </a>{" "}
+          inside DALI OS. Doing so deletes the stored tokens for that account
+          and stops the application from making Calendar API calls on your
+          behalf.
+        </p>
+        <p className="mt-3">
+          You can also revoke the application's access directly from your
+          Google account at{" "}
+          <a
+            href="https://myaccount.google.com/permissions"
+            className="text-accent-coral underline"
+            rel="noreferrer"
+          >
+            myaccount.google.com/permissions
+          </a>
+          . Revoking there invalidates the stored tokens immediately; the next
+          API call from the app will fail and the integration will be marked
+          disconnected.
+        </p>
+      </Section>
+
+      <Section title="Data retention">
+        <p>
+          Account, membership, and content data persists for as long as you
+          are an active or alumni member of the DALI Lab. Google OAuth tokens
+          are deleted when you disconnect the integration. Application logs
+          containing request metadata are retained for up to 30 days for
+          operational purposes.
+        </p>
+      </Section>
+
+      <Section title="How to request deletion">
+        <p>
+          To request deletion of your data, email{" "}
+          <a
+            href="mailto:staff@dali.dartmouth.edu"
+            className="text-accent-coral underline"
+          >
+            staff@dali.dartmouth.edu
+          </a>
+          . We will remove identifying account information within 30 days,
+          subject to records the Lab is required to retain for academic or
+          administrative reasons.
+        </p>
+      </Section>
+
+      <Section title="Changes to this policy">
+        <p>
+          When this policy changes in a material way, we will update the "Last
+          updated" date at the top and, where appropriate, notify active users
+          in-app. Earlier versions are available in the application's source
+          repository.
+        </p>
+      </Section>
+
+      <Section title="Contact">
+        <p>
+          Questions about this policy or how DALI OS handles your data:{" "}
+          <a
+            href="mailto:staff@dali.dartmouth.edu"
+            className="text-accent-coral underline"
+          >
+            staff@dali.dartmouth.edu
+          </a>
+          .
+        </p>
+      </Section>
+    </main>
+  );
+}
+
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="mt-8">
+      <h2 className="text-xl font-semibold mb-2">{title}</h2>
+      <div className="text-sm leading-relaxed text-foreground/90 space-y-2">
+        {children}
+      </div>
+    </section>
+  );
+}

--- a/dali-api/app/routes/terms.tsx
+++ b/dali-api/app/routes/terms.tsx
@@ -1,0 +1,167 @@
+// Public terms of service. Required for Google OAuth verification — paired
+// with /privacy. Kept short and accurate; updates ride alongside changes to
+// privacy.tsx.
+
+import type { Route } from "./+types/terms";
+
+export const meta: Route.MetaFunction = () => [
+  { title: "Terms of Service · DALI OS" },
+];
+
+const LAST_UPDATED = "May 20, 2026";
+
+export default function TermsOfService() {
+  return (
+    <main className="mx-auto max-w-3xl px-6 py-12 text-foreground">
+      <h1 className="font-heading text-3xl font-bold">Terms of Service</h1>
+      <p className="mt-1 text-sm text-muted-foreground">
+        Last updated: {LAST_UPDATED}
+      </p>
+
+      <Section title="About DALI OS">
+        <p>
+          DALI OS is an internal application operated by the{" "}
+          <a
+            href="https://dali.dartmouth.edu"
+            className="text-accent-coral underline"
+          >
+            DALI Lab
+          </a>{" "}
+          at Dartmouth College for hiring, staffing, scheduling, and
+          collaboration. It is provided to Lab members, applicants, and
+          authorized partners for use in connection with Lab activities.
+        </p>
+      </Section>
+
+      <Section title="Who may use it">
+        <p>
+          Access is granted by DALI Lab staff. By signing in you confirm that
+          you are using a Dartmouth, DALI, or otherwise-authorized account
+          extended to you for this purpose. Accounts may not be shared, and
+          credentials may not be transferred.
+        </p>
+      </Section>
+
+      <Section title="Acceptable use">
+        <ul className="list-disc pl-6 space-y-1.5">
+          <li>
+            Use DALI OS only for Lab-related work and only for the purposes
+            granted to your role.
+          </li>
+          <li>
+            Do not attempt to access data or features outside the scope of
+            your permissions, circumvent access controls, or interfere with
+            the service.
+          </li>
+          <li>
+            Do not upload content that violates Dartmouth's Acceptable Use
+            Policy, the law, or another person's rights.
+          </li>
+          <li>
+            Do not use the application to send unsolicited messages or
+            otherwise misuse its email or calendar integrations.
+          </li>
+        </ul>
+      </Section>
+
+      <Section title="Your content">
+        <p>
+          You retain ownership of content you author through DALI OS. By
+          using the application you grant the DALI Lab the right to store,
+          display, and process that content as needed to operate the
+          application and conduct Lab work.
+        </p>
+      </Section>
+
+      <Section title="Privacy">
+        <p>
+          Use of DALI OS is also governed by our{" "}
+          <a href="/privacy" className="text-accent-coral underline">
+            Privacy Policy
+          </a>
+          , which describes what data the application collects and how it is
+          handled — including the data accessed when you link a Google
+          account.
+        </p>
+      </Section>
+
+      <Section title="Third-party services">
+        <p>
+          DALI OS integrates with third-party services (Google, Slack, AWS,
+          Neon, Fly.io, among others). Your use of those services through the
+          application is also subject to their respective terms. Linking a
+          Google account is optional; you can disconnect it at any time.
+        </p>
+      </Section>
+
+      <Section title="Service availability and changes">
+        <p>
+          DALI OS is provided on an as-available basis. The Lab may modify,
+          suspend, or discontinue features at any time, and may change these
+          terms by updating this page and the "Last updated" date above.
+          Continued use after a change constitutes acceptance of the updated
+          terms.
+        </p>
+      </Section>
+
+      <Section title="No warranty">
+        <p>
+          The application is provided "as is," without warranty of any kind,
+          express or implied. To the maximum extent permitted by law, the
+          DALI Lab and Dartmouth College disclaim all warranties, including
+          warranties of merchantability, fitness for a particular purpose,
+          and non-infringement.
+        </p>
+      </Section>
+
+      <Section title="Limitation of liability">
+        <p>
+          To the maximum extent permitted by law, the DALI Lab, Dartmouth
+          College, and their staff are not liable for any indirect,
+          incidental, special, or consequential damages arising from your use
+          of, or inability to use, DALI OS.
+        </p>
+      </Section>
+
+      <Section title="Termination">
+        <p>
+          Access may be revoked at the Lab's discretion, including when you
+          are no longer affiliated with the Lab. You may stop using the
+          application at any time. Provisions intended to survive termination
+          — including those concerning ownership, no warranty, and
+          limitation of liability — will continue to apply.
+        </p>
+      </Section>
+
+      <Section title="Contact">
+        <p>
+          Questions about these terms:{" "}
+          <a
+            href="mailto:staff@dali.dartmouth.edu"
+            className="text-accent-coral underline"
+          >
+            staff@dali.dartmouth.edu
+          </a>
+          .
+        </p>
+      </Section>
+    </main>
+  );
+}
+
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="mt-8">
+      <h2 className="text-xl font-semibold mb-2">{title}</h2>
+      <div className="text-sm leading-relaxed text-foreground/90 space-y-2">
+        {children}
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `/privacy` and `/terms` as public routes (no auth, no app layout) so an unauthenticated Google reviewer can load them while validating the OAuth consent screen.
- Privacy policy explicitly names the scopes the app actually requests today: `https://www.googleapis.com/auth/calendar` (per-user calendar linking) and `https://www.googleapis.com/auth/gmail.send` (shared `applications@dali.dartmouth.edu` account only). Describes free/busy reads, event creation, AES-256-GCM token encryption, and the revoke flow.
- Terms of service is short and generic — acceptable use, as-is/no-warranty, termination.

## Why
Google's OAuth verification flow won't accept the app's consent screen without working privacy + terms URLs hosted on an authorized domain, and the privacy text has to call out each requested scope specifically — generic boilerplate gets rejected. These pages are the prereq for submitting `dali-os` for verification (or even just for letting non-`@dali.dartmouth.edu` users link calendars without hitting the "Google hasn't verified this app" warning).

## Notes for reviewer
- Pages live under `app/routes/` (alongside `login.tsx`) and are registered outside the `layout("routes/layout.tsx", [...])` block, since `layout.tsx`'s loader auth-redirects.
- Keep the Google sections in sync with `app/lib/google-calendar.ts` and `app/lib/gmail.ts` if the scopes ever change.
- Contact email is `staff@dali.dartmouth.edu`. Update if the lab has a different inbox they prefer for privacy / legal questions.
- Once these are live on `dali-api-prod.fly.dev`, the OAuth consent screen's "Application privacy policy" + "Application terms of service" fields can point to `https://dali-api-prod.fly.dev/privacy` and `.../terms` (or the Dartmouth subdomain if/when DNS is wired up).

## Test plan
- [ ] Visit `/privacy` and `/terms` while signed out — both should render without redirecting to `/login`.
- [ ] Visit them while signed in — same pages, no auth shell.
- [ ] Open in Google Search Console URL inspector once deployed to confirm they're indexable / publicly accessible.
- [ ] Cross-check the listed scopes match what `oauth.calendar.google.start.ts` and `admin.authorize-gmail.ts` actually request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781905133&installation_id=133523038&pr_number=582&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F582&signature=d40ffd9ae4f08cd3fd37fb731cd15fdb0aa88110be8f1a69201927dec0f3e952"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->