### PR TITLE
Add privacy/terms footer to login page for OAuth verification (#623)

### DIFF
--- a/dali-api/app/members/routes/members.tsx
+++ b/dali-api/app/members/routes/members.tsx
@@ -27,7 +27,6 @@ type MemberRow = {
   pronouns: string | null;
   classYear: number | null;
   photoUrl: string | null;
-  isAdmin: boolean;
   coreTitles: string[];
   // Each domain the member is eligible for, with their level — rendered as
   // pills in the Roles column. Same source as the staffing boards.
@@ -85,7 +84,6 @@ export async function loader({ request }: Route.LoaderArgs) {
       pronouns: true,
       classYear: true,
       photoUrl: true,
-      adminMembership: { select: { id: true } },
       coreAssignments: { select: { leadTitle: true } },
       domainEligibilities: {
         select: {
@@ -104,12 +102,11 @@ export async function loader({ request }: Route.LoaderArgs) {
     pronouns: u.pronouns,
     classYear: u.classYear,
     photoUrl: u.photoUrl,
-    isAdmin: u.adminMembership !== null,
-    // Dedupe lead titles across terms — a "Hiring Lead" who held the title
-    // for three terms should still show one chip.
-    coreTitles: Array.from(
-      new Set(u.coreAssignments.map((a) => a.leadTitle).filter((t): t is string => !!t)),
-    ),
+    // Core pills: one per distinct lead title (deduped across terms — a
+    // "Hiring Lead" who held the title for three terms shows one chip). A Core
+    // member with assignments but no title set still gets a plain "Core" pill
+    // so their Core status is visible rather than dropped.
+    coreTitles: deriveCoreTitles(u.coreAssignments),
     domainRoles: u.domainEligibilities.map((e) => ({
       domainName: e.domain.displayName,
       level: e.level,
@@ -126,6 +123,21 @@ export async function loader({ request }: Route.LoaderArgs) {
     selectedDomain: domainId,
     canEdit,
   };
+}
+
+// Distinct Core lead titles for a member's Roles column. Title-less Core
+// assignments collapse to a single "Core" pill so a Core member without a
+// specific title still shows up (rather than contributing no pill at all).
+function deriveCoreTitles(
+  assignments: { leadTitle: string | null }[],
+): string[] {
+  if (assignments.length === 0) return [];
+  const titles = new Set(
+    assignments.map((a) => a.leadTitle).filter((t): t is string => !!t),
+  );
+  const hasUntitled = assignments.some((a) => !a.leadTitle);
+  if (hasUntitled) titles.add("Core");
+  return Array.from(titles);
 }
 
 // Profile fields offered on the create form. Mirrors the editable text fields
@@ -445,7 +457,6 @@ function MembersTable({ rows }: { rows: MemberRow[] }) {
               <td className="px-4 py-2 text-muted-foreground">{m.email ?? "—"}</td>
               <td className="px-4 py-2">
                 <RolePills
-                  isAdmin={m.isAdmin}
                   coreTitles={m.coreTitles}
                   domainRoles={m.domainRoles}
                 />
@@ -491,7 +502,6 @@ function MemberCard({ member }: { member: MemberRow }) {
         )}
         <div className="mt-2">
           <RolePills
-            isAdmin={member.isAdmin}
             coreTitles={member.coreTitles}
             domainRoles={member.domainRoles}
           />
@@ -519,24 +529,17 @@ function Avatar({ photoUrl, name }: { photoUrl: string | null; name: string }) {
 }
 
 function RolePills({
-  isAdmin,
   coreTitles,
   domainRoles,
 }: {
-  isAdmin: boolean;
   coreTitles: string[];
   domainRoles: { domainName: string; level: string }[];
 }) {
-  if (!isAdmin && coreTitles.length === 0 && domainRoles.length === 0) {
+  if (coreTitles.length === 0 && domainRoles.length === 0) {
     return <span className="text-muted-foreground text-xs">—</span>;
   }
   return (
     <div className="flex flex-wrap gap-1.5">
-      {isAdmin && (
-        <span className="inline-flex items-center px-2 py-0.5 text-xs font-medium rounded bg-accent-coral/15 text-accent-coral">
-          Admin
-        </span>
-      )}
       {coreTitles.map((title) => (
         <span
           key={title}

--- a/dali-api/app/partners/routes/partners.applications.$id.tsx
+++ b/dali-api/app/partners/routes/partners.applications.$id.tsx
@@ -214,9 +214,9 @@ export async function action({ request, params }: Route.ActionArgs) {
     }
 
     // Earliest target term (targetTerms is sorted by sortKey asc) seeds the
-    // project's start term and scopes the per-domain role requests. Without a
-    // target term we still create the project, just with no role requests
-    // (ProjectRoleRequest requires a termId).
+    // project's term set and scopes the per-domain role requests. Without a
+    // target term we still create the project, just with no terms and no role
+    // requests (ProjectRoleRequest requires a termId).
     const firstTermId = app.targetTerms[0]?.termId ?? null;
     // PartnerApplicationDomain carries headcount but no level; new role
     // requests default to P1 (Learner) — the staffing board can refine.
@@ -236,7 +236,9 @@ export async function action({ request, params }: Route.ActionArgs) {
         data: {
           name: app.title,
           description: app.summary,
-          firstTermId,
+          ...(firstTermId
+            ? { projectTerms: { create: { termId: firstTermId } } }
+            : {}),
           partners: { create: { partnerOrgId: app.partnerOrgId } },
           ...(roleRequestRows.length > 0
             ? { roleRequests: { create: roleRequestRows } }

--- a/dali-api/app/projects/routes/projects.$id.tsx
+++ b/dali-api/app/projects/routes/projects.$id.tsx
@@ -15,7 +15,7 @@ import type { Route } from "./+types/projects.$id";
 import { prisma } from "~/lib/db";
 import { requireAuth } from "~/lib/auth";
 import { parseSessionCookie } from "~/lib/cookies";
-import { isHiringLead } from "~/lib/roles";
+import { isHiringLead, currentTerm } from "~/lib/roles";
 import { TaskBoard } from "../components/TaskBoard";
 import { type TimelineEpic, type EpicStatus } from "../components/EpicsTimeline";
 import {
@@ -63,7 +63,9 @@ export async function loader({ request, params }: Route.LoaderArgs) {
       repoUrls: true,
       overviewPageId: true,
       prdPageId: true,
-      firstTerm: { select: { id: true, code: true, sortKey: true } },
+      projectTerms: {
+        select: { term: { select: { id: true, code: true, sortKey: true } } },
+      },
       termCount: true,
       partners: { select: { partnerOrg: { select: { name: true } } } },
       termStatuses: {
@@ -285,7 +287,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   // displays declared domains directly; if none are declared, it falls back
   // to the union of domains seen on this project's bids + assignments so a
   // project that's actively being staffed still shows its domain footprint.
-  const [allDomains, bidDomains] = await Promise.all([
+  const [allDomains, bidDomains, allTerms] = await Promise.all([
     prisma.domain.findMany({
       where: { active: true },
       orderBy: { displayName: "asc" },
@@ -296,30 +298,34 @@ export async function loader({ request, params }: Route.LoaderArgs) {
       select: { domainId: true },
       distinct: ["domainId"],
     }),
+    prisma.term.findMany({
+      orderBy: { sortKey: "desc" },
+      select: { id: true, code: true },
+    }),
   ]);
   const declaredDomains = project.domains.map((d) => ({
     id: d.domain.id,
     name: d.domain.displayName,
   }));
 
-  // Planned terms for the scope grid: starting at firstTerm (by sortKey), the
-  // next `termCount` terms chronologically. We fetch them ascending so the
-  // `take: termCount` slice cuts off the future, then reverse so the display
-  // surfaces the most recent term first. Falls back to an empty list when
-  // no firstTerm is set (legacy project rows) — the scopes section then
-  // just doesn't render, no crash.
-  const plannedTerms: { id: string; code: string; sortKey: number }[] = (
-    project.firstTerm
-      ? await prisma.term.findMany({
-          where: { sortKey: { gte: project.firstTerm.sortKey } },
-          orderBy: { sortKey: "asc" },
-          take: Math.max(1, project.termCount),
-          select: { id: true, code: true, sortKey: true },
-        })
-      : []
-  )
-    .slice()
+  // The project's term set is now explicit (ProjectTerm rows), editable on
+  // this page, and need not be consecutive. Sorted descending so the display
+  // surfaces the most recent term first; the scope grid uses this same set.
+  const plannedTerms = project.projectTerms
+    .map((pt) => pt.term)
     .sort((a, b) => b.sortKey - a.sortKey);
+
+  // Start term is derived as the earliest term in the set (lowest sortKey),
+  // not a stored field. Null when the project has no terms yet.
+  const startTerm =
+    plannedTerms.length > 0 ? plannedTerms[plannedTerms.length - 1] : null;
+
+  // Active-this-term is derived from membership: the project is active iff the
+  // current term is in its set. Distinct from the manual status enum
+  // (Paused/Archived), which the lead still controls explicitly.
+  const current = await currentTerm();
+  const isActiveThisTerm =
+    current !== null && plannedTerms.some((t) => t.id === current.id);
 
   // Fetch all scope rows for this project (small N — at most |declared| ×
   // termCount, both single-digit in practice). Keyed by domainId+termId so
@@ -367,7 +373,9 @@ export async function loader({ request, params }: Route.LoaderArgs) {
       repoUrls: project.repoUrls,
       overviewPageId: project.overviewPageId,
       prdPageId: project.prdPageId,
-      firstTerm: project.firstTerm,
+      startTerm,
+      isActiveThisTerm,
+      actualTermCount: plannedTerms.length,
       termCount: project.termCount,
       partners: project.partners,
       domains: declaredDomains,
@@ -375,6 +383,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     },
     allDomainOptions: allDomains.map((d) => ({ id: d.id, name: d.displayName })),
     plannedTerms: plannedTerms.map((t) => ({ id: t.id, code: t.code })),
+    allTermOptions: allTerms,
     domainScopeGrid,
     teams,
     termStatuses,
@@ -499,6 +508,34 @@ export async function action({ request, params }: Route.ActionArgs) {
     return redirect(`/projects/${params.id}`);
   }
 
+  // Project term set. Full-replacement: the incoming set of termIds wins, so
+  // the same handler covers both adding and removing terms. Filtered to real
+  // Term ids so a stale value can't create an orphan row. The start term and
+  // active-this-term are derived from this set, not stored. Mirrors the
+  // `domains` handler above.
+  if (intent === "terms") {
+    const incoming = form.getAll("termId").map((v) => String(v));
+    const valid = incoming.length
+      ? await prisma.term.findMany({
+          where: { id: { in: incoming } },
+          select: { id: true },
+        })
+      : [];
+    const ids = valid.map((t) => t.id);
+    await prisma.$transaction([
+      prisma.projectTerm.deleteMany({ where: { projectId: params.id } }),
+      ...(ids.length
+        ? [
+            prisma.projectTerm.createMany({
+              data: ids.map((termId) => ({ projectId: params.id, termId })),
+              skipDuplicates: true,
+            }),
+          ]
+        : []),
+    ]);
+    return redirect(`/projects/${params.id}`);
+  }
+
   // Details form: calendar email, image, repos. (Description + name/status
   // are saved by their own segments above.)
   const calendarEmailRaw = (form.get("calendarEmail") as string | null)?.trim() ?? "";
@@ -512,8 +549,9 @@ export async function action({ request, params }: Route.ActionArgs) {
     .map((s) => s.trim())
     .filter(Boolean);
 
-  // termCount is the planned span (≥1 consecutive terms from the start term).
-  // Blank/invalid falls back to 1 rather than erroring the whole form.
+  // termCount is the *expected* span length (≥1), an independent target; the
+  // actual terms live in the ProjectTerm set (intent=terms). Blank/invalid
+  // falls back to 1 rather than erroring the whole form.
   const termCount = Math.max(1, Math.floor(Number(termCountRaw)) || 1);
 
   await prisma.project.update({
@@ -540,6 +578,7 @@ export default function ProjectDetail() {
     boardOptions,
     allDomainOptions,
     plannedTerms,
+    allTermOptions,
     domainScopeGrid,
     canEdit,
     collabToken,
@@ -603,6 +642,7 @@ export default function ProjectDetail() {
           documents={documents}
           allDomainOptions={allDomainOptions}
           plannedTerms={plannedTerms}
+          allTermOptions={allTermOptions}
           domainScopeGrid={domainScopeGrid}
           canEdit={canEdit}
           actionError={actionData?.error}
@@ -647,13 +687,25 @@ function ProjectHeader({
   const [editing, setEditing] = useState(false);
   const [resetKey, setResetKey] = useState(0);
 
+  // Actual terms vs the expected span: when they differ, show "N of M" so a
+  // partially-scheduled project reads as such. termCount is the expected target.
+  const actualTermCount = project.actualTermCount;
+  const termCountLabel =
+    actualTermCount === project.termCount
+      ? `${project.termCount} ${project.termCount === 1 ? "term" : "terms"}`
+      : `${actualTermCount} of ${project.termCount} terms`;
+
   const subtitle = (
     <p className="text-sm text-muted-foreground mt-1">
-      {project.firstTerm
-        ? `Start term ${project.firstTerm.code}`
-        : "No start term"}
+      {project.startTerm
+        ? `Start term ${project.startTerm.code}`
+        : "No terms yet"}
       {" · "}
-      {project.termCount} {project.termCount === 1 ? "term" : "terms"}
+      {termCountLabel}
+      {" · "}
+      <span className={project.isActiveThisTerm ? "text-accent-green" : undefined}>
+        {project.isActiveThisTerm ? "Active this term" : "Not this term"}
+      </span>
       {" · "}
       {partnerNames.length > 0 ? partnerNames.join(", ") : "No partners"}
     </p>
@@ -934,6 +986,124 @@ function DomainsChipsEditor({
           .
         </p>
       )}
+    </Form>
+  );
+}
+
+// Project terms — the editable term set (source of truth for which terms the
+// project runs). Same click-to-toggle, save-the-full-set pattern as Domains;
+// the action's intent=terms handler full-replaces ProjectTerm rows. The start
+// term and "active this term" are derived from this set, so no separate
+// start-term field is edited here. `expected` (termCount) is edited in the
+// Details section and shown here only as a target for context.
+function TermsSegment({
+  selected,
+  allTerms,
+  expected,
+  canEdit,
+}: {
+  selected: { id: string; code: string }[];
+  allTerms: { id: string; code: string }[];
+  expected: number;
+  canEdit: boolean;
+}) {
+  const submit = useSubmit();
+  const formRef = useRef<HTMLFormElement | null>(null);
+
+  return (
+    <EditableSection
+      title="Terms"
+      canEdit={canEdit}
+      onSave={() => { if (formRef.current) submit(formRef.current); }}
+    >
+      {({ editing, resetKey }) =>
+        editing ? (
+          <TermsChipsEditor
+            key={resetKey}
+            formRef={formRef}
+            initialSelectedIds={selected.map((t) => t.id)}
+            allTerms={allTerms}
+            expected={expected}
+          />
+        ) : selected.length > 0 ? (
+          <div className="flex flex-wrap gap-1.5">
+            {selected.map((t) => (
+              <span
+                key={t.id}
+                className="inline-flex items-center px-2 py-0.5 text-xs font-medium rounded bg-blue-50 text-blue-700 border border-blue-100"
+              >
+                {t.code}
+              </span>
+            ))}
+            {selected.length !== expected && (
+              <span className="text-xs text-muted-foreground self-center">
+                {selected.length} of {expected} expected
+              </span>
+            )}
+          </div>
+        ) : (
+          <p className="text-sm text-muted-foreground italic">
+            No terms yet{expected > 0 ? ` — ${expected} expected` : ""}.
+          </p>
+        )
+      }
+    </EditableSection>
+  );
+}
+
+function TermsChipsEditor({
+  formRef,
+  initialSelectedIds,
+  allTerms,
+  expected,
+}: {
+  formRef: React.MutableRefObject<HTMLFormElement | null>;
+  initialSelectedIds: string[];
+  allTerms: { id: string; code: string }[];
+  expected: number;
+}) {
+  const [selected, setSelected] = useState<Set<string>>(
+    () => new Set(initialSelectedIds),
+  );
+  function toggle(id: string) {
+    setSelected((cur) => {
+      const next = new Set(cur);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+  return (
+    <Form method="post" ref={formRef} className="flex flex-col gap-2">
+      <input type="hidden" name="intent" value="terms" />
+      {[...selected].map((id) => (
+        <input key={id} type="hidden" name="termId" value={id} />
+      ))}
+      <div className="flex flex-wrap gap-2">
+        {allTerms.map((t) => {
+          const isOn = selected.has(t.id);
+          return (
+            <button
+              key={t.id}
+              type="button"
+              onClick={() => toggle(t.id)}
+              aria-pressed={isOn}
+              className={`inline-flex items-center gap-1.5 px-2 py-1 rounded-md border text-sm cursor-pointer transition-colors ${
+                isOn
+                  ? "bg-accent-coral/15 border-accent-coral/40 text-foreground"
+                  : "bg-background border-border text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              {t.code}
+            </button>
+          );
+        })}
+      </div>
+      <p className="text-xs text-muted-foreground">
+        {selected.size} selected · {expected} expected. The start term is the
+        earliest selected; the project shows as active when the current term is
+        selected.
+      </p>
     </Form>
   );
 }
@@ -1220,6 +1390,7 @@ function OverviewTab({
   documents,
   allDomainOptions,
   plannedTerms,
+  allTermOptions,
   domainScopeGrid,
   canEdit,
   actionError,
@@ -1231,6 +1402,7 @@ function OverviewTab({
   documents: LoaderData["documents"];
   allDomainOptions: LoaderData["allDomainOptions"];
   plannedTerms: LoaderData["plannedTerms"];
+  allTermOptions: LoaderData["allTermOptions"];
   domainScopeGrid: LoaderData["domainScopeGrid"];
   canEdit: boolean;
   actionError?: string;
@@ -1257,6 +1429,15 @@ function OverviewTab({
         declared={project.domains}
         derived={project.derivedDomains}
         allDomains={allDomainOptions}
+        canEdit={canEdit}
+      />
+
+      {/* Project terms — the editable term set. Start term and active-this-term
+          are derived from this set; termCount (Details) is the expected target. */}
+      <TermsSegment
+        selected={plannedTerms}
+        allTerms={allTermOptions}
+        expected={project.termCount}
         canEdit={canEdit}
       />
 

--- a/dali-api/app/projects/routes/projects.list.tsx
+++ b/dali-api/app/projects/routes/projects.list.tsx
@@ -41,37 +41,47 @@ export async function loader({ request }: Route.LoaderArgs) {
   const { terms, selected, termId, isAll } = await resolveTermFilter(request);
 
   const projects = await prisma.project.findMany({
-    // A term filter scopes to Active projects whose start (first) term is the
-    // selected one — Paused/Archived projects are noise for a term view.
-    // "All terms" drops the filter entirely and stays the full archive view.
+    // A term filter scopes to Active projects that run in the selected term —
+    // i.e. the term is in the project's ProjectTerm set — since a project may
+    // span several terms. Paused/Archived are noise for a term view. "All
+    // terms" drops the filter entirely and stays the full archive view.
     where:
       isAll || !termId
         ? undefined
-        : { firstTermId: termId, status: "Active" },
+        : { projectTerms: { some: { termId } }, status: "Active" },
     orderBy: [{ status: "asc" }, { name: "asc" }],
     select: {
       id: true,
       name: true,
       status: true,
       imageUrl: true,
-      firstTerm: { select: { code: true } },
+      // Start term is derived as the earliest term in the set. Fetch ascending
+      // by sortKey and take the first.
+      projectTerms: {
+        select: { term: { select: { code: true, sortKey: true } } },
+      },
       partners: {
         select: { partnerOrg: { select: { name: true, logoUrl: true } } },
       },
     },
   });
 
-  const rows: ProjectRow[] = projects.map((p) => ({
-    id: p.id,
-    name: p.name,
-    status: p.status,
-    firstTermCode: p.firstTerm?.code ?? null,
-    imageUrl: p.imageUrl,
-    partners: p.partners.map((pp) => ({
-      name: pp.partnerOrg.name,
-      logoUrl: pp.partnerOrg.logoUrl,
-    })),
-  }));
+  const rows: ProjectRow[] = projects.map((p) => {
+    const startTerm = p.projectTerms
+      .map((pt) => pt.term)
+      .sort((a, b) => a.sortKey - b.sortKey)[0];
+    return {
+      id: p.id,
+      name: p.name,
+      status: p.status,
+      firstTermCode: startTerm?.code ?? null,
+      imageUrl: p.imageUrl,
+      partners: p.partners.map((pp) => ({
+        name: pp.partnerOrg.name,
+        logoUrl: pp.partnerOrg.logoUrl,
+      })),
+    };
+  });
 
   const [partnerOrgs, canEdit] = await Promise.all([
     prisma.partnerOrg.findMany({
@@ -96,7 +106,10 @@ export async function action({ request }: Route.ActionArgs) {
   const name = (form.get("name") as string | null)?.trim() ?? "";
   const description = (form.get("description") as string | null)?.trim() ?? "";
   const status = (form.get("status") as string | null) ?? "Active";
-  const firstTermId = (form.get("firstTermId") as string | null)?.trim() ?? "";
+  // The create form's term picker seeds the project's first term. The term set
+  // is then editable on the detail page; the start term is derived as the
+  // earliest member.
+  const initialTermId = (form.get("firstTermId") as string | null)?.trim() ?? "";
   const partnerOrgId = (form.get("partnerOrgId") as string | null)?.trim() ?? "";
 
   if (!name) return { error: "A project name is required." };
@@ -104,12 +117,12 @@ export async function action({ request }: Route.ActionArgs) {
   if (!STATUSES.includes(status as ProjectStatus)) {
     return { error: "Invalid status." };
   }
-  if (firstTermId) {
+  if (initialTermId) {
     const term = await prisma.term.findUnique({
-      where: { id: firstTermId },
+      where: { id: initialTermId },
       select: { id: true },
     });
-    if (!term) return { error: "That start term no longer exists." };
+    if (!term) return { error: "That term no longer exists." };
   }
   if (partnerOrgId) {
     const org = await prisma.partnerOrg.findUnique({
@@ -124,7 +137,10 @@ export async function action({ request }: Route.ActionArgs) {
       name,
       description: description === "" ? null : description,
       status: status as ProjectStatus,
-      firstTermId: firstTermId || null,
+      // Seed the initial term into the project's term set (if chosen).
+      ...(initialTermId
+        ? { projectTerms: { create: { termId: initialTermId } } }
+        : {}),
       // Optionally link a partner up front; further partners are managed on
       // the project detail page.
       ...(partnerOrgId

--- a/dali-api/app/routes/login.tsx
+++ b/dali-api/app/routes/login.tsx
@@ -258,6 +258,18 @@ export default function Login() {
               </button>
             </Form>
           </div>
+
+          {/* Public policy links. This page doubles as the app's public home
+              page for Google OAuth verification, which requires the home page
+              to link to the privacy policy. */}
+          <footer className="mt-10 flex items-center gap-4 text-xs text-muted-foreground">
+            <a href="/privacy" className="hover:text-foreground underline">
+              Privacy Policy
+            </a>
+            <a href="/terms" className="hover:text-foreground underline">
+              Terms of Service
+            </a>
+          </footer>
         </div>
       </div>
     </div>

--- a/dali-api/prisma/migrations/20260522170000_project_multi_terms/migration.sql
+++ b/dali-api/prisma/migrations/20260522170000_project_multi_terms/migration.sql
@@ -1,0 +1,49 @@
+-- Project term model: replace the single firstTerm + termCount "consecutive
+-- run" with an explicit, editable ProjectTerm set. termCount is retained as
+-- the *expected* span length; the start term becomes the earliest ProjectTerm.
+--
+-- DATA-LOSING: this drops Project.firstTermId. The backfill below preserves
+-- the existing planned span by materializing it into ProjectTerm rows BEFORE
+-- the column is dropped. Ordering matters: create -> backfill -> drop.
+
+-- CreateTable
+CREATE TABLE "ProjectTerm" (
+    "projectId" TEXT NOT NULL,
+    "termId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ProjectTerm_pkey" PRIMARY KEY ("projectId","termId")
+);
+
+-- CreateIndex
+CREATE INDEX "ProjectTerm_termId_idx" ON "ProjectTerm"("termId");
+
+-- AddForeignKey
+ALTER TABLE "ProjectTerm" ADD CONSTRAINT "ProjectTerm_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ProjectTerm" ADD CONSTRAINT "ProjectTerm_termId_fkey" FOREIGN KEY ("termId") REFERENCES "Term"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- Backfill: expand each project's (firstTerm, termCount) into explicit
+-- ProjectTerm rows. Mirrors the app's old planned-term computation: the
+-- termCount chronologically-earliest terms whose sortKey is >= the project's
+-- firstTerm.sortKey. Projects with a NULL firstTermId contribute no rows
+-- (they had no resolvable span and the UI already treated them as unset).
+INSERT INTO "ProjectTerm" ("projectId", "termId", "createdAt")
+SELECT p."id", t."id", CURRENT_TIMESTAMP
+FROM "Project" p
+JOIN "Term" ft ON ft."id" = p."firstTermId"
+JOIN LATERAL (
+    SELECT t2."id"
+    FROM "Term" t2
+    WHERE t2."sortKey" >= ft."sortKey"
+    ORDER BY t2."sortKey" ASC
+    LIMIT GREATEST(p."termCount", 1)
+) t ON TRUE
+WHERE p."firstTermId" IS NOT NULL;
+
+-- DropForeignKey
+ALTER TABLE "Project" DROP CONSTRAINT "Project_firstTermId_fkey";
+
+-- DropColumn (data-losing — preserved above as ProjectTerm rows)
+ALTER TABLE "Project" DROP COLUMN "firstTermId";

--- a/dali-api/prisma/schema.prisma
+++ b/dali-api/prisma/schema.prisma
@@ -1406,9 +1406,9 @@ model Term {
   instructorAssignments InstructorAssignment[]
   staffingCycles        StaffingCycle[]
   projectTermStatuses   ProjectTermStatus[]
+  projectTerms          ProjectTerm[]
   projectRoleRequests   ProjectRoleRequest[]
   staffingAssignments   StaffingAssignment[]
-  projectsAsFirstTerm   Project[]              @relation("ProjectFirstTerm")
   partnerApplications   PartnerApplicationTargetTerm[]
   intentToWork          IntentToWork[]
   projectDomainScopes   ProjectDomainScope[]
@@ -1586,14 +1586,11 @@ model Project {
   // "projectalpha@dali.dartmouth.edu"). Calendar events for this project
   // are owned by this identity, not the organizer's personal calendar.
   calendarEmail String?
-  // Term the project was first activated. Phase 1: nullable to allow
-  // creation in a transaction before the Term row may exist; in steady
-  // state all new Projects set this. Phase 2 enforces NOT NULL after
-  // backfilling any legacy rows.
-  firstTermId   String?
-  // Planned span: the project runs `termCount` consecutive terms starting at
-  // firstTerm (UI calls firstTerm the "start term"). Drives the required-
-  // headcount-per-term projection. 1 = single-term project.
+  // Expected span length: how many terms the project is *planned* to run, as
+  // a target. Independent of the actual ProjectTerm set — a project may have
+  // fewer terms added than expected (still being scheduled) or more. Drives
+  // the "N of M terms added" projection. The start term is derived as the
+  // earliest term in `projectTerms` (by Term.sortKey), not stored.
   termCount     Int           @default(1)
   status        ProjectStatus @default(Active)
 
@@ -1614,11 +1611,13 @@ model Project {
   // Git repositories for this project (URLs). Empty by default.
   repoUrls String[] @default([])
 
-  firstTerm    Term? @relation("ProjectFirstTerm", fields: [firstTermId], references: [id])
   overviewPage Page? @relation("ProjectOverview", fields: [overviewPageId], references: [id])
   prdPage      Page? @relation("ProjectPRD", fields: [prdPageId], references: [id])
 
   partners        ProjectPartner[]
+  // The project's planned term set — the source of truth for which terms the
+  // project runs. The start term is the earliest of these (by Term.sortKey).
+  projectTerms    ProjectTerm[]
   termStatuses    ProjectTermStatus[]
   assignments     ProjectAssignment[]
   roleRequests    ProjectRoleRequest[]
@@ -1649,6 +1648,25 @@ model ProjectDomain {
 
   @@id([projectId, domainId])
   @@index([domainId])
+}
+
+// Many-to-many join: which terms a project runs. Source of truth for the
+// project's planned term set — editable on the project detail page (add /
+// remove individual terms; the set need not be consecutive). The "start
+// term" is derived as the earliest of these by Term.sortKey, and a project
+// counts as active in a given term iff a row exists for that (project, term).
+// Project.termCount is the *expected* length of this set, not derived from it.
+model ProjectTerm {
+  projectId String
+  termId    String
+
+  project Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  term    Term    @relation(fields: [termId], references: [id])
+
+  createdAt DateTime @default(now())
+
+  @@id([projectId, termId])
+  @@index([termId])
 }
 
 // Per-term, per-domain free-text scope for a project. One cell per

--- a/dali-api/prisma/seed.ts
+++ b/dali-api/prisma/seed.ts
@@ -2907,9 +2907,19 @@ async function main() {
   for (const p of projectSeeds) {
     await prisma.project.upsert({
       where: { id: p.id },
-      update: { name: p.name, status: p.status, firstTermId: term26S?.id ?? null, termCount: p.termCount, imageUrl: p.imageUrl },
-      create: { id: p.id, name: p.name, status: p.status, firstTermId: term26S?.id ?? null, termCount: p.termCount, imageUrl: p.imageUrl },
+      update: { name: p.name, status: p.status, termCount: p.termCount, imageUrl: p.imageUrl },
+      create: { id: p.id, name: p.name, status: p.status, termCount: p.termCount, imageUrl: p.imageUrl },
     });
+    // Seed the project's term set. Only 26S exists in the seed DB, so each
+    // project gets that single term while termCount stays the (larger)
+    // expected target — exercising the "actual < expected" display.
+    if (term26S) {
+      await prisma.projectTerm.upsert({
+        where: { projectId_termId: { projectId: p.id, termId: term26S.id } },
+        update: {},
+        create: { projectId: p.id, termId: term26S.id },
+      });
+    }
     for (const partnerOrgId of p.partnerIds) {
       await prisma.projectPartner.upsert({
         where: { projectId_partnerOrgId: { projectId: p.id, partnerOrgId } },

--- a/dali-api/scripts/seed-intern-to-full-demo.ts
+++ b/dali-api/scripts/seed-intern-to-full-demo.ts
@@ -99,15 +99,19 @@ async function main() {
     await prisma.dALIMember.create({ data: { userId: intern.id } });
   }
 
-  // Project in the intern domain — needs a name and a firstTerm.
+  // Project in the intern domain — needs a name and a term in its set.
   const project = await prisma.project.upsert({
     where: { id: "demo-intern-project" },
-    update: { name: "ERAS Demo Project", firstTermId: term.id },
+    update: { name: "ERAS Demo Project" },
     create: {
       id: "demo-intern-project",
       name: "ERAS Demo Project",
-      firstTermId: term.id,
     },
+  });
+  await prisma.projectTerm.upsert({
+    where: { projectId_termId: { projectId: project.id, termId: term.id } },
+    update: {},
+    create: { projectId: project.id, termId: term.id },
   });
 
   await prisma.projectAssignment.upsert({


### PR DESCRIPTION
Google OAuth app verification requires the consent screen's "home page" URL to link to the privacy policy. The app's actual home page (/) is auth-gated and redirects logged-out visitors to /login, so the public home page for verification purposes is /login. Add a footer there linking the existing public /privacy and /terms pages.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/624"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782062616&installation_id=133523038&pr_number=624&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F624&signature=38f2124b9d0b84449151f174fe4fa9eed01e0ef4170c7692e3e5b964bb0163ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->