### PR TITLE
Fix duplicate finalized decisions via Decision supersession

### DIFF
--- a/dali-api/app/hiring/lib/__tests__/api.decisions.lineage.test.ts
+++ b/dali-api/app/hiring/lib/__tests__/api.decisions.lineage.test.ts
@@ -21,7 +21,9 @@ const mockPrisma = prisma as unknown as {
   gmailIntegration: { findFirst: ReturnType<typeof vi.fn> };
   decision: {
     findUnique: ReturnType<typeof vi.fn>;
+    findFirst: ReturnType<typeof vi.fn>;
     create: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
     findMany: ReturnType<typeof vi.fn>;
   };
   domainApplication: { findUnique: ReturnType<typeof vi.fn> };
@@ -43,7 +45,13 @@ beforeEach(() => {
   vi.clearAllMocks();
   (mockPrisma as any).dALIMember = { findUnique: vi.fn() };
   (mockPrisma as any).gmailIntegration = { findFirst: vi.fn() };
-  (mockPrisma as any).decision = { findUnique: vi.fn(), create: vi.fn(), findMany: vi.fn() };
+  (mockPrisma as any).decision = {
+    findUnique: vi.fn(),
+    findFirst: vi.fn().mockResolvedValue(null),
+    create: vi.fn(),
+    update: vi.fn().mockResolvedValue({}),
+    findMany: vi.fn(),
+  };
   (mockPrisma as any).domainApplication = { findUnique: vi.fn() };
   (mockPrisma as any).cycleDecisionEmail = { findUnique: vi.fn() };
   (mockPrisma as any).user = { findUnique: vi.fn() };
@@ -61,6 +69,7 @@ describe("Decision lineage (parentDecisionId)", () => {
     mockPrisma.decision.findUnique.mockResolvedValue({
       id: DRAFT_ID,
       stage: "Draft",
+      supersededAt: null,
       type: "Accepted",
       domainApplicationId: "da-1",
       notes: "drafted",
@@ -68,6 +77,7 @@ describe("Decision lineage (parentDecisionId)", () => {
       domainApplication: { application: { applicationCycleId: "cycle-1" } },
     });
     mockPrisma.decision.create.mockResolvedValue({ id: FINAL_ID });
+    mockPrisma.decision.findFirst.mockResolvedValue(null);
 
     const req = new Request("http://localhost/api/decisions/dec-draft/finalize", { method: "POST" });
     const res = await finalizeAction({ request: req, params: { id: DRAFT_ID }, context: {} } as any);
@@ -87,12 +97,14 @@ describe("Decision lineage (parentDecisionId)", () => {
     mockPrisma.decision.findUnique.mockResolvedValue({
       id: FINAL_ID,
       stage: "Final",
+      supersededAt: null,
       type: "Rejected",
       domainApplicationId: "da-1",
       notes: null,
       waitlistRank: null,
     });
     mockPrisma.decision.create.mockResolvedValue({ id: "dec-released" });
+    mockPrisma.decision.findFirst.mockResolvedValue(null);
     mockPrisma.domainApplication.findUnique.mockResolvedValue({
       challengeVersion: { domain: { id: "dom-1", name: "Engineering", displayName: "Engineering" } },
       domain: null,
@@ -141,6 +153,83 @@ describe("Decision lineage (parentDecisionId)", () => {
       expect(call[0].data.parentDecisionId).toBeUndefined();
       expect(call[0].data.stage).toBe("Draft");
     }
+  });
+
+  it("finalize: supersedes a prior non-superseded Final for the same applicant", async () => {
+    vi.mocked(isHiringLead).mockResolvedValue(true);
+    vi.mocked(isDomainLead).mockResolvedValue(false);
+    mockPrisma.decision.findUnique.mockResolvedValue({
+      id: DRAFT_ID,
+      stage: "Draft",
+      supersededAt: null,
+      type: "InvitedToInterview",
+      domainApplicationId: "da-1",
+      notes: null,
+      waitlistRank: null,
+      domainApplication: { application: { applicationCycleId: "cycle-1" } },
+    });
+    const PRIOR_FINAL_ID = "prior-final";
+    mockPrisma.decision.findFirst.mockResolvedValue({ id: PRIOR_FINAL_ID });
+    mockPrisma.decision.create.mockResolvedValue({ id: FINAL_ID });
+
+    const req = new Request("http://localhost/api/decisions/dec-draft/finalize", { method: "POST" });
+    const res = await finalizeAction({ request: req, params: { id: DRAFT_ID }, context: {} } as any);
+    expect(res.status).toBe(201);
+
+    expect(mockPrisma.decision.findFirst).toHaveBeenCalledWith({
+      where: { domainApplicationId: "da-1", stage: "Final", supersededAt: null },
+      select: { id: true },
+    });
+    expect(mockPrisma.decision.update).toHaveBeenNthCalledWith(1, {
+      where: { id: PRIOR_FINAL_ID },
+      data: { supersededAt: expect.any(Date) },
+    });
+    expect(mockPrisma.decision.update).toHaveBeenNthCalledWith(2, {
+      where: { id: PRIOR_FINAL_ID },
+      data: { supersededById: FINAL_ID },
+    });
+  });
+
+  it("finalize: rejects a superseded Draft", async () => {
+    vi.mocked(isHiringLead).mockResolvedValue(true);
+    vi.mocked(isDomainLead).mockResolvedValue(false);
+    mockPrisma.decision.findUnique.mockResolvedValue({
+      id: DRAFT_ID,
+      stage: "Draft",
+      supersededAt: new Date(),
+      type: "Rejected",
+      domainApplicationId: "da-1",
+      notes: null,
+      waitlistRank: null,
+      domainApplication: { application: { applicationCycleId: "cycle-1" } },
+    });
+
+    const req = new Request("http://localhost/api/decisions/dec-draft/finalize", { method: "POST" });
+    const res = await finalizeAction({ request: req, params: { id: DRAFT_ID }, context: {} } as any);
+    expect(res.status).toBe(409);
+    expect(mockPrisma.decision.create).not.toHaveBeenCalled();
+  });
+
+  it("release: rejects when an active Released already exists for the applicant", async () => {
+    vi.mocked(isHiringLead).mockResolvedValue(true);
+    mockPrisma.decision.findUnique.mockResolvedValue({
+      id: FINAL_ID,
+      stage: "Final",
+      supersededAt: null,
+      type: "Rejected",
+      domainApplicationId: "da-1",
+      notes: null,
+      waitlistRank: null,
+    });
+    mockPrisma.decision.findFirst.mockResolvedValue({
+      id: "existing-released",
+      type: "InvitedToInterview",
+    });
+
+    const req = new Request("http://localhost/api/decisions/dec-final/release", { method: "POST" });
+    const res = await releaseAction({ request: req, params: { id: FINAL_ID }, context: {} } as any);
+    expect(res.status).toBe(409);
+    expect(mockPrisma.decision.create).not.toHaveBeenCalled();
   });
 
   it("decisions loader: includes parent so callers can render drafter alongside finalizer", async () => {

--- a/dali-api/app/hiring/lib/__tests__/api.decisions.release.test.ts
+++ b/dali-api/app/hiring/lib/__tests__/api.decisions.release.test.ts
@@ -17,6 +17,7 @@ const mockPrisma = prisma as unknown as {
   dALIMember: { findUnique: ReturnType<typeof vi.fn> };
   decision: {
     findUnique: ReturnType<typeof vi.fn>;
+    findFirst: ReturnType<typeof vi.fn>;
     create: ReturnType<typeof vi.fn>;
   };
   domainApplication: { findUnique: ReturnType<typeof vi.fn> };
@@ -40,6 +41,7 @@ function setupFinalDecision(type: "Rejected" | "InvitedToInterview" | "Accepted"
   mockPrisma.decision.findUnique.mockResolvedValue({
     id: DECISION_ID,
     stage: "Final",
+    supersededAt: null,
     type,
     domainApplicationId: "da-1",
     notes: null,
@@ -78,7 +80,11 @@ function setupApplicantContext(opts: { domainName?: string | null } = {}) {
 beforeEach(() => {
   vi.clearAllMocks();
   (mockPrisma as any).dALIMember = { findUnique: vi.fn() };
-  (mockPrisma as any).decision = { findUnique: vi.fn(), create: vi.fn() };
+  (mockPrisma as any).decision = {
+    findUnique: vi.fn(),
+    findFirst: vi.fn().mockResolvedValue(null),
+    create: vi.fn(),
+  };
   (mockPrisma as any).domainApplication = { findUnique: vi.fn() };
   (mockPrisma as any).cycleDecisionEmail = { findUnique: vi.fn() };
   (mockPrisma as any).user = { findUnique: vi.fn() };

--- a/dali-api/app/hiring/lib/__tests__/api.delibs.close.test.ts
+++ b/dali-api/app/hiring/lib/__tests__/api.delibs.close.test.ts
@@ -16,7 +16,7 @@ const MEMBER_ID = "member-hl";
 const SESSION_ID = "session-1";
 
 const mockTx: any = {
-  decision: { create: vi.fn() },
+  decision: { create: vi.fn(), findFirst: vi.fn(), update: vi.fn() },
   delibsSession: { update: vi.fn() },
 };
 
@@ -32,7 +32,9 @@ const mockPrisma = prisma as unknown as {
 beforeEach(() => {
   vi.clearAllMocks();
 
-  mockTx.decision.create = vi.fn().mockResolvedValue({});
+  mockTx.decision.create = vi.fn().mockResolvedValue({ id: "new-draft" });
+  mockTx.decision.findFirst = vi.fn().mockResolvedValue(null);
+  mockTx.decision.update = vi.fn().mockResolvedValue({});
   mockTx.delibsSession.update = vi.fn().mockResolvedValue({});
 
   (mockPrisma as any).dALIMember = { findUnique: vi.fn() };
@@ -114,6 +116,61 @@ describe("POST /api/hiring/delibs/:id (intent=close)", () => {
         expect(data.waitlistRank).toBeNull();
       }
     }
+  });
+
+  it("supersedes a prior non-superseded Draft when re-closing delibs with a different column", async () => {
+    // Simulates the prod bug: applicant was first put in Reject and a Draft
+    // exists; delibs reopened and they were moved to Interview; closing
+    // again should supersede the old Reject Draft instead of leaving both
+    // active.
+    mockPrisma.delibsSession.findUnique.mockResolvedValue({
+      id: SESSION_ID,
+      type: "Initial",
+      columnOrder: { Interview: ["da-1"], Reject: [] },
+    });
+
+    const PRIOR_DRAFT_ID = "prior-draft-da-1";
+    mockTx.decision.findFirst = vi
+      .fn()
+      .mockResolvedValueOnce({ id: PRIOR_DRAFT_ID });
+    mockTx.decision.create = vi.fn().mockResolvedValue({ id: "new-draft-da-1" });
+
+    const res = await action({
+      request: makeCloseRequest(),
+      params: { id: SESSION_ID },
+      context: {},
+    } as any);
+
+    expect(res.status).toBe(200);
+
+    expect(mockTx.decision.findFirst).toHaveBeenCalledWith({
+      where: {
+        domainApplicationId: "da-1",
+        stage: "Draft",
+        supersededAt: null,
+      },
+      select: { id: true },
+    });
+
+    // First update marks prior as superseded (frees the unique slot).
+    expect(mockTx.decision.update).toHaveBeenNthCalledWith(1, {
+      where: { id: PRIOR_DRAFT_ID },
+      data: { supersededAt: expect.any(Date) },
+    });
+
+    expect(mockTx.decision.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        domainApplicationId: "da-1",
+        type: "InvitedToInterview",
+        stage: "Draft",
+      }),
+    });
+
+    // Second update links supersededById to the new row.
+    expect(mockTx.decision.update).toHaveBeenNthCalledWith(2, {
+      where: { id: PRIOR_DRAFT_ID },
+      data: { supersededById: "new-draft-da-1" },
+    });
   });
 
   it("creates Draft decisions for Initial sessions with no waitlistRank", async () => {

--- a/dali-api/app/hiring/lib/__tests__/lead.cycle.final-decisions-loader.test.ts
+++ b/dali-api/app/hiring/lib/__tests__/lead.cycle.final-decisions-loader.test.ts
@@ -88,8 +88,23 @@ describe("admin.cycle.$id loader — finalDecisions filter", () => {
     expect(finalCall).toBeDefined();
     expect(finalCall![0].where).toMatchObject({
       stage: "Final",
+      supersededAt: null,
       children: { none: { stage: "Released" } },
       domainApplication: { application: { applicationCycleId: CYCLE_ID } },
+    });
+  });
+
+  it("excludes superseded Released rows when computing released decision types", async () => {
+    const req = new Request(`http://localhost/hiring-lead-admin/cycle/${CYCLE_ID}`);
+    await loader({ request: req, params: { id: CYCLE_ID }, context: {} } as any);
+
+    const releasedCall = mockPrisma.decision.findMany.mock.calls.find(
+      (c: any[]) => c[0]?.where?.stage === "Released",
+    );
+    expect(releasedCall).toBeDefined();
+    expect(releasedCall![0].where).toMatchObject({
+      stage: "Released",
+      supersededAt: null,
     });
   });
 });

--- a/dali-api/app/hiring/lib/cycles.ts
+++ b/dali-api/app/hiring/lib/cycles.ts
@@ -110,6 +110,7 @@ export async function inferUnderReviewStage(
     where: {
       stage: "Released",
       type: "InvitedToInterview",
+      supersededAt: null,
       domainApplication: { application: { applicationCycleId: cycleId } },
     },
   });
@@ -135,6 +136,7 @@ export async function inferUnderReviewStage(
     where: {
       stage: "Released",
       type: { in: ["Accepted", "Rejected", "Waitlisted"] },
+      supersededAt: null,
       domainApplication: { application: { applicationCycleId: cycleId } },
     },
   });

--- a/dali-api/app/hiring/lib/domain-application-status.ts
+++ b/dali-api/app/hiring/lib/domain-application-status.ts
@@ -25,8 +25,12 @@ export const domainApplicationStatusInclude = {
       statusUpdates: true,
     },
   },
-  // Ordered newest-first so the first Released entry we encounter is the latest.
+  // Only the active (non-superseded) decisions feed status inference.
+  // Superseded rows are kept for audit history but should never drive what
+  // the applicant sees. Ordered newest-first so the first Released entry we
+  // encounter is the latest.
   decisions: {
+    where: { supersededAt: null },
     orderBy: { createdAt: "desc" as const },
   },
   // A DomainApplication can accumulate historical Interview rows across

--- a/dali-api/app/hiring/routes/api.cycles.$cycleId.available-slots.ts
+++ b/dali-api/app/hiring/routes/api.cycles.$cycleId.available-slots.ts
@@ -19,7 +19,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
       where: {
         selected: true,
         application: { userId: auth.user.sub, applicationCycleId: params.cycleId },
-        decisions: { some: { type: "InvitedToInterview" } },
+        decisions: { some: { type: "InvitedToInterview", supersededAt: null } },
       },
       select: { id: true },
     });

--- a/dali-api/app/hiring/routes/api.cycles.$cycleId.status.ts
+++ b/dali-api/app/hiring/routes/api.cycles.$cycleId.status.ts
@@ -135,7 +135,7 @@ export async function action({ request, params }: Route.ActionArgs) {
         selected: true,
         application: { applicationCycleId: params.cycleId!, ...inReviewPipelineFilter },
         decisions: {
-          none: { stage: "Released", type: { in: ["Accepted", "Waitlisted", "Rejected"] } },
+          none: { stage: "Released", type: { in: ["Accepted", "Waitlisted", "Rejected"] }, supersededAt: null },
         },
       },
     });

--- a/dali-api/app/hiring/routes/api.decisions.$id.finalize.ts
+++ b/dali-api/app/hiring/routes/api.decisions.$id.finalize.ts
@@ -34,6 +34,9 @@ export async function action({ request, params }: Route.ActionArgs) {
   if (decision.stage !== "Draft") {
     return Response.json({ error: "Only Draft decisions can be finalized" }, { status: 409 });
   }
+  if (decision.supersededAt !== null) {
+    return Response.json({ error: "This Draft has been superseded" }, { status: 409 });
+  }
 
   const gate = await requireApiSignedOrForbidden(
     auth.user.sub,
@@ -41,16 +44,47 @@ export async function action({ request, params }: Route.ActionArgs) {
   );
   if (gate) return gate;
 
-  const finalized = await prisma.decision.create({
-    data: {
-      domainApplicationId: decision.domainApplicationId,
-      type: decision.type,
-      stage: "Final",
-      madeById: auth.user.sub,
-      notes: decision.notes,
-      waitlistRank: decision.waitlistRank,
-      parentDecisionId: decision.id,
-    },
+  // Supersede any prior non-superseded Final for this applicant before
+  // creating the new one. The partial unique index requires the slot to be
+  // free before insert. See api.delibs.$id.ts close-delibs for the same
+  // pattern.
+  const finalized = await prisma.$transaction(async (tx) => {
+    const priorFinal = await tx.decision.findFirst({
+      where: {
+        domainApplicationId: decision.domainApplicationId,
+        stage: "Final",
+        supersededAt: null,
+      },
+      select: { id: true },
+    });
+
+    if (priorFinal) {
+      await tx.decision.update({
+        where: { id: priorFinal.id },
+        data: { supersededAt: new Date() },
+      });
+    }
+
+    const created = await tx.decision.create({
+      data: {
+        domainApplicationId: decision.domainApplicationId,
+        type: decision.type,
+        stage: "Final",
+        madeById: auth.user.sub,
+        notes: decision.notes,
+        waitlistRank: decision.waitlistRank,
+        parentDecisionId: decision.id,
+      },
+    });
+
+    if (priorFinal) {
+      await tx.decision.update({
+        where: { id: priorFinal.id },
+        data: { supersededById: created.id },
+      });
+    }
+
+    return created;
   });
 
   await logAuditEvent({

--- a/dali-api/app/hiring/routes/api.decisions.$id.release.ts
+++ b/dali-api/app/hiring/routes/api.decisions.$id.release.ts
@@ -42,6 +42,32 @@ export async function action({ request, params }: Route.ActionArgs) {
           { status: 409 }
         );
   }
+  if (decision.supersededAt !== null) {
+    return Response.json(
+      { error: "This Final has been superseded — release the current Final instead." },
+      { status: 409 },
+    );
+  }
+
+  // A Released decision triggers an applicant email. Don't auto-supersede an
+  // existing Released row — that would silently revoke a notice we already
+  // sent. Reversal needs to be an explicit, audited action; block here.
+  const existingReleased = await prisma.decision.findFirst({
+    where: {
+      domainApplicationId: decision.domainApplicationId,
+      stage: "Released",
+      supersededAt: null,
+    },
+    select: { id: true, type: true },
+  });
+  if (existingReleased) {
+    return Response.json(
+      {
+        error: `This applicant already has a released ${existingReleased.type} decision. Releasing again would send a conflicting notice.`,
+      },
+      { status: 409 },
+    );
+  }
 
   const domainApp = await prisma.domainApplication.findUnique({
     where: { id: decision.domainApplicationId },

--- a/dali-api/app/hiring/routes/api.delibs.$id.ts
+++ b/dali-api/app/hiring/routes/api.delibs.$id.ts
@@ -105,7 +105,28 @@ export async function action({ request, params }: Route.ActionArgs) {
 
       await prisma.$transaction(async (tx) => {
         for (const d of decisions) {
-          await tx.decision.create({
+          // The partial unique index on (domainApplicationId, stage) WHERE
+          // supersededAt IS NULL means we must vacate the slot before
+          // inserting the new row. Reopen + reclose with a different column
+          // produces this case. Three steps: find prior → mark superseded
+          // (frees the slot) → insert new → link supersededById.
+          const prior = await tx.decision.findFirst({
+            where: {
+              domainApplicationId: d.domainApplicationId,
+              stage: "Draft",
+              supersededAt: null,
+            },
+            select: { id: true },
+          });
+
+          if (prior) {
+            await tx.decision.update({
+              where: { id: prior.id },
+              data: { supersededAt: new Date() },
+            });
+          }
+
+          const created = await tx.decision.create({
             data: {
               domainApplicationId: d.domainApplicationId,
               type: d.type as any,
@@ -114,6 +135,13 @@ export async function action({ request, params }: Route.ActionArgs) {
               waitlistRank: d.waitlistRank,
             },
           });
+
+          if (prior) {
+            await tx.decision.update({
+              where: { id: prior.id },
+              data: { supersededById: created.id },
+            });
+          }
         }
 
         await tx.delibsSession.update({

--- a/dali-api/app/hiring/routes/api.domain-applications.$id.decisions.ts
+++ b/dali-api/app/hiring/routes/api.domain-applications.$id.decisions.ts
@@ -90,15 +90,65 @@ export async function action({ request, params }: Route.ActionArgs) {
     }
   }
 
-  const decision = await prisma.decision.create({
-    data: {
-      domainApplicationId: params.id,
-      type,
-      stage,
-      madeById: auth.user.sub,
-      notes: notes ?? null,
-      waitlistRank: waitlistRank ?? null,
-    },
+  // Block manual Released creation if one already exists for this applicant —
+  // releasing twice would send a conflicting notice. For Draft/Final we
+  // supersede the prior row in the same transaction so the partial unique
+  // index doesn't reject the insert.
+  if (stage === "Released") {
+    const existingReleased = await prisma.decision.findFirst({
+      where: {
+        domainApplicationId: params.id,
+        stage: "Released",
+        supersededAt: null,
+      },
+      select: { id: true, type: true },
+    });
+    if (existingReleased) {
+      return Response.json(
+        {
+          error: `This applicant already has a released ${existingReleased.type} decision.`,
+        },
+        { status: 409 },
+      );
+    }
+  }
+
+  const decision = await prisma.$transaction(async (tx) => {
+    const prior = await tx.decision.findFirst({
+      where: {
+        domainApplicationId: params.id,
+        stage,
+        supersededAt: null,
+      },
+      select: { id: true },
+    });
+
+    if (prior) {
+      await tx.decision.update({
+        where: { id: prior.id },
+        data: { supersededAt: new Date() },
+      });
+    }
+
+    const created = await tx.decision.create({
+      data: {
+        domainApplicationId: params.id,
+        type,
+        stage,
+        madeById: auth.user.sub,
+        notes: notes ?? null,
+        waitlistRank: waitlistRank ?? null,
+      },
+    });
+
+    if (prior) {
+      await tx.decision.update({
+        where: { id: prior.id },
+        data: { supersededById: created.id },
+      });
+    }
+
+    return created;
   });
 
   return Response.json(decision, { status: 201 });

--- a/dali-api/app/hiring/routes/api.domain-applications.$id.schedule-interview.ts
+++ b/dali-api/app/hiring/routes/api.domain-applications.$id.schedule-interview.ts
@@ -45,7 +45,7 @@ export async function action({ request, params }: Route.ActionArgs) {
   }
 
   const latestDecision = await prisma.decision.findFirst({
-    where: { domainApplicationId: da.id, stage: "Released" },
+    where: { domainApplicationId: da.id, stage: "Released", supersededAt: null },
     orderBy: { createdAt: "desc" },
   });
   if (!latestDecision || latestDecision.type !== "InvitedToInterview") {

--- a/dali-api/app/hiring/routes/domain-lead.delibs.$id.tsx
+++ b/dali-api/app/hiring/routes/domain-lead.delibs.$id.tsx
@@ -52,12 +52,12 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   const qualifyingFilter = session.type === "Initial"
     ? {
         reviews: { every: { submittedAt: { not: null } }, some: {} },
-        decisions: { none: { stage: { in: ["Final" as const, "Released" as const] } } },
+        decisions: { none: { stage: { in: ["Final" as const, "Released" as const] }, supersededAt: null } },
       }
     : isInternToFull
       ? {
           reviews: { every: { submittedAt: { not: null } }, some: {} },
-          decisions: { none: { stage: { in: ["Final" as const, "Released" as const] } } },
+          decisions: { none: { stage: { in: ["Final" as const, "Released" as const] }, supersededAt: null } },
         }
       : {
           interviews: { some: { status: "Completed" as const } },

--- a/dali-api/app/hiring/routes/domain-lead.tsx
+++ b/dali-api/app/hiring/routes/domain-lead.tsx
@@ -105,7 +105,7 @@ export async function loader({ request }: Route.LoaderArgs) {
                       },
                     },
                   },
-                  decisions: { orderBy: { createdAt: "desc" } },
+                  decisions: { where: { supersededAt: null }, orderBy: { createdAt: "desc" } },
                   // Scheduled drives status inference; Completed feeds the
                   // pre-decision "Post-interview" pill in the table.
                   // Cancelled rows stay filtered out (audit-only).
@@ -260,7 +260,7 @@ export async function loader({ request }: Route.LoaderArgs) {
               ...daDomainMatch,
               application: { applicationCycleId: cycle.id, ...inReviewPipelineFilter },
               reviews: { every: { submittedAt: { not: null } }, some: {} },
-              decisions: { none: { stage: { in: ["Final", "Released"] } } },
+              decisions: { none: { stage: { in: ["Final", "Released"] }, supersededAt: null } },
             },
           })
         : 0;
@@ -276,7 +276,7 @@ export async function loader({ request }: Route.LoaderArgs) {
               ...(isInternToFull
                 ? {
                     reviews: { every: { submittedAt: { not: null } }, some: {} },
-                    decisions: { none: { stage: { in: ["Final", "Released"] } } },
+                    decisions: { none: { stage: { in: ["Final", "Released"] }, supersededAt: null } },
                   }
                 : {
                     interviews: { some: { status: "Completed" } },
@@ -302,6 +302,7 @@ export async function loader({ request }: Route.LoaderArgs) {
         ? await prisma.decision.findMany({
             where: {
               stage: "Draft",
+              supersededAt: null,
               domainApplication: {
                 ...daDomainMatch,
                 application: { applicationCycleId: cycle.id },

--- a/dali-api/app/hiring/routes/lead.cycle.$id.tsx
+++ b/dali-api/app/hiring/routes/lead.cycle.$id.tsx
@@ -245,6 +245,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     : await prisma.decision.findMany({
         where: {
           stage: "Final",
+          supersededAt: null,
           children: { none: { stage: "Released" } },
           domainApplication: {
             application: { applicationCycleId: params.id },
@@ -294,6 +295,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     : await prisma.decision.findMany({
         where: {
           stage: "Released",
+          supersededAt: null,
           domainApplication: {
             application: { applicationCycleId: params.id },
           },
@@ -547,11 +549,12 @@ export async function action({ request, params }: Route.ActionArgs) {
     if (!validTypes.includes(decisionType as (typeof validTypes)[number])) {
       return new Response(JSON.stringify({ error: "Invalid decision type" }), { status: 400, headers: { "Content-Type": "application/json" } });
     }
-    // Lock once a Released decision of this type exists for this cycle.
+    // Lock once an active Released decision of this type exists for this cycle.
     const alreadyReleased = await prisma.decision.count({
       where: {
         stage: "Released",
         type: decisionType as (typeof validTypes)[number],
+        supersededAt: null,
         domainApplication: { application: { applicationCycleId: params.id } },
       },
     });

--- a/dali-api/app/hiring/routes/reviewer.tsx
+++ b/dali-api/app/hiring/routes/reviewer.tsx
@@ -196,7 +196,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     const qualifyingFilter = isInitial
       ? {
           reviews: { every: { submittedAt: { not: null } }, some: {} },
-          decisions: { none: { stage: { in: ["Final" as const, "Released" as const] } } },
+          decisions: { none: { stage: { in: ["Final" as const, "Released" as const] }, supersededAt: null } },
         }
       : {
           interviews: { some: { status: "Completed" as const } },

--- a/dali-api/prisma/migrations/20260523000000_decision_supersession/migration.sql
+++ b/dali-api/prisma/migrations/20260523000000_decision_supersession/migration.sql
@@ -1,0 +1,54 @@
+-- Decision supersession: enforce at most one non-superseded Decision per
+-- (domainApplication, stage). Older rows in a stage are marked superseded
+-- when a newer one is written; the partial unique index makes the duplicate
+-- state unrepresentable in the DB.
+--
+-- Order matters: add columns -> backfill existing duplicates -> create the
+-- partial unique index. The backfill must run before the index, otherwise
+-- the index creation fails on existing prod data.
+
+-- ── Columns ──────────────────────────────────────────────────────────────
+ALTER TABLE "Decision" ADD COLUMN "supersededAt" TIMESTAMP(3);
+ALTER TABLE "Decision" ADD COLUMN "supersededById" TEXT;
+
+ALTER TABLE "Decision"
+  ADD CONSTRAINT "Decision_supersededById_fkey"
+  FOREIGN KEY ("supersededById") REFERENCES "Decision"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE;
+
+CREATE INDEX "Decision_supersededById_idx" ON "Decision"("supersededById");
+
+-- ── Backfill ─────────────────────────────────────────────────────────────
+-- For each (domainApplicationId, stage) group with more than one row, keep
+-- the newest by createdAt as active and mark all older rows as superseded
+-- by it. supersededAt is set to NOW() (we don't know the original
+-- supersession time; this just records that the row was retired during the
+-- migration).
+WITH ranked AS (
+  SELECT
+    id,
+    "domainApplicationId",
+    stage,
+    "createdAt",
+    ROW_NUMBER() OVER (
+      PARTITION BY "domainApplicationId", stage
+      ORDER BY "createdAt" DESC
+    ) AS rn,
+    FIRST_VALUE(id) OVER (
+      PARTITION BY "domainApplicationId", stage
+      ORDER BY "createdAt" DESC
+    ) AS newest_id
+  FROM "Decision"
+)
+UPDATE "Decision" d
+SET
+  "supersededAt"   = NOW(),
+  "supersededById" = ranked.newest_id
+FROM ranked
+WHERE d.id = ranked.id
+  AND ranked.rn > 1;
+
+-- ── Partial unique index ─────────────────────────────────────────────────
+CREATE UNIQUE INDEX "Decision_one_active_per_stage"
+  ON "Decision" ("domainApplicationId", stage)
+  WHERE "supersededAt" IS NULL;

--- a/dali-api/prisma/migrations/20260523000000_decision_supersession/migration.sql
+++ b/dali-api/prisma/migrations/20260523000000_decision_supersession/migration.sql
@@ -48,6 +48,76 @@ FROM ranked
 WHERE d.id = ranked.id
   AND ranked.rn > 1;
 
+-- ── Manual overrides for known-misordered Finals ─────────────────────────
+-- For 5 PM-domain applicants, the generic newest-wins backfill above picks
+-- the WRONG survivor. Timeline (verified against Draft history): the lead
+-- correctly finalized a Rejected Draft, then accidentally double-finalized
+-- a stale InvitedToInterview Draft 30-90 seconds later. The newer Final is
+-- the mistake; intent was Rejected (confirmed by delibs lead on
+-- 2026-05-23). We flip the survivor for these 5 applicants here.
+--
+-- Safety: each block reads the current state before writing and skips the
+-- applicant if it doesn't match expectations (e.g. the row was manually
+-- corrected in prod between when this migration was written and when it
+-- runs). Order within each block matters — we never have two
+-- non-superseded Final rows visible to the partial unique index that
+-- gets created below.
+DO $$
+DECLARE
+  da RECORD;
+  reject_id TEXT;
+  interview_id TEXT;
+  da_ids TEXT[] := ARRAY[
+    'cmoyw0q4e0014ics9uo1kjtcz',  -- Eden Gray
+    'cmoxwaccx0086ias9r9p3dxvj',  -- Isabel Winer
+    'cmoo65ayu00iiias9qlp2rxzh',  -- Siddharth Vikram
+    'cmox8jylu001wias9h10t9c85',  -- Colleen Bailey
+    'cmowidmeq000mias9s9kjjta0'   -- Kailyn Holty
+  ];
+  current_da_id TEXT;
+BEGIN
+  FOREACH current_da_id IN ARRAY da_ids LOOP
+    -- Expected state after the generic backfill:
+    --   Reject row     -> supersededAt IS NOT NULL (was older)
+    --   Interview row  -> supersededAt IS NULL     (was newer, active)
+    SELECT id INTO reject_id
+    FROM "Decision"
+    WHERE "domainApplicationId" = current_da_id
+      AND stage = 'Final'
+      AND type = 'Rejected'
+      AND "supersededAt" IS NOT NULL;
+
+    SELECT id INTO interview_id
+    FROM "Decision"
+    WHERE "domainApplicationId" = current_da_id
+      AND stage = 'Final'
+      AND type = 'InvitedToInterview'
+      AND "supersededAt" IS NULL;
+
+    IF reject_id IS NULL OR interview_id IS NULL THEN
+      RAISE NOTICE 'Skipping override for % — state did not match expected post-backfill shape', current_da_id;
+      CONTINUE;
+    END IF;
+
+    -- Step 1: supersede the (currently active) Interview row, pointing it
+    -- at the Reject row as its supersedor. After this, BOTH rows for this
+    -- applicant have supersededAt IS NOT NULL — the partial unique index
+    -- (created below) sees no active row yet, so no conflict.
+    UPDATE "Decision"
+    SET "supersededAt"   = NOW(),
+        "supersededById" = reject_id
+    WHERE id = interview_id;
+
+    -- Step 2: un-supersede the Reject row, making it the sole active Final
+    -- for this applicant. Clear its supersededById (it previously pointed
+    -- at the Interview row from the generic backfill).
+    UPDATE "Decision"
+    SET "supersededAt"   = NULL,
+        "supersededById" = NULL
+    WHERE id = reject_id;
+  END LOOP;
+END $$;
+
 -- ── Partial unique index ─────────────────────────────────────────────────
 CREATE UNIQUE INDEX "Decision_one_active_per_stage"
   ON "Decision" ("domainApplicationId", stage)

--- a/dali-api/prisma/schema.prisma
+++ b/dali-api/prisma/schema.prisma
@@ -668,11 +668,13 @@ enum DecisionStage {
   Released // visible to applicant; triggers notification hook (hiring lead releases)
 }
 
-// Append-only, immutable decision records. Never updated — only created.
-// Current decision = latest record by createdAt.
-// To change a Draft: create a new record (supersedes old by timestamp).
-// To finalize: create new record with stage=Final.
-// To release: create new record with stage=Released.
+// Decision records form an append-only history. New rows are never deleted;
+// when a decision is replaced (e.g. delibs reopened and reclosed with a
+// different column, or a Draft re-finalized) the older row is marked
+// superseded and the new row becomes the active one. At most one
+// non-superseded row may exist per (domainApplication, stage) — enforced by
+// a partial unique index (see migration). Reads that need the "current"
+// decision should filter `supersededAt: null`.
 model Decision {
   id        String   @id @default(cuid())
   createdAt DateTime @default(now())
@@ -695,8 +697,17 @@ model Decision {
   parent           Decision?  @relation("DecisionLineage", fields: [parentDecisionId], references: [id])
   children         Decision[] @relation("DecisionLineage")
 
+  // Within-stage replacement. When a new Draft/Final/Released is created for
+  // a domainApplication that already has one at that stage, the older row's
+  // supersededAt/supersededById are set in the same transaction.
+  supersededAt   DateTime?
+  supersededById String?
+  supersededBy   Decision?  @relation("DecisionSupersession", fields: [supersededById], references: [id])
+  supersedes     Decision[] @relation("DecisionSupersession")
+
   @@index([domainApplicationId, createdAt])
   @@index([parentDecisionId])
+  @@index([supersededById])
 }
 
 // ─── Application Reviews ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

In prod we found applicants with multiple Final decisions of conflicting types (e.g. one `Rejected` + one `InvitedToInterview`). Root cause: nothing in the schema or write-paths prevented duplicate `Decision` rows for the same applicant at the same stage. Reopening delibs after a close, recoloring the applicant, and reclosing produced a second Draft alongside the first — both could then be finalized independently. Independently, rapid double-clicks on finalize/release produced same-type duplicates (in one case, three identical Released rows that sent three identical emails to the applicant).

This PR makes the bad state unrepresentable in the DB and self-heals existing duplicates via the migration backfill.

## What changes

**Schema**
- Add `Decision.supersededAt` + `supersededById` (self-FK for audit).
- Migration backfills existing duplicate `(domainApplicationId, stage)` groups: newest by `createdAt` wins; older rows are marked superseded by it.
- **Manual override block** for 5 PM-domain applicants where newest-wins picks the wrong survivor (see below).
- Partial unique index `(domainApplicationId, stage) WHERE supersededAt IS NULL`. Hand-written SQL since Prisma's DSL can't express partial uniqueness.

**Write handlers** — `api.delibs.$id.ts`, `api.decisions.$id.finalize.ts`, `api.decisions.$id.release.ts`, `api.domain-applications.$id.decisions.ts`
- Before inserting at a stage: find prior non-superseded row → mark it superseded (frees unique slot) → insert new → back-link `supersededById`. All in one tx.
- Finalize rejects superseded Drafts.
- Release rejects superseded Finals **and** blocks if an active Released already exists for the applicant. This last guard is what prevents the rapid-clicks case from sending multiple emails.

**Read paths** — added `supersededAt: null` everywhere status/gating depends on "current" decisions: `domain-application-status.ts`, `cycles.ts` counts, `domain-lead.tsx`, `domain-lead.delibs.$id.tsx`, `reviewer.tsx`, `lead.cycle.$id.tsx`, `api.cycles.$cycleId.status.ts`, `api.cycles.$cycleId.available-slots.ts`, `api.domain-applications.$id.schedule-interview.ts`. Decision history loader (`api.domain-applications.$id.decisions.ts`) intentionally returns all rows so the audit trail stays visible.

**Tests** — 4 new Vitest cases on top of existing coverage: close-delibs supersedes prior Draft, finalize supersedes prior Final, finalize rejects superseded Draft, release blocks when active Released exists.

## Prod scope the migration backfill will touch (verified by dry-run query)

| Stage | Groups | Rows superseded | Notes |
|---|---|---|---|
| Draft | 21 applicants | ~60 rows | 5 with Reject→Interview mixed pattern, rest same-type repeats |
| Final | 6 applicants | 7 rows | Generic backfill keeps newest. Manual override below corrects 5 PM cases. |
| Released | 1 applicant | 2 rows | One applicant has 3× identical `InvitedToInterview` Released rows from rapid double-click. All same type — backfill is harmless. Applicant received 3 identical emails; coordinate with hiring lead about an out-of-band acknowledgement. The release-already-exists guard in this PR prevents recurrence. |

### Manual Final-stage overrides (5 PM applicants)

For these 5, the lead correctly finalized a `Rejected` Draft, then accidentally double-finalized a stale `InvitedToInterview` Draft 30-90 seconds later. Newest-Final-wins would resurrect the mistake. The migration explicitly flips the survivor to `Rejected` for each (intent confirmed by delibs lead 2026-05-23):

| domainApplicationId | Applicant | Survivor |
|---|---|---|
| cmoyw0q4e0014ics9uo1kjtcz | Eden Gray | Rejected |
| cmoxwaccx0086ias9r9p3dxvj | Isabel Winer | Rejected |
| cmoo65ayu00iiias9qlp2rxzh | Siddharth Vikram | Rejected |
| cmox8jylu001wias9h10t9c85 | Colleen Bailey | Rejected |
| cmowidmeq000mias9s9kjjta0 | Kailyn Holty | Rejected |

Override block is guarded — it reads each applicant's current state and skips the override if prod was manually corrected between PR-write-time and deploy-time. After overrides + backfill, PM ends up with 7 active `InvitedToInterview` Finals, matching the delibs lead's intended outcome.

## Things reviewers should look at

- The hand-written migration `prisma/migrations/20260523000000_decision_supersession/migration.sql`. Order: add cols → generic newest-wins backfill → manual 5-row override → create partial unique index. The unique index would fail on existing prod data without the backfill running first.
- The migration backfill **modifies existing rows** (sets `supersededAt` + `supersededById` on older duplicates). It does **not** delete anything — superseded rows remain in the DB for audit.
- `migration-check.yml` may flag drift because the partial unique index isn't representable in `schema.prisma`. The schema model comment documents the invariant; the SQL is the source of truth for that index.
- `api.decisions.$id.release.ts` now hard-blocks re-release when an active Released exists. If we ever want a "revoke + re-release" flow, that needs to be a separate audited action — by design, this PR doesn't auto-supersede at the Released stage.

## Test plan

- [x] `npm test` (Vitest) — 889 tests pass, including the 4 new supersession tests
- [x] `npm run typecheck` — clean for files in this PR (pre-existing `scripts/` and `@dnd-kit/core` errors are unrelated)
- [x] Verified migration scope with dry-run query against prod
- [x] Confirmed with delibs lead that the 5 PM Final overrides should resolve to Rejected (not Interview)
- [ ] Deploy to dev (Neon dev branch gets restored from prod, so the migration runs against a prod copy)
- [ ] Confirm post-migration `SELECT (domainApplicationId, stage), COUNT(*) ... WHERE supersededAt IS NULL HAVING COUNT(*) > 1` returns zero rows
- [ ] Confirm PM domain now shows exactly 7 active `InvitedToInterview` Finals
- [ ] Confirm the 5 PM override applicants now show `Rejected` (not `InvitedToInterview`) in the UI
- [ ] Spot-check delibs reopen→recolumn→reclose flow in dev: prior Draft is superseded, only the newest is active
- [ ] Coordinate with hiring lead on the triple-email applicant before deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)