### PR TITLE
Split interview ICS so applicants don't see the interviewer guest list

### DIFF
--- a/dali-api/app/hiring/lib/interview-emails.ts
+++ b/dali-api/app/hiring/lib/interview-emails.ts
@@ -127,12 +127,18 @@ export async function sendInterviewInviteEmails(
     const applicant = await getApplicantRecipient(domainApplicationId);
     const interviewers = await getInterviewerRecipients(interviewId);
 
-    const attendees: IcsAttendee[] = [
-      ...(applicant ? [{ email: applicant.email, name: applicant.firstName }] : []),
-      ...interviewers.map((i) => ({ email: i.email, name: i.firstName })),
-    ];
-
-    const ics = buildInviteIcs({
+    // Two distinct ICS objects so the applicant's calendar guest list shows
+    // ONLY themselves while the interviewers get the joint view. Same UID
+    // (derived from interviewId), so per-account RSVP replies still reconcile
+    // to the same logical event on the organizer side.
+    const applicantAttendee: IcsAttendee[] = applicant
+      ? [{ email: applicant.email, name: applicant.firstName }]
+      : [];
+    const interviewerAttendees: IcsAttendee[] = interviewers.map((i) => ({
+      email: i.email,
+      name: i.firstName,
+    }));
+    const icsCommon = {
       interviewId: interview.id,
       summary: `DALI Interview — ${domainName}`,
       startTime: interview.startTime,
@@ -140,7 +146,11 @@ export async function sendInterviewInviteEmails(
       location: formatLocation(interview.location, interview.zoomJoinUrl),
       meetingUrl: interview.zoomJoinUrl,
       organizer: ORGANIZER,
-      attendees,
+    } as const;
+    const applicantIcs = buildInviteIcs({ ...icsCommon, attendees: applicantAttendee });
+    const interviewerIcs = buildInviteIcs({
+      ...icsCommon,
+      attendees: [...applicantAttendee, ...interviewerAttendees],
     });
 
     const sends: Promise<any>[] = [];
@@ -157,7 +167,7 @@ export async function sendInterviewInviteEmails(
           to: applicant.email,
           subject: rendered.subject,
           html: rendered.html,
-          ics,
+          ics: applicantIcs,
         }));
       }
     }
@@ -174,7 +184,7 @@ export async function sendInterviewInviteEmails(
           to: interviewer.email,
           subject: rendered.subject,
           html: rendered.html,
-          ics,
+          ics: interviewerIcs,
         }));
       }
     }
@@ -211,18 +221,26 @@ export async function sendInterviewCancelEmails(
     const applicant = await getApplicantRecipient(domainApplicationId);
     const interviewers = await getInterviewerRecipients(interviewId);
 
-    const attendees: IcsAttendee[] = [
-      ...(applicant ? [{ email: applicant.email, name: applicant.firstName }] : []),
-      ...interviewers.map((i) => ({ email: i.email, name: i.firstName })),
-    ];
-
-    const ics = buildCancelIcs({
+    // Per-recipient ICS so the applicant's cancellation only lists themselves.
+    // See sendInterviewInviteEmails for the rationale.
+    const applicantAttendee: IcsAttendee[] = applicant
+      ? [{ email: applicant.email, name: applicant.firstName }]
+      : [];
+    const interviewerAttendees: IcsAttendee[] = interviewers.map((i) => ({
+      email: i.email,
+      name: i.firstName,
+    }));
+    const icsCommon = {
       interviewId: interview.id,
       summary: `DALI Interview — ${domainName}`,
       startTime: interview.startTime,
       endTime: interview.endTime,
       organizer: ORGANIZER,
-      attendees,
+    } as const;
+    const applicantIcs = buildCancelIcs({ ...icsCommon, attendees: applicantAttendee });
+    const interviewerIcs = buildCancelIcs({
+      ...icsCommon,
+      attendees: [...applicantAttendee, ...interviewerAttendees],
     });
 
     const sends: Promise<any>[] = [];
@@ -239,7 +257,7 @@ export async function sendInterviewCancelEmails(
           to: applicant.email,
           subject: rendered.subject,
           html: rendered.html,
-          ics,
+          ics: applicantIcs,
         }));
       }
     }
