### PR TITLE
Inject systems@ as ATTENDEE in staging so Gmail renders the RSVP card…

### DIFF
--- a/dali-api/app/lib/__tests__/gmail.test.ts
+++ b/dali-api/app/lib/__tests__/gmail.test.ts
@@ -193,6 +193,51 @@ describe("sendEmail — ICS calendar attachment", () => {
     }
   });
 
+  it("injects systems@ as an extra ATTENDEE in staging so Gmail renders the RSVP card", async () => {
+    process.env.DALI_APP_ENV = "staging";
+    mockTokenAndSendOk();
+
+    await sendEmail({
+      refreshToken: "rt",
+      to: "applicant@example.com",
+      subject: "Invite",
+      html: "<p>hi</p>",
+      ics: sampleIcs,
+    });
+
+    const body = JSON.parse(fetchMock.mock.calls[1][1].body as string);
+    const decoded = decodeRaw(body.raw);
+    // Find any base64 block, decode, and check the staging attendee is present
+    // alongside the original attendees.
+    const blocks = [...decoded.matchAll(/Content-Transfer-Encoding: base64\r\n\r\n([A-Za-z0-9+/=\r\n]+?)\r\n\r\n--/g)];
+    expect(blocks.length).toBeGreaterThan(0);
+    const reconstructed = Buffer.from(blocks[0]![1].replace(/\r\n/g, ""), "base64").toString("utf8");
+    expect(reconstructed).toContain("mailto:kiran@example.com");
+    expect(reconstructed).toContain("mailto:systems@dali.dartmouth.edu");
+    // Inserted before END:VEVENT, not after — the redirect attendee must be
+    // inside the VEVENT block to be recognized.
+    expect(reconstructed).toMatch(/ATTENDEE[^\r\n]*systems@dali\.dartmouth\.edu\r\nEND:VEVENT/);
+  });
+
+  it("does NOT inject the staging attendee in prod", async () => {
+    process.env.DALI_APP_ENV = "prod";
+    mockTokenAndSendOk();
+
+    await sendEmail({
+      refreshToken: "rt",
+      to: "applicant@example.com",
+      subject: "Invite",
+      html: "<p>hi</p>",
+      ics: sampleIcs,
+    });
+
+    const body = JSON.parse(fetchMock.mock.calls[1][1].body as string);
+    const decoded = decodeRaw(body.raw);
+    const blocks = [...decoded.matchAll(/Content-Transfer-Encoding: base64\r\n\r\n([A-Za-z0-9+/=\r\n]+?)\r\n\r\n--/g)];
+    const reconstructed = Buffer.from(blocks[0]![1].replace(/\r\n/g, ""), "base64").toString("utf8");
+    expect(reconstructed).not.toContain("systems@dali.dartmouth.edu");
+  });
+
   it("falls back to the simple text/html structure when no ICS is provided", async () => {
     process.env.DALI_APP_ENV = "prod";
     mockTokenAndSendOk();

--- a/dali-api/app/lib/gmail.ts
+++ b/dali-api/app/lib/gmail.ts
@@ -158,6 +158,18 @@ function stagingBanner(originalTo: string): string {
   return `<div style="background:#fff3cd;border:1px solid #ffeeba;padding:12px;margin-bottom:12px;font-family:sans-serif;color:#856404;">[STAGING] This email would have been sent to <code>${originalTo}</code></div><hr/>`
 }
 
+// Gmail only renders the inline RSVP card when the recipient's email matches
+// an ATTENDEE in the ICS. In staging we rewrite the To: header to
+// STAGING_REDIRECT, but the ICS still carries the real attendees — so Gmail
+// sees no match and falls back to "just an attachment." Inject an extra
+// ATTENDEE line for the redirect inbox so the staging recipient is also a
+// recognized attendee. ICS in prod is never touched.
+function injectStagingAttendee(ics: string, email: string): string {
+  const line = `ATTENDEE;CN=Staging Redirect;RSVP=TRUE;PARTSTAT=NEEDS-ACTION;ROLE=REQ-PARTICIPANT:mailto:${email}`
+  // ICS uses CRLF per RFC 5545. Preserve it by matching with \r\n.
+  return ics.replace(/END:VEVENT/i, `${line}\r\nEND:VEVENT`)
+}
+
 export async function sendEmail({
   refreshToken,
   to,
@@ -180,13 +192,15 @@ export async function sendEmail({
 
   let actualTo = to
   let actualHtml = html
+  let actualIcs = ics
   if (env === 'staging') {
     actualTo = STAGING_REDIRECT
     actualHtml = stagingBanner(to) + html
+    if (actualIcs) actualIcs = injectStagingAttendee(actualIcs, STAGING_REDIRECT)
   }
 
   const accessToken = await getAccessToken(refreshToken)
-  const raw = makeRawEmail(actualTo, subject, actualHtml, ics)
+  const raw = makeRawEmail(actualTo, subject, actualHtml, actualIcs)
 
   const res = await fetch(
     `https://gmail.googleapis.com/gmail/v1/users/${GMAIL_USER}/messages/send`,


### PR DESCRIPTION
… (#614)

After #610 the MIME shape that arrives at Gmail's inbox is correct (text/calendar inline in multipart/alternative + application/ics attachment), but the inline RSVP card still doesn't appear in staging.

Cause: Gmail only renders the RSVP card when the recipient's email matches an ATTENDEE in the ICS. In staging the To: header is rewritten to systems@dali.dartmouth.edu (so we don't email real applicants), but the ICS still carries only the real attendees — Gmail sees no match and falls back to "just an attachment."

Inject an extra ATTENDEE line for STAGING_REDIRECT into the ICS in the staging branch only. ICS in prod is never touched, so production invites are byte-identical to before.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/615"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782055871&installation_id=133523038&pr_number=615&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F615&signature=365aac419baaf7119b716459b313b72fa998e7ed9bec46ef7284656bbc145f9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->