### PR TITLE
Sync interview recommendation dropdown; split rec notes per interviewer

### DIFF
--- a/dali-api/app/components/collab/useSharedString.ts
+++ b/dali-api/app/components/collab/useSharedString.ts
@@ -1,0 +1,78 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import * as Y from "yjs";
+import { HocuspocusProvider } from "@hocuspocus/provider";
+import { getCollabUrl } from "./util";
+
+/**
+ * Live-synced single string value backed by a Hocuspocus-persisted Y.Map.
+ *
+ * Use for small joint fields (dropdowns, single-select choices) where a full
+ * collaborative text editor is overkill. The Y.Map is persisted via the
+ * existing CollabDocument storage path, so the value survives reconnects.
+ *
+ * Sync model: on first connection, if the Y.Map is empty, the local
+ * `initialValue` is written into it so latecomers see something. Once any
+ * client writes, that value wins for everyone. `initialValue` is only read at
+ * bootstrap — later changes to it are ignored to avoid clobbering live edits.
+ */
+export function useSharedString(
+  documentName: string,
+  token: string | null | undefined,
+  initialValue: string,
+): {
+  value: string;
+  setValue: (next: string) => void;
+  synced: boolean;
+} {
+  const [value, setLocalValue] = useState(initialValue);
+  const [synced, setSynced] = useState(false);
+  const ymapRef = useRef<Y.Map<string> | null>(null);
+  const initialRef = useRef(initialValue);
+  initialRef.current = initialValue;
+
+  useEffect(() => {
+    if (!token) return;
+    const ydoc = new Y.Doc();
+    const provider = new HocuspocusProvider({
+      url: getCollabUrl(),
+      name: documentName,
+      document: ydoc,
+      token,
+    });
+    const ymap = ydoc.getMap<string>("shared");
+    ymapRef.current = ymap;
+
+    const handleSynced = () => {
+      const cur = ymap.get("value");
+      if (cur !== undefined) {
+        setLocalValue(cur);
+      } else if (initialRef.current) {
+        ymap.set("value", initialRef.current);
+      }
+      setSynced(true);
+    };
+
+    const handleChange = () => {
+      const cur = ymap.get("value");
+      setLocalValue(cur ?? "");
+    };
+
+    provider.on("synced", handleSynced);
+    ymap.observe(handleChange);
+
+    return () => {
+      provider.off("synced", handleSynced);
+      ymap.unobserve(handleChange);
+      ymapRef.current = null;
+      provider.destroy();
+      ydoc.destroy();
+    };
+  }, [documentName, token]);
+
+  const setValue = useCallback((next: string) => {
+    setLocalValue(next);
+    ymapRef.current?.set("value", next);
+  }, []);
+
+  return { value, setValue, synced };
+}

