### PR TITLE
Expose Hocuspocus WS port at Fly's edge; require 2 prod machines

### DIFF
--- a/dali-api/fly.dev.toml
+++ b/dali-api/fly.dev.toml
@@ -9,6 +9,9 @@ primary_region = "iad"
 
 [env]
   NODE_ENV = "development"
+  # Where the browser opens the Hocuspocus WebSocket. Must match the
+  # [[services]] block below; CSP also derives connect-src from this.
+  COLLAB_URL = "wss://os-dev.dali.dartmouth.edu:3002"
 
 [build.args]
   OMIT_DEV = "false"
@@ -19,6 +22,15 @@ primary_region = "iad"
   auto_stop_machines = "stop"
   auto_start_machines = true
   min_machines_running = 0
+
+# Hocuspocus collab server. See fly.prod.toml for the regression history.
+[[services]]
+  internal_port = 3002
+  protocol = "tcp"
+
+  [[services.ports]]
+    port = 3002
+    handlers = ["tls"]
 
 [[vm]]
   memory = "1gb"

--- a/dali-api/fly.prod.toml
+++ b/dali-api/fly.prod.toml
@@ -9,6 +9,9 @@ primary_region = "iad"
 
 [env]
   NODE_ENV = "production"
+  # Where the browser opens the Hocuspocus WebSocket. Must match the
+  # [[services]] block below; CSP also derives connect-src from this.
+  COLLAB_URL = "wss://os.dali.dartmouth.edu:3002"
 
 [build]
 
@@ -17,7 +20,25 @@ primary_region = "iad"
   force_https = true
   auto_stop_machines = "stop"
   auto_start_machines = true
-  min_machines_running = 1
+  # Two machines minimum so the Hocuspocus Redis fan-out path is actually
+  # exercised under steady-state traffic — with min=1, two interviewers on
+  # the same doc would always land on the same machine and sync locally,
+  # masking any breakage in the cross-machine layer.
+  min_machines_running = 2
+
+# Hocuspocus collab server runs in the same Node process on a second port.
+# Without this services block, port 3002 isn't exposed at Fly's edge and
+# every collaborative editor falls back to "connect, immediately disconnect."
+# Originally added in #68; accidentally dropped by the dark-mode PR (#130)
+# and the regression went unnoticed until interview notes in prod stopped
+# syncing.
+[[services]]
+  internal_port = 3002
+  protocol = "tcp"
+
+  [[services.ports]]
+    port = 3002
+    handlers = ["tls"]
 
 [[vm]]
   memory = "1gb"

--- a/dali-api/fly.staging.toml
+++ b/dali-api/fly.staging.toml
@@ -9,6 +9,9 @@ primary_region = "iad"
 
 [env]
   NODE_ENV = "production"
+  # Where the browser opens the Hocuspocus WebSocket. Must match the
+  # [[services]] block below; CSP also derives connect-src from this.
+  COLLAB_URL = "wss://os-staging.dali.dartmouth.edu:3002"
 
 [build]
 
@@ -18,6 +21,15 @@ primary_region = "iad"
   auto_stop_machines = "stop"
   auto_start_machines = true
   min_machines_running = 0
+
+# Hocuspocus collab server. See fly.prod.toml for the regression history.
+[[services]]
+  internal_port = 3002
+  protocol = "tcp"
+
+  [[services.ports]]
+    port = 3002
+    handlers = ["tls"]
 
 [[vm]]
   memory = "1gb"


### PR DESCRIPTION
## What's broken
Interview notes (and every other collaborative editor — reviewer feedback, project docs, etc.) silently fail to sync in prod. The Hocuspocus WebSocket server runs on internal port 3002, but Fly's edge only routes traffic to `internal_port = 3000` (the HTTP service). So every `wss://…:3002` handshake from the browser dies at Fly's edge.

## Root cause
\#68 added a `[[services]]` block exposing port 3002 in `fly.prod.toml`. \#130 (the dark-mode PR) accidentally deleted that block — the diff was unrelated to dark mode and looks like a stale-checkout artifact. The regression has been silent in prod since April 23 because nobody actually exercised collab there until this week's interview round.

`fly.staging.toml` and `fly.dev.toml` never had the block at all.

## Fix
1. Restore `[[services]]` for port 3002 in `fly.prod.toml`; add it to `fly.staging.toml` and `fly.dev.toml`.
2. Wire `COLLAB_URL` in each `[env]` block pointing at the canonical hostname:
   - prod: `wss://os.dali.dartmouth.edu:3002`
   - staging: `wss://os-staging.dali.dartmouth.edu:3002`
   - dev: `wss://os-dev.dali.dartmouth.edu:3002`
   Both `root.tsx` (browser embed) and `security-headers.ts` (CSP `connect-src`) read this env var, so dropping the `ws://localhost:3002` fallback in deployed environments also tightens CSP.
3. Bump prod's `min_machines_running` 1 → 2. With min=1 both interviewers always land on the same machine and the Hocuspocus Redis fan-out is never exercised — meaning we'd ship a broken cross-machine path and discover it only when an autoscale event split clients across two machines mid-interview.

## Manual follow-ups before/after merging
- [ ] Confirm the Fly certs already cover ports 3002 for the custom hostnames (`fly certs list -a dali-api-prod` etc.). LetsEncrypt certs from Fly cover all TLS handlers on the hostname, but worth verifying.
- [ ] Confirm `REDIS_URL` is set as a Fly secret on prod (and ideally staging) so the new \>1 machine prod actually fans out.
- [ ] After merge + prod deploy, verify in browser DevTools that a WS connection to `wss://os.dali.dartmouth.edu:3002/` opens and stays open during interview notes editing.

## Not in scope
- `fly.preview.toml` — preview app names are dynamic (`dali-api-pr-NNN`) so `COLLAB_URL` would need to be injected by the workflow, and CLAUDE.md guidance asks me not to touch workflows unless explicitly requested. Preview collab can be a follow-up if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/612"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782054444&installation_id=133523038&pr_number=612&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F612&signature=bbecf8691964a425867a823d83211b96ae66c559b6ea50d9d38e941e24dcbf17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->