### PR TITLE
Fix login page branding to satisfy Google OAuth verification

### DIFF
--- a/dali-api/app/routes/login.tsx
+++ b/dali-api/app/routes/login.tsx
@@ -9,7 +9,7 @@ const OAUTH_STATE_COOKIE = "__dali_oauth_state";
 const RATE_LIMIT_MAX = 5;
 const RATE_LIMIT_WINDOW_MS = 60_000;
 
-export const meta: Route.MetaFunction = () => [{ title: "Sign in · DALI OS" }];
+export const meta: Route.MetaFunction = () => [{ title: "DALI OS · Sign in" }];
 
 export async function loader({ request }: Route.LoaderArgs) {
   const auth = await requireAuth(request);
@@ -144,14 +144,19 @@ export default function Login() {
       {/* Right form panel */}
       <div className="w-full md:w-1/2 min-h-screen flex items-center justify-center px-6 md:px-12 lg:px-16 bg-page">
         <div className="w-full max-w-sm">
-          {/* Mobile-only logo (left panel is hidden on small screens) */}
-          <img
-            src="/logo-blue.svg"
-            alt="DALI Lab"
-            className="md:hidden h-12 w-auto mb-8"
-          />
+          {/* Mobile-only logo + wordmark (left panel is hidden on small screens) */}
+          <div className="md:hidden mb-8 flex items-center gap-3">
+            <img
+              src="/logo-blue.svg"
+              alt="DALI Lab"
+              className="h-12 w-auto"
+            />
+            <span className="font-heading text-2xl font-bold text-dark-blue">
+              DALI OS
+            </span>
+          </div>
           <h1 className="font-heading text-3xl font-bold text-dark-blue mb-2">
-            Sign in
+            Sign in to DALI OS
           </h1>
           <p className="text-muted-foreground mb-10">
             Select how you'd like to continue


### PR DESCRIPTION
## Summary
- Google OAuth verification flagged that the consent screen app name **DALI OS** did not match the visible name on the homepage URL (`os.dali.dartmouth.edu/login`).
- Root cause on the login page: `<title>` led with "Sign in", the `<h1>` was just "Sign in", and the only "DALI OS" heading lived in a `hidden md:flex` side panel — invisible on mobile, where Google's reviewers commonly check.
- Reordered the document title to **DALI OS · Sign in**, added a "DALI OS" wordmark next to the mobile logo, and updated the `<h1>` to **Sign in to DALI OS**.

## Test plan
- [ ] Visit `/login` on desktop — title reads "DALI OS · Sign in"; left panel still shows "Welcome to DALI OS"
- [ ] Visit `/login` on mobile viewport — "DALI OS" wordmark visible next to logo; h1 reads "Sign in to DALI OS"
- [ ] After deploy to prod, resubmit Google OAuth verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/669"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782184359&installation_id=133523038&pr_number=669&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F669&signature=420745e55e4975d066ad0b32888322fe8c25026f13223d34d2aa1fa0b82d6240"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->