--- a/dali-api/app/hiring/routes/interviewer.interview.$interviewId.tsx
+++ b/dali-api/app/hiring/routes/interviewer.interview.$interviewId.tsx
@@ -3,7 +3,6 @@ import { Link, useLoaderData } from 'react-router'
 import { redirect } from 'react-router'
 import {
   ArrowLeft,
-  Save,
   Clock,
   Check,
   Video,
@@ -21,6 +20,7 @@ import { presignAnswers } from '~/hiring/lib/presign'
 import { CollaborativeEditor } from '~/components/CollaborativeEditor'
 import { PresenceProvider } from '~/components/collab/PresenceProvider'
 import { PresenceBar } from '~/components/collab/PresenceBar'
+import { useSharedString } from '~/components/collab/useSharedString'
 import { RichTextViewer, isEmptyDoc } from '~/components/RichTextViewer'
 import { AnswerDisplay } from '~/hiring/components/ApplicationAnswers'
 import type { Route } from './+types/interviewer.interview.$interviewId'
@@ -189,11 +189,17 @@ export default function InterviewDetailPage() {
     if (c?.key) criteriaByKey[c.key] = { label: c.label ?? c.key }
   }
 
-  // Recommendation state (dropdown + mark-complete are still REST-based)
-  const [recommendation, setRecommendation] = useState<string>(
+  // Recommendation dropdown — synced live between interviewers via a Y.Map
+  // on a dedicated collab doc. Hocuspocus persists it, so the draft survives
+  // refresh; on Mark Complete the value is also written to interview.recommendation.
+  const {
+    value: recommendation,
+    setValue: setRecommendation,
+  } = useSharedString(
+    `interview:${interview.id}:rec-vote`,
+    collabToken,
     interview.recommendation ?? '',
   )
-  const [savingRecommendation, setSavingRecommendation] = useState(false)
 
   // Completed state
   const [isCompleted, setIsCompleted] = useState(
@@ -203,21 +209,6 @@ export default function InterviewDetailPage() {
 
   // Decline state
   const [declining, setDeclining] = useState(false)
-
-  // Save recommendation (dropdown value only — notes are handled by collab)
-  const handleSaveRecommendation = useCallback(async () => {
-    setSavingRecommendation(true)
-    try {
-      await fetch(`/api/hiring/interviews/${interview.id}/complete`, {
-        method: 'PATCH',
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ recommendation }),
-      })
-    } finally {
-      setSavingRecommendation(false)
-    }
-  }, [interview.id, recommendation])
 
   // Mark complete
   const handleMarkComplete = useCallback(async () => {
@@ -645,15 +636,18 @@ export default function InterviewDetailPage() {
 
             <div>
               <label className="block text-sm font-medium text-foreground/80 mb-1">
-                Recommendation Notes
+                Your Notes
               </label>
+              <p className="text-xs text-muted-foreground mb-2">
+                Private — only you can see these notes. Autosaved.
+              </p>
               {collabToken ? (
                 <CollaborativeEditor
                   editorId="recommendation"
-                  documentName={`interview:${interview.id}:recommendation`}
+                  documentName={`interview:${interview.id}:rec-notes-${myAssignment.id}`}
                   token={collabToken}
                   userName={userName}
-                  placeholder="Joint notes on the recommendation..."
+                  placeholder="Your notes on the recommendation..."
                 />
               ) : (
                 <div className="p-4 bg-yellow-50 rounded-lg border border-yellow-200 text-sm text-yellow-800">
@@ -663,14 +657,6 @@ export default function InterviewDetailPage() {
             </div>
 
             <div className="flex items-center gap-3">
-              <button
-                onClick={handleSaveRecommendation}
-                disabled={savingRecommendation || !recommendation}
-                className="inline-flex items-center px-4 py-2 text-sm font-medium text-foreground/80 bg-muted border border-gray-300 rounded-lg hover:bg-muted disabled:opacity-50"
-              >
-                <Save className="w-4 h-4 mr-1.5" />
-                {savingRecommendation ? 'Saving...' : 'Save Draft'}
-              </button>
               <button
                 onClick={handleMarkComplete}
                 disabled={!recommendation || completing}

--- a/dali-api/app/lib/collabAuth.ts
+++ b/dali-api/app/lib/collabAuth.ts
@@ -71,6 +71,16 @@ export async function authorizeCollabDoc(
       },
       select: { id: true },
     });
+
+    // Per-interviewer private notes: `interview:{id}:rec-notes-{assignmentId}`.
+    // Only the owner of that assignment may open the room. Hiring leads are
+    // intentionally excluded — these are private reasoning notes.
+    const field = parts[2]!;
+    if (field.startsWith("rec-notes-")) {
+      const assignmentId = field.slice("rec-notes-".length);
+      return !!assignment && assignment.id === assignmentId;
+    }
+
     if (assignment) return true;
     if (await isHiringLead(userSub)) return true;
     return false;


### PR DESCRIPTION
## Summary
The "Joint Recommendation" section on the interviewer notes page had a UX mismatch with its label:

- **Recommendation dropdown** (Strong Hire / Hire / …): local React state, saved over REST. Two interviewers picking different values would silently overwrite each other. The "Save Draft" button was hitting `PATCH /complete` which only handles POST/DELETE → 405 silent failure.
- **Recommendation Notes**: a single joint collab editor, so both interviewers shared one private-reasoning surface.

This PR:

1. **Dropdown is now live-synced** between interviewers via a Y.Map on a new collab doc `interview:{id}:rec-vote`. Hocuspocus persists the draft so it survives refresh; Mark Complete still writes the final value to `interview.recommendation` as before.
2. **Recommendation notes are now per-interviewer** — `interview:{id}:rec-notes-{assignmentId}`. `collabAuth.ts` enforces that only the owning assignment can open its own rec-notes room (hiring leads intentionally excluded — these are private reasoning notes).
3. **Save Draft button removed**: it was broken (405) and Yjs autosync makes it redundant.

## Files changed
- `app/components/collab/useSharedString.ts` (new) — small Y.Map-backed shared-string hook for single-value collab fields
- `app/hiring/routes/interviewer.interview.$interviewId.tsx` — dropdown wired through `useSharedString`, rec notes documentName scoped per assignment, "Recommendation Notes" → "Your Notes" with privacy hint, Save Draft removed
- `app/lib/collabAuth.ts` — strict per-assignment ownership check for `interview:{id}:rec-notes-{assignmentId}` rooms

## Notes
- Doc name still has 3 colon-separated parts so `parseDocName` / `authorizeCollabDoc` keep working. The new `rec-vote` and `rec-notes-*` fields don't match the known sync-back columns in `persistence.ts`, so the Y.Doc state persists via `CollabDocument` but nothing leaks back into `interview.recommendationNotes`.
- Legacy `interview.recommendationNotes` data is still rendered in the completed view if present, but won't get new writes (the complete endpoint already only persists `recommendation`).

## Test plan
- [ ] Two interviewers open the same interview side-by-side; one picks "Hire" → the other sees the dropdown update live
- [ ] Refresh — dropdown value persists for both interviewers
- [ ] Each interviewer's "Your Notes" is independent and not visible to the other
- [ ] Attempting to open another interviewer's `rec-notes-{assignmentId}` room (e.g., via crafted WS) is rejected by `authorizeCollabDoc`
- [ ] Mark Complete writes the synced recommendation to the DB and locks the form
- [ ] Reopen still works and pre-fills the previously chosen value
- [ ] Already-completed interviews with legacy `interview.recommendationNotes` text still render that text in the completed view

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/609"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782050735&installation_id=133523038&pr_number=609&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F609&signature=dac3a18860c4868661e07f2a33ca25ec18d2fd96d6a4d0fc3414622555df023c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->