### PR TITLE
Gmail-friendly interview invites + min booking lead time

### DIFF
--- a/dali-api/app/hiring/lib/__tests__/api.my-interview.reschedule.test.ts
+++ b/dali-api/app/hiring/lib/__tests__/api.my-interview.reschedule.test.ts
@@ -40,7 +40,7 @@ beforeEach(() => {
 
   mockTx.interview.findFirst = vi.fn();
   mockTx.interview.update = vi.fn();
-  mockTx.interviewConfig.findUnique = vi.fn().mockResolvedValue({ rescheduleNoticeHours: 12 });
+  mockTx.interviewConfig.findUnique = vi.fn().mockResolvedValue({ rescheduleNoticeHours: 12, bookingNoticeHours: 0 });
 
   // $transaction receives (callback, options); invoke the callback with mockTx
   (mockPrisma as any).$transaction = vi.fn(async (cb: any) => cb(mockTx));
@@ -64,7 +64,7 @@ function makeRequest(body: Record<string, unknown>) {
 describe("POST /api/hiring/my-interview/reschedule", () => {
   it("returns 400 when domainApplicationId is missing", async () => {
     const res = await action({
-      request: makeRequest({ newStart: "2026-01-01T10:00:00Z", newEnd: "2026-01-01T10:30:00Z" }),
+      request: makeRequest({ newStart: "2027-01-01T10:00:00Z", newEnd: "2027-01-01T10:30:00Z" }),
       params: {},
       context: {},
     } as any);
@@ -93,8 +93,8 @@ describe("POST /api/hiring/my-interview/reschedule", () => {
     await action({
       request: makeRequest({
         domainApplicationId: DA_ID_A,
-        newStart: "2026-01-01T10:00:00Z",
-        newEnd: "2026-01-01T10:30:00Z",
+        newStart: "2027-01-01T10:00:00Z",
+        newEnd: "2027-01-01T10:30:00Z",
       }),
       params: {},
       context: {},
@@ -131,8 +131,8 @@ describe("POST /api/hiring/my-interview/reschedule", () => {
     const res = await action({
       request: makeRequest({
         domainApplicationId: DA_ID_A,
-        newStart: "2026-01-01T10:00:00Z",
-        newEnd: "2026-01-01T10:30:00Z",
+        newStart: "2027-01-01T10:00:00Z",
+        newEnd: "2027-01-01T10:30:00Z",
       }),
       params: {},
       context: {},
@@ -164,8 +164,8 @@ describe("POST /api/hiring/my-interview/reschedule", () => {
     const res = await action({
       request: makeRequest({
         domainApplicationId: DA_ID_B,
-        newStart: "2026-01-01T10:00:00Z",
-        newEnd: "2026-01-01T10:30:00Z",
+        newStart: "2027-01-01T10:00:00Z",
+        newEnd: "2027-01-01T10:30:00Z",
       }),
       params: {},
       context: {},

--- a/dali-api/app/hiring/lib/interview-emails.ts
+++ b/dali-api/app/hiring/lib/interview-emails.ts
@@ -8,7 +8,12 @@ import { sendEmail } from "~/lib/gmail";
 import { type InterpolationVars } from "~/lib/email";
 import { getApplicationsGmailRefreshToken } from "~/lib/gmail-integration";
 import { renderForSlot, notificationSlot } from "./email-variables";
-import { buildInviteIcs, buildCancelIcs } from "./interview-ics";
+import { buildInviteIcs, buildCancelIcs, type IcsAttendee } from "./interview-ics";
+
+const ORGANIZER: IcsAttendee = {
+  email: "applications@dali.dartmouth.edu",
+  name: "DALI Lab",
+};
 
 function formatLocation(location: string, meetingUrl?: string | null): string {
   if (location === "PodAppa") return "Pod Appa, DALI Lab";
@@ -119,6 +124,14 @@ export async function sendInterviewInviteEmails(
       meetingUrl: interview.zoomJoinUrl ?? undefined,
     };
 
+    const applicant = await getApplicantRecipient(domainApplicationId);
+    const interviewers = await getInterviewerRecipients(interviewId);
+
+    const attendees: IcsAttendee[] = [
+      ...(applicant ? [{ email: applicant.email, name: applicant.firstName }] : []),
+      ...interviewers.map((i) => ({ email: i.email, name: i.firstName })),
+    ];
+
     const ics = buildInviteIcs({
       interviewId: interview.id,
       summary: `DALI Interview — ${domainName}`,
@@ -126,10 +139,9 @@ export async function sendInterviewInviteEmails(
       endTime: interview.endTime,
       location: formatLocation(interview.location, interview.zoomJoinUrl),
       meetingUrl: interview.zoomJoinUrl,
+      organizer: ORGANIZER,
+      attendees,
     });
-
-    const applicant = await getApplicantRecipient(domainApplicationId);
-    const interviewers = await getInterviewerRecipients(interviewId);
 
     const sends: Promise<any>[] = [];
 
@@ -196,15 +208,22 @@ export async function sendInterviewCancelEmails(
       location: formatLocation(interview.location, interview.zoomJoinUrl),
     };
 
+    const applicant = await getApplicantRecipient(domainApplicationId);
+    const interviewers = await getInterviewerRecipients(interviewId);
+
+    const attendees: IcsAttendee[] = [
+      ...(applicant ? [{ email: applicant.email, name: applicant.firstName }] : []),
+      ...interviewers.map((i) => ({ email: i.email, name: i.firstName })),
+    ];
+
     const ics = buildCancelIcs({
       interviewId: interview.id,
       summary: `DALI Interview — ${domainName}`,
       startTime: interview.startTime,
       endTime: interview.endTime,
+      organizer: ORGANIZER,
+      attendees,
     });
-
-    const applicant = await getApplicantRecipient(domainApplicationId);
-    const interviewers = await getInterviewerRecipients(interviewId);
 
     const sends: Promise<any>[] = [];
 
@@ -282,13 +301,16 @@ export async function sendReassignmentEmails(
       include: { user: { select: { firstName: true, daliEmail: true } } },
     });
     if (removedCI?.user.daliEmail) {
+      const removedName = removedCI.user.firstName ?? "Interviewer";
       const cancelIcs = buildCancelIcs({
         interviewId: interview.id,
         summary: `DALI Interview — ${domainName}`,
         startTime: interview.startTime,
         endTime: interview.endTime,
+        organizer: ORGANIZER,
+        attendees: [{ email: removedCI.user.daliEmail, name: removedName }],
       });
-      const firstName = removedCI.user.firstName ?? "Interviewer";
+      const firstName = removedName;
       const rendered = await renderFromBinding(
         interview.applicationCycleId,
         "InterviewCancelledInterviewer",
@@ -311,6 +333,8 @@ export async function sendReassignmentEmails(
       include: { user: { select: { firstName: true, daliEmail: true } } },
     });
     if (newCI?.user.daliEmail) {
+      const applicant = await getApplicantRecipient(domainApplicationId);
+      const interviewers = await getInterviewerRecipients(interviewId);
       const inviteIcs = buildInviteIcs({
         interviewId: interview.id,
         summary: `DALI Interview — ${domainName}`,
@@ -318,6 +342,11 @@ export async function sendReassignmentEmails(
         endTime: interview.endTime,
         location: formatLocation(interview.location, interview.zoomJoinUrl),
         meetingUrl: interview.zoomJoinUrl,
+        organizer: ORGANIZER,
+        attendees: [
+          ...(applicant ? [{ email: applicant.email, name: applicant.firstName }] : []),
+          ...interviewers.map((i) => ({ email: i.email, name: i.firstName })),
+        ],
       });
       const firstName = newCI.user.firstName ?? "Interviewer";
       const rendered = await renderFromBinding(
@@ -366,6 +395,14 @@ export async function sendLocationChangeEmails(
       meetingUrl: interview.zoomJoinUrl ?? undefined,
     };
 
+    const applicant = await getApplicantRecipient(domainApplicationId);
+    const interviewers = await getInterviewerRecipients(interviewId);
+
+    const attendees: IcsAttendee[] = [
+      ...(applicant ? [{ email: applicant.email, name: applicant.firstName }] : []),
+      ...interviewers.map((i) => ({ email: i.email, name: i.firstName })),
+    ];
+
     const ics = buildInviteIcs({
       interviewId: interview.id,
       summary: `DALI Interview — ${domainName}`,
@@ -374,10 +411,9 @@ export async function sendLocationChangeEmails(
       location: formatLocation(interview.location, interview.zoomJoinUrl),
       meetingUrl: interview.zoomJoinUrl,
       description: "Updated location",
+      organizer: ORGANIZER,
+      attendees,
     });
-
-    const applicant = await getApplicantRecipient(domainApplicationId);
-    const interviewers = await getInterviewerRecipients(interviewId);
 
     const sends: Promise<any>[] = [];
 

--- a/dali-api/app/hiring/lib/interview-ics.ts
+++ b/dali-api/app/hiring/lib/interview-ics.ts
@@ -2,6 +2,11 @@
 // Produces RFC 5545 VCALENDAR strings that Gmail, Outlook, and Apple Calendar
 // handle as inline calendar invites when attached via the `ics` param on sendEmail.
 
+export interface IcsAttendee {
+  email: string;
+  name?: string;
+}
+
 export interface IcsEventParams {
   interviewId: string;
   summary: string;
@@ -10,6 +15,8 @@ export interface IcsEventParams {
   location: string; // "Pod Appa, DALI Lab" / "Pod Momo, DALI Lab" / "Online"
   meetingUrl?: string | null;
   description?: string;
+  organizer: IcsAttendee;
+  attendees: IcsAttendee[];
 }
 
 function formatIcsDate(d: Date): string {
@@ -24,8 +31,18 @@ function uid(interviewId: string): string {
   return `interview-${interviewId}@dali.dartmouth.edu`;
 }
 
+function organizerLine(org: IcsAttendee): string {
+  const cn = org.name ? `;CN=${escapeIcsText(org.name)}` : "";
+  return `ORGANIZER${cn}:mailto:${org.email}`;
+}
+
+function attendeeLine(att: IcsAttendee): string {
+  const cn = att.name ? `;CN=${escapeIcsText(att.name)}` : "";
+  return `ATTENDEE${cn};RSVP=TRUE;PARTSTAT=NEEDS-ACTION;ROLE=REQ-PARTICIPANT:mailto:${att.email}`;
+}
+
 export function buildInviteIcs(params: IcsEventParams): string {
-  const { interviewId, summary, startTime, endTime, location, meetingUrl, description } = params;
+  const { interviewId, summary, startTime, endTime, location, meetingUrl, description, organizer, attendees } = params;
 
   const locationLine = meetingUrl ? `${location} — ${meetingUrl}` : location;
   const descLines = [description, meetingUrl ? `Join: ${meetingUrl}` : null].filter(Boolean).join("\\n");
@@ -44,6 +61,8 @@ export function buildInviteIcs(params: IcsEventParams): string {
     `SUMMARY:${escapeIcsText(summary)}`,
     `LOCATION:${escapeIcsText(locationLine)}`,
     ...(descLines ? [`DESCRIPTION:${escapeIcsText(descLines)}`] : []),
+    organizerLine(organizer),
+    ...attendees.map(attendeeLine),
     "SEQUENCE:0",
     "STATUS:CONFIRMED",
     "END:VEVENT",
@@ -53,8 +72,10 @@ export function buildInviteIcs(params: IcsEventParams): string {
   return lines.join("\r\n");
 }
 
-export function buildCancelIcs(params: Pick<IcsEventParams, "interviewId" | "summary" | "startTime" | "endTime">): string {
-  const { interviewId, summary, startTime, endTime } = params;
+export function buildCancelIcs(
+  params: Pick<IcsEventParams, "interviewId" | "summary" | "startTime" | "endTime" | "organizer" | "attendees">,
+): string {
+  const { interviewId, summary, startTime, endTime, organizer, attendees } = params;
 
   const lines = [
     "BEGIN:VCALENDAR",
@@ -68,6 +89,8 @@ export function buildCancelIcs(params: Pick<IcsEventParams, "interviewId" | "sum
     `DTSTART:${formatIcsDate(startTime)}`,
     `DTEND:${formatIcsDate(endTime)}`,
     `SUMMARY:${escapeIcsText(summary)}`,
+    organizerLine(organizer),
+    ...attendees.map(attendeeLine),
     "SEQUENCE:1",
     "STATUS:CANCELLED",
     "END:VEVENT",

--- a/dali-api/app/hiring/lib/scheduling.ts
+++ b/dali-api/app/hiring/lib/scheduling.ts
@@ -69,7 +69,8 @@ export async function computeAvailableSlots(
   });
   if (!config) return [];
 
-  const { slotDurationMinutes, bufferMinutes, dayStartHour, dayEndHour, interviewStartDate, interviewEndDate, timezone } = config;
+  const { slotDurationMinutes, bufferMinutes, dayStartHour, dayEndHour, interviewStartDate, interviewEndDate, timezone, bookingNoticeHours } = config;
+  const earliestBookable = new Date(Date.now() + bookingNoticeHours * 60 * 60_000);
 
   // Load all cycle interviewers with their availability and booked interviews.
   // The interviewAssignments include filters out assignments whose parent
@@ -129,6 +130,7 @@ export async function computeAvailableSlots(
   const results: AvailableSlot[] = [];
 
   for (const slotStart of candidates) {
+    if (slotStart < earliestBookable) continue;
     const slotEnd = new Date(slotStart.getTime() + slotDurationMinutes * 60_000);
 
     // Require two distinct humans — one free in-domain, one free cross-domain.

--- a/dali-api/app/hiring/routes/api.cycles.$cycleId.interview-config.ts
+++ b/dali-api/app/hiring/routes/api.cycles.$cycleId.interview-config.ts
@@ -18,6 +18,7 @@ const InterviewConfigSchema = z
     timezone: z.string().min(1).max(100).optional(),
     rescheduleNoticeHours: z.number().int().min(0).max(168).optional(),
     cancelNoticeHours: z.number().int().min(0).max(168).optional(),
+    bookingNoticeHours: z.number().int().min(0).max(168).optional(),
   })
   .refine(
     (v) =>
@@ -78,6 +79,7 @@ export async function action({ request, params }: Route.ActionArgs) {
       interviewEndDate: new Date(body.interviewEndDate),
       rescheduleNoticeHours: body.rescheduleNoticeHours ?? 12,
       cancelNoticeHours: body.cancelNoticeHours ?? 0,
+      bookingNoticeHours: body.bookingNoticeHours ?? 12,
       timezone: body.timezone ?? "America/New_York",
     },
     create: {
@@ -90,6 +92,7 @@ export async function action({ request, params }: Route.ActionArgs) {
       interviewEndDate: new Date(body.interviewEndDate),
       rescheduleNoticeHours: body.rescheduleNoticeHours ?? 12,
       cancelNoticeHours: body.cancelNoticeHours ?? 0,
+      bookingNoticeHours: body.bookingNoticeHours ?? 12,
       timezone: body.timezone ?? "America/New_York",
     },
   });

--- a/dali-api/app/hiring/routes/api.domain-applications.$id.schedule-interview.ts
+++ b/dali-api/app/hiring/routes/api.domain-applications.$id.schedule-interview.ts
@@ -73,6 +73,14 @@ export async function action({ request, params }: Route.ActionArgs) {
   const slotStart = new Date(startTime);
   const slotEnd = new Date(slotStart.getTime() + config.slotDurationMinutes * 60_000);
 
+  const earliestBookable = new Date(Date.now() + config.bookingNoticeHours * 60 * 60_000);
+  if (slotStart < earliestBookable) {
+    return Response.json(
+      { error: `Interviews must be booked at least ${config.bookingNoticeHours} hours in advance` },
+      { status: 409 },
+    );
+  }
+
   try {
     const interview = await assignInterviewers(
       da.application.applicationCycleId,

--- a/dali-api/app/hiring/routes/api.my-interview.reschedule.ts
+++ b/dali-api/app/hiring/routes/api.my-interview.reschedule.ts
@@ -71,6 +71,12 @@ export async function action({ request }: Route.ActionArgs) {
           throw new Error("__TOO_LATE_TO_RESCHEDULE__");
         }
 
+        const bookingNoticeHours = config?.bookingNoticeHours ?? 12;
+        const earliestBookable = new Date(Date.now() + bookingNoticeHours * 60 * 60_000);
+        if (new Date(newStart) < earliestBookable) {
+          throw new Error("__TOO_SOON_TO_BOOK__");
+        }
+
         // DomainApplications always attach to a domain-scoped challenge
         // version on Standard cycles (the only cycleType that schedules
         // interviews); filter out any null domainIds defensively.
@@ -123,6 +129,9 @@ export async function action({ request }: Route.ActionArgs) {
     }
     if (err?.message === "__TOO_LATE_TO_RESCHEDULE__") {
       return withCors(request, Response.json({ error: "Too late to reschedule — please contact the DALI team" }, { status: 403 }));
+    }
+    if (err?.message === "__TOO_SOON_TO_BOOK__") {
+      return withCors(request, Response.json({ error: "That slot is too soon — pick a time further out" }, { status: 409 }));
     }
     return withCors(request, Response.json({ error: err?.message ?? "Failed to reschedule" }, { status: 409 }));
   }

--- a/dali-api/app/hiring/routes/lead.cycle.$id.tsx
+++ b/dali-api/app/hiring/routes/lead.cycle.$id.tsx
@@ -38,6 +38,7 @@ interface InterviewConfig {
   interviewEndDate: string
   rescheduleNoticeHours: number
   cancelNoticeHours: number
+  bookingNoticeHours: number
   timezone: string
 }
 
@@ -1066,6 +1067,7 @@ export default function HiringLeadCycleDetails() {
     interviewEndDate: '',
     rescheduleNoticeHours: 12,
     cancelNoticeHours: 0,
+    bookingNoticeHours: 12,
     timezone: 'America/New_York',
   })
   const [configSaved, setConfigSaved] = useState(false)
@@ -1695,6 +1697,16 @@ export default function HiringLeadCycleDetails() {
                 onChange={e => setConfig(c => ({ ...c, interviewEndDate: e.target.value }))}
                 className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm"
               />
+            </div>
+            <div>
+              <label className="block text-sm font-bold text-foreground/80 mb-1">Booking Notice</label>
+              <select
+                value={config.bookingNoticeHours}
+                onChange={e => setConfig(c => ({ ...c, bookingNoticeHours: Number(e.target.value) }))}
+                className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm"
+              >
+                {[0, 1, 2, 4, 6, 8, 12, 24, 48].map(h => <option key={h} value={h}>{h === 0 ? 'No minimum' : `${h} hours ahead`}</option>)}
+              </select>
             </div>
             <div>
               <label className="block text-sm font-bold text-foreground/80 mb-1">Reschedule Notice</label>

--- a/dali-api/prisma/migrations/20260521000000_interview_config_booking_notice/migration.sql
+++ b/dali-api/prisma/migrations/20260521000000_interview_config_booking_notice/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "InterviewConfig" ADD COLUMN "bookingNoticeHours" INTEGER NOT NULL DEFAULT 12;

--- a/dali-api/prisma/schema.prisma
+++ b/dali-api/prisma/schema.prisma
@@ -481,6 +481,7 @@ model InterviewConfig {
 
   rescheduleNoticeHours Int @default(12) // minimum hours before interview to allow reschedule
   cancelNoticeHours     Int @default(0) // minimum hours before interview to allow cancel (0 = up until start)
+  bookingNoticeHours    Int @default(12) // minimum hours an applicant must book in the future
 
   timezone String @default("America/New_York")
 }


### PR DESCRIPTION
## Summary
- **Gmail invite cards**: ICS now carries `ORGANIZER` + `ATTENDEE` lines so Gmail renders the inline Yes/Maybe/No card and auto-adds the event to the recipient's calendar instead of just attaching an .ics file. Cancel ICS carries them too so Gmail can correlate the cancel with the original event.
- **Min booking lead time**: new `InterviewConfig.bookingNoticeHours` (Int, default 12). Enforced on booking + reschedule, and filtered out of `computeAvailableSlots` so the UI never even surfaces a slot the server will reject. Configurable per cycle from the lead cycle page next to the existing reschedule/cancel-notice selectors.

## Files of note
- `dali-api/app/hiring/lib/interview-ics.ts` — builder signature now requires `organizer` + `attendees`.
- `dali-api/app/hiring/lib/interview-emails.ts` — each send aggregates applicant + active interviewers as the attendee list (one ICS, all recipients).
- `dali-api/app/hiring/lib/scheduling.ts` — slot filter.
- `dali-api/app/hiring/routes/api.domain-applications.$id.schedule-interview.ts` and `api.my-interview.reschedule.ts` — lead-time enforcement (409).
- `dali-api/prisma/migrations/20260521000000_interview_config_booking_notice/` — additive nullable-safe column with default 12.

## Test plan
- [ ] CI: vitest + Playwright + migration-check + build-check
- [ ] Manual: book an interview from an applicant account in staging; confirm Gmail (interviewer + applicant) shows the invite card with RSVP buttons and the event lands on Google Calendar
- [ ] Manual: reschedule the interview; confirm old event is cancelled and new event is added on both sides
- [ ] Manual: try to book a slot starting in < 12h — verify it's hidden in the picker and rejected on direct POST
- [ ] Manual: lead config page — change Booking Notice, save, verify it persists

## Notes
- Pre-existing typecheck errors in `app/hiring/routes/reviewer.tsx` and the untracked `scripts/*` files are unrelated to this PR.
- ICS `SEQUENCE` is unchanged (still 0 for invites, 1 for cancels). Updates that re-use the same UID with `SEQUENCE:0` may still be treated as duplicates by Google Calendar — happy to follow up with a counter on `Interview` if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/584"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781977197&installation_id=133523038&pr_number=584&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F584&signature=6fab331a69b070a46578afe749adfd727f575c05a0c6e64fb01d42d7868810cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->