@@ -256,7 +274,7 @@ export async function sendInterviewCancelEmails(
           to: interviewer.email,
           subject: rendered.subject,
           html: rendered.html,
-          ics,
+          ics: interviewerIcs,
         }));
       }
     }
@@ -398,12 +416,16 @@ export async function sendLocationChangeEmails(
     const applicant = await getApplicantRecipient(domainApplicationId);
     const interviewers = await getInterviewerRecipients(interviewId);
 
-    const attendees: IcsAttendee[] = [
-      ...(applicant ? [{ email: applicant.email, name: applicant.firstName }] : []),
-      ...interviewers.map((i) => ({ email: i.email, name: i.firstName })),
-    ];
-
-    const ics = buildInviteIcs({
+    // Per-recipient ICS so the applicant only sees themselves in the updated
+    // event. See sendInterviewInviteEmails for rationale.
+    const applicantAttendee: IcsAttendee[] = applicant
+      ? [{ email: applicant.email, name: applicant.firstName }]
+      : [];
+    const interviewerAttendees: IcsAttendee[] = interviewers.map((i) => ({
+      email: i.email,
+      name: i.firstName,
+    }));
+    const icsCommon = {
       interviewId: interview.id,
       summary: `DALI Interview — ${domainName}`,
       startTime: interview.startTime,
@@ -412,7 +434,11 @@ export async function sendLocationChangeEmails(
       meetingUrl: interview.zoomJoinUrl,
       description: "Updated location",
       organizer: ORGANIZER,
-      attendees,
+    } as const;
+    const applicantIcs = buildInviteIcs({ ...icsCommon, attendees: applicantAttendee });
+    const interviewerIcs = buildInviteIcs({
+      ...icsCommon,
+      attendees: [...applicantAttendee, ...interviewerAttendees],
     });
 
     const sends: Promise<any>[] = [];
@@ -429,7 +455,7 @@ export async function sendLocationChangeEmails(
           to: applicant.email,
           subject: rendered.subject,
           html: rendered.html,
-          ics,
+          ics: applicantIcs,
         }));
       }
     }
@@ -446,7 +472,7 @@ export async function sendLocationChangeEmails(
           to: interviewer.email,
           subject: rendered.subject,
           html: rendered.html,
-          ics,
+          ics: interviewerIcs,
         }));
       }
     }


### PR DESCRIPTION
## Why
Currently, the invite / cancel / location-change paths build **one** ICS with every attendee (applicant + all interviewers) and send the same file to everyone. On the applicant's side, Google Calendar then displays the interviewers' names + emails in the "Guests" panel of the event card — i.e., the candidate can see exactly who is interviewing them before the interview.

## What
For each affected path, build **two** ICS objects per send:

```
applicantIcs:    ATTENDEE = [applicant]                 → applicant's email
interviewerIcs:  ATTENDEE = [applicant, ...interviewers] → each interviewer's email
```

Same UID across both (derived from interview id) so RSVP replies still reconcile to the same logical event on the organizer side. Interviewers keep the joint view (they need to know who they're interviewing + see each other); applicants only see themselves.

## Files
- `app/hiring/lib/interview-emails.ts` — invite, cancel, location-change paths each construct an applicant-only ICS and an interviewer-joint ICS

## What's not touched
The reassignment path is already correctly siloed:
- removed interviewer's cancel ICS lists only themselves
- new interviewer gets the joint view
- applicant isn't emailed at all

## Test plan
- [ ] Send a staging invite. Open the applicant's `systems@` view and confirm "Guests" shows only the applicant + the staging redirect attendee (no interviewer names/emails).
- [ ] Same email: confirm the interviewer-side ICS shows applicant + all interviewers.
- [ ] Cancel an interview from staging; confirm same split for the cancellation.
- [ ] Location change an interview; confirm same split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/620"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782057711&installation_id=133523038&pr_number=620&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F620&signature=6992f1fdafddb1db72ac919f974657070ce55a7b736378bcbafeb79f0bf81af5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->