### PR TITLE
Forms: reference question for projects active in an author-chosen term

### DIFF
--- a/dali-api/app/forms/components/FormDetail.tsx
+++ b/dali-api/app/forms/components/FormDetail.tsx
@@ -34,7 +34,7 @@ function formatDateTime(iso: string) {
 // version, and a read-only preview of the selected version otherwise. Saving
 // appends a new immutable version (handled by the route action).
 export function FormDetail() {
-  const { form, backTo } = useLoaderData<typeof loader>();
+  const { form, terms, backTo } = useLoaderData<typeof loader>();
   const submit = useSubmit();
 
   const [selectedVersionId, setSelectedVersionId] = useState<string | null>(
@@ -180,6 +180,7 @@ export function FormDetail() {
               <FormBuilderTab
                 initialQuestions={selectedVersion?.questions ?? []}
                 initialDescription={selectedVersion?.description ?? null}
+                terms={terms}
                 onSave={handleSave}
                 onCancel={
                   form.versions.length === 0

--- a/dali-api/app/forms/lib/forms-data.ts
+++ b/dali-api/app/forms/lib/forms-data.ts
@@ -11,7 +11,7 @@
 import { z } from "zod";
 import { prisma } from "~/lib/db";
 import type { Question } from "~/types";
-import { isReferenceSourceKey } from "./reference-sources.shared";
+import { isReferenceSourceKey, referenceSourceNeedsTerm } from "./reference-sources.shared";
 
 const QUESTION_TYPES: Question["type"][] = [
   "text",
@@ -364,6 +364,15 @@ export async function runFormsAction(
         if (q.type === "reference" && !isReferenceSourceKey(q.data.referenceSource))
           return {
             error: `"${q.data.label}" is a reference question but has no valid data source.`,
+            status: 400,
+          };
+        if (
+          q.type === "reference" &&
+          referenceSourceNeedsTerm(q.data.referenceSource) &&
+          !q.data.referenceTermId
+        )
+          return {
+            error: `"${q.data.label}" needs a term selected for its data source.`,
             status: 400,
           };
       }

--- a/dali-api/app/forms/lib/public-form.ts
+++ b/dali-api/app/forms/lib/public-form.ts
@@ -80,6 +80,7 @@ export async function loadPublicForm(
       if (q.type !== "reference") return q;
       const options = await resolveReferenceOptions(q.data.referenceSource, {
         userId,
+        termId: q.data.referenceTermId,
       });
       return { ...q, data: { ...q.data, referenceOptions: options } };
     }),
@@ -131,6 +132,7 @@ async function validateAnswers(
     if (answer == null || answer === "") continue; // required-ness handled above
     const options = await resolveReferenceOptions(q.data.referenceSource, {
       userId,
+      termId: q.data.referenceTermId,
     });
     if (!options.some((o) => o.value === answer)) {
       return {

--- a/dali-api/app/forms/lib/reference-sources.shared.ts
+++ b/dali-api/app/forms/lib/reference-sources.shared.ts
@@ -7,6 +7,11 @@
 export const REFERENCE_SOURCE_LABELS = {
   "projects:open-this-term": "Projects — open this term",
   "projects:active": "Projects — all active",
+  // Projects whose term set includes a specific term chosen by the form
+  // author (stored on the question as `data.referenceTermId`). Unlike
+  // `open-this-term`, the term is fixed at authoring time rather than
+  // resolved to the current term at fill time.
+  "projects:active-in-term": "Projects — active in a chosen term",
   "domains:active": "Domains — active",
   // Member-scoped: only the domains THIS member is eligible in. Resolved per
   // filling member, so it's empty on the public (unauthenticated) fill path.
@@ -19,6 +24,19 @@ export function isReferenceSourceKey(
   key: string | undefined | null,
 ): key is ReferenceSourceKey {
   return !!key && key in REFERENCE_SOURCE_LABELS;
+}
+
+// Sources whose options depend on a term the form author picks, stored on the
+// question as `data.referenceTermId`. The editor shows a term picker for these
+// and the server loader filters by that term.
+const TERM_SCOPED_SOURCES = new Set<ReferenceSourceKey>([
+  "projects:active-in-term",
+]);
+
+export function referenceSourceNeedsTerm(
+  key: string | undefined | null,
+): boolean {
+  return isReferenceSourceKey(key) && TERM_SCOPED_SOURCES.has(key);
 }
 
 // For the editor's source dropdown: [{ key, label }] in declaration order.

--- a/dali-api/app/forms/lib/reference-sources.ts
+++ b/dali-api/app/forms/lib/reference-sources.ts
@@ -27,9 +27,14 @@ export type ReferenceOption = { value: string; label: string };
 
 // Context a loader may use to scope its options. `userId` is the member
 // filling the form, when known — absent on the public/unauthenticated path.
-// Most loaders ignore it; member-scoped sources require it and degrade to []
-// without it.
-export type ReferenceContext = { userId?: string | null };
+// `termId` is per-question authoring config (the term the form author chose
+// for a term-scoped source), not member context. Most loaders ignore both;
+// member-scoped sources require userId, term-scoped sources require termId,
+// and each degrades to [] without what it needs.
+export type ReferenceContext = {
+  userId?: string | null;
+  termId?: string | null;
+};
 
 const LOADERS = {
   // Projects with at least one open role this term — mirrors the projects a
@@ -54,6 +59,22 @@ const LOADERS = {
   "projects:active": async () => {
     const projects = await prisma.project.findMany({
       where: { status: { not: "Archived" } },
+      orderBy: { name: "asc" },
+      select: { id: true, name: true },
+    });
+    return projects.map((p) => ({ value: p.id, label: p.name }));
+  },
+  // Non-archived projects whose term set includes the term the form author
+  // chose (ctx.termId, from the question's data.referenceTermId). Term-scoped:
+  // with no termId it resolves to [] rather than listing every project, so a
+  // misconfigured question yields an empty dropdown instead of wrong data.
+  "projects:active-in-term": async (ctx?: ReferenceContext) => {
+    if (!ctx?.termId) return [];
+    const projects = await prisma.project.findMany({
+      where: {
+        status: { not: "Archived" },
+        projectTerms: { some: { termId: ctx.termId } },
+      },
       orderBy: { name: "asc" },
       select: { id: true, name: true },
     });
@@ -93,6 +114,7 @@ export {
   REFERENCE_SOURCE_LABELS,
   isReferenceSourceKey,
   referenceSourceChoices,
+  referenceSourceNeedsTerm,
 } from "./reference-sources.shared";
 export type { ReferenceSourceKey } from "./reference-sources.shared";
 

--- a/dali-api/app/forms/routes/forms.edit.$formId.tsx
+++ b/dali-api/app/forms/routes/forms.edit.$formId.tsx
@@ -2,6 +2,7 @@ import { redirect } from "react-router";
 import type { Route } from "./+types/forms.edit.$formId";
 import { requireAuth } from "~/lib/auth";
 import { isHiringLead } from "~/lib/roles";
+import { prisma } from "~/lib/db";
 import { loadFormForEdit, runFormsAction } from "~/forms/lib/forms-data";
 import { FormDetail } from "~/forms/components/FormDetail";
 
@@ -17,8 +18,18 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 
   const form = await loadFormForEdit(params.formId);
   if (!form) return redirect("/forms");
+  // Terms for term-scoped reference questions (e.g. projects active in a
+  // chosen term). Newest first so the most likely choices are at the top.
+  const terms = await prisma.term.findMany({
+    orderBy: { sortKey: "desc" },
+    select: { id: true, code: true },
+  });
   // Return the user to the form's folder (or top level) on "Back".
-  return { form, backTo: form.folderId ? `/forms/${form.folderId}` : "/forms" };
+  return {
+    form,
+    terms,
+    backTo: form.folderId ? `/forms/${form.folderId}` : "/forms",
+  };
 }
 
 export async function action({ request }: Route.ActionArgs) {

--- a/dali-api/app/hiring/components/ChallengeBuilder.tsx
+++ b/dali-api/app/hiring/components/ChallengeBuilder.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import { GripVertical, Plus, Pencil, Trash2, Save } from 'lucide-react'
 import type { Question } from '~/types'
 import { RichTextEditor } from '~/components/RichTextEditor'
-import { referenceSourceChoices } from '~/forms/lib/reference-sources.shared'
+import { referenceSourceChoices, referenceSourceNeedsTerm } from '~/forms/lib/reference-sources.shared'
 
 const ACCEPT_PRESETS = [
   { label: 'PDF', value: 'application/pdf' },
@@ -47,6 +47,7 @@ export interface BuildQuestionInput {
   maxWordsEnabled?: boolean
   maxWordsValue?: number | string
   referenceSource?: string
+  referenceTermId?: string
 }
 
 export function buildQuestion(input: BuildQuestionInput): Question {
@@ -63,6 +64,7 @@ export function buildQuestion(input: BuildQuestionInput): Question {
     maxWordsEnabled,
     maxWordsValue,
     referenceSource,
+    referenceTermId,
   } = input
 
   let maxWords: number | undefined
@@ -91,6 +93,10 @@ export function buildQuestion(input: BuildQuestionInput): Question {
       maxWords,
       referenceSource:
         type === 'reference' ? referenceSource || undefined : undefined,
+      referenceTermId:
+        type === 'reference' && referenceSourceNeedsTerm(referenceSource)
+          ? referenceTermId || undefined
+          : undefined,
     },
   }
 }
@@ -101,6 +107,9 @@ interface FormBuilderTabProps {
   onSave?: (payload: { questions: Question[]; description: unknown }) => void
   onCancel?: () => void
   isGeneralForm?: boolean
+  // Terms offered for term-scoped reference sources (e.g. projects active in a
+  // chosen term). Empty/omitted when no term picker is needed.
+  terms?: { id: string; code: string }[]
 }
 export function FormBuilderTab({
   initialQuestions = [],
@@ -108,6 +117,7 @@ export function FormBuilderTab({
   onSave,
   onCancel,
   isGeneralForm = false,
+  terms = [],
 }: FormBuilderTabProps) {
   const [questions, setQuestions] = useState<Question[]>(initialQuestions)
   const [description, setDescription] = useState<unknown>(initialDescription ?? null)
@@ -196,6 +206,7 @@ export function FormBuilderTab({
       maxWordsEnabled,
       maxWordsValue,
       referenceSource: editForm.data.referenceSource,
+      referenceTermId: editForm.data.referenceTermId,
     })
     if (isAdding) {
       setQuestions([...questions, updatedQuestion])
@@ -419,6 +430,37 @@ export function FormBuilderTab({
                 Choices are pulled live when the form is filled — e.g. projects
                 open for staffing this term.
               </p>
+
+              {referenceSourceNeedsTerm(editForm.data?.referenceSource) && (
+                <div className="mt-3">
+                  <label className="block text-sm font-medium text-foreground/80 mb-1">
+                    Term
+                  </label>
+                  <select
+                    value={editForm.data?.referenceTermId || ''}
+                    onChange={(e) =>
+                      setEditForm({
+                        ...editForm,
+                        data: {
+                          ...editForm.data!,
+                          referenceTermId: e.target.value || undefined,
+                        },
+                      })
+                    }
+                    className="block w-full rounded-md border border-gray-300 bg-card text-foreground shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm p-2"
+                  >
+                    <option value="">Select a term…</option>
+                    {terms.map((t) => (
+                      <option key={t.id} value={t.id}>
+                        {t.code}
+                      </option>
+                    ))}
+                  </select>
+                  <p className="text-xs text-muted-foreground mt-1">
+                    Projects whose term set includes this term will be listed.
+                  </p>
+                </div>
+              )}
             </div>
           )}
 

--- a/dali-api/app/types.ts
+++ b/dali-api/app/types.ts
@@ -121,6 +121,11 @@ export interface Question {
     maxWords?: number
     // Set only for `type: 'reference'`. A key into REFERENCE_SOURCES.
     referenceSource?: string
+    // Set only for term-scoped reference sources (e.g.
+    // 'projects:active-in-term'): the Term the form author chose to scope the
+    // options to. Resolved at fill time by the loader; ignored by sources that
+    // aren't term-scoped.
+    referenceTermId?: string
     // Transient: populated by the server at fill time from the resolved
     // source (label shown, value = stored answer / DB id). Never persisted —
     // save-version rebuilds `data` and drops it.


### PR DESCRIPTION
## What

Adds a new `reference`-question data source — **"Projects — active in a chosen term"** (`projects:active-in-term`). The form author picks a specific **term** in the form editor, and at fill time the question's dropdown lists projects whose term set includes that term.

This builds on the multi-term project model (`ProjectTerm`, #626): "active in a term" = the project has a `ProjectTerm` row for that term.

## Why

The existing `projects:open-this-term` source resolves to the *current* term at fill time — the author can't target a specific term. This adds an author-chosen, fixed term. (Reference questions were previously parameterless by design; this introduces the first per-question parameter, `data.referenceTermId`, scoped narrowly to term-scoped sources.)

## How it works

- **`reference-sources.shared.ts`** — new key + label; `referenceSourceNeedsTerm()` flags which sources need a term.
- **`reference-sources.ts`** — loader lists non-archived projects filtered by `projectTerms: { some: { termId } }`; `ReferenceContext.termId` carries the author's choice. With no term it returns `[]` (empty dropdown) rather than listing everything.
- **`types.ts`** — `Question.data.referenceTermId` persists the choice on the (immutable) form version.
- **`ChallengeBuilder.tsx`** (the shared form builder) — a **term picker shown only when the selected source is term-scoped**; `buildQuestion`/`handleSaveEdit` persist `referenceTermId`. New optional `terms` prop on `FormBuilderTab`.
- **`forms.edit.$formId.tsx` + `FormDetail.tsx`** — load the term list and thread it to the builder.
- **`public-form.ts`** — pass `referenceTermId` into option resolution on **both** the render and submit-validation paths (server re-resolves and rejects stale answers).
- **`forms-data.ts`** — saving a term-scoped reference question **without** a term is rejected with a clear error, so a misconfigured question can't ship a silently-empty dropdown.

## Scope / safety

- No schema change, no migration (relies on `ProjectTerm` already on `dev` via #626).
- The stored answer is still a real `projectId`, so downstream structured flows (e.g. staffing) keep working.
- No collaborative-doc (`yjs`/Tiptap) schema touched.

## Testing

- `npm test` — **878 passed**.
- `npm run typecheck` — no new errors in any touched file (25 pre-existing `scripts/*.ts` errors exist identically on `dev`).
- No existing unit test covers the reference-source loaders (they do live Prisma queries with no mocking harness in the repo), so none needed updating; behavior is exercised via the fill path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/627"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782070542&installation_id=133523038&pr_number=627&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F627&signature=0dd2b63660fec9a5c9deba53f3b53dbab04a32b0142290ac4528dff780af5f37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->