### PR TITLE
Track ICS SEQUENCE on Interview; fan out reassignment updates

### DIFF
--- a/dali-api/app/hiring/lib/__tests__/interview-ics.test.ts
+++ b/dali-api/app/hiring/lib/__tests__/interview-ics.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { buildInviteIcs, buildCancelIcs } from "../interview-ics";
+
+const baseInvite = {
+  interviewId: "abc",
+  summary: "DALI Interview",
+  startTime: new Date("2026-05-27T18:00:00Z"),
+  endTime: new Date("2026-05-27T18:30:00Z"),
+  location: "Pod Momo, DALI Lab",
+  organizer: { email: "applications@dali.dartmouth.edu", name: "DALI Lab" },
+  attendees: [{ email: "kiran@example.com", name: "Kiran" }],
+};
+
+describe("buildInviteIcs — SEQUENCE", () => {
+  it("uses the sequence passed in", () => {
+    const ics = buildInviteIcs({ ...baseInvite, sequence: 0 });
+    expect(ics).toMatch(/^SEQUENCE:0$/m);
+  });
+
+  it("emits an updated sequence for follow-up publishes", () => {
+    const ics = buildInviteIcs({ ...baseInvite, sequence: 3 });
+    expect(ics).toMatch(/^SEQUENCE:3$/m);
+    expect(ics).not.toMatch(/^SEQUENCE:0$/m);
+  });
+
+  it("includes METHOD:REQUEST for invites/updates", () => {
+    const ics = buildInviteIcs({ ...baseInvite, sequence: 0 });
+    expect(ics).toContain("METHOD:REQUEST");
+    expect(ics).toContain("STATUS:CONFIRMED");
+  });
+});
+
+describe("buildCancelIcs — SEQUENCE", () => {
+  const baseCancel = {
+    interviewId: "abc",
+    summary: "DALI Interview",
+    startTime: new Date("2026-05-27T18:00:00Z"),
+    endTime: new Date("2026-05-27T18:30:00Z"),
+    organizer: { email: "applications@dali.dartmouth.edu", name: "DALI Lab" },
+    attendees: [{ email: "kiran@example.com", name: "Kiran" }],
+  };
+
+  it("uses the sequence passed in", () => {
+    const ics = buildCancelIcs({ ...baseCancel, sequence: 4 });
+    expect(ics).toMatch(/^SEQUENCE:4$/m);
+  });
+
+  it("emits METHOD:CANCEL and STATUS:CANCELLED", () => {
+    const ics = buildCancelIcs({ ...baseCancel, sequence: 1 });
+    expect(ics).toContain("METHOD:CANCEL");
+    expect(ics).toContain("STATUS:CANCELLED");
+  });
+});

--- a/dali-api/app/hiring/lib/interview-emails.ts
+++ b/dali-api/app/hiring/lib/interview-emails.ts
@@ -80,6 +80,20 @@ async function getInterviewerRecipients(interviewId: string): Promise<Recipient[
     .filter((r): r is Recipient => r !== null);
 }
 
