### PR TITLE
Open all subtabs + autoselect first subtab when clicking a parent nav item

### DIFF
--- a/dali-api/app/components/Layout.tsx
+++ b/dali-api/app/components/Layout.tsx
@@ -121,6 +121,21 @@ export function Layout({ user, isHiringLead = false, isAdmin = false, isDomainLe
     })
   }
 
+  // Force-expand without toggling. Used when clicking a parent label so the
+  // sidebar reveals the parent's subtabs alongside the navigation, rather
+  // than collapsing them off-screen if the user had previously closed the
+  // group.
+  const setAreaExpanded = (key: AreaKey) => {
+    setUserExpanded((prev) => {
+      if (prev[key] === true) return prev
+      const next = { ...prev, [key]: true }
+      if (typeof window !== 'undefined') {
+        window.localStorage.setItem(EXPANDED_AREAS_KEY, JSON.stringify(next))
+      }
+      return next
+    })
+  }
+
   const activeAreaKey: AreaKey | null =
     path.startsWith('/admin-console') ? 'admin-console'
     : path.startsWith('/hiring') ? 'hiring'
@@ -409,7 +424,17 @@ export function Layout({ user, isHiringLead = false, isAdmin = false, isDomainLe
                   type="button"
                   title={collapsed ? area.label : undefined}
                   aria-expanded={expanded}
-                  onClick={() => toggleAreaExpanded(area.key, area.active)}
+                  onClick={() => {
+                    // Clicking the parent label opens its group AND navigates
+                    // to the first subtab (or area.to if there are none).
+                    // Chevron click (next to this button) keeps the pure
+                    // toggle, so users who want to just collapse a group
+                    // still can.
+                    setAreaExpanded(area.key)
+                    const target = area.sections[0]?.to ?? area.to
+                    const label = area.sections[0]?.label ?? area.label
+                    openInWorkspace({ url: target, label })
+                  }}
                   className={`flex-1 flex items-center gap-3 ${collapsed ? 'px-3 py-2 justify-center' : 'pl-3 pr-1 py-2'} text-sm font-heading font-semibold text-left transition-colors ${
                     area.active ? 'text-white' : 'text-white/65 hover:text-white'
                   }`}


### PR DESCRIPTION
## Summary
- Clicking a parent area in the sidebar (Hiring / Projects / Members / Partners / Admin Console) now opens the group AND navigates to its first subtab in the workspace, instead of just expand/collapse with no navigation.
- The chevron next to the label keeps the pure toggle behavior, so users can still close an expanded group without navigating away.

## Why
Before this change, a new user clicking "Hiring" got an expanded menu but no page change — they had to make a second click on a subtab to actually land somewhere. The parent-as-toggle behavior was unintuitive given every parent has subtabs.

## Test plan
- [ ] Sign in. With Hiring collapsed, click the **Hiring** label → group expands, workspace tab opens on `/hiring/reviewer` (or first visible subtab for your role).
- [ ] Click the chevron next to **Hiring** → group collapses; the open workspace tab stays put.
- [ ] Click **Projects** → expands, opens `/projects/list`. Click **Members** → opens `/members`. Click **Admin Console** (if admin) → opens `/admin-console/members`.
- [ ] Collapse the sidebar entirely (the outer collapse toggle), click a parent icon → workspace navigates to first subtab; subtabs aren't visible while collapsed but persist as expanded once you reopen the sidebar.
- [ ] User with no Domain-Lead access: clicking **Hiring** opens whichever subtab is first in their filtered list (Reviews), not a 404 on `/hiring/domain-lead`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/583"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781975762&installation_id=133523038&pr_number=583&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F583&signature=3375b3de114b9ebbaa30968b0f02e3665f58a7378a3e03042fd1ef8d4f316e28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->