### PR TITLE
TabWorkspace: keep tab iframes mounted so switching no longer reloads

### DIFF
--- a/dali-api/app/components/TabWorkspace.tsx
+++ b/dali-api/app/components/TabWorkspace.tsx
@@ -135,6 +135,11 @@ export function TabWorkspace({ initialTabs, apiRef, onActiveUrlChange }: TabWork
   const hydrated = useRef(false)
   const dragSourceRef = useRef<DragSource | null>(null)
   const [dragOver, setDragOver] = useState<DragOver | null>(null)
+  // Tabs whose iframes are kept alive in the DOM. Switching tabs toggles
+  // visibility instead of unmounting, so scroll/form/JS state is preserved.
+  // Lazy-mount on first activation — avoids slamming the server on hydrate
+  // when many tabs were persisted across sessions.
+  const [mountedTabIds, setMountedTabIds] = useState<Set<string>>(() => new Set())
 
   // Hydrate from localStorage on first client render.
   useEffect(() => {
@@ -216,6 +221,22 @@ export function TabWorkspace({ initialTabs, apiRef, onActiveUrlChange }: TabWork
     } catch {
       // ignore quota / disabled storage
     }
+  }, [state])
+
+  // Whenever a tab becomes the active tab in any pane, ensure its iframe is
+  // mounted. Tabs only mount when actually viewed; persisted-but-unvisited
+  // tabs stay dormant until clicked.
+  useEffect(() => {
+    setMountedTabIds((prev) => {
+      let next: Set<string> | null = null
+      for (const pane of state.panes) {
+        if (pane.activeTabId && !prev.has(pane.activeTabId)) {
+          if (!next) next = new Set(prev)
+          next.add(pane.activeTabId)
+        }
+      }
+      return next ?? prev
+    })
   }, [state])
 
   // Imperative API for the sidebar to open new tabs.
@@ -747,18 +768,26 @@ export function TabWorkspace({ initialTabs, apiRef, onActiveUrlChange }: TabWork
               )}
             </div>
 
-            {/* iframe content */}
-            <div className="flex-1 min-h-0 bg-section-bg">
-              {activeTab ? (
-                <iframe
-                  key={activeTab.id}
-                  src={addEmbedParam(activeTab.url)}
-                  title={activeTab.label}
-                  className="w-full h-full border-0"
-                  onLoad={onIframeLoad}
-                />
-              ) : (
-                <div className="w-full h-full flex items-center justify-center text-muted-foreground/60 text-sm">
+            {/* One iframe per opened tab; non-active tabs hidden via
+                display:none so switching preserves scroll/form/JS state
+                instead of reloading. */}
+            <div className="flex-1 min-h-0 bg-section-bg relative">
+              {pane.tabs.map((tab) => {
+                if (!mountedTabIds.has(tab.id)) return null
+                const isActive = tab.id === pane.activeTabId
+                return (
+                  <iframe
+                    key={tab.id}
+                    src={addEmbedParam(tab.url)}
+                    title={tab.label}
+                    className="absolute inset-0 w-full h-full border-0"
+                    style={{ display: isActive ? 'block' : 'none' }}
+                    onLoad={onIframeLoad}
+                  />
+                )
+              })}
+              {!activeTab && (
+                <div className="absolute inset-0 flex items-center justify-center text-muted-foreground/60 text-sm">
                   No content
                 </div>
               )}


### PR DESCRIPTION
## Summary

- Each opened tab now keeps a live iframe in the DOM; switching tabs toggles `display: none` instead of unmounting, so scroll position, form state, and in-page JS state are preserved across switches.
- Iframes are lazy-mounted on first activation. Restoring a session with many persisted tabs no longer slams the server on hydrate — only the focused tab loads, the rest load on first click.
- First step toward "Notion-style" tabs. Cross-pane drag still reloads (iframe DOM node gets re-parented); the next push will hoist iframes into a portal host so even that survives.

## Implementation

In `app/components/TabWorkspace.tsx`:

- New `mountedTabIds: Set<string>` tracks which tabs have ever been activated.
- A new effect adds the active tab of each pane to the set whenever state changes — purely additive, so React skips re-renders when there's nothing to add.
- The iframe slot now renders one `<iframe>` per mounted tab in `pane.tabs`, absolutely-positioned and `display: none` when not active.

Closed tabs and dropped panes leave stale IDs in `mountedTabIds`; the render filter (`pane.tabs.map`) ignores them, so this is harmless and bounded by session activity.

## Test plan

- [x] `npm run typecheck` — clean across `app/` (remaining errors are pre-existing in one-off `scripts/`)
- [x] `npm test` — 889/889 passing
- [ ] Manual: switch between two tabs in the workspace, confirm scroll position and any in-page form state survive
- [ ] Manual: open a tab, switch away, switch back — should be instant, no spinner
- [ ] Manual: restore a session with 5+ persisted tabs — only the focused tab should load on hydrate; clicking a previously-unloaded tab loads it once
- [ ] Manual: split pane, close pane, close tab — no orphan iframes left visible
- [ ] Manual: drag a tab across panes — expected to reload (documented limitation, addressed in push 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/641"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782155120&installation_id=133523038&pr_number=641&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F641&signature=f2b92f084f8127764718cf2674037c595bd752bc700bcdfd7e215054e9bc1855"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->