### PR TITLE
Fix Gmail dropping ICS calendar part on send

### DIFF
--- a/dali-api/app/lib/__tests__/gmail.test.ts
+++ b/dali-api/app/lib/__tests__/gmail.test.ts
@@ -93,6 +93,114 @@ describe("sendEmail — prod environment", () => {
   });
 });
 
+describe("sendEmail — ICS calendar attachment", () => {
+  const sampleIcs = [
+    "BEGIN:VCALENDAR",
+    "VERSION:2.0",
+    "METHOD:REQUEST",
+    "BEGIN:VEVENT",
+    "UID:interview-abc@dali.dartmouth.edu",
+    "DTSTART:20260522T141500Z",
+    "DTEND:20260522T150000Z",
+    "SUMMARY:DALI Interview",
+    "ORGANIZER;CN=DALI Lab:mailto:applications@dali.dartmouth.edu",
+    "ATTENDEE;CN=Kiran;RSVP=TRUE:mailto:kiran@example.com",
+    "END:VEVENT",
+    "END:VCALENDAR",
+  ].join("\r\n");
+
+  it("wraps the body in multipart/mixed so Gmail preserves the calendar attachment", async () => {
+    process.env.DALI_APP_ENV = "prod";
+    mockTokenAndSendOk();
+
+    await sendEmail({
+      refreshToken: "rt",
+      to: "kiran@example.com",
+      subject: "DALI Lab Interview Invitation",
+      html: "<p>See you there.</p>",
+      ics: sampleIcs,
+    });
+
+    const body = JSON.parse(fetchMock.mock.calls[1][1].body as string);
+    const decoded = decodeRaw(body.raw);
+
+    // Top-level must be multipart/mixed — multipart/alternative gets rewritten
+    // by Gmail's send endpoint and the calendar part is dropped.
+    expect(decoded).toMatch(/^Content-Type: multipart\/mixed; boundary="[^"]+"/m);
+
+    // Calendar part is present with method, attachment disposition, and filename.
+    expect(decoded).toContain("Content-Type: text/calendar; charset=utf-8; method=REQUEST");
+    expect(decoded).toContain('Content-Disposition: attachment; filename="invite.ics"');
+
+    // HTML body still lives inside a nested multipart/alternative.
+    expect(decoded).toContain("Content-Type: multipart/alternative;");
+    expect(decoded).toContain("Content-Type: text/html; charset=utf-8");
+    expect(decoded).toContain("<p>See you there.</p>");
+
+    // The ICS itself round-trips through base64.
+    const base64Block = decoded.match(/Content-Transfer-Encoding: base64\r\n\r\n([A-Za-z0-9+/=\r\n]+?)\r\n\r\n--/)?.[1];
+    expect(base64Block).toBeTruthy();
+    const reconstructed = Buffer.from(base64Block!.replace(/\r\n/g, ""), "base64").toString("utf8");
+    expect(reconstructed).toBe(sampleIcs);
+  });
+
+  it("preserves METHOD:CANCEL from the ICS in the Content-Type method parameter", async () => {
+    process.env.DALI_APP_ENV = "prod";
+    mockTokenAndSendOk();
+
+    const cancelIcs = sampleIcs.replace("METHOD:REQUEST", "METHOD:CANCEL");
+    await sendEmail({
+      refreshToken: "rt",
+      to: "kiran@example.com",
+      subject: "Interview Cancelled",
+      html: "<p>Cancelled.</p>",
+      ics: cancelIcs,
+    });
+
+    const body = JSON.parse(fetchMock.mock.calls[1][1].body as string);
+    const decoded = decodeRaw(body.raw);
+    expect(decoded).toContain("Content-Type: text/calendar; charset=utf-8; method=CANCEL");
+  });
+
+  it("wraps base64 at 76 chars per line (RFC 2045)", async () => {
+    process.env.DALI_APP_ENV = "prod";
+    mockTokenAndSendOk();
+
+    await sendEmail({
+      refreshToken: "rt",
+      to: "kiran@example.com",
+      subject: "Invite",
+      html: "<p>x</p>",
+      ics: sampleIcs,
+    });
+
+    const body = JSON.parse(fetchMock.mock.calls[1][1].body as string);
+    const decoded = decodeRaw(body.raw);
+    const base64Block = decoded.match(/Content-Transfer-Encoding: base64\r\n\r\n([A-Za-z0-9+/=\r\n]+?)\r\n\r\n--/)?.[1] ?? "";
+    for (const line of base64Block.split("\r\n")) {
+      expect(line.length).toBeLessThanOrEqual(76);
+    }
+  });
+
+  it("falls back to the simple text/html structure when no ICS is provided", async () => {
+    process.env.DALI_APP_ENV = "prod";
+    mockTokenAndSendOk();
+
+    await sendEmail({
+      refreshToken: "rt",
+      to: "kiran@example.com",
+      subject: "No calendar",
+      html: "<p>Plain.</p>",
+    });
+
+    const body = JSON.parse(fetchMock.mock.calls[1][1].body as string);
+    const decoded = decodeRaw(body.raw);
+    expect(decoded).not.toContain("multipart/mixed");
+    expect(decoded).not.toContain("text/calendar");
+    expect(decoded).toMatch(/^Content-Type: text\/html; charset=utf-8$/m);
+  });
+});
+
 describe("sendEmail — header injection defense", () => {
   function headerLines(decoded: string): string[] {
     const headerBlock = decoded.split("\r\n\r\n", 1)[0];

--- a/dali-api/app/lib/gmail.ts
+++ b/dali-api/app/lib/gmail.ts
@@ -28,13 +28,21 @@ function sanitizeHeader(value: string): string {
   return value.replace(/[\r\n]/g, '')
 }
 
+function wrapBase64(s: string, width = 76): string {
+  return s.match(new RegExp(`.{1,${width}}`, 'g'))?.join('\r\n') ?? s
+}
+
 function makeRawEmail(to: string, subject: string, htmlBody: string, ics?: string): string {
+  const headers = [
+    `From: DALI Lab <${GMAIL_USER}>`,
+    `To: ${sanitizeHeader(to)}`,
+    `Subject: ${sanitizeHeader(subject)}`,
+    'MIME-Version: 1.0',
+  ]
+
   if (!ics) {
     const msg = [
-      `From: DALI Lab <${GMAIL_USER}>`,
-      `To: ${sanitizeHeader(to)}`,
-      `Subject: ${sanitizeHeader(subject)}`,
-      'MIME-Version: 1.0',
+      ...headers,
       'Content-Type: text/html; charset=utf-8',
       '',
       htmlBody,
@@ -45,27 +53,43 @@ function makeRawEmail(to: string, subject: string, htmlBody: string, ics?: strin
   // Extract METHOD from the ICS content (e.g. REQUEST or CANCEL)
   const methodMatch = ics.match(/METHOD:(\w+)/)
   const method = methodMatch?.[1] ?? 'REQUEST'
-  const boundary = `----=_Part_${Date.now()}`
+
+  // multipart/mixed
+  //   ├─ multipart/alternative
+  //   │    └─ text/html
+  //   └─ text/calendar; method=…  (Content-Disposition: attachment)
+  //
+  // A flat multipart/alternative with text/html + text/calendar gets
+  // rewritten by Gmail's users.messages.send endpoint, which discards the
+  // calendar alternative. Nesting under multipart/mixed forces Gmail to
+  // treat the calendar as a real attachment and preserve it through send,
+  // which is also what makes the inline RSVP card appear in the inbox.
+  const ts = Date.now()
+  const outer = `----=_Outer_${ts}`
+  const inner = `----=_Inner_${ts}`
 
   const msg = [
-    `From: DALI Lab <${GMAIL_USER}>`,
-    `To: ${sanitizeHeader(to)}`,
-    `Subject: ${sanitizeHeader(subject)}`,
-    'MIME-Version: 1.0',
-    `Content-Type: multipart/alternative; boundary="${boundary}"`,
+    ...headers,
+    `Content-Type: multipart/mixed; boundary="${outer}"`,
     '',
-    `--${boundary}`,
+    `--${outer}`,
+    `Content-Type: multipart/alternative; boundary="${inner}"`,
+    '',
+    `--${inner}`,
     'Content-Type: text/html; charset=utf-8',
     '',
     htmlBody,
     '',
-    `--${boundary}`,
-    `Content-Type: text/calendar; charset=utf-8; method=${method}`,
+    `--${inner}--`,
+    '',
+    `--${outer}`,
+    `Content-Type: text/calendar; charset=utf-8; method=${method}; name="invite.ics"`,
+    'Content-Disposition: attachment; filename="invite.ics"',
     'Content-Transfer-Encoding: base64',
     '',
-    Buffer.from(ics).toString('base64'),
+    wrapBase64(Buffer.from(ics).toString('base64')),
     '',
-    `--${boundary}--`,
+    `--${outer}--`,
   ].join('\r\n')
   return Buffer.from(msg).toString('base64url')
 }


### PR DESCRIPTION
## Summary

- Interview invite emails were arriving with only `text/plain` + `text/html` — the `text/calendar` part was missing, so Gmail never showed the inline RSVP card (even after #584 added ORGANIZER/ATTENDEE).
- **Root cause:** Gmail's `users.messages.send` rewrites the MIME tree for `multipart/alternative` and silently discards non-html/text alternative parts. Confirmed against a downloaded `.eml` of a real sent invite — boundary string was Gmail-generated (`000000000000…`) and the calendar part was gone.
- **Fix:** switch `makeRawEmail` in `dali-api/app/lib/gmail.ts` to `multipart/mixed` with the ICS as a real attachment (`Content-Disposition: attachment; filename="invite.ics"`), nesting the HTML inside `multipart/alternative`. Also wrap base64 at 76 chars per RFC 2045.

## Why this is the right structure

Gmail preserves attachments in `multipart/mixed` through send, and `text/calendar; method=REQUEST` with an attachment disposition is also the canonical trigger for the inbox-side RSVP card.

```
multipart/mixed
├── multipart/alternative
│   └── text/html
└── text/calendar; method=REQUEST   <- now reaches the recipient
    Content-Disposition: attachment; filename="invite.ics"
```

## Scope

Only `makeRawEmail` changes. All four calendar email paths in `interview-emails.ts` share this code path, so they're all covered:

- `sendInterviewInviteEmails` (METHOD:REQUEST)
- `sendInterviewCancelEmails` (METHOD:CANCEL)
- `sendReassignmentEmails` (both REQUEST + CANCEL)
- `sendLocationChangeEmails` (METHOD:REQUEST)

Non-ICS sends (decision emails, extension notice, application confirmation, `api.email.send`, `portal.apply`) take the unchanged `text/html`-only branch.

## Test plan

- [x] `npx vitest run app/lib/__tests__/gmail.test.ts` — 10/10 passing, including 4 new tests asserting multipart/mixed envelope, attachment disposition, METHOD:CANCEL preservation, 76-char base64 wrapping, and that the no-ICS path stays simple `text/html`.
- [ ] Staging: trigger an interview booking, confirm the email at `systems@dali.dartmouth.edu` shows the Gmail RSVP card (Yes / Maybe / No) above the body and adds the event to Google Calendar on click.
- [ ] Staging: trigger a cancel, confirm Gmail offers to remove the matching event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/603"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782007520&installation_id=133523038&pr_number=603&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F603&signature=a16d2a72bb0efbb2355c67c4d38ad3e874c876f8dd3ed74f8c035620b6a07fad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->