### PR TITLE
Soften the coral accent

### DIFF
--- a/dali-api/app/app.css
+++ b/dali-api/app/app.css
@@ -4,7 +4,7 @@
 
 @theme {
   /* ── DALI brand colors (exact hex, per official style guide §3.1) ── */
-  --color-accent-coral:       #FF8B81;  /* "Sunrise" — primary CTA */
+  --color-accent-coral:       #FF9580;  /* "Sunrise" — primary CTA (softened from #FF8B81, keeps white-text contrast) */
   --color-accent-coral-light: #FFA991;  /* hover / soft coral */
   --color-accent-teal:        #00ADAB;  /* primary accent */
   --color-accent-teal-light:  #80D5CD;  /* soft / hover teal */
@@ -126,7 +126,7 @@
     --color-input: hsl(215 28% 18%);
     --color-ring: #00ADAB;
     /* Brand primaries stay vivid in dark mode (guide §3.5) */
-    --color-accent-coral:        #FF8B81;
+    --color-accent-coral:        #FF9580;  /* softened from #FF8B81, keeps white-text contrast */
     --color-accent-coral-light:  #FFA991;
     --color-accent-teal:         #00ADAB;
     --color-accent-teal-light:   #80D5CD;


### PR DESCRIPTION
## What

Softens the DALI coral accent from **#FF8B81** to **#FF9580** by changing the single `--color-accent-coral` token definition in `app.css` (both the light `@theme` block and the dark-mode override).

Because every `accent-coral` utility class (`bg-`, `text-`, `border-`, `ring-`, gradients, etc.) resolves through this token, this one change softens the color everywhere it's used — primary CTA buttons, the calendar "Busy" indicators, active tab pills — without editing any of the ~326 call sites across 48 files.

## Why

The previous coral read as too harsh/neon, especially in dark mode. The softer tone is warmer and easier on the eye.

## Readability note

White text sits on `bg-accent-coral` in ~44 files (including the shared `ui/Button.tsx` primary variant). #FF9580 was chosen to keep roughly the same white-text contrast as the original (~2.1:1 vs the original 2.27:1) so those buttons stay legible — rather than the even-lighter #FFA991 (1.85:1) that prompted this. Note: white-on-coral was already below WCAG AA before this change; this PR preserves the status quo on contrast rather than regressing it.

The `--color-accent-coral-light` hover token (#FFA991) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/642"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782155481&installation_id=133523038&pr_number=642&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F642&signature=fef9526088f5bd044f18aaa51e3ce4ed7591ebd5e5570c7b2828a104f7bcfdcf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->