### PR TITLE
Two-click confirm on Core-title removal

### DIFF
--- a/dali-api/app/admin-console/components/admin-console-shared.tsx
+++ b/dali-api/app/admin-console/components/admin-console-shared.tsx
@@ -233,18 +233,44 @@ export function AdminToggle({ member, disabled }: { member: Member; disabled?: b
   );
 }
 
+// Two-click confirm: the first click "arms" the button (shows "Remove?"),
+// the second click actually submits. Removing a Core title is destructive
+// and Core is self-perpetuating, so we want a guard against stray clicks
+// without the disruption of a window.confirm() modal. Auto-disarms after
+// 3s so a stray hover doesn't leave the button armed indefinitely.
 function RemoveCoreTitleButton({ assignmentId }: { assignmentId: string }) {
   const fetcher = useFetcher();
+  const [armed, setArmed] = useState(false);
+
+  useEffect(() => {
+    if (!armed) return;
+    const t = setTimeout(() => setArmed(false), 3000);
+    return () => clearTimeout(t);
+  }, [armed]);
+
+  if (!armed) {
+    return (
+      <button
+        type="button"
+        onClick={() => setArmed(true)}
+        aria-label="Remove Core title"
+        className="hover:text-green-900 ml-0.5 p-2 -m-1.5 inline-flex items-center justify-center"
+      >
+        <X className="w-3 h-3" />
+      </button>
+    );
+  }
+
   return (
     <fetcher.Form method="post" className="inline">
       <input type="hidden" name="intent" value="remove-core-title" />
       <input type="hidden" name="assignmentId" value={assignmentId} />
       <button
         type="submit"
-        aria-label="Remove Core title"
-        className="hover:text-green-900 ml-0.5 p-2 -m-1.5 inline-flex items-center justify-center"
+        aria-label="Confirm remove Core title"
+        className="ml-1 px-1.5 py-0.5 rounded text-[10px] font-semibold uppercase tracking-wide bg-red-600 text-white hover:bg-red-700"
       >
-        <X className="w-3 h-3" />
+        Remove?
       </button>
     </fetcher.Form>
   );


### PR DESCRIPTION
## Summary

Follow-up to #637. Adds a two-click confirm to the X on a Core-title chip so a stray click doesn't quietly demote a Core member. Core is self-perpetuating (any Core can remove any Core), so an accidental removal is hard to spot and hard to recover from.

- First click on the X **arms** a red **"Remove?"** button.
- Second click on "Remove?" actually submits.
- Armed state **auto-disarms after 3s** so a stray hover doesn't leave it primed.

Server-side gating is unchanged — the action handler still accepts the submit from any Core/Admin caller. The friction is UI-only, aimed at stray clicks rather than authorization.

## Test plan

- [x] `npm run typecheck` — clean in `app/`.
- [x] `npm test` — 920 / 920 passing (no test changes; the server path is unchanged).
- [ ] Manual: as Core, open Operations → Roles → click X on a Core-title chip → red "Remove?" button appears → click it → chip removed.
- [ ] Manual: as Core, click X then wait ~4s without clicking → button reverts to plain X.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/671"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782185490&installation_id=133523038&pr_number=671&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F671&signature=5438a13633aeda73eb2493a9cf225f8f6c77fd5634c15c6e83b73d15dcedc304"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->