### PR TITLE
Hide Admin pill in members directory; show all Core titles

### DIFF
--- a/dali-api/app/members/routes/members.tsx
+++ b/dali-api/app/members/routes/members.tsx
@@ -27,7 +27,6 @@ type MemberRow = {
   pronouns: string | null;
   classYear: number | null;
   photoUrl: string | null;
-  isAdmin: boolean;
   coreTitles: string[];
   // Each domain the member is eligible for, with their level — rendered as
   // pills in the Roles column. Same source as the staffing boards.
@@ -85,7 +84,6 @@ export async function loader({ request }: Route.LoaderArgs) {
       pronouns: true,
       classYear: true,
       photoUrl: true,
-      adminMembership: { select: { id: true } },
       coreAssignments: { select: { leadTitle: true } },
       domainEligibilities: {
         select: {
@@ -104,12 +102,11 @@ export async function loader({ request }: Route.LoaderArgs) {
     pronouns: u.pronouns,
     classYear: u.classYear,
     photoUrl: u.photoUrl,
-    isAdmin: u.adminMembership !== null,
-    // Dedupe lead titles across terms — a "Hiring Lead" who held the title
-    // for three terms should still show one chip.
-    coreTitles: Array.from(
-      new Set(u.coreAssignments.map((a) => a.leadTitle).filter((t): t is string => !!t)),
-    ),
+    // Core pills: one per distinct lead title (deduped across terms — a
+    // "Hiring Lead" who held the title for three terms shows one chip). A Core
+    // member with assignments but no title set still gets a plain "Core" pill
+    // so their Core status is visible rather than dropped.
+    coreTitles: deriveCoreTitles(u.coreAssignments),
     domainRoles: u.domainEligibilities.map((e) => ({
       domainName: e.domain.displayName,
       level: e.level,
@@ -126,6 +123,21 @@ export async function loader({ request }: Route.LoaderArgs) {
     selectedDomain: domainId,
     canEdit,
   };
+}
+
+// Distinct Core lead titles for a member's Roles column. Title-less Core
+// assignments collapse to a single "Core" pill so a Core member without a
+// specific title still shows up (rather than contributing no pill at all).
+function deriveCoreTitles(
+  assignments: { leadTitle: string | null }[],
+): string[] {
+  if (assignments.length === 0) return [];
+  const titles = new Set(
+    assignments.map((a) => a.leadTitle).filter((t): t is string => !!t),
+  );
+  const hasUntitled = assignments.some((a) => !a.leadTitle);
+  if (hasUntitled) titles.add("Core");
+  return Array.from(titles);
 }
 
 // Profile fields offered on the create form. Mirrors the editable text fields
@@ -445,7 +457,6 @@ function MembersTable({ rows }: { rows: MemberRow[] }) {
               <td className="px-4 py-2 text-muted-foreground">{m.email ?? "—"}</td>
               <td className="px-4 py-2">
                 <RolePills
-                  isAdmin={m.isAdmin}
                   coreTitles={m.coreTitles}
                   domainRoles={m.domainRoles}
                 />
@@ -491,7 +502,6 @@ function MemberCard({ member }: { member: MemberRow }) {
         )}
         <div className="mt-2">
           <RolePills
-            isAdmin={member.isAdmin}
             coreTitles={member.coreTitles}
             domainRoles={member.domainRoles}
           />
@@ -519,24 +529,17 @@ function Avatar({ photoUrl, name }: { photoUrl: string | null; name: string }) {
 }
 
 function RolePills({
-  isAdmin,
   coreTitles,
   domainRoles,
 }: {
-  isAdmin: boolean;
   coreTitles: string[];
   domainRoles: { domainName: string; level: string }[];
 }) {
-  if (!isAdmin && coreTitles.length === 0 && domainRoles.length === 0) {
+  if (coreTitles.length === 0 && domainRoles.length === 0) {
     return <span className="text-muted-foreground text-xs">—</span>;
   }
   return (
     <div className="flex flex-wrap gap-1.5">
-      {isAdmin && (
-        <span className="inline-flex items-center px-2 py-0.5 text-xs font-medium rounded bg-accent-coral/15 text-accent-coral">
-          Admin
-        </span>
-      )}
       {coreTitles.map((title) => (
         <span
           key={title}


### PR DESCRIPTION
## What

Two changes to the members directory (`/members`) Roles column:

1. **Removed the "Admin" pill.** Admin status is no longer surfaced as a role in this directory. Also drops the now-dead `isAdmin` field from the row type, the loader mapping, and the `adminMembership` select on the query (so we no longer fetch it).
2. **Core members without a `leadTitle` now show a "Core" pill.** Previously the Roles column only rendered Core members who had a specific `leadTitle` set — title-less Core assignments were filtered out, so those members appeared role-less (in practice only "Hiring Lead" tended to show). Core members with titled assignments still render their specific title(s); a member with any untitled Core assignment additionally gets a plain "Core" pill.

## Why

Admin isn't meant to read as a directory "role," and plain Core members were invisible in the Roles column. New `deriveCoreTitles()` helper centralizes the dedupe + fallback logic.

## Behavior note

An Admin who is *not* also Core and has no domain role will now show "—" (no roles) in this directory, by design — admin is no longer a role here.

## Scope

- One file: `dali-api/app/members/routes/members.tsx`.
- This is the `/members` directory only — **not** `/admin-console/members` (separate route, unchanged).
- No permissions/auth logic touched. `roles.ts` and all access gates are untouched; this is purely what the directory *displays*.

## Testing

- `npm test` — 878 passed.
- `npm run typecheck` — no new errors in `members.tsx` (the ~29 pre-existing errors under `scripts/*.ts` on `dev` are unrelated).
- No existing unit/e2e test covers this view's RolePills, so none needed updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/625"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782066898&installation_id=133523038&pr_number=625&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F625&signature=d7dce5e60b7e8259277f40d934cc1b2d3e7004527e0dccac49beef585296cbd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->