### PR TITLE
Add Google site verification meta tag

### DIFF
--- a/dali-api/app/root.tsx
+++ b/dali-api/app/root.tsx
@@ -46,6 +46,10 @@ export function Layout({ children }: { children: React.ReactNode }) {
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta
+          name="google-site-verification"
+          content="s4kefSeLQR8Y2pXHEif-nQKDZXN5ZZ8GcD2r8X1ixC4"
+        />
         <meta name="collab-url" content={collabUrl} suppressHydrationWarning />
         <Meta />
         <Links />


### PR DESCRIPTION
## Summary
- Adds `<meta name=\"google-site-verification\" ...>` to the root `Layout` so it ships in `<head>` on every route, including the unauthenticated login page that Google's crawler hits at `/`.

## Test plan
- [ ] After deploy, view-source the production root URL and confirm the meta tag is present in `<head>` before `<body>`.
- [ ] Re-run verification in Google Search Console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/640"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782153648&installation_id=133523038&pr_number=640&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F640&signature=0a28f9b45626a01d9d535781a46a2f702f21a2dadfee74bd10afd4cc2e6c53e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->