### PR TITLE
Default user groups: auto-create per Term/Project/Domain + Core

### DIFF
--- a/dali-api/app/admin-console/__tests__/api.domains.create.test.ts
+++ b/dali-api/app/admin-console/__tests__/api.domains.create.test.ts
@@ -19,12 +19,22 @@ const ADMIN_ID = "admin-1";
 
 const mockPrisma = prisma as unknown as {
   domain: { create: ReturnType<typeof vi.fn> };
+  groupDefinition: { upsert: ReturnType<typeof vi.fn> };
 };
 
 beforeEach(() => {
   vi.clearAllMocks();
   (mockPrisma as any).domain = {
-    create: vi.fn(async ({ data }: any) => ({ id: "new", name: data.name })),
+    create: vi.fn(async ({ data }: any) => ({
+      id: "new",
+      name: data.name,
+      displayName: data.displayName,
+    })),
+  };
+  // ensureDomainGroup runs after a successful create — stub the upsert so
+  // the post-create hook resolves without touching a real DB.
+  (mockPrisma as any).groupDefinition = {
+    upsert: vi.fn(async () => ({})),
   };
   vi.mocked(requireAuth).mockResolvedValue({
     ok: true,

--- a/dali-api/app/admin-console/routes/admin-console.announcements.tsx
+++ b/dali-api/app/admin-console/routes/admin-console.announcements.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { redirect, useLoaderData } from "react-router";
 import type { Route } from "./+types/admin-console.announcements";
 import { prisma } from "~/lib/db";
+import { listVisibleGroupsForUser } from "~/lib/groups";
 import { requireAuth } from "~/lib/auth";
 import { isAdmin } from "~/lib/roles";
 import {
@@ -28,16 +29,13 @@ export async function loader({ request }: Route.LoaderArgs) {
   if (!auth.ok) return redirect("/login");
   if (!(await isAdmin(auth.user.sub))) return redirect("/");
 
-  const [users, groups, forms] = await Promise.all([
+  const [users, visibleGroups, forms] = await Promise.all([
     prisma.user.findMany({
       where: { daliMember: { isNot: null } },
       orderBy: [{ lastName: "asc" }, { firstName: "asc" }],
       select: { id: true, firstName: true, lastName: true, daliEmail: true },
     }),
-    prisma.groupDefinition.findMany({
-      orderBy: { name: "asc" },
-      select: { id: true, name: true },
-    }),
+    listVisibleGroupsForUser(auth.user.sub),
     prisma.form.findMany({
       where: { published: true },
       orderBy: { name: "asc" },
@@ -51,7 +49,7 @@ export async function loader({ request }: Route.LoaderArgs) {
       name: `${u.firstName} ${u.lastName}`.trim(),
       email: u.daliEmail,
     })),
-    groups,
+    groups: visibleGroups.map((g) => ({ id: g.id, name: g.name })),
     publishedForms: forms,
   };
 }

--- a/dali-api/app/admin-console/routes/admin-console.domains.tsx
+++ b/dali-api/app/admin-console/routes/admin-console.domains.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { redirect, useLoaderData, useFetcher } from "react-router";
 import type { Route } from "./+types/admin-console.domains";
 import { prisma } from "~/lib/db";
+import { ensureDomainGroup } from "~/lib/groups";
 import { requireAuth } from "~/lib/auth";
 import { isAdmin, currentTerm } from "~/lib/roles";
 import { describeDomainUsage } from "./api.domains.$domainId";
@@ -108,9 +109,10 @@ export async function action({ request }: Route.ActionArgs) {
     // stripping non-alnum (admin can rename later). displayName mirrors
     // name on create; both editable post-create.
     const code = name.replace(/[^A-Za-z0-9]/g, "") || "Domain";
-    await prisma.domain.create({
+    const domain = await prisma.domain.create({
       data: { name, code, displayName: name },
     });
+    await ensureDomainGroup(domain.id, domain.displayName);
     return null;
   }
 

--- a/dali-api/app/admin-console/routes/api.domains.ts
+++ b/dali-api/app/admin-console/routes/api.domains.ts
@@ -1,6 +1,7 @@
 import type { Route } from "./+types/api.domains";
 import { z } from "zod";
 import { prisma } from "~/lib/db";
+import { ensureDomainGroup } from "~/lib/groups";
 import { requireAuth } from "~/lib/auth";
 import { isHiringLead, isDomainLead, isAdmin } from "~/lib/roles";
 import { withCors, handlePreflight } from "~/lib/cors";
@@ -69,5 +70,6 @@ export async function action({ request }: Route.ActionArgs) {
   const domain = await prisma.domain.create({
     data: { name, code, displayName: name },
   });
+  await ensureDomainGroup(domain.id, domain.displayName);
   return withCors(request, Response.json(domain, { status: 201 }));
 }

--- a/dali-api/app/admin-console/routes/api.groups.$groupId.ts
+++ b/dali-api/app/admin-console/routes/api.groups.$groupId.ts
@@ -23,9 +23,17 @@ export async function action({ request, params }: Route.ActionArgs) {
   const groupId = params.groupId!;
 
   if (request.method === "DELETE") {
-    const existing = await prisma.groupDefinition.findUnique({ where: { id: groupId } });
+    const existing = await prisma.groupDefinition.findUnique({
+      where: { id: groupId },
+      select: { systemKey: true },
+    });
     if (!existing)
       return withCors(request, Response.json({ error: "Not found" }, { status: 404 }));
+    if (existing.systemKey)
+      return withCors(
+        request,
+        Response.json({ error: "System-managed groups cannot be deleted" }, { status: 400 }),
+      );
     await prisma.groupDefinition.delete({ where: { id: groupId } });
     return withCors(request, new Response(null, { status: 204 }));
   }
@@ -33,6 +41,26 @@ export async function action({ request, params }: Route.ActionArgs) {
   if (request.method === "PUT" || request.method === "PATCH") {
     const body = await parseJson(request, UpdateGroupSchema);
     if (body instanceof Response) return withCors(request, body);
+
+    const existing = await prisma.groupDefinition.findUnique({
+      where: { id: groupId },
+      select: { type: true, systemKey: true },
+    });
+    if (!existing)
+      return withCors(request, Response.json({ error: "Not found" }, { status: 404 }));
+    // Member edits are blocked on Dynamic groups (resolution is derived from
+    // assignments). A name change on a system group would also drift from the
+    // ensure*Group canonical label, so we block that too.
+    if (existing.systemKey)
+      return withCors(
+        request,
+        Response.json({ error: "System-managed groups cannot be edited" }, { status: 400 }),
+      );
+    if (existing.type !== "Static" && body.staticMemberIds !== undefined)
+      return withCors(
+        request,
+        Response.json({ error: "Dynamic groups update automatically from assignments" }, { status: 400 }),
+      );
 
     const updated = await prisma.groupDefinition.update({
       where: { id: groupId },

--- a/dali-api/app/admin-console/routes/api.groups.ts
+++ b/dali-api/app/admin-console/routes/api.groups.ts
@@ -1,6 +1,7 @@
 import type { Route } from "./+types/api.groups";
 import { z } from "zod";
 import { prisma } from "~/lib/db";
+import { listVisibleGroupsForUser } from "~/lib/groups";
 import { requireAuth } from "~/lib/auth";
 import { isAdmin } from "~/lib/roles";
 import { withCors, handlePreflight } from "~/lib/cors";
@@ -20,9 +21,8 @@ export async function loader({ request }: Route.LoaderArgs) {
   if (!(await isAdmin(auth.user.sub)))
     return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
 
-  const groups = await prisma.groupDefinition.findMany({
-    orderBy: { name: "asc" },
-  });
+  // Per-viewer visibility: a group surfaces only when the caller is a member.
+  const groups = await listVisibleGroupsForUser(auth.user.sub);
   return withCors(request, Response.json(groups));
 }
 

--- a/dali-api/app/calendar/routes/calendar.tsx
+++ b/dali-api/app/calendar/routes/calendar.tsx
@@ -18,6 +18,7 @@ import {
 } from "lucide-react";
 import { requireAuth } from "~/lib/auth";
 import { prisma } from "~/lib/db";
+import { listVisibleGroupsForUser } from "~/lib/groups";
 import { computeFreeIntervals, type Interval } from "~/lib/availability";
 import { CalendarActionSchema } from "~/lib/calendar-schemas";
 import { fetchBusyEvents, listCalendarsForLink } from "~/lib/google-calendar";
@@ -72,7 +73,9 @@ type CalendarLinkDTO = {
 type GroupOption = {
   id: string;
   name: string;
-  staticMemberIds: string[];
+  // Resolved members for this group at load time (either explicit static list
+  // or the resolved Dynamic membership). The picker treats both uniformly.
+  memberIds: string[];
 };
 
 type UserOption = {
@@ -160,10 +163,9 @@ export async function loader({ request }: Route.LoaderArgs) {
       where: { userId },
       orderBy: { linkedAt: "asc" },
     }),
-    prisma.groupDefinition.findMany({
-      select: { id: true, name: true, staticMemberIds: true },
-      orderBy: { name: "asc" },
-    }),
+    listVisibleGroupsForUser(userId).then((rows) =>
+      rows.map((r) => ({ id: r.id, name: r.name, memberIds: r.memberIds })),
+    ),
     prisma.user.findMany({
       select: { id: true, firstName: true, lastName: true, daliEmail: true },
       orderBy: [{ lastName: "asc" }, { firstName: "asc" }],
@@ -1488,7 +1490,7 @@ function ScheduleView({ data }: { data: LoaderData }) {
     const set = new Set<string>(selectedUserIds);
     for (const gid of selectedGroupIds) {
       const g = groupsById.get(gid);
-      if (g) for (const uid of g.staticMemberIds) set.add(uid);
+      if (g) for (const uid of g.memberIds) set.add(uid);
     }
     return Array.from(set);
   })();
@@ -1878,7 +1880,7 @@ function ParticipantPicker({
             <span
               key={`g:${gid}`}
               className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800"
-              title={`${g.staticMemberIds.length} member${g.staticMemberIds.length === 1 ? "" : "s"}`}
+              title={`${g.memberIds.length} member${g.memberIds.length === 1 ? "" : "s"}`}
             >
               <UsersRound className="w-3 h-3" />
               {g.name}
@@ -1996,7 +1998,7 @@ function ParticipantPicker({
                 >
                   <span>{g.name}</span>
                   <span className="text-xs text-muted-foreground">
-                    {g.staticMemberIds.length} member{g.staticMemberIds.length === 1 ? "" : "s"}
+                    {g.memberIds.length} member{g.memberIds.length === 1 ? "" : "s"}
                   </span>
                 </button>
               ))

--- a/dali-api/app/lib/groups.ts
+++ b/dali-api/app/lib/groups.ts
@@ -2,13 +2,98 @@ import { prisma } from "~/lib/db";
 
 // Single source of truth for resolving a GroupDefinition to its member userIds.
 // Notification fan-out and meeting participant resolution both go through this.
+// Static groups return their explicit member list; Dynamic groups dispatch on
+// dynamicQuery and resolve against the underlying entity (term/project/domain
+// assignments, or current-term Core).
 export async function resolveGroupMembers(groupId: string): Promise<string[]> {
   const group = await prisma.groupDefinition.findUnique({
     where: { id: groupId },
-    select: { staticMemberIds: true },
+    select: { type: true, dynamicQuery: true, staticMemberIds: true },
   });
   if (!group) return [];
-  return group.staticMemberIds;
+  if (group.type === "Static") return group.staticMemberIds;
+  if (!group.dynamicQuery) return [];
+  return resolveDynamicQuery(group.dynamicQuery);
+}
+
+// Resolve a dynamicQuery string to userIds. Exported for callers that already
+// have the query in hand (e.g. visibility filters that batch-resolve groups).
+export async function resolveDynamicQuery(query: string): Promise<string[]> {
+  const [kind, id] = query.split(":", 2);
+  switch (kind) {
+    case "term":
+      return id ? resolveTermMembers(id) : [];
+    case "project":
+      return id ? resolveProjectMembers(id) : [];
+    case "domain":
+      return id ? resolveDomainMembers(id) : [];
+    case "core":
+      return resolveCoreMembers();
+    default:
+      return [];
+  }
+}
+
+async function resolveTermMembers(termId: string): Promise<string[]> {
+  // A member is "active in term T" if they have any project assignment, Core
+  // assignment, instructor assignment, or mentorship pair (as mentor or
+  // mentee) in T. DomainEligibility is term-independent and not included.
+  const [projects, core, instructors, mentorshipMentee, mentorshipMentor] =
+    await Promise.all([
+      prisma.projectAssignment.findMany({ where: { termId }, select: { userId: true } }),
+      prisma.coreAssignment.findMany({ where: { termId }, select: { userId: true } }),
+      prisma.instructorAssignment.findMany({ where: { termId }, select: { userId: true } }),
+      prisma.mentorshipPair.findMany({ where: { termId }, select: { menteeUserId: true } }),
+      prisma.mentorshipPair.findMany({ where: { termId }, select: { mentorUserId: true } }),
+    ]);
+  const set = new Set<string>();
+  for (const r of projects) set.add(r.userId);
+  for (const r of core) set.add(r.userId);
+  for (const r of instructors) set.add(r.userId);
+  for (const r of mentorshipMentee) set.add(r.menteeUserId);
+  for (const r of mentorshipMentor) set.add(r.mentorUserId);
+  return [...set];
+}
+
+async function resolveProjectMembers(projectId: string): Promise<string[]> {
+  const rows = await prisma.projectAssignment.findMany({
+    where: { projectId },
+    select: { userId: true },
+    distinct: ["userId"],
+  });
+  return rows.map((r) => r.userId);
+}
+
+async function resolveDomainMembers(domainId: string): Promise<string[]> {
+  const rows = await prisma.domainEligibility.findMany({
+    where: { domainId },
+    select: { userId: true },
+  });
+  return rows.map((r) => r.userId);
+}
+
+async function resolveCoreMembers(): Promise<string[]> {
+  const termId = await getCurrentTermId();
+  if (!termId) return [];
+  const rows = await prisma.coreAssignment.findMany({
+    where: { termId },
+    select: { userId: true },
+    distinct: ["userId"],
+  });
+  return rows.map((r) => r.userId);
+}
+
+// Current term = the Term whose [startDate, endDate] window contains now.
+// If multiple windows overlap (rare seed edge case), prefer the largest
+// sortKey. Returns null if no term covers today.
+export async function getCurrentTermId(): Promise<string | null> {
+  const now = new Date();
+  const term = await prisma.term.findFirst({
+    where: { startDate: { lte: now }, endDate: { gte: now } },
+    orderBy: { sortKey: "desc" },
+    select: { id: true },
+  });
+  return term?.id ?? null;
 }
 
 // Every current lab member's userId. "Lab member" = a User with a DALIMember
@@ -24,4 +109,128 @@ export async function resolveAllLabMembers(): Promise<string[]> {
     select: { id: true },
   });
   return users.map((u) => u.id);
+}
+
+export type VisibleGroup = {
+  id: string;
+  name: string;
+  type: "Static" | "Dynamic";
+  dynamicQuery: string | null;
+  systemKey: string | null;
+  memberIds: string[];
+};
+
+// Returns the groups the given user belongs to. Static membership is read
+// directly off the row; Dynamic groups are resolved via dynamicQuery. Use this
+// at every list site so groups stay hidden from non-members.
+export async function listVisibleGroupsForUser(
+  userId: string,
+): Promise<VisibleGroup[]> {
+  const groups = await prisma.groupDefinition.findMany({
+    orderBy: { name: "asc" },
+    select: {
+      id: true,
+      name: true,
+      type: true,
+      dynamicQuery: true,
+      staticMemberIds: true,
+      systemKey: true,
+    },
+  });
+
+  const resolved = await Promise.all(
+    groups.map(async (g) => {
+      const memberIds =
+        g.type === "Static"
+          ? g.staticMemberIds
+          : g.dynamicQuery
+            ? await resolveDynamicQuery(g.dynamicQuery)
+            : [];
+      return {
+        id: g.id,
+        name: g.name,
+        type: g.type,
+        dynamicQuery: g.dynamicQuery,
+        systemKey: g.systemKey,
+        memberIds,
+      };
+    }),
+  );
+
+  return resolved.filter((g) => g.memberIds.includes(userId));
+}
+
+// Idempotent helpers used at entity-creation sites. Each ensures the matching
+// default group exists; the unique systemKey makes repeated calls safe.
+export async function ensureTermGroup(termId: string, code: string) {
+  const systemKey = `term:${termId}`;
+  await prisma.groupDefinition.upsert({
+    where: { systemKey },
+    update: { name: `Term ${code}` },
+    create: {
+      name: `Term ${code}`,
+      type: "Dynamic",
+      dynamicQuery: systemKey,
+      systemKey,
+    },
+  });
+}
+
+export async function ensureProjectGroup(projectId: string, name: string) {
+  const systemKey = `project:${projectId}`;
+  await prisma.groupDefinition.upsert({
+    where: { systemKey },
+    update: { name: `Project ${name}` },
+    create: {
+      name: `Project ${name}`,
+      type: "Dynamic",
+      dynamicQuery: systemKey,
+      systemKey,
+    },
+  });
+}
+
+export async function ensureDomainGroup(domainId: string, displayName: string) {
+  const systemKey = `domain:${domainId}`;
+  await prisma.groupDefinition.upsert({
+    where: { systemKey },
+    update: { name: `Domain ${displayName}` },
+    create: {
+      name: `Domain ${displayName}`,
+      type: "Dynamic",
+      dynamicQuery: systemKey,
+      systemKey,
+    },
+  });
+}
+
+export async function ensureCoreGroup() {
+  await prisma.groupDefinition.upsert({
+    where: { systemKey: "core" },
+    update: {},
+    create: {
+      name: "Core",
+      type: "Dynamic",
+      dynamicQuery: "core",
+      systemKey: "core",
+    },
+  });
+}
+
+// Idempotent backfill: ensures every existing Term/Project/Domain has its
+// default group, plus the Core singleton. Called after seed runs so a fresh
+// `prisma migrate reset && prisma db seed` ends with all default groups
+// present (the migration alone covers prod, where data already exists).
+export async function syncDefaultGroups() {
+  const [terms, projects, domains] = await Promise.all([
+    prisma.term.findMany({ select: { id: true, code: true } }),
+    prisma.project.findMany({ select: { id: true, name: true } }),
+    prisma.domain.findMany({ select: { id: true, displayName: true } }),
+  ]);
+  await Promise.all([
+    ensureCoreGroup(),
+    ...terms.map((t) => ensureTermGroup(t.id, t.code)),
+    ...projects.map((p) => ensureProjectGroup(p.id, p.name)),
+    ...domains.map((d) => ensureDomainGroup(d.id, d.displayName)),
+  ]);
 }

--- a/dali-api/app/members/routes/members.groups.tsx
+++ b/dali-api/app/members/routes/members.groups.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { redirect, useLoaderData, useFetcher } from "react-router";
 import type { Route } from "./+types/members.groups";
 import { prisma } from "~/lib/db";
+import { listVisibleGroupsForUser } from "~/lib/groups";
 import { requireAuth } from "~/lib/auth";
 import { canViewForms } from "~/lib/roles";
 import { Users, Plus, Trash2, X } from "lucide-react";
@@ -11,7 +12,9 @@ export const meta: Route.MetaFunction = () => [{ title: "Groups · Members · DA
 type GroupRow = {
   id: string;
   name: string;
-  staticMemberIds: string[];
+  type: "Static" | "Dynamic";
+  systemKey: string | null;
+  memberIds: string[];
 };
 
 type UserOption = {
@@ -27,7 +30,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   if (!(await canViewForms(auth.user.sub))) return redirect("/members");
 
   const [groups, users] = await Promise.all([
-    prisma.groupDefinition.findMany({ orderBy: { name: "asc" } }),
+    listVisibleGroupsForUser(auth.user.sub),
     prisma.user.findMany({
       select: { id: true, firstName: true, lastName: true, daliEmail: true },
       orderBy: [{ lastName: "asc" }, { firstName: "asc" }],
@@ -62,6 +65,13 @@ export async function action({ request }: Route.ActionArgs) {
   if (intent === "delete-group") {
     const groupId = String(formData.get("groupId") ?? "");
     if (!groupId) return Response.json({ error: "groupId is required" }, { status: 400 });
+    const group = await prisma.groupDefinition.findUnique({
+      where: { id: groupId },
+      select: { systemKey: true },
+    });
+    if (!group) return Response.json({ error: "Group not found" }, { status: 404 });
+    if (group.systemKey)
+      return Response.json({ error: "System-managed groups cannot be deleted" }, { status: 400 });
     await prisma.groupDefinition.delete({ where: { id: groupId } });
     return null;
   }
@@ -71,6 +81,8 @@ export async function action({ request }: Route.ActionArgs) {
     const userId = String(formData.get("userId") ?? "");
     const group = await prisma.groupDefinition.findUnique({ where: { id: groupId } });
     if (!group) return Response.json({ error: "Group not found" }, { status: 404 });
+    if (group.type !== "Static")
+      return Response.json({ error: "Dynamic groups update automatically from assignments" }, { status: 400 });
     const next = group.staticMemberIds.filter((id) => id !== userId);
     if (next.length === 0)
       return Response.json({ error: "Cannot remove last member; delete the group instead" }, { status: 400 });
@@ -83,6 +95,8 @@ export async function action({ request }: Route.ActionArgs) {
     const userId = String(formData.get("userId") ?? "");
     const group = await prisma.groupDefinition.findUnique({ where: { id: groupId } });
     if (!group) return Response.json({ error: "Group not found" }, { status: 404 });
+    if (group.type !== "Static")
+      return Response.json({ error: "Dynamic groups update automatically from assignments" }, { status: 400 });
     if (group.staticMemberIds.includes(userId)) return null;
     await prisma.groupDefinition.update({
       where: { id: groupId },
@@ -304,7 +318,8 @@ function GroupCard({
   const [addingMember, setAddingMember] = useState(false);
   const [query, setQuery] = useState("");
 
-  const available = users.filter((u) => !group.staticMemberIds.includes(u.id));
+  const isSystem = group.systemKey !== null;
+  const available = users.filter((u) => !group.memberIds.includes(u.id));
   const filtered = available.filter((u) => {
     if (!query) return true;
     const q = query.toLowerCase();
@@ -319,26 +334,33 @@ function GroupCard({
       <div className="flex items-center justify-between">
         <h3 className="font-medium text-foreground">
           {group.name}
+          {isSystem && (
+            <span className="ml-2 px-1.5 py-0.5 rounded text-[10px] font-medium bg-blue-50 text-blue-700 border border-blue-200 uppercase tracking-wide">
+              Auto
+            </span>
+          )}
           <span className="ml-2 text-xs font-normal text-muted-foreground">
-            {group.staticMemberIds.length} member{group.staticMemberIds.length === 1 ? "" : "s"}
+            {group.memberIds.length} member{group.memberIds.length === 1 ? "" : "s"}
           </span>
         </h3>
-        <fetcher.Form method="post" onSubmit={(e) => {
-          if (!confirm(`Delete group "${group.name}"?`)) e.preventDefault();
-        }}>
-          <input type="hidden" name="intent" value="delete-group" />
-          <input type="hidden" name="groupId" value={group.id} />
-          <button
-            type="submit"
-            aria-label="Delete group"
-            className="text-muted-foreground hover:text-red-600 p-1"
-          >
-            <Trash2 className="w-4 h-4" />
-          </button>
-        </fetcher.Form>
+        {!isSystem && (
+          <fetcher.Form method="post" onSubmit={(e) => {
+            if (!confirm(`Delete group "${group.name}"?`)) e.preventDefault();
+          }}>
+            <input type="hidden" name="intent" value="delete-group" />
+            <input type="hidden" name="groupId" value={group.id} />
+            <button
+              type="submit"
+              aria-label="Delete group"
+              className="text-muted-foreground hover:text-red-600 p-1"
+            >
+              <Trash2 className="w-4 h-4" />
+            </button>
+          </fetcher.Form>
+        )}
       </div>
       <div className="flex flex-wrap gap-1.5">
-        {group.staticMemberIds.map((uid) => {
+        {group.memberIds.map((uid) => {
           const u = usersById.get(uid);
           return (
             <span
@@ -346,22 +368,24 @@ function GroupCard({
               className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-800"
             >
               {u ? userLabel(u) : uid}
-              <fetcher.Form method="post" className="inline">
-                <input type="hidden" name="intent" value="remove-member" />
-                <input type="hidden" name="groupId" value={group.id} />
-                <input type="hidden" name="userId" value={uid} />
-                <button
-                  type="submit"
-                  aria-label="Remove from group"
-                  className="hover:text-purple-600"
-                >
-                  <X className="w-3 h-3" />
-                </button>
-              </fetcher.Form>
+              {!isSystem && (
+                <fetcher.Form method="post" className="inline">
+                  <input type="hidden" name="intent" value="remove-member" />
+                  <input type="hidden" name="groupId" value={group.id} />
+                  <input type="hidden" name="userId" value={uid} />
+                  <button
+                    type="submit"
+                    aria-label="Remove from group"
+                    className="hover:text-purple-600"
+                  >
+                    <X className="w-3 h-3" />
+                  </button>
+                </fetcher.Form>
+              )}
             </span>
           );
         })}
-        {!addingMember && available.length > 0 && (
+        {!isSystem && !addingMember && available.length > 0 && (
           <button
             type="button"
             onClick={() => setAddingMember(true)}
@@ -371,7 +395,7 @@ function GroupCard({
           </button>
         )}
       </div>
-      {addingMember && (
+      {!isSystem && addingMember && (
         <div className="border border-border rounded-md bg-background p-2 space-y-2">
           <input
             type="text"

--- a/dali-api/app/projects/routes/projects.$id.tsx
+++ b/dali-api/app/projects/routes/projects.$id.tsx
@@ -13,6 +13,7 @@ import { Check, Pencil, X } from "lucide-react";
 import { EditableSection } from "~/components/EditableSection";
 import type { Route } from "./+types/projects.$id";
 import { prisma } from "~/lib/db";
+import { ensureProjectGroup } from "~/lib/groups";
 import { requireAuth } from "~/lib/auth";
 import { parseSessionCookie } from "~/lib/cookies";
 import { isHiringLead, currentTerm } from "~/lib/roles";
@@ -423,6 +424,7 @@ export async function action({ request, params }: Route.ActionArgs) {
       where: { id: params.id },
       data: { name, status: status as ProjectStatus },
     });
+    await ensureProjectGroup(params.id, name);
     return redirect(`/projects/${params.id}`);
   }
 

--- a/dali-api/app/projects/routes/projects.list.tsx
+++ b/dali-api/app/projects/routes/projects.list.tsx
@@ -11,6 +11,7 @@ import type { Route } from "./+types/projects.list";
 import { requireAuth } from "~/lib/auth";
 import { isHiringLead } from "~/lib/roles";
 import { prisma } from "~/lib/db";
+import { ensureProjectGroup } from "~/lib/groups";
 import { ViewToggle, useViewPreference } from "~/components/ViewToggle";
 import { TermFilter } from "~/components/TermFilter";
 import { resolveTermFilter } from "~/lib/terms";
@@ -147,8 +148,9 @@ export async function action({ request }: Route.ActionArgs) {
         ? { partners: { create: { partnerOrgId } } }
         : {}),
     },
-    select: { id: true },
+    select: { id: true, name: true },
   });
+  await ensureProjectGroup(created.id, created.name);
   return redirect(`/projects/${created.id}`);
 }
 

--- a/dali-api/prisma/migrations/20260522180000_default_user_groups/migration.sql
+++ b/dali-api/prisma/migrations/20260522180000_default_user_groups/migration.sql
@@ -1,0 +1,58 @@
+-- Default, system-managed user groups: one dynamic group per Term, Project,
+-- and Domain, plus a single "Core" group. systemKey marks them so they can
+-- be located on backfill and protected from manual edits/deletes.
+
+ALTER TABLE "GroupDefinition" ADD COLUMN "systemKey" TEXT;
+CREATE UNIQUE INDEX "GroupDefinition_systemKey_key" ON "GroupDefinition"("systemKey");
+
+-- Backfill one Dynamic group per Term.
+INSERT INTO "GroupDefinition" ("id", "name", "type", "dynamicQuery", "staticMemberIds", "systemKey", "createdAt")
+SELECT
+    'grp_term_' || t."id",
+    'Term ' || t."code",
+    'Dynamic',
+    'term:' || t."id",
+    ARRAY[]::text[],
+    'term:' || t."id",
+    CURRENT_TIMESTAMP
+FROM "Term" t
+ON CONFLICT ("systemKey") DO NOTHING;
+
+-- Backfill one Dynamic group per Project.
+INSERT INTO "GroupDefinition" ("id", "name", "type", "dynamicQuery", "staticMemberIds", "systemKey", "createdAt")
+SELECT
+    'grp_project_' || p."id",
+    'Project ' || p."name",
+    'Dynamic',
+    'project:' || p."id",
+    ARRAY[]::text[],
+    'project:' || p."id",
+    CURRENT_TIMESTAMP
+FROM "Project" p
+ON CONFLICT ("systemKey") DO NOTHING;
+
+-- Backfill one Dynamic group per Domain.
+INSERT INTO "GroupDefinition" ("id", "name", "type", "dynamicQuery", "staticMemberIds", "systemKey", "createdAt")
+SELECT
+    'grp_domain_' || d."id",
+    'Domain ' || d."displayName",
+    'Dynamic',
+    'domain:' || d."id",
+    ARRAY[]::text[],
+    'domain:' || d."id",
+    CURRENT_TIMESTAMP
+FROM "Domain" d
+ON CONFLICT ("systemKey") DO NOTHING;
+
+-- Singleton Core group, resolved at query time to current-term Core members.
+INSERT INTO "GroupDefinition" ("id", "name", "type", "dynamicQuery", "staticMemberIds", "systemKey", "createdAt")
+VALUES (
+    'grp_core',
+    'Core',
+    'Dynamic',
+    'core',
+    ARRAY[]::text[],
+    'core',
+    CURRENT_TIMESTAMP
+)
+ON CONFLICT ("systemKey") DO NOTHING;

--- a/dali-api/prisma/schema.prisma
+++ b/dali-api/prisma/schema.prisma
@@ -1291,10 +1291,20 @@ model GroupDefinition {
   id              String    @id @default(cuid())
   name            String
   type            GroupType
-  // For dynamic groups: structured query identifier (e.g. "core:current-term").
+  // For dynamic groups: structured query identifier dispatched in app code.
+  // Recognized forms:
+  //   - "term:<termId>"     – members with any assignment/mentorship in that term
+  //   - "project:<projectId>" – members assigned to that project (any term)
+  //   - "domain:<domainId>" – members holding eligibility in that domain
+  //   - "core"              – Core members for the current term
   dynamicQuery    String?
   // For static groups: explicit member list.
   staticMemberIds String[]
+  // Marks a group as system-managed (auto-created and kept in sync with an
+  // underlying entity). Matches the canonical dynamicQuery form for default
+  // groups, or null for user-created groups. Used to prevent duplicate
+  // backfill and block manual edits/deletes from the UI.
+  systemKey       String?   @unique
 
   createdAt DateTime @default(now())
 }

--- a/dali-api/prisma/seed.ts
+++ b/dali-api/prisma/seed.ts
@@ -7,6 +7,7 @@ import {
 } from "../app/projects/lib/bid-validation.js";
 import { interpretIntentForm } from "../app/projects/lib/intent-form-interpreter.js";
 import { replaceIntentSet } from "../app/projects/lib/intent-validation.js";
+import { syncDefaultGroups } from "../app/lib/groups.js";
 import type { Question } from "../app/types.js";
 
 const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL! });
@@ -3694,6 +3695,10 @@ async function main() {
 
   // MCP OAuth clients are no longer seeded — clients register themselves
   // via RFC 7591 Dynamic Client Registration at /oauth/register.
+
+  // Default system-managed user groups: one per Term/Project/Domain + Core.
+  // Idempotent; safe to re-run.
+  await syncDefaultGroups();
 }
 
 main()


### PR DESCRIPTION
## Summary
- Auto-creates one **Dynamic** `GroupDefinition` per Term, Project, and Domain, plus a singleton **Core** group, identified by a unique `systemKey` and resolved at query time from the underlying assignment / eligibility tables.
- `resolveGroupMembers` now dispatches on `dynamicQuery` (`term:<id>`, `project:<id>`, `domain:<id>`, `core`), so notification fan-out, meeting scoping, and pickers all stay in sync as assignments change.
- Every group-listing site (`members/groups`, calendar picker, admin announcements composer, `GET /admin-console/groups`) now filters through `listVisibleGroupsForUser`, so a group only surfaces to people in it.
- System-managed groups (`systemKey != null`) are read-only in the UI and API — no manual add/remove/delete; they re-sync from the canonical entity instead.
- Backfill: migration seeds default groups for existing rows; `syncDefaultGroups()` runs at the end of `seed.ts` so `prisma migrate reset && prisma db seed` ends in the same state.

## Files of note
- `dali-api/prisma/schema.prisma` — `GroupDefinition.systemKey` (unique).
- `dali-api/prisma/migrations/20260522180000_default_user_groups/migration.sql` — adds column + backfills.
- `dali-api/app/lib/groups.ts` — dynamic resolvers, `listVisibleGroupsForUser`, `ensureTermGroup` / `ensureProjectGroup` / `ensureDomainGroup` / `ensureCoreGroup` / `syncDefaultGroups`.
- Project + domain create/rename sites call the ensure helpers; seed calls `syncDefaultGroups` at the end.

## Test plan
- [ ] `npm run typecheck` (passes — pre-existing `scripts/` errors only).
- [ ] `prisma migrate dev` then `prisma db seed` against a fresh local DB; verify one group per Term/Project/Domain plus a single Core group.
- [ ] As a member assigned to one project, confirm `members/groups` only lists groups they're in.
- [ ] As Admin, confirm system groups show an "Auto" badge with no add/remove/delete affordances; API returns 400 on edit/delete attempts.
- [ ] Send an announcement to a Term group; verify fan-out hits the expected member set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/632"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782078804&installation_id=133523038&pr_number=632&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F632&signature=f3d94cdf3ec18157c189aeab69f628f0d40d42e912bcc487ef2b5fc1de0f49ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->