### PR TITLE
Applications detail: show rubric criterion labels in Scores

### DIFF
--- a/dali-api/app/hiring/routes/applications.$domainApplicationId.tsx
+++ b/dali-api/app/hiring/routes/applications.$domainApplicationId.tsx
@@ -7,7 +7,7 @@ import { getUserRoles } from "~/lib/roles";
 import { requirePageSignedOrRedirect } from "~/hiring/lib/confidentiality";
 import { presignAnswers } from "~/hiring/lib/presign";
 import { ApplicationViewer } from "~/hiring/components/ApplicationViewer";
-import type { Question } from "~/types";
+import type { Question, RubricCriterion } from "~/types";
 
 export const meta: Route.MetaFunction = ({ data }) => {
   const name = (data as { applicantName?: string } | undefined)?.applicantName;
@@ -50,7 +50,14 @@ export async function loader({ request, params }: Route.LoaderArgs) {
           applicationCycleId: true,
           generalChallengeVersion: { select: { questions: true, description: true } },
           internToFullFormVersion: { select: { questions: true } },
-          applicationCycle: { select: { name: true, cycleType: true } },
+          applicationCycle: {
+            select: {
+              name: true,
+              cycleType: true,
+              generalRubricVersion: { select: { criteria: true } },
+              domains: { select: { domainId: true, rubricVersion: { select: { criteria: true } } } },
+            },
+          },
           user: { select: { firstName: true, lastName: true } },
         },
       },
@@ -101,6 +108,20 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   for (const q of generalQuestions) questionLabels[q.key] = q.data.label;
   for (const q of (da.challengeVersion?.questions as unknown as Question[]) ?? []) {
     questionLabels[q.key] = q.data.label;
+  }
+
+  // Criterion labels for the Scores list: the cycle's general rubric plus this
+  // domain's rubric. Scores are keyed by criterion key (e.g. "crit-1778..."),
+  // so without this map the page renders the raw keys.
+  const cycle = da.application.applicationCycle;
+  const criterionLabels: Record<string, string> = {};
+  const generalCriteria =
+    (cycle.generalRubricVersion?.criteria as unknown as RubricCriterion[]) ?? [];
+  const domainCriteria =
+    (cycle.domains.find((d) => d.domainId === effectiveDomainId)?.rubricVersion
+      ?.criteria as unknown as RubricCriterion[]) ?? [];
+  for (const c of [...generalCriteria, ...domainCriteria]) {
+    criterionLabels[c.key] = c.label;
   }
 
   // Submitted reviews for THIS domain application, with reviewer identity.
@@ -175,6 +196,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     domainName,
     application,
     questionLabels,
+    criterionLabels,
     reviews,
     selectedReviewId,
   };
@@ -264,7 +286,12 @@ export default function ApplicationReadOnlyDetail() {
                   </select>
                 </div>
 
-                {selected && <ReviewView review={selected} />}
+                {selected && (
+                  <ReviewView
+                    review={selected}
+                    criterionLabels={data.criterionLabels}
+                  />
+                )}
               </div>
             )}
           </div>
@@ -276,6 +303,7 @@ export default function ApplicationReadOnlyDetail() {
 
 function ReviewView({
   review,
+  criterionLabels,
 }: {
   review: {
     reviewerName: string;
@@ -285,6 +313,7 @@ function ReviewView({
     overallRecommendation: string | null;
     submittedAt: string | null;
   };
+  criterionLabels: Record<string, string>;
 }) {
   const scoreEntries = Object.entries(review.scores ?? {});
   return (
@@ -318,7 +347,9 @@ function ReviewView({
                 key={key}
                 className="flex items-center justify-between text-sm border-b border-border/60 py-1"
               >
-                <span className="text-muted-foreground">{key}</span>
+                <span className="text-muted-foreground">
+                  {criterionLabels[key] ?? key}
+                </span>
                 <span className="font-medium text-foreground">{value}</span>
               </li>
             ))}


### PR DESCRIPTION
## Problem

On the read-only application detail page (`/hiring/applications/:domainApplicationId`), the **Scores** list rendered each review's scores keyed by the raw criterion key, e.g.:

```
crit-1778536310454    2
crit-1778536314390    1
```

The loader fetched the review `scores` (`Record<criterionKey, number>`) but never fetched the rubric criteria that hold the human-readable labels, so the component fell back to printing the keys. The reviewer-facing page already resolves these labels; this read-only view just never wired it up.

## Fix

In `applications.$domainApplicationId.tsx`:
- Extend the loader's cycle query to pull `generalRubricVersion.criteria` and the domains' `rubricVersion.criteria`.
- Build a `criterionLabels` (`key → label`) map from the cycle's general rubric plus *this domain application's* domain rubric.
- Render `criterionLabels[key] ?? key` in the Scores list — falling back to the raw key only if a criterion was deleted/renamed.

Result:

```
Communication       2
Technical Skills     4
Design Sense         1
```

## Notes

- Display-only change. No schema, migration, or stored-data changes.
- Matches the reviewer page's behavior: general rubric + the single domain's rubric for this domain application.
- Typecheck passes for the edited file. (Pre-existing `tsc` errors live only in unrelated `scripts/*.ts`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/648"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782157965&installation_id=133523038&pr_number=648&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F648&signature=22239ccae5b928f97340a5a049a1c3ccef5b4838ac520c9ece7837dafd7d7ef8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->