### PR TITLE
Add machine-readable app-name signals for Google OAuth verification

### DIFF
--- a/dali-api/app/root.tsx
+++ b/dali-api/app/root.tsx
@@ -25,9 +25,19 @@ export const links: Route.LinksFunction = () => [
   { rel: "alternate icon", href: "/favicon.ico" },
   { rel: "apple-touch-icon", href: "/icon-blue.svg" },
   { rel: "mask-icon", href: "/icon-blue.svg", color: "#1E5779" },
+  { rel: "manifest", href: "/manifest.webmanifest" },
 ];
 
-export const meta: Route.MetaFunction = () => [{ title: "DALI OS" }];
+// og:site_name and application-name pin the app's name to "DALI OS" for
+// crawlers (Google's OAuth verification reads these). Without them Google
+// falls back to the domain/favicon and resolves the name as "DALI Lab",
+// which fails the consent-screen name-match check.
+export const meta: Route.MetaFunction = () => [
+  { title: "DALI OS" },
+  { name: "application-name", content: "DALI OS" },
+  { property: "og:site_name", content: "DALI OS" },
+  { property: "og:title", content: "DALI OS" },
+];
 
 export function Layout({ children }: { children: React.ReactNode }) {
   // Published as a <meta> tag rather than an inline <script> so that

--- a/dali-api/public/manifest.webmanifest
+++ b/dali-api/public/manifest.webmanifest
@@ -1,0 +1,23 @@
+{
+  "name": "DALI OS",
+  "short_name": "DALI OS",
+  "description": "DALI Lab's internal tool for hiring, staffing, scheduling, and collaboration.",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#1E5779",
+  "icons": [
+    {
+      "src": "/icon-blue.svg",
+      "type": "image/svg+xml",
+      "sizes": "any",
+      "purpose": "any"
+    },
+    {
+      "src": "/icon-blue.png",
+      "type": "image/png",
+      "sizes": "360x360",
+      "purpose": "any"
+    }
+  ]
+}


### PR DESCRIPTION
## Problem

Google's OAuth verification keeps reporting that the consent-screen app name **"DALI OS"** does not match the app name on the home page — even after #669 made the login page (the configured OAuth home page) visibly say "DALI OS" in its title, h1, and wordmark.

## Root cause

The page had **no machine-readable app-name signals** — no `og:site_name`, no `og:title`, no `application-name` meta, and no web manifest. Google's verification tooling reads structured metadata, not just rendered headings. Absent those signals it falls back to the domain and favicon, which carry the **"DALI Lab"** branding (logo alt text, links to `dali.dartmouth.edu`) — producing the name mismatch.

## Change

- [`app/root.tsx`](dali-api/app/root.tsx): add `application-name`, `og:site_name`, and `og:title` meta tags (all "DALI OS") and a `<link rel="manifest">`.
- [`public/manifest.webmanifest`](dali-api/public/manifest.webmanifest): new web manifest with `name`/`short_name` = "DALI OS", reusing the existing `icon-blue` assets.

## Required follow-up (outside this repo)

This removes the ambiguity, but Google likely cached an older crawl. After deploy:
1. Confirm the **App name** field in the Google Cloud Console OAuth consent screen is literally `DALI OS`.
2. **Re-submit for verification** so Google re-crawls — the error persists from the stale crawl until re-triggered.

## Testing

- `npm run typecheck`: changed files produce zero errors. (The pre-existing `scripts/` Prisma type errors are present on `dev` too and are unrelated.)
- Manifest validated as JSON.

No collab/CRDT, schema, or migration changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/674"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782186255&installation_id=133523038&pr_number=674&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F674&signature=6d7b3b4fb13f0aabdad2c12e8794705384bba355987bc101790ab774a29ec6b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->