+// Atomically bumps the persistent ICS SEQUENCE counter and returns the new
+// value. Call before generating an update / cancel ICS so the publish
+// receives a sequence strictly greater than the previous one — required by
+// RFC 5545 for receiving calendars to apply the update instead of treating
+// the new ICS as a duplicate.
+async function bumpIcsSequence(interviewId: string): Promise<number> {
+  const updated = await prisma.interview.update({
+    where: { id: interviewId },
+    data: { icsSequence: { increment: 1 } },
+    select: { icsSequence: true },
+  });
+  return updated.icsSequence;
+}
+
 async function renderFromBinding(
   applicationCycleId: string,
   notificationType: NotificationType,
@@ -146,6 +160,9 @@ export async function sendInterviewInviteEmails(
       location: formatLocation(interview.location, interview.zoomJoinUrl),
       meetingUrl: interview.zoomJoinUrl,
       organizer: ORGANIZER,
+      // Initial REQUEST uses the row's current sequence (0 for a fresh
+      // interview). No bump here — bumps happen on updates / cancels.
+      sequence: interview.icsSequence,
     } as const;
     const applicantIcs = buildInviteIcs({ ...icsCommon, attendees: applicantAttendee });
     const interviewerIcs = buildInviteIcs({
@@ -230,12 +247,18 @@ export async function sendInterviewCancelEmails(
       email: i.email,
       name: i.firstName,
     }));
+    // Bump first so the CANCEL's SEQUENCE is strictly greater than the
+    // previous REQUEST's — required for receiving calendars to actually drop
+    // the event instead of treating the CANCEL as stale.
+    const sequence = await bumpIcsSequence(interview.id);
+
     const icsCommon = {
       interviewId: interview.id,
       summary: `DALI Interview — ${domainName}`,
       startTime: interview.startTime,
       endTime: interview.endTime,
       organizer: ORGANIZER,
+      sequence,
     } as const;
     const applicantIcs = buildCancelIcs({ ...icsCommon, attendees: applicantAttendee });
     const interviewerIcs = buildCancelIcs({
@@ -311,6 +334,11 @@ export async function sendReassignmentEmails(
       meetingUrl: interview.zoomJoinUrl ?? undefined,
     };
 
+    // Bump once for the whole reassignment so the CANCEL to the removed
+    // interviewer and the REQUEST(update) to everyone else share the same
+    // SEQUENCE (both strictly greater than the previous publish).
+    const sequence = await bumpIcsSequence(interview.id);
+
     const sends: Promise<any>[] = [];
 
     // Cancel ICS to removed interviewer
@@ -327,6 +355,7 @@ export async function sendReassignmentEmails(
         endTime: interview.endTime,
         organizer: ORGANIZER,
         attendees: [{ email: removedCI.user.daliEmail, name: removedName }],
+        sequence,
       });
       const firstName = removedName;
       const rendered = await renderFromBinding(
@@ -345,40 +374,70 @@ export async function sendReassignmentEmails(
       }
     }
 
-    // Invite ICS to new interviewer
-    const newCI = await prisma.cycleInterviewer.findUnique({
-      where: { id: newCycleInterviewerId },
-      include: { user: { select: { firstName: true, daliEmail: true } } },
+    // REQUEST(update) to everyone STILL on the interview: applicant +
+    // unchanged interviewers + the newly-added interviewer. Same SEQUENCE
+    // for all so unchanged participants' calendars accept the update and
+    // re-render the guest list (departed interviewer removed). The new
+    // interviewer's calendar treats this UID as a fresh event and adds it.
+    //
+    // getInterviewerRecipients reads InterviewAssignment.status="Active",
+    // which the reassign endpoint has already updated by the time we run:
+    // the removed assignment is "Replaced" and the new one is "Active".
+    const applicant = await getApplicantRecipient(domainApplicationId);
+    const currentInterviewers = await getInterviewerRecipients(interviewId);
+    const applicantAttendee: IcsAttendee[] = applicant
+      ? [{ email: applicant.email, name: applicant.firstName }]
+      : [];
+    const interviewerAttendees: IcsAttendee[] = currentInterviewers.map((i) => ({
+      email: i.email,
+      name: i.firstName,
+    }));
+    const updateCommon = {
+      interviewId: interview.id,
+      summary: `DALI Interview — ${domainName}`,
+      startTime: interview.startTime,
+      endTime: interview.endTime,
+      location: formatLocation(interview.location, interview.zoomJoinUrl),
+      meetingUrl: interview.zoomJoinUrl,
+      organizer: ORGANIZER,
+      sequence,
+    } as const;
+    const applicantIcs = buildInviteIcs({ ...updateCommon, attendees: applicantAttendee });
+    const interviewerIcs = buildInviteIcs({
+      ...updateCommon,
+      attendees: [...applicantAttendee, ...interviewerAttendees],
     });
-    if (newCI?.user.daliEmail) {
-      const applicant = await getApplicantRecipient(domainApplicationId);
-      const interviewers = await getInterviewerRecipients(interviewId);
-      const inviteIcs = buildInviteIcs({
-        interviewId: interview.id,
-        summary: `DALI Interview — ${domainName}`,
-        startTime: interview.startTime,
-        endTime: interview.endTime,
-        location: formatLocation(interview.location, interview.zoomJoinUrl),
-        meetingUrl: interview.zoomJoinUrl,
-        organizer: ORGANIZER,
-        attendees: [
-          ...(applicant ? [{ email: applicant.email, name: applicant.firstName }] : []),
-          ...interviewers.map((i) => ({ email: i.email, name: i.firstName })),
-        ],
-      });
-      const firstName = newCI.user.firstName ?? "Interviewer";
+
+    if (applicant) {
       const rendered = await renderFromBinding(
         interview.applicationCycleId,
-        "InterviewInviteMentor",
-        { firstName, ...baseVars },
+        "InterviewConfirmedApplicant",
+        { firstName: applicant.firstName, ...baseVars },
       );
       if (rendered) {
         sends.push(sendEmail({
           refreshToken,
-          to: newCI.user.daliEmail,
+          to: applicant.email,
           subject: rendered.subject,
           html: rendered.html,
-          ics: inviteIcs,
+          ics: applicantIcs,
+        }));
+      }
+    }
+
+    for (const interviewer of currentInterviewers) {
+      const rendered = await renderFromBinding(
+        interview.applicationCycleId,
+        "InterviewInviteMentor",
+        { firstName: interviewer.firstName, ...baseVars },
+      );
+      if (rendered) {
+        sends.push(sendEmail({
+          refreshToken,
+          to: interviewer.email,
+          subject: rendered.subject,
+          html: rendered.html,
+          ics: interviewerIcs,
         }));
       }
     }
@@ -425,6 +484,11 @@ export async function sendLocationChangeEmails(
       email: i.email,
       name: i.firstName,
     }));
+    // Bump first so the update's SEQUENCE is strictly greater than the
+    // previous publish — without this Google Calendar treats the new ICS as
+    // a duplicate and the location change silently doesn't propagate.
+    const sequence = await bumpIcsSequence(interview.id);
+
     const icsCommon = {
       interviewId: interview.id,
       summary: `DALI Interview — ${domainName}`,
@@ -434,6 +498,7 @@ export async function sendLocationChangeEmails(
       meetingUrl: interview.zoomJoinUrl,
       description: "Updated location",
       organizer: ORGANIZER,
+      sequence,
     } as const;
     const applicantIcs = buildInviteIcs({ ...icsCommon, attendees: applicantAttendee });
     const interviewerIcs = buildInviteIcs({

--- a/dali-api/app/hiring/lib/interview-ics.ts
+++ b/dali-api/app/hiring/lib/interview-ics.ts
@@ -17,6 +17,11 @@ export interface IcsEventParams {
   description?: string;
   organizer: IcsAttendee;
   attendees: IcsAttendee[];
+  // ICS SEQUENCE for this event. RFC 5545 requires UPDATEs to use a value
+  // strictly greater than the previous publish for receiving calendars to
+  // recognize the update. Tracked persistently on Interview.icsSequence and
+  // incremented before each location-change / reassignment / cancel send.
+  sequence: number;
 }
 
 function formatIcsDate(d: Date): string {
@@ -42,7 +47,7 @@ function attendeeLine(att: IcsAttendee): string {
 }
 
 export function buildInviteIcs(params: IcsEventParams): string {
-  const { interviewId, summary, startTime, endTime, location, meetingUrl, description, organizer, attendees } = params;
+  const { interviewId, summary, startTime, endTime, location, meetingUrl, description, organizer, attendees, sequence } = params;
 
   const locationLine = meetingUrl ? `${location} — ${meetingUrl}` : location;
   const descLines = [description, meetingUrl ? `Join: ${meetingUrl}` : null].filter(Boolean).join("\\n");
@@ -63,7 +68,7 @@ export function buildInviteIcs(params: IcsEventParams): string {
     ...(descLines ? [`DESCRIPTION:${escapeIcsText(descLines)}`] : []),
     organizerLine(organizer),
     ...attendees.map(attendeeLine),
-    "SEQUENCE:0",
+    `SEQUENCE:${sequence}`,
     "STATUS:CONFIRMED",
     "END:VEVENT",
     "END:VCALENDAR",
@@ -73,9 +78,9 @@ export function buildInviteIcs(params: IcsEventParams): string {
 }
 
 export function buildCancelIcs(
-  params: Pick<IcsEventParams, "interviewId" | "summary" | "startTime" | "endTime" | "organizer" | "attendees">,
+  params: Pick<IcsEventParams, "interviewId" | "summary" | "startTime" | "endTime" | "organizer" | "attendees" | "sequence">,
 ): string {
-  const { interviewId, summary, startTime, endTime, organizer, attendees } = params;
+  const { interviewId, summary, startTime, endTime, organizer, attendees, sequence } = params;
 
   const lines = [
     "BEGIN:VCALENDAR",
@@ -91,7 +96,7 @@ export function buildCancelIcs(
     `SUMMARY:${escapeIcsText(summary)}`,
     organizerLine(organizer),
     ...attendees.map(attendeeLine),
-    "SEQUENCE:1",
+    `SEQUENCE:${sequence}`,
     "STATUS:CANCELLED",
     "END:VEVENT",
     "END:VCALENDAR",

--- a/dali-api/prisma/migrations/20260522160000_add_interview_ics_sequence/migration.sql
+++ b/dali-api/prisma/migrations/20260522160000_add_interview_ics_sequence/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Interview" ADD COLUMN "icsSequence" INTEGER NOT NULL DEFAULT 0;

--- a/dali-api/prisma/schema.prisma
+++ b/dali-api/prisma/schema.prisma
@@ -595,6 +595,12 @@ model Interview {
   recommendation      String?
   recommendationNotes String?
 
+  // RFC 5545 SEQUENCE for the ICS calendar event tied to this interview.
+  // Bumped before each location-change / reassignment / cancel ICS send so
+  // receiving calendars actually apply the update instead of treating the
+  // new ICS as a duplicate of the previous publish.
+  icsSequence Int @default(0)
+
   assignments InterviewAssignment[]
 
   @@index([applicationCycleId, startTime])


### PR DESCRIPTION
## Why
Two pre-existing defects in the calendar-invite update flow surfaced during the trace done in #620:

### 1. `SEQUENCE` was hardcoded
- `buildInviteIcs` always emitted `SEQUENCE:0`.
- `buildCancelIcs` always emitted `SEQUENCE:1`.

Per RFC 5545 every `REQUEST` update must use a `SEQUENCE` strictly greater than the previous publish, or receiving calendars (Google Calendar in particular) dedupe the new ICS against the prior one and silently fail to apply the change. **\`sendLocationChangeEmails\` was effectively a no-op on the receiver side** — the email arrived but Google Calendar wouldn't change \`LOCATION\`.

### 2. Reassignments only notified the swap pair
\`sendReassignmentEmails\` emailed:
- the **removed** interviewer (CANCEL)
- the **newly-added** interviewer (REQUEST)

…but the **applicant** and **unchanged interviewers** got nothing. Their calendars kept showing the departed interviewer in the guest list right up until the interview happened.

## What

- New column \`Interview.icsSequence Int @default(0)\` + migration.
- \`buildInviteIcs\` / \`buildCancelIcs\` now take \`sequence: number\`. Removed the hardcoded values.
- New helper \`bumpIcsSequence(interviewId)\` does \`prisma.interview.update({ data: { icsSequence: { increment: 1 } } })\` and returns the new value. Atomic per call.
- Each path uses the right sequence:
  - **Initial invite**: reads \`interview.icsSequence\` (typically 0), **no bump** — the row's current value IS the initial publish.
  - **Cancel**: bump → use new value → CANCEL.
  - **Location change**: bump → use new value → REQUEST update.
  - **Reassignment**: bump once, then emit:
    - 1× CANCEL to the removed interviewer
    - 1× REQUEST(update) to the applicant — ATTENDEE list = **applicant only** (preserves the #620 split — applicant never sees the interviewer roster)
    - 1× REQUEST(update) per currently-active interviewer — ATTENDEE list = applicant + all interviewers (joint view)
    - All four payloads share the same bumped SEQUENCE so receiving calendars accept them as the same logical update.

The per-recipient applicant-solo / interviewer-joint ATTENDEE split from #620 is preserved across the new fan-out.

## Files
- \`prisma/schema.prisma\` — add \`icsSequence\`
- \`prisma/migrations/20260522160000_add_interview_ics_sequence/migration.sql\`
- \`app/hiring/lib/interview-ics.ts\` — \`sequence\` in the params type, threaded into both builders
- \`app/hiring/lib/interview-emails.ts\` — \`bumpIcsSequence\` helper + wiring; reassignment fans out to applicant (solo ICS) + all current interviewers (joint ICS)
- \`app/hiring/lib/__tests__/interview-ics.test.ts\` — new unit tests verifying SEQUENCE/METHOD/STATUS wiring

## Migration safety
- \`ADD COLUMN … INTEGER NOT NULL DEFAULT 0\` — backfills existing rows to 0. Already-scheduled interviews were published at the old \`SEQUENCE:0\`; their next update will bump to 1, which is strictly greater. No data drift.

## Test plan
- [x] \`npm test\` — 878/878 passing locally
- [ ] Staging: book an interview, change location, confirm the applicant's calendar event picks up the new location (it shouldn't have, pre-PR).
- [ ] Staging: reassign an interviewer, confirm applicant + unchanged interviewer calendars now show the new guest list. Also confirm the **applicant's** event card still shows only themselves in the guest panel (i.e. the #620 split is intact).
- [ ] Cancel an interview, confirm the event still drops cleanly from all recipients' calendars (sequence bumped from N → N+1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)