### PR TITLE
Fix missing Gmail RSVP card on interview invitations

### DIFF
--- a/dali-api/app/lib/__tests__/gmail.test.ts
+++ b/dali-api/app/lib/__tests__/gmail.test.ts
@@ -109,7 +109,7 @@ describe("sendEmail — ICS calendar attachment", () => {
     "END:VCALENDAR",
   ].join("\r\n");
 
-  it("wraps the body in multipart/mixed so Gmail preserves the calendar attachment", async () => {
+  it("places text/calendar inline in multipart/alternative AND as an application/ics attachment", async () => {
     process.env.DALI_APP_ENV = "prod";
     mockTokenAndSendOk();
 
@@ -124,27 +124,35 @@ describe("sendEmail — ICS calendar attachment", () => {
     const body = JSON.parse(fetchMock.mock.calls[1][1].body as string);
     const decoded = decodeRaw(body.raw);
 
-    // Top-level must be multipart/mixed — multipart/alternative gets rewritten
-    // by Gmail's send endpoint and the calendar part is dropped.
+    // Top-level multipart/mixed wrapping body alternatives + the attachment.
     expect(decoded).toMatch(/^Content-Type: multipart\/mixed; boundary="[^"]+"/m);
 
-    // Calendar part is present with method, attachment disposition, and filename.
-    expect(decoded).toContain("Content-Type: text/calendar; charset=utf-8; method=REQUEST");
-    expect(decoded).toContain('Content-Disposition: attachment; filename="invite.ics"');
-
-    // HTML body still lives inside a nested multipart/alternative.
+    // Body alternatives: text/plain → text/html → text/calendar (order matters
+    // for clients that pick the "best" alternative, per RFC 2046 §5.1.4).
     expect(decoded).toContain("Content-Type: multipart/alternative;");
+    expect(decoded).toContain("Content-Type: text/plain; charset=utf-8");
     expect(decoded).toContain("Content-Type: text/html; charset=utf-8");
     expect(decoded).toContain("<p>See you there.</p>");
 
-    // The ICS itself round-trips through base64.
-    const base64Block = decoded.match(/Content-Transfer-Encoding: base64\r\n\r\n([A-Za-z0-9+/=\r\n]+?)\r\n\r\n--/)?.[1];
-    expect(base64Block).toBeTruthy();
-    const reconstructed = Buffer.from(base64Block!.replace(/\r\n/g, ""), "base64").toString("utf8");
-    expect(reconstructed).toBe(sampleIcs);
+    // text/calendar appears INLINE (no Content-Disposition: attachment on this
+    // part) — that's what triggers Gmail's RSVP card.
+    expect(decoded).toContain("Content-Type: text/calendar; charset=utf-8; method=REQUEST");
+
+    // application/ics attachment for non-Gmail clients. Different MIME from
+    // text/calendar so Gmail doesn't dedupe/drop one.
+    expect(decoded).toContain('Content-Type: application/ics; name="invite.ics"');
+    expect(decoded).toContain('Content-Disposition: attachment; filename="invite.ics"');
+
+    // ICS round-trips through base64 (check both copies).
+    const blocks = [...decoded.matchAll(/Content-Transfer-Encoding: base64\r\n\r\n([A-Za-z0-9+/=\r\n]+?)\r\n\r\n--/g)];
+    expect(blocks.length).toBeGreaterThanOrEqual(2);
+    for (const m of blocks) {
+      const reconstructed = Buffer.from(m[1].replace(/\r\n/g, ""), "base64").toString("utf8");
+      expect(reconstructed).toBe(sampleIcs);
+    }
   });
 
-  it("preserves METHOD:CANCEL from the ICS in the Content-Type method parameter", async () => {
+  it("preserves METHOD:CANCEL from the ICS in the inline calendar Content-Type", async () => {
     process.env.DALI_APP_ENV = "prod";
     mockTokenAndSendOk();
 
@@ -176,9 +184,12 @@ describe("sendEmail — ICS calendar attachment", () => {
 
     const body = JSON.parse(fetchMock.mock.calls[1][1].body as string);
     const decoded = decodeRaw(body.raw);
-    const base64Block = decoded.match(/Content-Transfer-Encoding: base64\r\n\r\n([A-Za-z0-9+/=\r\n]+?)\r\n\r\n--/)?.[1] ?? "";
-    for (const line of base64Block.split("\r\n")) {
-      expect(line.length).toBeLessThanOrEqual(76);
+    const blocks = [...decoded.matchAll(/Content-Transfer-Encoding: base64\r\n\r\n([A-Za-z0-9+/=\r\n]+?)\r\n\r\n--/g)];
+    expect(blocks.length).toBeGreaterThan(0);
+    for (const m of blocks) {
+      for (const line of m[1].split("\r\n")) {
+        expect(line.length).toBeLessThanOrEqual(76);
+      }
     }
   });
 

--- a/dali-api/app/lib/gmail.ts
+++ b/dali-api/app/lib/gmail.ts
@@ -32,6 +32,25 @@ function wrapBase64(s: string, width = 76): string {
   return s.match(new RegExp(`.{1,${width}}`, 'g'))?.join('\r\n') ?? s
 }
 
+// Minimal HTML → plain text. Good enough for a text/plain alternative;
+// Gmail rarely shows it but standards-compliant clients fall back to it
+// and some heuristics in mail providers prefer messages that include it.
+function htmlToPlainText(html: string): string {
+  return html
+    .replace(/<\s*br\s*\/?\s*>/gi, '\n')
+    .replace(/<\/p\s*>/gi, '\n\n')
+    .replace(/<\/h[1-6]\s*>/gi, '\n\n')
+    .replace(/<[^>]+>/g, '')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/\n{3,}/g, '\n\n')
+    .trim()
+}
+
 function makeRawEmail(to: string, subject: string, htmlBody: string, ics?: string): string {
   const headers = [
     `From: DALI Lab <${GMAIL_USER}>`,
@@ -54,19 +73,34 @@ function makeRawEmail(to: string, subject: string, htmlBody: string, ics?: strin
   const methodMatch = ics.match(/METHOD:(\w+)/)
   const method = methodMatch?.[1] ?? 'REQUEST'
 
-  // multipart/mixed
-  //   ├─ multipart/alternative
-  //   │    └─ text/html
-  //   └─ text/calendar; method=…  (Content-Disposition: attachment)
+  // Calendar invite MIME — mirrors the structure Google Calendar itself
+  // emits, which is what triggers Gmail's inline RSVP card on the receiving
+  // side:
   //
-  // A flat multipart/alternative with text/html + text/calendar gets
-  // rewritten by Gmail's users.messages.send endpoint, which discards the
-  // calendar alternative. Nesting under multipart/mixed forces Gmail to
-  // treat the calendar as a real attachment and preserve it through send,
-  // which is also what makes the inline RSVP card appear in the inbox.
+  //   multipart/mixed
+  //     ├─ multipart/alternative
+  //     │    ├─ text/plain
+  //     │    ├─ text/html
+  //     │    └─ text/calendar; method=REQUEST   (INLINE — Gmail reads this
+  //     │                                         to render Yes / Maybe / No
+  //     │                                         and add-to-calendar)
+  //     └─ application/ics; name=invite.ics      (separate attachment for
+  //                                                Outlook / Apple Mail —
+  //                                                application/ics, not
+  //                                                text/calendar, so Gmail
+  //                                                doesn't dedupe and drop
+  //                                                the inline part)
+  //
+  // The prior approach (only text/calendar as an attachment under
+  // multipart/mixed) preserved the ICS through Gmail's send-API rewriting
+  // but did NOT trigger the inline RSVP card — Gmail only renders that
+  // when text/calendar sits inside multipart/alternative as a body
+  // alternative.
   const ts = Date.now()
   const outer = `----=_Outer_${ts}`
   const inner = `----=_Inner_${ts}`
+  const icsBase64 = wrapBase64(Buffer.from(ics).toString('base64'))
+  const plainText = htmlToPlainText(htmlBody)
 
   const msg = [
     ...headers,
@@ -76,18 +110,29 @@ function makeRawEmail(to: string, subject: string, htmlBody: string, ics?: strin
     `Content-Type: multipart/alternative; boundary="${inner}"`,
     '',
     `--${inner}`,
+    'Content-Type: text/plain; charset=utf-8',
+    '',
+    plainText,
+    '',
+    `--${inner}`,
     'Content-Type: text/html; charset=utf-8',
     '',
     htmlBody,
     '',
+    `--${inner}`,
+    `Content-Type: text/calendar; charset=utf-8; method=${method}`,
+    'Content-Transfer-Encoding: base64',
+    '',
+    icsBase64,
+    '',
     `--${inner}--`,
     '',
     `--${outer}`,
-    `Content-Type: text/calendar; charset=utf-8; method=${method}; name="invite.ics"`,
+    'Content-Type: application/ics; name="invite.ics"',
     'Content-Disposition: attachment; filename="invite.ics"',
     'Content-Transfer-Encoding: base64',
     '',
-    wrapBase64(Buffer.from(ics).toString('base64')),
+    icsBase64,
     '',
     `--${outer}--`,
   ].join('\r\n')

--- a/dali-api/app/lib/gmail.ts
+++ b/dali-api/app/lib/gmail.ts
@@ -36,19 +36,34 @@ function wrapBase64(s: string, width = 76): string {
 // Gmail rarely shows it but standards-compliant clients fall back to it
 // and some heuristics in mail providers prefer messages that include it.
 function htmlToPlainText(html: string): string {
-  return html
+  // Replace block-level closers/breaks with newlines BEFORE stripping tags
+  // so paragraph structure survives.
+  let text = html
     .replace(/<\s*br\s*\/?\s*>/gi, '\n')
     .replace(/<\/p\s*>/gi, '\n\n')
     .replace(/<\/h[1-6]\s*>/gi, '\n\n')
-    .replace(/<[^>]+>/g, '')
+
+  // Strip tags in a loop until stable. A single `<[^>]+>` pass on
+  // `<scr<script>ipt>` would leave `<script>` behind; iterating prevents
+  // that smuggling pattern.
+  let prev: string
+  do {
+    prev = text
+    text = prev.replace(/<[^>]+>/g, '')
+  } while (text !== prev)
+
+  // Decode only entities that can't reintroduce angle brackets into the
+  // output (`&lt;` / `&gt;` deliberately left encoded so a tag-strip-then-
+  // decode sequence can't smuggle script-like content back into the body).
+  // `&amp;` is decoded LAST so `&amp;nbsp;` lands as `&nbsp;` rather than
+  // double-unescaping into a space.
+  text = text
     .replace(/&nbsp;/g, ' ')
-    .replace(/&amp;/g, '&')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
     .replace(/&quot;/g, '"')
     .replace(/&#39;/g, "'")
-    .replace(/\n{3,}/g, '\n\n')
-    .trim()
+    .replace(/&amp;/g, '&')
+
+  return text.replace(/\n{3,}/g, '\n\n').trim()
 }
 
 function makeRawEmail(to: string, subject: string, htmlBody: string, ics?: string): string {


### PR DESCRIPTION
## Summary
After #603 the ICS attachment survived Gmail's `users.messages.send` rewriting, but the inline RSVP card ("Yes / Maybe / No" + add-to-calendar) still didn't appear in recipients' inboxes — Gmail only renders that card when `text/calendar` sits **inside** `multipart/alternative` as a body alternative, not as a top-level attachment.

The previous structure was:

```
multipart/mixed
├── multipart/alternative
│   └── text/html
└── text/calendar; method=REQUEST  (Content-Disposition: attachment)
```

Gmail received the file as `invite.ics`, but treated it as just an attachment.

This PR mirrors the structure Google Calendar itself emits:

```
multipart/mixed
├── multipart/alternative
│   ├── text/plain          (HTML stripped — keeps the alternative 3-way)
│   ├── text/html
│   └── text/calendar; method=REQUEST   ← INLINE; triggers Gmail RSVP card
└── application/ics; name=invite.ics    ← attachment for Outlook / Apple Mail
                                          (application/ics so Gmail doesn't
                                          dedupe and drop the inline copy)
```

## Why not flat multipart/alternative
#603 found that flat `multipart/alternative` with only `text/html` + `text/calendar` got the calendar dropped by Gmail's send-API rewrite. This PR keeps the outer `multipart/mixed` wrapper and adds a `text/plain` alternative so we now have three body alternatives (plain / html / calendar) — matches Google's own pattern and is the structure most likely to survive the rewrite while still rendering the RSVP card.

## Files changed
- `app/lib/gmail.ts` — new MIME shape in `makeRawEmail`; added a small `htmlToPlainText` helper for the text/plain alternative.
- `app/lib/__tests__/gmail.test.ts` — updated structure assertions; both base64 copies of the ICS are checked for content + line wrapping.

## Reference
The user-supplied EML on a staging interview invite showed the ICS arriving (good — #603 worked) but with no RSVP card in Gmail. The fix targets specifically the RSVP-card rendering, not deliverability.

## Test plan
- [ ] `npm test app/lib/__tests__/gmail.test.ts` passes locally (verified)
- [ ] Send a staging interview invite to a Gmail recipient and confirm:
  - "Yes / Maybe / No" RSVP buttons appear in the message header
  - Gmail offers "Add to calendar" / pre-fills the event
  - The `invite.ics` attachment is also downloadable for non-Gmail clients
- [ ] Repeat for METHOD:CANCEL (cancellation email) — Gmail should reflect the cancellation
- [ ] Repeat for reassignment + location change paths (same `makeRawEmail` code path)
- [ ] If RSVP card still doesn't appear in Gmail, the next step is switching to the Google Calendar API (`events.insert` with `sendUpdates=all`), which has Google handle the invite end-to-end — but that's a larger change and worth trying this fix first

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/610"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782051138&installation_id=133523038&pr_number=610&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F610&signature=f5240722a11ff5b52d5b3be05038dd2e3f53b9402b9fb26bdb50bb9e05519a12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->