### PR TITLE
Bulk-apply domain reviewers as interviewers

### DIFF
--- a/dali-api/app/hiring/routes/api.cycles.$cycleId.interviewers.ts
+++ b/dali-api/app/hiring/routes/api.cycles.$cycleId.interviewers.ts
@@ -10,6 +10,13 @@ const CreateInterviewerSchema = z.object({
   domainId: z.string().min(1).max(100),
 });
 
+const ApplyReviewersSchema = z.object({
+  action: z.literal("applyAllReviewers"),
+  domainId: z.string().min(1).max(100),
+});
+
+const PostBodySchema = z.union([ApplyReviewersSchema, CreateInterviewerSchema]);
+
 const DeleteInterviewerSchema = z.object({
   interviewerId: z.string().min(1).max(100),
 });
@@ -61,8 +68,60 @@ export async function action({ request, params }: Route.ActionArgs) {
   }
 
   if (request.method === "POST") {
-    const body = await parseJson(request, CreateInterviewerSchema);
+    const body = await parseJson(request, PostBodySchema);
     if (body instanceof Response) return body;
+
+    if ("action" in body) {
+      const { domainId } = body;
+
+      const [reviewers, existingInterviewers] = await Promise.all([
+        prisma.cycleReviewer.findMany({
+          where: { applicationCycleId: params.cycleId, domainId },
+          select: { userId: true },
+        }),
+        prisma.cycleInterviewer.findMany({
+          where: { applicationCycleId: params.cycleId, domainId },
+          select: { userId: true },
+        }),
+      ]);
+
+      const existing = new Set(existingInterviewers.map((i) => i.userId));
+      const toCreate = reviewers
+        .map((r) => r.userId)
+        .filter((userId) => !existing.has(userId));
+
+      if (toCreate.length > 0) {
+        await prisma.cycleInterviewer.createMany({
+          data: toCreate.map((userId) => ({
+            userId,
+            applicationCycleId: params.cycleId!,
+            domainId,
+          })),
+          skipDuplicates: true,
+        });
+      }
+
+      const created = await prisma.cycleInterviewer.findMany({
+        where: {
+          applicationCycleId: params.cycleId,
+          domainId,
+          userId: { in: toCreate },
+        },
+        include: {
+          user: { select: { firstName: true, lastName: true, daliEmail: true } },
+        },
+      });
+
+      return Response.json(
+        {
+          added: created.length,
+          skipped: reviewers.length - created.length,
+          interviewers: created,
+        },
+        { status: 201 },
+      );
+    }
+
     const { userId, domainId } = body;
 
     const interviewer = await prisma.cycleInterviewer.create({

--- a/dali-api/app/hiring/routes/domain-lead.tsx
+++ b/dali-api/app/hiring/routes/domain-lead.tsx
@@ -834,7 +834,12 @@ export default function DomainLeadDashboard() {
                     <div className={`grid grid-cols-1 ${isInternToFull ? "" : "md:grid-cols-2"} gap-4`}>
                       <ReviewerSection cycleId={cycle.id} domainId={assignment.domainId} initialReviewers={cycleReviewers} />
                       {!isInternToFull && (
-                        <InterviewerSection cycleId={cycle.id} domainId={assignment.domainId} initialInterviewers={interviewers ?? []} />
+                        <InterviewerSection
+                          cycleId={cycle.id}
+                          domainId={assignment.domainId}
+                          initialInterviewers={interviewers ?? []}
+                          reviewers={cycleReviewers}
+                        />
                       )}
                     </div>
                   </Section>
@@ -1592,15 +1597,18 @@ function RubricPicker({ cycleId, domainId, options, selectedId, locked }: {
   );
 }
 
-function InterviewerSection({ cycleId, domainId, initialInterviewers }: {
+function InterviewerSection({ cycleId, domainId, initialInterviewers, reviewers }: {
   cycleId: string;
   domainId: string;
   initialInterviewers: any[];
+  reviewers: any[];
 }) {
   const [interviewers, setInterviewers] = useState(initialInterviewers);
   const [members, setMembers] = useState<any[]>([]);
   const [selectedMemberId, setSelectedMemberId] = useState("");
   const [pendingRemove, setPendingRemove] = useState<any | null>(null);
+  const [pendingApplyReviewers, setPendingApplyReviewers] = useState(false);
+  const [applyingReviewers, setApplyingReviewers] = useState(false);
 
   // Resync from props after the loader revalidates.
   useEffect(() => { setInterviewers(initialInterviewers); }, [initialInterviewers]);
@@ -1627,6 +1635,34 @@ function InterviewerSection({ cycleId, domainId, initialInterviewers }: {
     }
   }
 
+  async function applyAllReviewers() {
+    setApplyingReviewers(true);
+    try {
+      const res = await fetch(`/api/hiring/cycles/${cycleId}/interviewers`, {
+        method: "POST", credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "applyAllReviewers", domainId }),
+      });
+      if (res.ok) {
+        const result = await res.json();
+        const added = (result.interviewers ?? []).map((i: any) => ({
+          ...i,
+          availabilityHours: 0,
+          availabilityBlockCount: 0,
+          availabilityBlocks: [],
+        }));
+        setInterviewers(prev => [...prev, ...added]);
+      } else {
+        const err = await res.json().catch(() => ({}));
+        alert(`Failed to apply reviewers: ${err.error ?? res.statusText}`);
+      }
+    } catch (e) {
+      alert(`Failed to apply reviewers: ${e instanceof Error ? e.message : String(e)}`);
+    } finally {
+      setApplyingReviewers(false);
+    }
+  }
+
   async function removeInterviewer(interviewerId: string) {
     try {
       const res = await fetch(`/api/hiring/cycles/${cycleId}/interviewers`, {
@@ -1649,6 +1685,7 @@ function InterviewerSection({ cycleId, domainId, initialInterviewers }: {
 
   const existingMemberIds = new Set(interviewers.map((i: any) => i.userId));
   const availableMembers = members.filter(m => !existingMemberIds.has(m.id));
+  const reviewersToApply = reviewers.filter((r: any) => !existingMemberIds.has(r.userId));
   const pendingName = pendingRemove
     ? (pendingRemove.user?.firstName && pendingRemove.user?.lastName
         ? `${pendingRemove.user.firstName} ${pendingRemove.user.lastName}`
@@ -1683,6 +1720,22 @@ function InterviewerSection({ cycleId, domainId, initialInterviewers }: {
             className="flex items-center gap-1 px-3 py-2 text-sm font-medium rounded-lg bg-blue-600 hover:bg-blue-700 text-white transition disabled:opacity-50"
           >
             <Plus className="w-4 h-4" /> Add
+          </button>
+        </div>
+        <div className="flex items-center justify-between gap-2 pt-1">
+          <span className="text-xs text-muted-foreground">
+            {reviewersToApply.length > 0
+              ? `${reviewersToApply.length} reviewer${reviewersToApply.length === 1 ? "" : "s"} not yet assigned as interviewer${reviewersToApply.length === 1 ? "" : "s"}.`
+              : reviewers.length > 0
+                ? "All reviewers are already interviewers."
+                : "No reviewers assigned to this domain yet."}
+          </span>
+          <button
+            onClick={() => setPendingApplyReviewers(true)}
+            disabled={reviewersToApply.length === 0 || applyingReviewers}
+            className="flex items-center gap-1 px-3 py-1.5 text-xs font-medium rounded-lg border border-border bg-card hover:bg-muted/50 text-foreground transition disabled:opacity-50"
+          >
+            Apply all reviewers
           </button>
         </div>
         {interviewers.length > 0 ? (
@@ -1740,6 +1793,21 @@ function InterviewerSection({ cycleId, domainId, initialInterviewers }: {
           onConfirm={() => {
             if (pendingRemove) removeInterviewer(pendingRemove.id);
             setPendingRemove(null);
+          }}
+        />
+        <ConfirmDialog
+          open={pendingApplyReviewers}
+          title={`Apply ${reviewersToApply.length} reviewer${reviewersToApply.length === 1 ? "" : "s"} as interviewer${reviewersToApply.length === 1 ? "" : "s"}?`}
+          body={
+            <p>
+              Every reviewer for this domain who isn't already an interviewer will be added. They'll still need to submit availability before they can be scheduled.
+            </p>
+          }
+          confirmLabel="Apply reviewers"
+          onCancel={() => setPendingApplyReviewers(false)}
+          onConfirm={() => {
+            setPendingApplyReviewers(false);
+            applyAllReviewers();
           }}
         />
       </div>


### PR DESCRIPTION
## Summary
- Adds an "Apply all reviewers" button to the Interviewers panel on the Domain Lead page.
- Extends `POST /api/hiring/cycles/:cycleId/interviewers` to accept `{ action: "applyAllReviewers", domainId }`, which creates a `CycleInterviewer` for every `CycleReviewer` in the domain that isn't already an interviewer (idempotent via `skipDuplicates`).
- Existing single-add `{ userId, domainId }` shape continues to work — the body is validated as a discriminated union.

## Notes
- The bulk action is auth-gated identically to the single-add path (hiring lead or domain lead).
- The confirm dialog shows the exact count of reviewers that will be added (skipping anyone already assigned).
- Added members start with no availability blocks, same as the single-add flow.

## Test plan
- [ ] On a domain with some reviewers and some overlap with interviewers, click "Apply all reviewers" → only the non-overlapping reviewers are added.
- [ ] On a domain whose reviewers are all already interviewers, button is disabled and copy reads "All reviewers are already interviewers."
- [ ] On a domain with no reviewers, button is disabled and copy reads "No reviewers assigned to this domain yet."
- [ ] Single-add interviewer flow still works.
- [ ] Non-lead user cannot hit the bulk endpoint (403).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/595"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781992288&installation_id=133523038&pr_number=595&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F595&signature=863a91f781ca69e7c0af95667bf276a9de56bed578f35db1a0837240b85df0b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->