### PR TITLE
Add privacy/terms footer to login page for OAuth verification

### DIFF
--- a/dali-api/app/routes/login.tsx
+++ b/dali-api/app/routes/login.tsx
@@ -258,6 +258,18 @@ export default function Login() {
               </button>
             </Form>
           </div>
+
+          {/* Public policy links. This page doubles as the app's public home
+              page for Google OAuth verification, which requires the home page
+              to link to the privacy policy. */}
+          <footer className="mt-10 flex items-center gap-4 text-xs text-muted-foreground">
+            <a href="/privacy" className="hover:text-foreground underline">
+              Privacy Policy
+            </a>
+            <a href="/terms" className="hover:text-foreground underline">
+              Terms of Service
+            </a>
+          </footer>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## What

Adds a footer to the login page (`/login`) linking the existing public **Privacy Policy** (`/privacy`) and **Terms of Service** (`/terms`) pages.

## Why

Google's OAuth app verification requires the consent screen's **home page URL to contain a link to the privacy policy**. The app's real home page (`/`) is auth-gated — logged-out visitors (including Google's reviewer) get redirected to `/login` — so it can never satisfy that check. The practical public "home page" for verification is `/login`, and it had no policy links.

With this change, `https://os.dali.dartmouth.edu/login` renders privacy + terms links to an unauthenticated visitor.

## Scope

- One file: `dali-api/app/routes/login.tsx` (+12 lines, a `<footer>`).
- No route, auth, or behavior changes. The `/privacy` and `/terms` routes already exist and are already public.

## Note for the verification submission (outside this PR)

This PR only handles the home-page→privacy-link requirement. Two other steps are console-side, not code:
- In the OAuth consent screen, the **privacy and terms URLs are currently swapped** (privacy points at `/terms`, terms points at `/privacy`) and should be corrected.
- Change the consent screen's **home page URL to `…/login`** (the bare `/` will keep failing).
- The **domain-ownership** error is resolved in Google Search Console (likely needs Dartmouth DNS access), not here.

## Testing

- `npm run typecheck` introduces no new errors in `login.tsx`. (There are ~29 pre-existing TS errors under `scripts/*.ts` on `dev`, unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/623"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782061510&installation_id=133523038&pr_number=623&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F623&signature=d66506c468ceff0fe8527a839d6169626f4872251cb42532500a770f7e3ab939"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->