### PR TITLE
Drop question-type constraint on staffing slot column mapping

### DIFF
--- a/dali-api/app/projects/lib/__tests__/slot-roles.test.ts
+++ b/dali-api/app/projects/lib/__tests__/slot-roles.test.ts
@@ -310,21 +310,20 @@ describe("validateMapping (project-bids)", () => {
     expect(r).toEqual({ ok: true });
   });
 
-  it("still fails when a project column points at a non-reference question", () => {
+  it("accepts a non-reference question on the project role (type constraint dropped)", () => {
+    // A plain text question mapped to `project` no longer fails validation —
+    // question-type constraints aren't enforced. The bid interpreter coerces
+    // the answer to an id at read time and skips it if it isn't a real
+    // project, so a mismatched type is a no-op rather than a save error. Here
+    // `p` is a 4th (repeatable) project column on top of the required spine.
     const r = validateMapping(
       "project-bids",
       [q("p", "text"), ...REQ_PROJ_QS],
-      withBidRequirements(
-        [
-          { source: "question", questionKey: "p", role: "project", label: "P", order: 0 },
-        ],
-        { skipProjects: true },
-      ),
+      withBidRequirements([
+        { source: "question", questionKey: "p", role: "project", label: "P", order: 0 },
+      ]),
     );
-    // Only 1 project column, and the one supplied is non-reference. The
-    // type mismatch is the per-entry failure that fires before completeness
-    // is checked.
-    expect(r).toMatchObject({ ok: false });
+    expect(r).toEqual({ ok: true });
   });
 
   it("still fails when an entry points at a since-deleted question", () => {

--- a/dali-api/app/projects/lib/slot-roles.ts
+++ b/dali-api/app/projects/lib/slot-roles.ts
@@ -13,12 +13,9 @@
 import type { Question } from "~/types";
 import type { Slot } from "./form-slots";
 
-// A reference question's source family decides whether it can fill a
-// project/domain role (the answer must be a real DB id — see
-// reference-sources.ts). Kept here as a constraint, not a detector.
-const PROJECT_SOURCES = ["projects:open-this-term", "projects:active"];
-const DOMAIN_SOURCES = ["domains:active"];
-
+// `QuestionTypeConstraint` still declares each role's intended shape (and
+// drives the `person` identity boundary), but mapping a question to a role no
+// longer enforces the question's type — see questionFitsConstraint.
 export type QuestionTypeConstraint =
   | "reference-project" // reference question, project source
   | "reference-domain" // reference question, domain source
@@ -229,37 +226,21 @@ export function parseColumnMapping(json: unknown): ColumnMapping | null {
 }
 
 function questionFitsConstraint(
-  q: Question,
+  _q: Question,
   constraint: QuestionTypeConstraint,
 ): boolean {
-  switch (constraint) {
-    case "any":
-    case "display":
-      // A display column just shows whatever the question holds — it feeds no
-      // staffing write, so any question type fits.
-      return true;
-    case "text":
-      return q.type === "text" || q.type === "textarea";
-    case "person":
-      // A person role is never satisfiable by a question — only by the
-      // `submitter` builtin (checked separately in validateMapping).
-      return false;
-    case "choice":
-      // A fixed-option question (select) or free text we later coerce.
-      return q.type === "select" || q.type === "text";
-    case "reference-project":
-      return (
-        q.type === "reference" &&
-        !!q.data.referenceSource &&
-        PROJECT_SOURCES.includes(q.data.referenceSource)
-      );
-    case "reference-domain":
-      return (
-        q.type === "reference" &&
-        !!q.data.referenceSource &&
-        DOMAIN_SOURCES.includes(q.data.referenceSource)
-      );
-  }
+  // Question-type constraints are intentionally NOT enforced: a manager may
+  // map any question to any role. The interpreters degrade gracefully when an
+  // answer doesn't match the role's expected shape — e.g. the bid interpreter
+  // coerces the `project` answer to an id and simply skips it when it isn't a
+  // real project id (bid-form-interpreter.ts), rather than erroring. So a
+  // mismatched type produces no staffing write, never a save failure.
+  //
+  // `person` is the one exception, and it isn't a question-type rule: a person
+  // role can only be filled by the `submitter` builtin (server-derived
+  // identity), never by a client-supplied question answer. Keeping it
+  // unsatisfiable-by-question preserves that identity boundary.
+  return constraint !== "person";
 }
 
 export type MappingCheck = { ok: true } | { ok: false; reason: string };


### PR DESCRIPTION
## What

The project-bids and intent-to-work column mappers rejected saving a mapping when a question's type didn't match its role's expected shape — e.g. the **Project** column on the bids page only accepted a reference-to-project question. This drops that constraint: **any question may now back any role**.

## How

- `questionFitsConstraint` no longer enforces a question type. It only preserves the `person` identity boundary — a `person` role is fillable solely by the server-derived `submitter` builtin, never by a client-supplied answer.
- Interpreters already degrade gracefully on a shape mismatch: the bid interpreter coerces the project answer to an id and **skips** it when it isn't a real project (`bid-form-interpreter.ts`), so a wrong type is a no-op, not a save failure.
- Removed the now-dead `PROJECT_SOURCES` / `DOMAIN_SOURCES` constants.
- **Unchanged:** required-count (project-bids still needs 3 ranked project columns + the `submitter`/`hiredRoles` builtins) and per-term-duplicate checks.

## Tests

- Rewrote the slot-roles test that asserted a non-reference question on the Project role fails → it now asserts it's **accepted**.
- `npm test` (slot-roles + bid-form-interpreter): 34 passing.

> Note: pre-existing typecheck errors under `dali-api/scripts/*` exist on `dev` and are unrelated to this change (it touches only `slot-roles.ts` + its test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/633"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782079125&installation_id=133523038&pr_number=633&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F633&signature=124d424d4fb721175f9dccb78fae0efbf6926a947e3a61c98a2f7ea23d017c2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->