### PR TITLE
Prefer Standard cycle in analytics when Fellowship is also open

### DIFF
--- a/dali-api/app/hiring/routes/analytics.tsx
+++ b/dali-api/app/hiring/routes/analytics.tsx
@@ -70,6 +70,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     id: c.id,
     name: c.name,
     status: c.statusUpdates[0]?.newStatus ?? "Draft",
+    cycleType: c.cycleType,
   }));
 
   if (cycles.length === 0) {
@@ -88,9 +89,15 @@ export async function loader({ request }: Route.LoaderArgs) {
 
   const url = new URL(request.url);
   const requestedCycleId = url.searchParams.get("cycleId");
+  const isActive = (c: { status: string }) =>
+    ["Open", "UnderReview"].includes(c.status);
+  // Prefer a Standard active cycle over an InternToFull (Fellowship) one when
+  // both are open simultaneously — Fellowship runs in parallel but views
+  // should default to the main hiring cycle.
   const selectedCycle =
     (requestedCycleId ? cycles.find((c) => c.id === requestedCycleId) : null) ??
-    cycles.find((c) => ["Open", "UnderReview"].includes(c.status)) ??
+    cycles.find((c) => isActive(c) && c.cycleType === "Standard") ??
+    cycles.find(isActive) ??
     cycles[0];
   const cycleId = selectedCycle.id;
   const cycleStatus = selectedCycle.status as


### PR DESCRIPTION
## Summary
- Analytics defaulted to the most recently created Open/UnderReview cycle, which surfaced the Fellowship (InternToFull) cycle when it ran alongside a Standard hiring cycle.
- Default selection now prefers a Standard active cycle over an InternToFull one; the cycle selector still lists both so leads can switch via `?cycleId=`.

## Test plan
- [ ] With only a Standard cycle Open: analytics loads it (unchanged).
- [ ] With only a Fellowship cycle Open: analytics loads it (unchanged).
- [ ] With both Open: analytics defaults to the Standard cycle.
- [ ] `?cycleId=<fellowship>` still routes to the Fellowship cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/593"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781990265&installation_id=133523038&pr_number=593&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F593&signature=5e7362e01b435276cc1a5a5d87f7e32925e21aeec52dc6be3381e210913a6c69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->