### PR TITLE
Fix 404 + un-clearable interview-assignment notification

### DIFF
--- a/dali-api/app/components/Layout.tsx
+++ b/dali-api/app/components/Layout.tsx
@@ -598,7 +598,16 @@ export function Layout({ user, isHiringLead = false, isAdmin = false, isDomainLe
                           key={t.id}
                           type="button"
                           title={t.title}
-                          onClick={() => openInWorkspace({ url: t.link!, label: t.title })}
+                          onClick={() => {
+                            // Tasks are notification rows — POST /read clears
+                            // the tile + drops the count once the user acts.
+                            fetch(`/api/notifications/${t.id}/read`, {
+                              method: 'POST',
+                              credentials: 'include',
+                              keepalive: true,
+                            })
+                            openInWorkspace({ url: t.link!, label: t.title })
+                          }}
                           className={`${cls} text-white/55 hover:text-white hover:bg-white/5`}
                         >
                           <span className="truncate">{t.title}</span>

--- a/dali-api/app/hiring/lib/interview-notifications.ts
+++ b/dali-api/app/hiring/lib/interview-notifications.ts
@@ -85,7 +85,7 @@ export async function notifyInterviewAssigned(args: {
         kind: "General" as const,
         title,
         body,
-        link: `/interviewer/interview/${a.interview.id}`,
+        link: `/hiring/interviewer/interview/${a.interview.id}`,
         dueAt: a.interview.startTime,
         interviewAssignmentId: a.id,
       };

--- a/dali-api/app/routes/home.tsx
+++ b/dali-api/app/routes/home.tsx
@@ -165,6 +165,27 @@ function AttentionBanner({
               <a
                 key={t.id}
                 href={t.link}
+                onClick={(e) => {
+                  // Tasks are themselves notification rows, so POST /read
+                  // clears the tile + the count once the user acts on it.
+                  // keepalive lets the request survive the navigation.
+                  fetch(`/api/notifications/${t.id}/read`, {
+                    method: "POST",
+                    credentials: "include",
+                    keepalive: true,
+                  });
+                  // Inside a TabWorkspace iframe: hand the URL to the parent
+                  // shell so the user lands in a real tab instead of being
+                  // stranded in the chrome-less embed.
+                  const link = t.link!;
+                  if (link.startsWith("/") && window.self !== window.top) {
+                    e.preventDefault();
+                    window.parent.postMessage(
+                      { type: "dali:openTab", url: link, label: t.title },
+                      window.location.origin,
+                    );
+                  }
+                }}
                 className={`${cls} hover:border-accent-coral/50 transition-colors`}
               >
                 {inner}

--- a/dali-api/prisma/migrations/20260523200000_repair_interview_notification_links/migration.sql
+++ b/dali-api/prisma/migrations/20260523200000_repair_interview_notification_links/migration.sql
@@ -1,0 +1,16 @@
+-- Repair interview-assignment notification links written with the wrong
+-- path. The helper in #639 and the backfill SELECT in #643 both wrote
+-- `link = /interviewer/interview/<id>`, but the registered route is
+-- `/hiring/interviewer/interview/<id>`. Without the `/hiring/` prefix
+-- the recipient hits a 404 when they open the tile from the bell or
+-- the home tasks banner.
+--
+-- Scoped to interview-assignment notifications via `interviewAssignmentId
+-- IS NOT NULL` so unrelated `/interviewer/...` links (none exist today,
+-- but the guard keeps it future-proof) are left alone. Idempotent: rows
+-- already on the correct path are filtered out by the LIKE pattern.
+
+UPDATE "Notification"
+SET "link" = '/hiring' || "link"
+WHERE "interviewAssignmentId" IS NOT NULL
+  AND "link" LIKE '/interviewer/interview/%';


### PR DESCRIPTION
## Summary
Follow-up to #639 / #643. Two bugs surfaced once interviewers actually saw the notifications:

1. **404 on click.** The helper in #639 and the backfill SELECT in #643 both wrote `link = /interviewer/interview/<id>`, but the registered route is `/hiring/interviewer/interview/<id>`. Anyone clicking a notification tile got a 404. Helper now writes the correct path, and a new repair migration prepends `/hiring` to every interview-assignment notification already on the bad path (the backfill's affected rows + any rows the live helper wrote since #639 deployed).
2. **Task tile never cleared.** The home banner task tile and the sidebar task tile both navigated without POSTing `/api/notifications/<id>/read`, so the tile stayed unread + the count never dropped even after the user opened the linked page. The `NotificationCard` further down the banner already had this wired; both task tiles now mirror the same `keepalive` POST.

## Why a new migration
#643's `20260523190000_backfill_...` migration is already applied on dev — per CLAUDE.md ("Never hand-edit an applied migration file") the link repair ships as a separate, additive migration: `20260523200000_repair_interview_notification_links`. Idempotent: scoped to `interviewAssignmentId IS NOT NULL` AND `link LIKE '/interviewer/interview/%'`, so re-running matches zero rows once it's applied.

## Test plan
- [ ] After deploy, every existing assignment-notification tile (home banner + sidebar) links to a page that loads, not a 404.
- [ ] Clicking a task tile in either place clears the tile and decrements the count on the next poll.
- [ ] A fresh interview assignment fires a notification with the correct `/hiring/...` link.
- [ ] `mark all read` still clears interview tasks (unchanged path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/647"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782157950&installation_id=133523038&pr_number=647&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F647&signature=ca543bc8769b385fa9d10c4d6d9d2172fbcec73df71a253db8347617e7d4fce2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->