### PR TITLE
Tag staging emails + calendar invites with [STAGING] in subject and SUMMARY

### DIFF
--- a/dali-api/app/lib/__tests__/gmail.test.ts
+++ b/dali-api/app/lib/__tests__/gmail.test.ts
@@ -67,7 +67,8 @@ describe("sendEmail — staging environment", () => {
     expect(decoded).not.toContain("To: applicant@example.com");
     expect(decoded).toContain("[STAGING]");
     expect(decoded).toContain("applicant@example.com");
-    expect(decoded).toContain("Subject: Hello");
+    // Subject also gets the [STAGING] tag so the inbox row is visually distinct.
+    expect(decoded).toContain("Subject: [STAGING] Hello");
   });
 });
 
@@ -217,6 +218,46 @@ describe("sendEmail — ICS calendar attachment", () => {
     // Inserted before END:VEVENT, not after — the redirect attendee must be
     // inside the VEVENT block to be recognized.
     expect(reconstructed).toMatch(/ATTENDEE[^\r\n]*systems@dali\.dartmouth\.edu\r\nEND:VEVENT/);
+  });
+
+  it("prefixes the ICS SUMMARY with [STAGING] so the calendar event title is tagged", async () => {
+    process.env.DALI_APP_ENV = "staging";
+    mockTokenAndSendOk();
+
+    await sendEmail({
+      refreshToken: "rt",
+      to: "applicant@example.com",
+      subject: "Invite",
+      html: "<p>hi</p>",
+      ics: sampleIcs,
+    });
+
+    const body = JSON.parse(fetchMock.mock.calls[1][1].body as string);
+    const decoded = decodeRaw(body.raw);
+    const blocks = [...decoded.matchAll(/Content-Transfer-Encoding: base64\r\n\r\n([A-Za-z0-9+/=\r\n]+?)\r\n\r\n--/g)];
+    const reconstructed = Buffer.from(blocks[0]![1].replace(/\r\n/g, ""), "base64").toString("utf8");
+    expect(reconstructed).toContain("SUMMARY:[STAGING] DALI Interview");
+    expect(reconstructed).not.toMatch(/^SUMMARY:DALI Interview/m);
+  });
+
+  it("does NOT prefix the ICS SUMMARY in prod", async () => {
+    process.env.DALI_APP_ENV = "prod";
+    mockTokenAndSendOk();
+
+    await sendEmail({
+      refreshToken: "rt",
+      to: "applicant@example.com",
+      subject: "Invite",
+      html: "<p>hi</p>",
+      ics: sampleIcs,
+    });
+
+    const body = JSON.parse(fetchMock.mock.calls[1][1].body as string);
+    const decoded = decodeRaw(body.raw);
+    const blocks = [...decoded.matchAll(/Content-Transfer-Encoding: base64\r\n\r\n([A-Za-z0-9+/=\r\n]+?)\r\n\r\n--/g)];
+    const reconstructed = Buffer.from(blocks[0]![1].replace(/\r\n/g, ""), "base64").toString("utf8");
+    expect(reconstructed).not.toContain("[STAGING]");
+    expect(reconstructed).toContain("SUMMARY:DALI Interview");
   });
 
   it("does NOT inject the staging attendee in prod", async () => {

--- a/dali-api/app/lib/gmail.ts
+++ b/dali-api/app/lib/gmail.ts
@@ -170,6 +170,14 @@ function injectStagingAttendee(ics: string, email: string): string {
   return ics.replace(/END:VEVENT/i, `${line}\r\nEND:VEVENT`)
 }
 
+// Mark the event title (SUMMARY) with a [STAGING] tag so the Google Calendar
+// view of a staging-redirected invite is visually distinct from a real one.
+function prefixIcsSummary(ics: string, prefix: string): string {
+  // ^ with /m matches start-of-line after \n (CRLF-safe). Prefixes the first
+  // SUMMARY line in the VEVENT.
+  return ics.replace(/^SUMMARY:/m, `SUMMARY:${prefix}`)
+}
+
 export async function sendEmail({
   refreshToken,
   to,
@@ -191,16 +199,21 @@ export async function sendEmail({
   }
 
   let actualTo = to
+  let actualSubject = subject
   let actualHtml = html
   let actualIcs = ics
   if (env === 'staging') {
     actualTo = STAGING_REDIRECT
+    actualSubject = `[STAGING] ${subject}`
     actualHtml = stagingBanner(to) + html
-    if (actualIcs) actualIcs = injectStagingAttendee(actualIcs, STAGING_REDIRECT)
+    if (actualIcs) {
+      actualIcs = injectStagingAttendee(actualIcs, STAGING_REDIRECT)
+      actualIcs = prefixIcsSummary(actualIcs, '[STAGING] ')
+    }
   }
 
   const accessToken = await getAccessToken(refreshToken)
-  const raw = makeRawEmail(actualTo, subject, actualHtml, actualIcs)
+  const raw = makeRawEmail(actualTo, actualSubject, actualHtml, actualIcs)
 
   const res = await fetch(
     `https://gmail.googleapis.com/gmail/v1/users/${GMAIL_USER}/messages/send`,


### PR DESCRIPTION
## Why
The HTML banner already calls out a staging email once you open it, but the inbox row and — more importantly — the Google Calendar event card both look identical to a real production invite. Once Gmail auto-adds the ICS to the staging mailbox's calendar, the event title is just "DALI Interview — Data Development", which is easy to confuse with a real upcoming interview at a glance.

## What
In staging only:
- Prefix the email **Subject** with `[STAGING] `
- Prefix the ICS **SUMMARY** (= calendar event title) with `[STAGING] `

Prod is byte-identical to before this change.

## Tests
- 14 passing (`npm test gmail`)
- New: SUMMARY is prefixed in staging, not in prod
- New: Subject is prefixed in staging
- Existing staging-banner test updated to assert `Subject: [STAGING] Hello`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/618"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782056515&installation_id=133523038&pr_number=618&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F618&signature=936ab5526cf048953f13b7b789f593b7aa81edbce71d530d4d533296ad3267fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->