### PR TITLE
Fix My Interviews list missing manually-reassigned interviews

### DIFF
--- a/dali-api/app/hiring/routes/api.cycles.$cycleId.my-interviews.$interviewId.notes.ts
+++ b/dali-api/app/hiring/routes/api.cycles.$cycleId.my-interviews.$interviewId.notes.ts
@@ -14,13 +14,21 @@ async function getAssignment(userId: string, cycleId: string, interviewId: strin
   const member = await prisma.dALIMember.findUnique({ where: { userId } });
   if (!member) return null;
 
-  const interviewer = await prisma.cycleInterviewer.findFirst({
+  // A member can have multiple CycleInterviewer rows in the same cycle (one
+  // per domain) — match across all of them so manually-reassigned interviews
+  // resolve to the correct assignment regardless of which row was used.
+  const interviewerRows = await prisma.cycleInterviewer.findMany({
     where: { userId, applicationCycleId: cycleId },
+    select: { id: true },
   });
-  if (!interviewer) return null;
+  if (interviewerRows.length === 0) return null;
 
   return prisma.interviewAssignment.findFirst({
-    where: { interviewId, cycleInterviewerId: interviewer.id, status: "Active" },
+    where: {
+      interviewId,
+      cycleInterviewerId: { in: interviewerRows.map((r) => r.id) },
+      status: "Active",
+    },
   });
 }
 

--- a/dali-api/app/hiring/routes/api.cycles.$cycleId.my-interviews.ts
+++ b/dali-api/app/hiring/routes/api.cycles.$cycleId.my-interviews.ts
@@ -14,16 +14,23 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   const member = await prisma.dALIMember.findUnique({ where: { userId: auth.user.sub } });
   if (!member) return withCors(request, Response.json([]));
 
-  const interviewer = await prisma.cycleInterviewer.findFirst({
+  // A member can have multiple CycleInterviewer rows in the same cycle (one
+  // per domain), and a manual reassignment can write an assignment under any
+  // of them — so fetch assignments across ALL of the member's rows.
+  const interviewerRows = await prisma.cycleInterviewer.findMany({
     where: { userId: auth.user.sub, applicationCycleId: params.cycleId },
+    select: { id: true },
   });
-  if (!interviewer) return withCors(request, Response.json([]));
+  if (interviewerRows.length === 0) return withCors(request, Response.json([]));
 
   const gate = await requireApiSignedOrForbidden(auth.user.sub, params.cycleId!);
   if (gate) return withCors(request, gate);
 
   const assignments = await prisma.interviewAssignment.findMany({
-    where: { cycleInterviewerId: interviewer.id, status: "Active" },
+    where: {
+      cycleInterviewerId: { in: interviewerRows.map((r) => r.id) },
+      status: "Active",
+    },
     include: {
       interview: {
         include: {


### PR DESCRIPTION
## Summary
- A member can have multiple `CycleInterviewer` rows in one cycle (one per domain). When a hiring lead manually reassigns an interview via `api.interviews.$id.reassign`, the new `InterviewAssignment` is written under whichever `CycleInterviewer` row the swap dropdown selected — which may not be the row `findFirst` returns for the same user.
- As a result the assignment vanishes from the interviewer's personal **My Interviews** list (and the notes link disappears) even though it correctly shows in the domain lead dashboard and the scheduled interviewers table.
- Match assignments across **all** of the member's `CycleInterviewer` rows for the cycle in both the listing loader and the notes GET/POST endpoint, mirroring the pattern already used in `api.cycles.$cycleId.my-interviews.$interviewId.decline.ts`.

## Files changed
- `app/hiring/routes/api.cycles.$cycleId.my-interviews.ts`
- `app/hiring/routes/api.cycles.$cycleId.my-interviews.$interviewId.notes.ts`

## Test plan
- [ ] As a lab member with `CycleInterviewer` rows in multiple domains, have a hiring lead reassign you onto an interview tied to a domain different from your "default" row, then confirm the interview appears in **My Interviews**
- [ ] Open notes from that interview and confirm both note version history GET and POST autosave work
- [ ] Existing single-domain interviewer flows still load their assignments and notes
- [ ] Decline flow still works (unchanged path, regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/606"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782049772&installation_id=133523038&pr_number=606&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F606&signature=a56465bb9243175f10348fed4b6f0a7c4424103ab369213505ba5cbd49c569e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->