### PR TITLE
Calendar UX overhaul + partners/library/sidebar polish (#679)

### DIFF
--- a/dali-api/app/admin-console/routes/admin-console.domains.tsx
+++ b/dali-api/app/admin-console/routes/admin-console.domains.tsx
@@ -263,7 +263,7 @@ function DomainLeadsForDomain({ domain, members }: { domain: DomainWithCounts; m
           <button
             type="button"
             onClick={() => setOpen(!open)}
-            className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-muted text-muted-foreground hover:bg-muted"
+            className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-muted text-muted-foreground hover:bg-muted/70 transition-colors"
           >
             + Lead
             <ChevronDown className="w-3 h-3" />
@@ -279,7 +279,7 @@ function DomainLeadsForDomain({ domain, members }: { domain: DomainWithCounts; m
                     value={search}
                     onChange={(e) => setSearch(e.target.value)}
                     placeholder="Search members…"
-                    className="w-full px-2 py-1 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    className="w-full px-2 py-1 text-sm border border-border rounded-md bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-accent-coral/30"
                   />
                 </div>
                 <div className="py-1 max-h-64 overflow-y-auto">
@@ -305,6 +305,17 @@ function DomainLeadsForDomain({ domain, members }: { domain: DomainWithCounts; m
   );
 }
 
+// Domain-eligibility level (P1/P2/P3) shown as a colored badge that is itself
+// the level picker: the native <select> sits invisibly on top so a click opens
+// the level menu, while the styled badge underneath renders the current value.
+// Transparent background — distinguished by text color only (P1 muted, P2 teal,
+// P3 coral).
+const LEVEL_BADGE: Record<"P1" | "P2" | "P3", string> = {
+  P1: "text-muted-foreground",
+  P2: "text-accent-teal",
+  P3: "text-accent-coral",
+};
+
 function EligibilityLevelSelect({
   domainId,
   userId,
@@ -315,17 +326,27 @@ function EligibilityLevelSelect({
   level: "P1" | "P2" | "P3";
 }) {
   const fetcher = useFetcher();
+  // Optimistic: reflect the just-submitted level while the request is in flight.
+  const pending = fetcher.formData?.get("level");
+  const shown = (typeof pending === "string" ? pending : level) as "P1" | "P2" | "P3";
   return (
-    <fetcher.Form method="post" className="inline">
+    <fetcher.Form method="post" className="relative inline-flex">
       <input type="hidden" name="intent" value="set-eligibility-level" />
       <input type="hidden" name="userId" value={userId} />
       <input type="hidden" name="domainId" value={domainId} />
+      <span
+        className={`inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-bold leading-none ${LEVEL_BADGE[shown]}`}
+        aria-hidden="true"
+      >
+        {shown}
+      </span>
       <select
         name="level"
-        defaultValue={level}
+        value={shown}
         onChange={(e) => fetcher.submit(e.currentTarget.form)}
-        className="bg-transparent text-xs font-medium pl-1 pr-0.5 py-0 focus:outline-none cursor-pointer"
+        className="absolute inset-0 w-full h-full opacity-0 cursor-pointer"
         aria-label="Eligibility level"
+        title="Change level"
       >
         {ALLOWED_LEVELS.map((l) => (
           <option key={l} value={l}>{l}</option>
@@ -344,7 +365,7 @@ function RemoveEligibilityButton({ eligibilityId }: { eligibilityId: string }) {
       <button
         type="submit"
         aria-label="Remove eligibility"
-        className="hover:text-amber-900 ml-0.5 p-2 -m-1.5 inline-flex items-center justify-center"
+        className="inline-flex items-center justify-center rounded-full p-0.5 text-amber-700/70 hover:text-amber-900 hover:bg-amber-100"
       >
         <X className="w-3 h-3" />
       </button>
@@ -377,7 +398,8 @@ function AddEligibilityForm({
             type="submit"
             name="level"
             value={l}
-            className="px-1.5 py-0.5 text-[10px] font-medium rounded bg-muted text-muted-foreground hover:bg-amber-100 hover:text-amber-800"
+            title={`Assign ${l}`}
+            className={`px-1.5 py-0.5 text-[10px] font-bold leading-none rounded border border-border hover:bg-muted/50 ${LEVEL_BADGE[l]}`}
           >
             {l}
           </button>
@@ -406,10 +428,9 @@ function DomainMembersForDomain({ domain, members }: { domain: DomainWithCounts;
       {domain.eligibilities.map((e) => (
         <span
           key={e.id}
-          className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-800"
+          className="inline-flex items-center gap-1.5 pl-2 pr-1 py-0.5 rounded-full text-xs font-medium bg-amber-50 text-amber-900 border border-amber-200"
         >
           {memberLabel(e.user)}
-          <span className="text-[10px] opacity-70">·</span>
           <EligibilityLevelSelect domainId={domain.id} userId={e.user.id} level={e.level} />
           <RemoveEligibilityButton eligibilityId={e.id} />
         </span>
@@ -420,7 +441,7 @@ function DomainMembersForDomain({ domain, members }: { domain: DomainWithCounts;
           <button
             type="button"
             onClick={() => setOpen(!open)}
-            className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-muted text-muted-foreground hover:bg-muted"
+            className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-muted text-muted-foreground hover:bg-muted/70 transition-colors"
           >
             + Member
             <ChevronDown className="w-3 h-3" />
@@ -436,7 +457,7 @@ function DomainMembersForDomain({ domain, members }: { domain: DomainWithCounts;
                     value={search}
                     onChange={(e) => setSearch(e.target.value)}
                     placeholder="Search members…"
-                    className="w-full px-2 py-1 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-amber-500"
+                    className="w-full px-2 py-1 text-sm border border-border rounded-md bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-accent-coral/30"
                   />
                   <p className="mt-1.5 text-[10px] text-muted-foreground/70">
                     Click a level (P1/P2/P3) to assign. Defaults to P1 if you click the name.
@@ -544,13 +565,13 @@ export default function AdminConsoleDomains() {
                 value={name}
                 onChange={(e) => setName(e.target.value)}
                 placeholder="New domain name"
-                className="px-2 py-1 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="px-2 py-1 text-sm border border-border rounded-md bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-accent-coral/30"
                 disabled={isCreating}
               />
               <button
                 type="submit"
                 disabled={isCreating || !name.trim()}
-                className="inline-flex items-center gap-1 px-2.5 py-1 rounded-md text-xs font-medium bg-gray-900 text-white hover:bg-gray-800 disabled:opacity-50"
+                className="inline-flex items-center gap-1 px-2.5 py-1 rounded-md text-xs font-medium bg-accent-coral text-white hover:bg-accent-coral/90 transition-colors disabled:opacity-50"
               >
                 <Plus className="w-3 h-3" />
                 Create

--- a/dali-api/app/app.css
+++ b/dali-api/app/app.css
@@ -310,6 +310,15 @@ html {
   color-scheme: light dark;
 }
 
+/* The sidebar shell is dark navy in both color modes. Force a dark scrollbar
+   for its scroll area so the (light-mode) browser scrollbar track doesn't paint
+   a pale strip against the dark nav. `color-scheme: dark` covers WebKit/Blink;
+   `scrollbar-color` covers Firefox (thumb / track tuned to the navy). */
+.sidebar-scroll {
+  color-scheme: dark;
+  scrollbar-color: hsl(203 20% 45%) transparent;
+}
+
 body {
   background-color: var(--color-background);
   color: var(--color-foreground);

--- a/dali-api/app/calendar/routes/__tests__/calendar-now.test.ts
+++ b/dali-api/app/calendar/routes/__tests__/calendar-now.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect } from "vitest";
 import { getZonedHourFraction } from "~/lib/timezone";
 
-// The calendar grid renders 8 AM–9 PM (HOURS = [8..20]); the now-line is shown
-// only when the current fractional hour falls inside [8, 21) and hidden
-// otherwise. This mirrors the predicate in WeekGrid.
+// The calendar grid renders 8 AM–9 PM rows (HOURS = [8..21]) with the body
+// extending to 10 PM; the now-line is shown only when the current fractional
+// hour falls inside [8, 22) and hidden otherwise. This mirrors the predicate in
+// WeekGrid.
 const GRID_MIN_HOUR = 8;
-const GRID_MAX_HOUR = 21;
+const GRID_MAX_HOUR = 22;
 const isNowLineVisible = (frac: number) =>
   frac >= GRID_MIN_HOUR && frac < GRID_MAX_HOUR;
 
@@ -30,10 +31,17 @@ describe("getZonedHourFraction", () => {
     expect(isNowLineVisible(frac)).toBe(false);
   });
 
-  it("hides the line after 9 PM", () => {
+  it("shows the line at 9:30 PM (inside the extended range)", () => {
     // 2026-01-15 02:30:00Z is 21:30 EST on 2026-01-14.
     const frac = getZonedHourFraction(new Date("2026-01-15T02:30:00Z"), "America/New_York");
     expect(frac).toBe(21.5);
+    expect(isNowLineVisible(frac)).toBe(true);
+  });
+
+  it("hides the line after 10 PM", () => {
+    // 2026-01-15 03:30:00Z is 22:30 EST on 2026-01-14.
+    const frac = getZonedHourFraction(new Date("2026-01-15T03:30:00Z"), "America/New_York");
+    expect(frac).toBe(22.5);
     expect(isNowLineVisible(frac)).toBe(false);
   });
 });

--- a/dali-api/app/calendar/routes/api.scheduled-meetings.$id.cancel.ts
+++ b/dali-api/app/calendar/routes/api.scheduled-meetings.$id.cancel.ts
@@ -1,0 +1,28 @@
+import type { Route } from "./+types/api.scheduled-meetings.$id.cancel";
+import { requireAuth } from "~/lib/auth";
+import { withCors, handlePreflight } from "~/lib/cors";
+import { cancelScheduledMeeting } from "~/lib/scheduled-meeting";
+
+export async function action({ request, params }: Route.ActionArgs) {
+  const preflight = handlePreflight(request);
+  if (preflight) return preflight;
+
+  const auth = await requireAuth(request);
+  if (!auth.ok) return withCors(request, auth.response);
+  if (auth.user.type === "applicant")
+    return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
+
+  if (request.method !== "POST") {
+    return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));
+  }
+
+  const result = await cancelScheduledMeeting(params.id!, auth.user.sub);
+  if (!result.ok) {
+    return withCors(request, Response.json({ error: result.error }, { status: result.status }));
+  }
+
+  return withCors(
+    request,
+    Response.json({ ok: true, alreadyCancelled: result.alreadyCancelled }),
+  );
+}

--- a/dali-api/app/calendar/routes/calendar.tsx
+++ b/dali-api/app/calendar/routes/calendar.tsx
@@ -1,5 +1,6 @@
 import { Link, redirect, useFetcher, useLoaderData, useRevalidator } from "react-router";
-import { Fragment, useEffect, useRef, useState } from "react";
+import { Fragment, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import {
   ChevronLeft,
   ChevronRight,
@@ -11,15 +12,14 @@ import {
   CalendarDays,
   Building2,
   Wifi,
-  Copy,
   UsersRound,
   X,
   RefreshCw,
+  RotateCcw,
 } from "lucide-react";
 import { requireAuth } from "~/lib/auth";
 import { prisma } from "~/lib/db";
 import { listVisibleGroupsForUser } from "~/lib/groups";
-import { computeFreeIntervals, type Interval } from "~/lib/availability";
 import { CalendarActionSchema } from "~/lib/calendar-schemas";
 import { fetchBusyEvents, listCalendarsForLink } from "~/lib/google-calendar";
 import { getZonedHourFraction, getZonedYMD, zonedDayStartUtc } from "~/lib/timezone";
@@ -89,11 +89,23 @@ type LoaderData = {
   timezone: string;
   defaultEventBufferMin: number;
   workingHours: WhDay[];
+  // True once the user has saved any working-hours state (even "all off"). The
+  // client uses this to (a) show the master toggle as off for brand-new users
+  // and (b) seed the full week on first edit so unsaved defaults aren't lost.
+  hasPersistedWorkingHours: boolean;
   manualBlocks: ManualBlockDTO[];
   calendarLinks: CalendarLinkDTO[];
   weekStartIso: string;
   weekEndIso: string;
-  busyIntervals: { startIso: string; endIso: string }[];
+  // External (Google) events for display: real titles + per-calendar colour,
+  // straight from events.list (not the merged availability intervals, which
+  // drop titles). Manual blocks render separately from data.manualBlocks.
+  externalEvents: {
+    startIso: string;
+    endIso: string;
+    title: string;
+    color: string | null;
+  }[];
   ingestionError: string | null;
   groups: GroupOption[];
   users: UserOption[];
@@ -234,7 +246,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   const [externalBusyRaw, calendarLinks] = await Promise.all([
     fetchBusyEvents(userId, weekStart, weekEnd).catch((err) => {
       ingestionError = err instanceof Error ? err.message : "Failed to fetch external busy";
-      return [] as { start: string; end: string }[];
+      return [] as Awaited<ReturnType<typeof fetchBusyEvents>>;
     }),
     Promise.all(
       links.map(async (l): Promise<CalendarLinkDTO> => {
@@ -270,40 +282,11 @@ export async function loader({ request }: Route.LoaderArgs) {
     ),
   ]);
 
-  const externalBusy: Interval[] = externalBusyRaw.map((b) => ({
-    start: new Date(b.start),
-    end: new Date(b.end),
-  }));
-
-  // computeFreeIntervals takes a flat list of (dayOfWeek, start, end) entries —
-  // expand each day's segments into its own entry.
-  const workingHoursFlat = workingHours.flatMap((d) =>
-    d.segments.map((s) => ({
-      dayOfWeek: d.dayOfWeek,
-      enabled: true,
-      startMinute: s.startMinute,
-      endMinute: s.endMinute,
-    })),
-  );
-
-  const { busy } = computeFreeIntervals({
-    windowStart: weekStart,
-    windowEnd: weekEnd,
-    workingHours: workingHoursFlat,
-    manualBlocks: blocks.map((b) => ({
-      startTime: b.startTime,
-      endTime: b.endTime,
-      recurrenceRule: b.recurrenceRule,
-    })),
-    externalBusy,
-    bufferMin,
-    timezone,
-  });
-
   const data: LoaderData = {
     timezone,
     defaultEventBufferMin: bufferMin,
     workingHours,
+    hasPersistedWorkingHours: hasAnyPersisted,
     manualBlocks: blocks.map((b) => ({
       id: b.id,
       title: b.title,
@@ -314,9 +297,11 @@ export async function loader({ request }: Route.LoaderArgs) {
     calendarLinks,
     weekStartIso: weekStart.toISOString(),
     weekEndIso: weekEnd.toISOString(),
-    busyIntervals: busy.map((i: Interval) => ({
-      startIso: i.start.toISOString(),
-      endIso: i.end.toISOString(),
+    externalEvents: externalBusyRaw.map((e) => ({
+      startIso: e.start,
+      endIso: e.end,
+      title: e.title ?? "Busy",
+      color: e.color ?? null,
     })),
     ingestionError,
     groups,
@@ -416,6 +401,49 @@ export async function action({ request }: Route.ActionArgs) {
 
     case "reset-working-hours": {
       await prisma.workingHoursDay.deleteMany({ where: { userId } });
+      return null;
+    }
+
+    case "seed-working-hours": {
+      // Materialize the supplied full-week segment set in one transaction. Used
+      // when the user first turns Working Hours on (or edits a day) while the
+      // state is still the in-memory default: persisting only the edited day
+      // would leave the other days with no rows, and the loader's
+      // "hasAnyPersisted ⇒ unlisted day is empty" rule would then silently wipe
+      // the default Mon–Fri hours. Seeding all days at once keeps them.
+      for (const d of input.days) {
+        for (const s of d.segments) {
+          if (s.startMinute >= s.endMinute) {
+            return Response.json({ error: "startMinute must be < endMinute" }, { status: 400 });
+          }
+        }
+      }
+      await prisma.$transaction(async (tx) => {
+        await tx.workingHoursDay.deleteMany({ where: { userId } });
+        const rows = input.days.flatMap((d) =>
+          d.segments.length > 0
+            ? d.segments.map((s) => ({
+                userId,
+                dayOfWeek: d.dayOfWeek,
+                enabled: true,
+                startMinute: s.startMinute,
+                endMinute: s.endMinute,
+                location: s.location,
+              }))
+            : [
+                // Sentinel "explicitly empty" row, same as set-working-segments.
+                {
+                  userId,
+                  dayOfWeek: d.dayOfWeek,
+                  enabled: false,
+                  startMinute: 0,
+                  endMinute: 1,
+                  location: "InPerson" as const,
+                },
+              ],
+        );
+        if (rows.length > 0) await tx.workingHoursDay.createMany({ data: rows });
+      });
       return null;
     }
 
@@ -530,6 +558,18 @@ function coerceFormToAction(raw: Record<string, FormDataEntryValue>): unknown {
         segments,
       };
     }
+    case "seed-working-hours": {
+      const daysRaw = get("days");
+      let days: unknown = [];
+      if (daysRaw) {
+        try {
+          days = JSON.parse(daysRaw);
+        } catch {
+          // Leave empty; zod will surface the validation error.
+        }
+      }
+      return { intent, days };
+    }
     case "copy-weekdays":
     case "reset-working-hours":
       return { intent };
@@ -579,7 +619,7 @@ export default function CalendarPage() {
 
   return (
     <div className="flex flex-col gap-5">
-      <div className="flex items-center gap-2">
+      <div className="inline-flex self-start rounded-lg border border-border bg-muted/40 p-0.5">
         <PillButton active={tab === "availability"} onClick={() => setTab("availability")}>
           My Availability
         </PillButton>
@@ -608,8 +648,8 @@ function PillButton({
       onClick={onClick}
       className={`px-4 py-1.5 text-sm font-semibold rounded-md transition-colors ${
         active
-          ? "bg-accent-coral text-white"
-          : "text-foreground hover:bg-muted"
+          ? "bg-accent-coral text-white shadow-sm"
+          : "text-muted-foreground hover:text-foreground hover:bg-background/60"
       }`}
     >
       {children}
@@ -623,11 +663,13 @@ function PillButton({
 
 function AvailabilityView({ data }: { data: LoaderData }) {
   // Fill the available iframe viewport (minus tab bar + page padding) so the
-  // grid extends to the screen edge. Floor at 56rem so the 13-hour grid never
-  // gets clipped by the inner overflow-hidden on short viewports.
+  // grid extends to the screen edge. Floor at 56rem so the grid never gets
+  // clipped by the inner overflow-hidden on short viewports.
+  // Drag-to-create now lives inside AvailabilityWeekGrid: the selection stays
+  // drawn on the grid and the editor opens as a popover anchored beside it.
   return (
-    <div className="grid grid-cols-1 lg:grid-cols-[400px_1fr] gap-6 lg:h-[max(calc(100vh-9rem),56rem)] lg:min-h-0">
-      <aside className="flex flex-col gap-6 lg:overflow-y-auto lg:overflow-x-hidden lg:pr-2 lg:min-h-0">
+    <div className="grid grid-cols-1 lg:grid-cols-[400px_1fr] gap-6 lg:h-[max(calc(100vh-9rem),56rem)] lg:min-h-0 px-3 pt-2">
+      <aside className="flex flex-col gap-6 lg:overflow-y-auto lg:overflow-x-hidden lg:pr-6 lg:min-h-0">
         <header>
           <h1 className="font-heading text-2xl font-bold text-foreground">Availability</h1>
           <p className="text-sm text-muted-foreground mt-1">
@@ -635,12 +677,15 @@ function AvailabilityView({ data }: { data: LoaderData }) {
           </p>
         </header>
         <CalendarIntegrationsCard links={data.calendarLinks} ingestionError={data.ingestionError} />
-        <WorkingHoursCard workingHours={data.workingHours} />
+        <WorkingHoursCard
+          workingHours={data.workingHours}
+          hasPersisted={data.hasPersistedWorkingHours}
+        />
         <EventBuffersCard bufferMin={data.defaultEventBufferMin} />
         <ManualBlocksCard blocks={data.manualBlocks} timezone={data.timezone} />
       </aside>
       <div className="lg:overflow-hidden lg:min-h-0">
-        <AvailabilityWeekGrid data={data} />
+        <AvailabilityWeekGrid data={data} enableDragCreate />
       </div>
     </div>
   );
@@ -797,9 +842,48 @@ function SubCalendarRow({ linkId, cal }: { linkId: string; cal: SubCalendarDTO }
   );
 }
 
-function WorkingHoursCard({ workingHours }: { workingHours: WhDay[] }) {
-  const copyFetcher = useFetcher();
+function WorkingHoursCard({
+  workingHours,
+  hasPersisted,
+}: {
+  workingHours: WhDay[];
+  hasPersisted: boolean;
+}) {
   const resetFetcher = useFetcher();
+  const toggleFetcher = useFetcher();
+
+  // "On" once the user has saved any working-hours state. While a master-toggle
+  // submit is in flight, reflect the in-flight intent optimistically.
+  const pendingToggleIntent =
+    typeof toggleFetcher.formData?.get("intent") === "string"
+      ? (toggleFetcher.formData.get("intent") as string)
+      : null;
+  const enabled =
+    pendingToggleIntent === "seed-working-hours"
+      ? true
+      : pendingToggleIntent === "reset-working-hours"
+        ? false
+        : hasPersisted;
+
+  const turnOn = () => {
+    // Persist the full Mon–Fri 9–5 default in one shot so the editor opens with
+    // sensible values and every day has a real row.
+    const days = defaultWorkingHours().map((d) => ({
+      dayOfWeek: d.dayOfWeek,
+      segments: d.segments.map((s) => ({
+        startMinute: s.startMinute,
+        endMinute: s.endMinute,
+        location: s.location,
+      })),
+    }));
+    toggleFetcher.submit(
+      { intent: "seed-working-hours", days: JSON.stringify(days) },
+      { method: "post" },
+    );
+  };
+  const turnOff = () =>
+    toggleFetcher.submit({ intent: "reset-working-hours" }, { method: "post" });
+
   return (
     <section>
       <div className="flex items-center justify-between mb-3">
@@ -808,35 +892,65 @@ function WorkingHoursCard({ workingHours }: { workingHours: WhDay[] }) {
           Working Hours
         </h2>
         <div className="flex items-center gap-1">
-          <copyFetcher.Form method="post">
-            <input type="hidden" name="intent" value="copy-weekdays" />
-            <button
-              type="submit"
-              title="Copy Monday's hours to Tue–Fri"
-              className="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium rounded-md border border-border hover:bg-muted transition-colors text-muted-foreground"
-            >
-              <Copy className="w-3 h-3" />
-              Weekdays
-            </button>
-          </copyFetcher.Form>
-          <resetFetcher.Form method="post">
-            <input type="hidden" name="intent" value="reset-working-hours" />
-            <button
-              type="submit"
-              aria-label="Reset working hours to defaults"
-              title="Reset to defaults"
-              className="p-1 text-muted-foreground hover:text-destructive hover:bg-destructive/10 rounded-md transition-colors"
-            >
-              <Trash2 className="w-3.5 h-3.5" />
-            </button>
-          </resetFetcher.Form>
+          {enabled && (
+            <>
+              <resetFetcher.Form
+                method="post"
+                onSubmit={(e) => {
+                  // Re-seed the default week rather than wiping to "off" — this
+                  // button resets hours, it doesn't disable the feature.
+                  e.preventDefault();
+                  const days = defaultWorkingHours().map((d) => ({
+                    dayOfWeek: d.dayOfWeek,
+                    segments: d.segments.map((s) => ({
+                      startMinute: s.startMinute,
+                      endMinute: s.endMinute,
+                      location: s.location,
+                    })),
+                  }));
+                  resetFetcher.submit(
+                    { intent: "seed-working-hours", days: JSON.stringify(days) },
+                    { method: "post" },
+                  );
+                }}
+              >
+                <button
+                  type="submit"
+                  aria-label="Reset working hours to defaults"
+                  title="Reset to defaults"
+                  className="p-1 text-muted-foreground hover:text-foreground hover:bg-muted rounded-md transition-colors"
+                >
+                  <RotateCcw className="w-3.5 h-3.5" />
+                </button>
+              </resetFetcher.Form>
+            </>
+          )}
+          {/* Master on/off switch */}
+          <button
+            type="button"
+            role="switch"
+            aria-checked={enabled}
+            aria-label="Working hours enabled"
+            onClick={enabled ? turnOff : turnOn}
+            className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${
+              enabled ? "bg-accent-coral" : "bg-border"
+            }`}
+          >
+            <span
+              className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${
+                enabled ? "translate-x-4" : "translate-x-0.5"
+              }`}
+            />
+          </button>
         </div>
       </div>
-      <div className="bg-card border border-border rounded-md p-3 flex flex-col gap-2">
-        {workingHours.map((d) => (
-          <DayRow key={d.dayOfWeek} day={d} />
-        ))}
-      </div>
+      {enabled && (
+        <div className="bg-card border border-border rounded-md p-3 flex flex-col gap-2">
+          {workingHours.map((d) => (
+            <DayRow key={d.dayOfWeek} day={d} allDays={workingHours} />
+          ))}
+        </div>
+      )}
     </section>
   );
 }
@@ -845,17 +959,22 @@ const DAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 
 type LocalSegment = { startMinute: number; endMinute: number; location: "InPerson" | "Remote" };
 
-function DayRow({ day }: { day: WhDay }) {
+function DayRow({ day, allDays }: { day: WhDay; allDays: WhDay[] }) {
   const fetcher = useFetcher();
   // Optimistic state: while a submit is pending, render the in-flight values
-  // rather than the loader values so edits feel instant.
+  // rather than the loader values so edits feel instant. We submit the whole
+  // week (seed-working-hours), so pull this day's slice back out of `days`.
   const pending = fetcher.formData;
   const pendingSegments: LocalSegment[] | null = (() => {
     if (!pending) return null;
-    const raw = pending.get("segments");
+    const raw = pending.get("days");
     if (typeof raw !== "string") return null;
     try {
-      return JSON.parse(raw) as LocalSegment[];
+      const parsed = JSON.parse(raw) as {
+        dayOfWeek: number;
+        segments: LocalSegment[];
+      }[];
+      return parsed.find((d) => d.dayOfWeek === day.dayOfWeek)?.segments ?? [];
     } catch {
       return null;
     }
@@ -870,13 +989,24 @@ function DayRow({ day }: { day: WhDay }) {
 
   const enabled = segments.length > 0;
 
+  // Persist the whole week every time so a day that currently has no DB row
+  // (e.g. an unsaved default) isn't dropped by the loader's "unlisted ⇒ empty"
+  // rule. `next` replaces this day's segments; other days carry through as-is.
   const submitSegments = (next: LocalSegment[]) => {
+    const days = allDays.map((d) =>
+      d.dayOfWeek === day.dayOfWeek
+        ? { dayOfWeek: d.dayOfWeek, segments: next }
+        : {
+            dayOfWeek: d.dayOfWeek,
+            segments: d.segments.map((s) => ({
+              startMinute: s.startMinute,
+              endMinute: s.endMinute,
+              location: s.location,
+            })),
+          },
+    );
     fetcher.submit(
-      {
-        intent: "set-working-segments",
-        dayOfWeek: String(day.dayOfWeek),
-        segments: JSON.stringify(next),
-      },
+      { intent: "seed-working-hours", days: JSON.stringify(days) },
       { method: "post" },
     );
   };
@@ -952,15 +1082,20 @@ function DayRow({ day }: { day: WhDay }) {
                   icon={<Wifi className="w-3.5 h-3.5" />}
                 />
               </div>
-              <button
-                type="button"
-                onClick={() => removeSegment(idx)}
-                aria-label={`Remove ${DAY_LABELS[day.dayOfWeek]} segment ${idx + 1}`}
-                title="Remove segment"
-                className="p-1 text-muted-foreground hover:text-destructive hover:bg-destructive/10 rounded-md transition-colors"
-              >
-                <Trash2 className="w-3.5 h-3.5" />
-              </button>
+              {/* With a single segment the day checkbox already removes it
+                  (un-checking clears the day), so the delete button only
+                  appears when there are multiple segments to pick from. */}
+              {segments.length > 1 && (
+                <button
+                  type="button"
+                  onClick={() => removeSegment(idx)}
+                  aria-label={`Remove ${DAY_LABELS[day.dayOfWeek]} segment ${idx + 1}`}
+                  title="Remove segment"
+                  className="p-1 text-muted-foreground hover:text-destructive hover:bg-destructive/10 rounded-md transition-colors"
+                >
+                  <X className="w-3.5 h-3.5" />
+                </button>
+              )}
             </div>
           ))}
           <button
@@ -1052,9 +1187,7 @@ function EventBuffersCard({ bufferMin }: { bufferMin: number }) {
     { label: "5m", value: 5 },
     { label: "10m", value: 10 },
     { label: "15m", value: 15 },
-    { label: "30m", value: 30 },
-    { label: "45m", value: 45 },
-    { label: "60m", value: 60 },
+    { label: "30m", value: 30 }
   ];
   return (
     <section>
@@ -1063,9 +1196,6 @@ function EventBuffersCard({ bufferMin }: { bufferMin: number }) {
         Event Buffers
       </h2>
       <div className="bg-card border border-border rounded-md p-3">
-        <p className="text-xs text-muted-foreground mb-3">
-          Add padding around all calendar and manual events so you're never booked back-to-back.
-        </p>
         <div className="flex flex-wrap gap-2">
           {options.map((o) => (
             <button
@@ -1263,7 +1393,9 @@ function WeekToolbar({
   onRefresh,
   refreshing,
 }: {
-  legend: { color: string; label: string }[];
+  // `color` is a Tailwind bg-* class; `swatch` is a raw CSS color for tints
+  // that are computed at runtime (e.g. the availability gradient stops).
+  legend: { color?: string; swatch?: string; label: string }[];
   monthLabel: string;
   weekStartIso: string;
   onRefresh?: () => void;
@@ -1321,7 +1453,10 @@ function WeekToolbar({
       <div className="flex items-center gap-3 text-xs text-muted-foreground">
         {legend.map((l) => (
           <span key={l.label} className="inline-flex items-center gap-1.5">
-            <span className={`inline-block w-3 h-3 rounded-sm ${l.color}`} />
+            <span
+              className={`inline-block w-3 h-3 rounded-sm border border-border ${l.color ?? ""}`}
+              style={l.swatch ? { backgroundColor: l.swatch } : undefined}
+            />
             {l.label}
           </span>
         ))}
@@ -1330,8 +1465,12 @@ function WeekToolbar({
   );
 }
 
-const HOURS = [8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20];
-const HOUR_PX = 56;
+// Visible hour rows: 8am through 9pm (the grid body bottom edge is 10pm).
+const HOURS = [8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21];
+const HOUR_PX = 54;
+// Grid is snapped/subdivided into 10-minute cells.
+const SUBDIVISIONS_PER_HOUR = 6; // 60 / 10
+const SNAP_HOURS = 1 / SUBDIVISIONS_PER_HOUR; // 10 minutes as a fraction of an hour
 
 // Refetch when the tab regains focus (visibilitychange covers tab switches,
 // focus covers window-level focus on browsers that don't fire visibilitychange
@@ -1364,7 +1503,15 @@ function useNow(intervalMs = 60_000): Date | null {
   return now;
 }
 
-function AvailabilityWeekGrid({ data }: { data: LoaderData }) {
+function AvailabilityWeekGrid({
+  data,
+  enableDragCreate = false,
+}: {
+  data: LoaderData;
+  // When set, dragging a range commits a selection (kept drawn on the grid) and
+  // opens the create-editor popover anchored beside it.
+  enableDragCreate?: boolean;
+}) {
   const revalidator = useRevalidator();
   const refresh = () => revalidator.revalidate();
   useRefreshOnFocus(refresh);
@@ -1374,11 +1521,24 @@ function AvailabilityWeekGrid({ data }: { data: LoaderData }) {
     return { dayOfWeek: d.getUTCDay(), num: d.getUTCDate(), dateUtc: d };
   });
 
-  // Build per-day event blocks from busy intervals.
-  const eventsByDay: Record<number, EventBlock[]> = {};
-  for (const b of data.busyIntervals) {
-    const start = new Date(b.startIso);
-    const end = new Date(b.endIso);
+  // Committed drag selection: the grid coordinates (for drawing + anchoring the
+  // popover) plus the resolved local datetime strings the editor form needs.
+  const [selection, setSelection] = useState<
+    | {
+        dayIdx: number;
+        startHour: number;
+        endHour: number;
+        startLocal: string;
+        endLocal: string;
+      }
+    | null
+  >(null);
+
+  // Place one block into the right day column. Returns false if the event
+  // falls outside the visible week (so callers can skip it).
+  const placeBlock = (startIso: string, endIso: string, block: Omit<EventBlock, "startHour" | "duration">, into: Record<number, EventBlock[]>) => {
+    const start = new Date(startIso);
+    const end = new Date(endIso);
     const ymd = getZonedYMD(start, data.timezone);
     const dayMidnight = zonedDayStartUtc(ymd.year, ymd.month, ymd.day, data.timezone);
     const startHour = (start.getTime() - dayMidnight.getTime()) / 3_600_000;
@@ -1386,15 +1546,28 @@ function AvailabilityWeekGrid({ data }: { data: LoaderData }) {
     const dayIdx = days.findIndex(
       (d) => d.dateUtc.getUTCFullYear() === ymd.year && d.dateUtc.getUTCMonth() + 1 === ymd.month && d.dateUtc.getUTCDate() === ymd.day,
     );
-    if (dayIdx < 0) continue;
-    if (!eventsByDay[dayIdx]) eventsByDay[dayIdx] = [];
-    eventsByDay[dayIdx].push({
-      startHour,
-      duration,
-      label: "Busy",
+    if (dayIdx < 0) return;
+    if (!into[dayIdx]) into[dayIdx] = [];
+    into[dayIdx].push({ startHour, duration, ...block });
+  };
+
+  // Build per-day event blocks: external (Google) events with their real title
+  // and source-calendar colour, plus the user's own manual blocks.
+  const eventsByDay: Record<number, EventBlock[]> = {};
+  for (const e of data.externalEvents) {
+    placeBlock(e.startIso, e.endIso, {
+      label: e.title,
+      className: e.color ? "" : EVENT_CORAL,
+      bgColor: e.color ?? undefined,
+      borderClassName: e.color ? undefined : "border-accent-coral-light",
+    }, eventsByDay);
+  }
+  for (const b of data.manualBlocks) {
+    placeBlock(b.startTime, b.endTime, {
+      label: b.title || "Busy",
       className: EVENT_CORAL,
       borderClassName: "border-accent-coral-light",
-    });
+    }, eventsByDay);
   }
 
   const monthLabel = new Intl.DateTimeFormat("en-US", {
@@ -1402,6 +1575,19 @@ function AvailabilityWeekGrid({ data }: { data: LoaderData }) {
     month: "long",
     year: "numeric",
   }).format(weekStart);
+
+  // Legend: one swatch per enabled, coloured sub-calendar (so a multi-calendar
+  // week shows which colour maps to which calendar). Dedupe by colour.
+  const calLegend: { swatch: string; label: string }[] = [];
+  const seenColors = new Set<string>();
+  for (const link of data.calendarLinks) {
+    for (const sub of link.subCalendars ?? []) {
+      if (sub.enabled && sub.color && !seenColors.has(sub.color)) {
+        seenColors.add(sub.color);
+        calLegend.push({ swatch: sub.color, label: sub.summary });
+      }
+    }
+  }
 
   return (
     <section className="bg-card border border-border rounded-lg p-4 flex flex-col">
@@ -1411,19 +1597,80 @@ function AvailabilityWeekGrid({ data }: { data: LoaderData }) {
         onRefresh={refresh}
         refreshing={revalidator.state !== "idle"}
         legend={[
-          { color: "bg-accent-green", label: "Available" },
-          { color: "bg-muted", label: "Outside Hours" },
-          { color: "bg-accent-coral", label: "Busy" },
+          // Free time is left uncolored, so it carries no legend swatch.
+          // Only meaningful when working hours are on (otherwise no stripes).
+          ...(data.hasPersistedWorkingHours
+            ? [{ color: "bg-muted", label: "Outside Hours" }]
+            : []),
+          // Per-calendar colours when available; else a single generic "Busy".
+          ...(calLegend.length > 0
+            ? calLegend
+            : [{ color: "bg-accent-coral", label: "Busy" }]),
         ]}
       />
+      {enableDragCreate && (
+        <p className="px-1 pb-2 text-[11px] text-muted-foreground">
+          Drag a range on the grid to create a block or meeting.
+        </p>
+      )}
       <WeekGrid
         days={days}
         showProviderRow
+        showSubHourGrid
         timezone={data.timezone}
         backgroundLayer={(dayIdx) =>
-          workingHoursStripeLayer(data.workingHours, days[dayIdx].dayOfWeek, { wash: true })
+          workingHoursStripeLayer(data.workingHours, days[dayIdx].dayOfWeek, {
+            enabled: data.hasPersistedWorkingHours,
+          })
         }
         eventsByDay={eventsByDay}
+        onDayPointerSelect={
+          enableDragCreate
+            ? (dayIdx, startHour, endHour) => {
+                const day = days[dayIdx];
+                if (!day) return;
+                setSelection({
+                  dayIdx,
+                  startHour,
+                  endHour,
+                  startLocal: dayHourToLocal(day.dateUtc, startHour),
+                  endLocal: dayHourToLocal(day.dateUtc, endHour),
+                });
+              }
+            : undefined
+        }
+        selection={
+          selection
+            ? { dayIdx: selection.dayIdx, startHour: selection.startHour, endHour: selection.endHour }
+            : null
+        }
+        selectionPopover={
+          selection
+            ? () => (
+                <CreateFromDragPopover
+                  data={data}
+                  startLocal={selection.startLocal}
+                  endLocal={selection.endLocal}
+                  onClose={() => setSelection(null)}
+                />
+              )
+            : undefined
+        }
+        onSelectionDismiss={() => setSelection(null)}
+        onSelectionResize={(startHour, endHour) =>
+          setSelection((prev) => {
+            if (!prev) return prev;
+            const day = days[prev.dayIdx];
+            if (!day) return prev;
+            return {
+              ...prev,
+              startHour,
+              endHour,
+              startLocal: dayHourToLocal(day.dateUtc, startHour),
+              endLocal: dayHourToLocal(day.dateUtc, endHour),
+            };
+          })
+        }
       />
     </section>
   );
@@ -1432,6 +1679,20 @@ function AvailabilityWeekGrid({ data }: { data: LoaderData }) {
 // Hard-coded dark text that doesn't flip in dark mode (the dark-blue token does).
 const EVENT_TEXT = "text-[hsl(203_38%_18%)]";
 const EVENT_CORAL = `bg-accent-coral-light ${EVENT_TEXT}`;
+
+// Schedule-preview availability tint: interpolate from white (no one free) to a
+// deep green (everyone free) by `frac` (0..1). Lerping the color itself — not
+// just opacity over a fixed light green — gives real contrast between the
+// "few free" and "all free" ends. The deep end is darker/more saturated than
+// the accent-green token so the gradient reads clearly.
+const AVAIL_DEEP_GREEN: [number, number, number] = [46, 125, 50]; // #2E7D32
+function availabilityTint(frac: number): string {
+  const f = Math.max(0, Math.min(1, frac));
+  const r = Math.round(255 + (AVAIL_DEEP_GREEN[0] - 255) * f);
+  const g = Math.round(255 + (AVAIL_DEEP_GREEN[1] - 255) * f);
+  const b = Math.round(255 + (AVAIL_DEEP_GREEN[2] - 255) * f);
+  return `rgb(${r}, ${g}, ${b})`;
+}
 
 /* ------------------------------------------------------------------ */
 /* Schedule view                                                        */
@@ -1476,6 +1737,325 @@ function toDatetimeLocal(d: Date): string {
   return (
     `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}` +
     `T${pad(d.getHours())}:${pad(d.getMinutes())}`
+  );
+}
+
+// Map a grid day column (UTC-midnight anchored, as the WeekGrid stores its days)
+// + a fractional hour into the "YYYY-MM-DDTHH:mm" datetime-local string. Shared
+// by the schedule grid and the availability drag-to-create handler.
+function dayHourToLocal(dayDateUtc: Date, hour: number): string {
+  const y = dayDateUtc.getUTCFullYear();
+  const m = dayDateUtc.getUTCMonth();
+  const d = dayDateUtc.getUTCDate();
+  const h = Math.floor(hour);
+  const mins = Math.round((hour - h) * 60);
+  return toDatetimeLocal(new Date(y, m, d, h, mins));
+}
+
+/* ------------------------------------------------------------------ */
+/* Drag-to-create side modal (My Availability tab)                      */
+/* ------------------------------------------------------------------ */
+
+type DragCreateKind = "block" | "meeting";
+
+function CreateFromDragPopover({
+  data,
+  startLocal,
+  endLocal,
+  onClose,
+}: {
+  data: LoaderData;
+  startLocal: string;
+  endLocal: string;
+  onClose: () => void;
+}) {
+  const revalidator = useRevalidator();
+  const [kind, setKind] = useState<DragCreateKind>("block");
+  const [title, setTitle] = useState("");
+  const [start, setStart] = useState(startLocal);
+  const [end, setEnd] = useState(endLocal);
+  // Follow the committed selection while the user resizes it on the grid (the
+  // startLocal/endLocal props change). Manual edits to the inputs below still
+  // win until the next resize re-syncs.
+  useEffect(() => {
+    setStart(startLocal);
+    setEnd(endLocal);
+  }, [startLocal, endLocal]);
+  const [repeats, setRepeats] = useState<Repeats>("none");
+  const [selectedUserIds, setSelectedUserIds] = useState<string[]>([]);
+  const [selectedGroupIds, setSelectedGroupIds] = useState<string[]>([]);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const googleLinks = data.calendarLinks.filter((l) => l.provider === "Google" && l.enabled);
+  const [organizerCalendarLinkId, setOrganizerCalendarLinkId] = useState<string>(
+    googleLinks[0]?.id ?? "",
+  );
+
+  const usersById = new Map(data.users.map((u) => [u.id, u]));
+  const groupsById = new Map(data.groups.map((g) => [g.id, g]));
+  const resolvedParticipantIds = (() => {
+    const set = new Set<string>(selectedUserIds);
+    for (const gid of selectedGroupIds) {
+      const g = groupsById.get(gid);
+      if (g) for (const uid of g.memberIds) set.add(uid);
+    }
+    return Array.from(set);
+  })();
+
+  const startEndValid =
+    !!start && !!end && new Date(end).getTime() > new Date(start).getTime();
+  const duration = durationMinutesBetween(start, end);
+  const canSubmit = title.trim().length > 0 && startEndValid && !submitting;
+
+  // Close on Escape.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!canSubmit) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      if (kind === "block") {
+        // Manual blocks are owned by the route action (add-manual-block).
+        const body = new FormData();
+        body.set("intent", "add-manual-block");
+        body.set("title", title.trim());
+        body.set("startTime", new Date(start).toISOString());
+        body.set("endTime", new Date(end).toISOString());
+        const rrule = repeatsToRRule(repeats);
+        if (rrule) body.set("recurrenceRule", rrule);
+        const res = await fetch("/calendar", { method: "POST", credentials: "include", body });
+        if (!res.ok) {
+          const j = await res.json().catch(() => null);
+          setError(j?.error ?? "Failed to create block");
+          return;
+        }
+      } else {
+        // Meetings reuse the scheduled-meeting endpoint: invitees, recurrence,
+        // and (when an organizer calendar + invitees are present) a real Google
+        // Calendar invite. A solo meeting stays in-app only.
+        const payload: Record<string, unknown> = {
+          title: title.trim(),
+          durationMinutes: duration,
+          startTime: new Date(start).toISOString(),
+        };
+        const rrule = repeatsToRRule(repeats);
+        if (rrule) payload.recurrenceRule = rrule;
+        if (organizerCalendarLinkId) payload.organizerCalendarLinkId = organizerCalendarLinkId;
+        if (selectedGroupIds.length === 1 && selectedUserIds.length === 0) {
+          payload.scopeType = "Group";
+          payload.groupId = selectedGroupIds[0];
+        } else if (resolvedParticipantIds.length > 0) {
+          payload.scopeType = "UserList";
+          payload.participantUserIds = resolvedParticipantIds;
+        } else {
+          payload.scopeType = "None";
+        }
+        const res = await fetch("/api/scheduled-meetings", {
+          method: "POST",
+          credentials: "include",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        });
+        const j = await res.json().catch(() => null);
+        if (!res.ok) {
+          setError(j?.error ?? "Failed to create meeting");
+          return;
+        }
+      }
+      revalidator.revalidate();
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Network error");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div
+      className="w-80 max-h-[26rem] overflow-y-auto rounded-lg border border-border bg-card shadow-xl"
+      role="dialog"
+      aria-modal="false"
+      aria-label="New on your calendar"
+    >
+      <div className="flex items-center justify-between px-3 py-2 border-b border-border sticky top-0 bg-card z-10">
+        <h2 className="font-heading font-semibold text-sm text-foreground">New on your calendar</h2>
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close"
+          className="p-1 text-muted-foreground hover:text-foreground rounded-md hover:bg-muted"
+        >
+          <X className="w-4 h-4" />
+        </button>
+      </div>
+
+      <form onSubmit={submit} className="p-3 space-y-3">
+          {/* Type toggle */}
+          <div className="inline-flex rounded-md border border-border p-0.5 bg-background">
+            <button
+              type="button"
+              onClick={() => setKind("block")}
+              className={`px-3 py-1.5 text-xs font-semibold rounded transition-colors ${
+                kind === "block" ? "bg-accent-coral text-white" : "text-muted-foreground hover:bg-muted"
+              }`}
+            >
+              Personal block
+            </button>
+            <button
+              type="button"
+              onClick={() => setKind("meeting")}
+              className={`px-3 py-1.5 text-xs font-semibold rounded transition-colors ${
+                kind === "meeting" ? "bg-accent-coral text-white" : "text-muted-foreground hover:bg-muted"
+              }`}
+            >
+              Meeting
+            </button>
+          </div>
+          <p className="text-xs text-muted-foreground">
+            {kind === "block"
+              ? "Blocks your own time. Not shared with anyone."
+              : "Invites people and (with a linked Google account) sends a Google Calendar invite."}
+          </p>
+
+          <div>
+            <label htmlFor="drag-title" className="block text-sm font-medium text-foreground mb-1">
+              Title
+            </label>
+            <input
+              id="drag-title"
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              required
+              autoFocus
+              placeholder={kind === "block" ? "e.g. Focus time" : "e.g. Design sync"}
+              className="w-full px-3 py-2 text-sm border border-border rounded-md bg-background text-foreground"
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label htmlFor="drag-start" className="block text-sm font-medium text-foreground mb-1">
+                Starts
+              </label>
+              <input
+                id="drag-start"
+                type="datetime-local"
+                value={start}
+                onChange={(e) => setStart(e.target.value)}
+                className="w-full px-2 py-2 text-sm border border-border rounded-md bg-background text-foreground"
+              />
+            </div>
+            <div>
+              <label htmlFor="drag-end" className="block text-sm font-medium text-foreground mb-1">
+                Ends
+              </label>
+              <input
+                id="drag-end"
+                type="datetime-local"
+                value={end}
+                min={start || undefined}
+                onChange={(e) => setEnd(e.target.value)}
+                className={`w-full px-2 py-2 text-sm border rounded-md bg-background text-foreground ${
+                  startEndValid ? "border-border" : "border-red-500"
+                }`}
+              />
+            </div>
+          </div>
+          {!startEndValid && <p className="text-xs text-red-600">End must be after start.</p>}
+
+          <div>
+            <label htmlFor="drag-repeats" className="block text-sm font-medium text-foreground mb-1">
+              Repeats
+            </label>
+            <select
+              id="drag-repeats"
+              value={repeats}
+              onChange={(e) => setRepeats(e.target.value as Repeats)}
+              className="w-full px-3 py-2 text-sm border border-border rounded-md bg-background text-foreground"
+            >
+              {REPEATS_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {kind === "meeting" && (
+            <>
+              <div>
+                <label
+                  htmlFor="drag-organizer"
+                  className="block text-sm font-medium text-foreground mb-1"
+                >
+                  Send invite from
+                </label>
+                {googleLinks.length === 0 ? (
+                  <p className="text-xs text-muted-foreground">
+                    No Google calendar linked. The meeting will be in-app only.
+                  </p>
+                ) : (
+                  <select
+                    id="drag-organizer"
+                    value={organizerCalendarLinkId}
+                    onChange={(e) => setOrganizerCalendarLinkId(e.target.value)}
+                    className="w-full px-3 py-2 text-sm border border-border rounded-md bg-background text-foreground"
+                  >
+                    <option value="">No invite (in-app notification only)</option>
+                    {googleLinks.map((l) => (
+                      <option key={l.id} value={l.id}>
+                        {l.displayName ? `${l.displayName} — ${l.externalEmail}` : l.externalEmail}
+                      </option>
+                    ))}
+                  </select>
+                )}
+              </div>
+
+              <ParticipantPicker
+                users={data.users}
+                groups={data.groups}
+                selectedUserIds={selectedUserIds}
+                selectedGroupIds={selectedGroupIds}
+                onChangeUsers={setSelectedUserIds}
+                onChangeGroups={setSelectedGroupIds}
+                usersById={usersById}
+                groupsById={groupsById}
+                resolvedCount={resolvedParticipantIds.length}
+              />
+            </>
+          )}
+
+          {error && <p className="text-sm text-red-700">{error}</p>}
+
+          <div className="flex items-center justify-end gap-2 pt-1">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-3 py-2 text-sm font-medium rounded-md border border-border hover:bg-muted"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={!canSubmit}
+              className="px-4 py-2 rounded-md bg-accent-coral text-white text-sm font-medium hover:bg-accent-coral/90 transition-colors disabled:opacity-50"
+            >
+              {submitting ? "Creating…" : kind === "block" ? "Add block" : "Create meeting"}
+            </button>
+          </div>
+        </form>
+    </div>
   );
 }
 
@@ -1530,6 +2110,7 @@ function ScheduleView({ data }: { data: LoaderData }) {
         showingSelfOnly={resolvedParticipantIds.length === 0}
         users={data.users}
         workingHours={data.workingHours}
+        workingHoursEnabled={data.hasPersistedWorkingHours}
         durationMinutes={duration}
         timezone={data.timezone}
         weekStartIso={data.weekStartIso}
@@ -2027,6 +2608,7 @@ function ScheduleWeekGrid({
   showingSelfOnly = false,
   users,
   workingHours,
+  workingHoursEnabled,
   durationMinutes,
   timezone,
   weekStartIso,
@@ -2042,6 +2624,8 @@ function ScheduleWeekGrid({
   users: UserOption[];
   // The viewer's own working hours, used to stripe out non-working hours.
   workingHours: WhDay[];
+  // False when the Working Hours feature is off — suppresses the stripes.
+  workingHoursEnabled: boolean;
   durationMinutes: number;
   timezone: string;
   weekStartIso: string;
@@ -2053,6 +2637,10 @@ function ScheduleWeekGrid({
   const [data, setData] = useState<GroupAvailResponse | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // When set (via the participant roster below the toolbar), the grid overlays
+  // just this one participant's free intervals so you can read one person's
+  // availability at a glance instead of the aggregate gradient.
+  const [hoveredUserId, setHoveredUserId] = useState<string | null>(null);
   // Bumped to force the fetch effect to re-run without changing inputs (manual
   // refresh button + tab-focus refresh).
   const [refreshKey, setRefreshKey] = useState(0);
@@ -2130,7 +2718,7 @@ function ScheduleWeekGrid({
   // already encoded in the cell's saturation.
   const eventsByDay: Record<number, EventBlock[]> = {};
   const totalParticipants = participantIds.length;
-  const CELL_HOURS = 0.25;
+  const CELL_HOURS = SNAP_HOURS; // 10-minute availability cells
   const GRID_START_H = HOURS[0];
   const GRID_END_H = HOURS[HOURS.length - 1] + 1;
   const CELLS_PER_DAY = Math.round((GRID_END_H - GRID_START_H) / CELL_HOURS);
@@ -2186,6 +2774,39 @@ function ScheduleWeekGrid({
         return cells;
       })
     : [];
+
+  // Per-day free blocks for the single hovered participant. When set, the grid
+  // paints these (solid green) instead of the aggregate gradient so the user
+  // can read one person's availability at a glance. Each interval is clamped to
+  // the visible [GRID_START_H, GRID_END_H) window of its day column.
+  const hoveredFreeByColIdx: { startHour: number; durationHours: number }[][] =
+    data && hoveredUserId
+      ? (() => {
+          const free = data.perUser.find((u) => u.userId === hoveredUserId)?.free ?? [];
+          const ivs = free
+            .map((iv) => ({
+              startMs: new Date(iv.startIso).getTime(),
+              endMs: new Date(iv.endIso).getTime(),
+            }))
+            .sort((a, b) => a.startMs - b.startMs);
+          return days.map((_, colIdx) => {
+            const dayStartMs = weekStart.getTime() + colIdx * 86_400_000;
+            const winStartMs = dayStartMs + GRID_START_H * 3_600_000;
+            const winEndMs = dayStartMs + GRID_END_H * 3_600_000;
+            const blocks: { startHour: number; durationHours: number }[] = [];
+            for (const iv of ivs) {
+              const s = Math.max(iv.startMs, winStartMs);
+              const e = Math.min(iv.endMs, winEndMs);
+              if (e <= s) continue;
+              blocks.push({
+                startHour: (s - dayStartMs) / 3_600_000,
+                durationHours: (e - s) / 3_600_000,
+              });
+            }
+            return blocks;
+          });
+        })()
+      : [];
 
   // Compute the selected-slot overlay (rendered separately so we can show a
   // hover popover with attending vs. unavailable participants).
@@ -2246,19 +2867,17 @@ function ScheduleWeekGrid({
   return (
     <section className="bg-card border border-border rounded-lg p-4 flex flex-col">
       <WeekToolbar
-        monthLabel={showingSelfOnly ? "Your availability" : "Schedule preview"}
+        monthLabel={"Schedule preview"}
         weekStartIso={weekStartIso}
         onRefresh={refresh}
         refreshing={loading || revalidator.state !== "idle"}
         legend={
           showingSelfOnly
-            ? [
-                { color: "bg-[rgba(132,188,105,0.8)]", label: "Free" },
-              ]
+            ? [{ swatch: availabilityTint(1), label: "Free" }]
             : [
-                { color: "bg-[rgba(132,188,105,0.18)]", label: "Few free" },
-                { color: "bg-[rgba(132,188,105,0.5)]", label: "Some free" },
-                { color: "bg-[rgba(132,188,105,0.8)]", label: "All free" },
+                { swatch: availabilityTint(0.33), label: "Few free" },
+                { swatch: availabilityTint(0.66), label: "Some free" },
+                { swatch: availabilityTint(1), label: "All free" },
               ]
         }
       />
@@ -2270,31 +2889,48 @@ function ScheduleWeekGrid({
           {error && (
             <div className="px-4 py-2 text-xs text-red-700">{error}</div>
           )}
-          {onSelectRange && (
-            <p className="px-4 py-1 text-[11px] text-muted-foreground">
-              Drag a range on the grid to set the meeting time.
-            </p>
+          {!showingSelfOnly && data && participantIds.length > 0 && (
+            <ParticipantAvailabilityRoster
+              participantIds={participantIds}
+              users={users}
+              hoveredUserId={hoveredUserId}
+              onHover={setHoveredUserId}
+            />
           )}
           <WeekGrid
             days={days}
             eventsByDay={eventsByDay}
-            showQuarterHourGrid
+            showSubHourGrid
             timezone={timezone}
             backgroundLayer={(dayIdx) => (
               <>
-                {/* Gradient first so the working-hours stripes draw on top. */}
-                {(tintsByColIdx[dayIdx] ?? []).map((t, i) => (
-                  <BlockBlock
-                    key={`tint-${i}`}
-                    topHour={GRID_START_H}
-                    startHour={t.startHour}
-                    duration={CELL_HOURS}
-                    style={{
-                      backgroundColor: `rgba(132, 188, 105, ${0.15 + 0.65 * t.alpha})`,
-                    }}
-                  />
-                ))}
-                {workingHoursStripeLayer(workingHours, days[dayIdx].dayOfWeek)}
+                {hoveredUserId ? (
+                  // One participant's own free intervals (solid green), so the
+                  // user can read that person's availability at a glance.
+                  (hoveredFreeByColIdx[dayIdx] ?? []).map((b, i) => (
+                    <BlockBlock
+                      key={`hover-${i}`}
+                      topHour={GRID_START_H}
+                      startHour={b.startHour}
+                      duration={b.durationHours}
+                      style={{ backgroundColor: availabilityTint(1) }}
+                    />
+                  ))
+                ) : (
+                  /* Aggregate gradient. Drawn first so the stripes layer on top. */
+                  (tintsByColIdx[dayIdx] ?? []).map((t, i) => (
+                    <BlockBlock
+                      key={`tint-${i}`}
+                      topHour={GRID_START_H}
+                      startHour={t.startHour}
+                      duration={CELL_HOURS}
+                      style={{ backgroundColor: availabilityTint(t.alpha) }}
+                    />
+                  ))
+                )}
+                {workingHoursStripeLayer(workingHours, days[dayIdx].dayOfWeek, {
+                  enabled: workingHoursEnabled,
+                })}
               </>
             )}
             overlayLayer={(dayIdx) => {
@@ -2306,6 +2942,9 @@ function ScheduleWeekGrid({
                   duration={selectedSlot.duration}
                   available={selectedSlot.available}
                   unavailable={selectedSlot.unavailable}
+                  // Flip the popover to the left edge for the rightmost columns
+                  // (Fri/Sat) so the attendee list isn't clipped off-screen.
+                  flipLeft={dayIdx >= 5}
                 />
               );
             }}
@@ -2314,15 +2953,10 @@ function ScheduleWeekGrid({
                 ? (dayIdx, startHour, endHour) => {
                     const day = days[dayIdx];
                     if (!day) return;
-                    const y = day.dateUtc.getUTCFullYear();
-                    const m = day.dateUtc.getUTCMonth();
-                    const d = day.dateUtc.getUTCDate();
-                    const toLocal = (hour: number) => {
-                      const h = Math.floor(hour);
-                      const mins = Math.round((hour - h) * 60);
-                      return toDatetimeLocal(new Date(y, m, d, h, mins));
-                    };
-                    onSelectRange(toLocal(startHour), toLocal(endHour));
+                    onSelectRange(
+                      dayHourToLocal(day.dateUtc, startHour),
+                      dayHourToLocal(day.dateUtc, endHour),
+                    );
                   }
                 : undefined
             }
@@ -2333,16 +2967,66 @@ function ScheduleWeekGrid({
   );
 }
 
+// Roster of the picked participants. Hovering a name asks the grid to overlay
+// just that person's free intervals (see hoveredUserId in ScheduleWeekGrid).
+function ParticipantAvailabilityRoster({
+  participantIds,
+  users,
+  hoveredUserId,
+  onHover,
+}: {
+  participantIds: string[];
+  users: UserOption[];
+  hoveredUserId: string | null;
+  onHover: (userId: string | null) => void;
+}) {
+  const usersById = new Map(users.map((u) => [u.id, u]));
+  return (
+    <div className="px-2 pb-4 flex flex-wrap items-center gap-1.5">
+      {participantIds.map((uid) => {
+        const u = usersById.get(uid) ?? {
+          id: uid,
+          firstName: uid,
+          lastName: "",
+          daliEmail: null,
+        };
+        const active = hoveredUserId === uid;
+        return (
+          <button
+            key={uid}
+            type="button"
+            onMouseEnter={() => onHover(uid)}
+            onMouseLeave={() => onHover(null)}
+            onFocus={() => onHover(uid)}
+            onBlur={() => onHover(null)}
+            className={`px-2 py-0.5 rounded-full text-xs font-medium transition-colors ${
+              active
+                ? "bg-accent-green text-[hsl(203_38%_18%)]"
+                : "bg-muted text-muted-foreground hover:bg-muted/70"
+            }`}
+          >
+            {userLabel(u)}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
 function SelectedSlotBlock({
   startHour,
   duration,
   available,
   unavailable,
+  flipLeft = false,
 }: {
   startHour: number;
   duration: number;
   available: UserOption[];
   unavailable: UserOption[];
+  // Open the attendee popover toward the left for rightmost columns so it
+  // doesn't get clipped off the right edge of the screen.
+  flipLeft?: boolean;
 }) {
   const [open, setOpen] = useState(false);
   const total = available.length + unavailable.length;
@@ -2374,7 +3058,9 @@ function SelectedSlotBlock({
       </div>
       {open && (
         <div
-          className="absolute left-full ml-2 top-0 z-40 w-56 rounded-md shadow-lg p-2 text-xs"
+          className={`absolute top-0 z-40 w-56 rounded-md shadow-lg p-2 text-xs ${
+            flipLeft ? "right-full mr-2" : "left-full ml-2"
+          }`}
           style={{
             backgroundColor: "var(--color-card)",
             color: "var(--color-foreground)",
@@ -2428,6 +3114,9 @@ type EventBlock = {
   label: string;
   /** Tailwind classes for the colored body (bg + text). */
   className: string;
+  /** Arbitrary hex background (e.g. a Google calendar colour). Overrides the
+   *  className background when set; text flips to a readable on-colour shade. */
+  bgColor?: string;
   /** Border color class for the outer wrapper (defaults to matching the body). */
   borderClassName?: string;
   /** Background tint for the buffer strip + frame (e.g. "bg-accent-coral/25"). */
@@ -2447,7 +3136,11 @@ function WeekGrid({
   overlayLayer,
   showProviderRow = false,
   onDayPointerSelect,
-  showQuarterHourGrid = false,
+  selection,
+  selectionPopover,
+  onSelectionDismiss,
+  onSelectionResize,
+  showSubHourGrid = false,
   timezone,
 }: {
   days: { dayOfWeek: number; num: number; dateUtc: Date }[];
@@ -2456,7 +3149,15 @@ function WeekGrid({
   overlayLayer?: (dayIdx: number) => React.ReactNode;
   showProviderRow?: boolean;
   onDayPointerSelect?: (dayIdx: number, startHour: number, endHour: number) => void;
-  showQuarterHourGrid?: boolean;
+  // A committed selection (controlled by the parent) drawn as a persistent
+  // accent block. selectionPopover renders the editor in a viewport-clamped
+  // portal; onSelectionDismiss fires when the user clicks the grid backdrop.
+  // onSelectionResize fires while dragging the block's top/bottom handles.
+  selection?: { dayIdx: number; startHour: number; endHour: number } | null;
+  selectionPopover?: () => React.ReactNode;
+  onSelectionDismiss?: () => void;
+  onSelectionResize?: (startHour: number, endHour: number) => void;
+  showSubHourGrid?: boolean;
   // When set, the column matching "today" in this timezone is highlighted and a
   // horizontal current-time line is drawn in it.
   timezone?: string;
@@ -2491,11 +3192,19 @@ function WeekGrid({
     null | { dayIdx: number; anchor: number; hover: number }
   >(null);
 
+  // Resize-drag state for the committed selection's top/bottom handles. `edge`
+  // says which end is moving; `fixed` is the opposite end's hour (held still).
+  const [resize, setResize] = useState<
+    null | { edge: "start" | "end"; fixed: number }
+  >(null);
+
   // Column DOM refs so window-level mousemove can compute Y relative to the
   // column the drag started in, even when the cursor strays elsewhere.
   const columnRefs = useRef<(HTMLDivElement | null)[]>([]);
+  // The committed selection block element, so the portal popover can anchor to
+  // its real on-screen rect and clamp itself to the viewport.
+  const selectionRef = useRef<HTMLDivElement | null>(null);
 
-  const SNAP_HOURS = 0.25; // 15 minutes
   const MIN_HOUR = HOURS[0];
   const MAX_HOUR = HOURS[HOURS.length - 1] + 1;
 
@@ -2508,6 +3217,11 @@ function WeekGrid({
   const onDayMouseDown = (dayIdx: number) => (e: React.MouseEvent<HTMLDivElement>) => {
     if (!onDayPointerSelect) return;
     if (e.button !== 0) return;
+    // While a selection's editor is open, freeze the grid: a new drag would
+    // move the committed selection out from under the open form. (The popover
+    // itself lives in a body portal, so its clicks never reach a column — this
+    // only guards clicks on the grid behind/around it.)
+    if (selection) return;
     const rect = e.currentTarget.getBoundingClientRect();
     const h = hourFromY(e.clientY - rect.top);
     setDrag({ dayIdx, anchor: h, hover: h });
@@ -2542,7 +3256,45 @@ function WeekGrid({
     };
   }, [drag, onDayPointerSelect, MAX_HOUR]);
 
+  // Resizing the committed selection by dragging its top/bottom handle. The
+  // moving edge follows the cursor (snapped, clamped, never crossing the fixed
+  // edge); onSelectionResize streams the new range up so the popover form and
+  // the block stay in sync live.
+  const startResize = (edge: "start" | "end") => (e: React.MouseEvent) => {
+    if (!selection || !onSelectionResize) return;
+    if (e.button !== 0) return;
+    e.preventDefault();
+    e.stopPropagation();
+    setResize({ edge, fixed: edge === "start" ? selection.endHour : selection.startHour });
+  };
+
+  useEffect(() => {
+    if (!resize || !selection || !onSelectionResize) return;
+    const col = columnRefs.current[selection.dayIdx];
+    const onMove = (e: MouseEvent) => {
+      if (!col) return;
+      const rect = col.getBoundingClientRect();
+      const h = hourFromY(e.clientY - rect.top);
+      // Keep at least one snap-step of height and don't let edges cross.
+      if (resize.edge === "start") {
+        const start = Math.min(h, resize.fixed - SNAP_HOURS);
+        onSelectionResize(Math.max(MIN_HOUR, start), resize.fixed);
+      } else {
+        const end = Math.max(h, resize.fixed + SNAP_HOURS);
+        onSelectionResize(resize.fixed, Math.min(MAX_HOUR, end));
+      }
+    };
+    const onUp = () => setResize(null);
+    window.addEventListener("mousemove", onMove);
+    window.addEventListener("mouseup", onUp);
+    return () => {
+      window.removeEventListener("mousemove", onMove);
+      window.removeEventListener("mouseup", onUp);
+    };
+  }, [resize, selection, onSelectionResize, MIN_HOUR, MAX_HOUR]);
+
   return (
+    <div className="relative">
     <div className="flex border border-border rounded-md overflow-hidden select-none">
       {/* Hour axis */}
       <div className="flex flex-col w-14 border-r border-border bg-card text-[11px] text-muted-foreground">
@@ -2578,26 +3330,21 @@ function WeekGrid({
           >
             {HOURS.map((_, i) => (
               <Fragment key={i}>
+                {/* Hour line — distinctly heavier (2px, darker) than the faint
+                    10-minute sub-hour lines. */}
                 <div
-                  className="absolute left-0 right-0 border-t border-foreground/30"
+                  className="absolute left-0 right-0 border-t-2 border-foreground/45"
                   style={{ top: i * HOUR_PX }}
                 />
-                {showQuarterHourGrid && (
-                  <>
+                {showSubHourGrid &&
+                  // 10-minute sub-hour lines (skip index 0; that's the hour line).
+                  Array.from({ length: SUBDIVISIONS_PER_HOUR - 1 }).map((_, s) => (
                     <div
-                      className="absolute left-0 right-0 border-t border-foreground/30"
-                      style={{ top: i * HOUR_PX + HOUR_PX * 0.25 }}
+                      key={s}
+                      className="absolute left-0 right-0 border-t border-foreground/[0.08]"
+                      style={{ top: i * HOUR_PX + (HOUR_PX * (s + 1)) / SUBDIVISIONS_PER_HOUR }}
                     />
-                    <div
-                      className="absolute left-0 right-0 border-t border-foreground/30"
-                      style={{ top: i * HOUR_PX + HOUR_PX * 0.5 }}
-                    />
-                    <div
-                      className="absolute left-0 right-0 border-t border-foreground/30"
-                      style={{ top: i * HOUR_PX + HOUR_PX * 0.75 }}
-                    />
-                  </>
-                )}
+                  ))}
               </Fragment>
             ))}
             {backgroundLayer?.(idx)}
@@ -2616,22 +3363,58 @@ function WeekGrid({
               const heightHours = Math.max(SNAP_HOURS, hi - lo);
               return (
                 <div
-                  className="absolute left-0 right-0 border-2 pointer-events-none rounded-sm z-30 shadow-md"
+                  className="absolute left-0 right-0 border-2 border-accent-coral bg-accent-coral/15 pointer-events-none rounded-sm z-30 shadow-md"
                   style={{
                     top: (lo - MIN_HOUR) * HOUR_PX,
                     height: heightHours * HOUR_PX,
-                    borderColor: "var(--color-foreground)",
                   }}
                 >
-                  <div
-                    className="px-1 py-0.5 text-[11px] font-semibold rounded-sm m-1 inline-block shadow-sm"
-                    style={{
-                      color: "var(--color-foreground)",
-                      backgroundColor: "var(--color-card)",
-                    }}
-                  >
+                  <div className="px-1 py-0.5 text-[11px] font-semibold rounded-sm m-1 inline-block shadow-sm bg-accent-coral text-white">
                     {formatHourMinute(lo)} – {formatHourMinute(hi)}
                   </div>
+                </div>
+              );
+            })()}
+            {/* Committed selection block — stays drawn where the drag landed,
+                with top/bottom handles to resize it. The editor popover renders
+                in a viewport-clamped portal (below), not clipped by the grid. */}
+            {selection && selection.dayIdx === idx && (() => {
+              const lo = selection.startHour;
+              const hi = selection.endHour;
+              const top = (lo - MIN_HOUR) * HOUR_PX;
+              const height = Math.max(SNAP_HOURS, hi - lo) * HOUR_PX;
+              const resizable = !!onSelectionResize;
+              return (
+                <div
+                  ref={selectionRef}
+                  className={`absolute left-0 right-0 border-2 border-accent-coral bg-accent-coral/15 rounded-sm z-30 ${
+                    resizable ? "" : "pointer-events-none"
+                  }`}
+                  style={{ top, height }}
+                >
+                  <div className="px-1 py-0.5 text-[11px] font-semibold rounded-sm m-1 inline-block bg-accent-coral text-white pointer-events-none">
+                    {formatHourMinute(lo)} – {formatHourMinute(hi)}
+                  </div>
+                  {resizable && (
+                    <>
+                      {/* Top handle */}
+                      <div
+                        onMouseDown={startResize("start")}
+                        className="absolute -top-1 left-0 right-0 h-2 cursor-ns-resize flex items-center justify-center group"
+                        aria-label="Adjust start time"
+                      >
+                        <span className="w-8 h-1 rounded-full bg-accent-coral group-hover:h-1.5 transition-all" />
+                      </div>
+                      {/* Bottom handle */}
+                      <div
+                        onMouseDown={startResize("end")}
+                        className="absolute -bottom-1 left-0 right-0 h-2 cursor-ns-resize flex items-center justify-center group"
+                        aria-label="Adjust end time"
+                      >
+                        <span className="w-8 h-1 rounded-full bg-accent-coral group-hover:h-1.5 transition-all" />
+                      </div>
+                    </>
+                  )}
                 </div>
               );
             })()}
@@ -2654,10 +3437,13 @@ function WeekGrid({
                   }}
                 >
                   <div
-                    className={`absolute left-0 right-0 px-1.5 py-1 text-[11px] font-medium overflow-hidden ${e.className}`}
+                    className={`absolute left-0 right-0 px-1.5 py-1 text-[11px] font-medium overflow-hidden ${e.className} ${
+                      e.bgColor ? "text-white" : ""
+                    }`}
                     style={{
                       top: bufferBefore * HOUR_PX,
                       height: e.duration * HOUR_PX,
+                      ...(e.bgColor ? { backgroundColor: e.bgColor } : {}),
                     }}
                   >
                     {e.label && <span className="truncate block">{e.label}</span>}
@@ -2666,25 +3452,22 @@ function WeekGrid({
               );
             })}
             {overlayLayer?.(idx)}
-            {showQuarterHourGrid &&
+            {/* Redraw the grid lines above the availability tint so they stay
+                visible. Hour lines bolder than the 10-minute sub-hour lines. */}
+            {showSubHourGrid &&
               HOURS.map((_, i) => (
                 <Fragment key={`grid-fg-${i}`}>
                   <div
-                    className="absolute left-0 right-0 border-t border-foreground/20 pointer-events-none z-20"
+                    className="absolute left-0 right-0 border-t-2 border-foreground/40 pointer-events-none z-20"
                     style={{ top: i * HOUR_PX }}
                   />
-                  <div
-                    className="absolute left-0 right-0 border-t border-foreground/20 pointer-events-none z-20"
-                    style={{ top: i * HOUR_PX + HOUR_PX * 0.25 }}
-                  />
-                  <div
-                    className="absolute left-0 right-0 border-t border-foreground/20 pointer-events-none z-20"
-                    style={{ top: i * HOUR_PX + HOUR_PX * 0.5 }}
-                  />
-                  <div
-                    className="absolute left-0 right-0 border-t border-foreground/20 pointer-events-none z-20"
-                    style={{ top: i * HOUR_PX + HOUR_PX * 0.75 }}
-                  />
+                  {Array.from({ length: SUBDIVISIONS_PER_HOUR - 1 }).map((_, s) => (
+                    <div
+                      key={s}
+                      className="absolute left-0 right-0 border-t border-foreground/[0.08] pointer-events-none z-20"
+                      style={{ top: i * HOUR_PX + (HOUR_PX * (s + 1)) / SUBDIVISIONS_PER_HOUR }}
+                    />
+                  ))}
                 </Fragment>
               ))}
           </div>
@@ -2692,6 +3475,87 @@ function WeekGrid({
         );
       })}
     </div>
+    {/* Editor popover — rendered in a portal at <body>, anchored to the
+        selection block's real screen rect and clamped to the viewport, so it
+        is never clipped by the grid's overflow or the screen edge. */}
+    {selection && selectionPopover && (
+      <SelectionPopoverPortal
+        anchorRef={selectionRef}
+        onDismiss={() => onSelectionDismiss?.()}
+      >
+        {selectionPopover()}
+      </SelectionPopoverPortal>
+    )}
+    </div>
+  );
+}
+
+// Floats the selection editor next to the committed block. Renders into <body>
+// (so the grid's overflow-hidden can't clip it) and positions itself fixed,
+// preferring the block's right side but flipping left / shifting up to stay
+// fully on-screen. A transparent full-viewport backdrop captures outside clicks
+// to dismiss — and, being in a portal, never lets a click reach a grid column.
+function SelectionPopoverPortal({
+  anchorRef,
+  onDismiss,
+  children,
+}: {
+  anchorRef: React.RefObject<HTMLElement | null>;
+  onDismiss: () => void;
+  children: React.ReactNode;
+}) {
+  const cardRef = useRef<HTMLDivElement | null>(null);
+  const [pos, setPos] = useState<{ left: number; top: number } | null>(null);
+
+  useLayoutEffect(() => {
+    const place = () => {
+      const anchor = anchorRef.current;
+      const card = cardRef.current;
+      if (!anchor || !card) return;
+      const a = anchor.getBoundingClientRect();
+      const cw = card.offsetWidth;
+      const ch = card.offsetHeight;
+      const gap = 8;
+      const margin = 8;
+      const vw = window.innerWidth;
+      const vh = window.innerHeight;
+      // Prefer the right of the block; flip left if it would overflow.
+      let left = a.right + gap;
+      if (left + cw + margin > vw) left = a.left - gap - cw;
+      left = Math.max(margin, Math.min(left, vw - cw - margin));
+      // Align the top with the block, then clamp within the viewport.
+      let top = a.top;
+      top = Math.max(margin, Math.min(top, vh - ch - margin));
+      setPos({ left, top });
+    };
+    place();
+    window.addEventListener("resize", place);
+    window.addEventListener("scroll", place, true);
+    return () => {
+      window.removeEventListener("resize", place);
+      window.removeEventListener("scroll", place, true);
+    };
+  }, [anchorRef, children]);
+
+  if (typeof document === "undefined") return null;
+
+  return createPortal(
+    <div className="fixed inset-0 z-50">
+      <div
+        className="absolute inset-0"
+        onMouseDown={onDismiss}
+        aria-hidden="true"
+      />
+      <div
+        data-calendar-popover
+        className="absolute"
+        style={{ left: pos?.left ?? -9999, top: pos?.top ?? -9999, visibility: pos ? "visible" : "hidden" }}
+        onMouseDown={(e) => e.stopPropagation()}
+      >
+        {children}
+      </div>
+    </div>,
+    document.body,
   );
 }
 
@@ -2727,8 +3591,11 @@ function DayBg({ className, style }: { className?: string; style?: React.CSSProp
 function workingHoursStripeLayer(
   workingHours: WhDay[],
   dow: number,
-  options?: { wash?: boolean },
+  options?: { enabled?: boolean },
 ): React.ReactNode {
+  // When the Working Hours feature is off, the whole day is unrestricted — draw
+  // no "outside hours" stripes at all.
+  if (options?.enabled === false) return null;
   const wh = workingHours.find((w) => w.dayOfWeek === dow);
   if (!wh || wh.segments.length === 0) return <DayBg style={STRIPE_STYLE} />;
   const sorted = wh.segments
@@ -2763,16 +3630,6 @@ function workingHoursStripeLayer(
           style={STRIPE_STYLE}
         />
       ))}
-      {options?.wash &&
-        merged.map((s, i) => (
-          <BlockBlock
-            key={`wash-${i}`}
-            topHour={dayStart}
-            startHour={s.start}
-            duration={s.end - s.start}
-            className="bg-accent-green/20 dark:bg-accent-green/15"
-          />
-        ))}
     </>
   );
 }

--- a/dali-api/app/components/Layout.tsx
+++ b/dali-api/app/components/Layout.tsx
@@ -31,6 +31,8 @@ import {
   GraduationCap,
   ListTodo,
   Megaphone,
+  SplitSquareHorizontal,
+  ExternalLink,
 } from 'lucide-react'
 import { userInitials } from '~/lib/display'
 import { TabWorkspace, type TabWorkspaceHandle, type OpenTabRequest } from '~/components/TabWorkspace'
@@ -89,8 +91,17 @@ export function Layout({ user, photoUrl, isCore = false, isAdmin = false, isDoma
   })
   const workspaceRef = useRef<TabWorkspaceHandle | null>(null)
 
+  // Right-click context menu for a sidebar subtab. `x`/`y` are viewport
+  // coordinates; `req` is the tab to act on.
+  const [subtabMenu, setSubtabMenu] = useState<
+    null | { x: number; y: number; req: OpenTabRequest }
+  >(null)
+
   const openInWorkspace = (req: OpenTabRequest) => {
     workspaceRef.current?.openTab(req)
+  }
+  const openToSide = (req: OpenTabRequest) => {
+    workspaceRef.current?.openTabToSide(req)
   }
 
   useEffect(() => {
@@ -547,7 +558,7 @@ export function Layout({ user, photoUrl, isCore = false, isAdmin = false, isDoma
       )}
 
       {/* Areas + nested sections */}
-      <nav className="flex-1 overflow-y-auto py-3 px-2 flex flex-col gap-0.5">
+      <nav className="sidebar-scroll flex-1 overflow-y-auto py-3 px-2 flex flex-col gap-0.5">
         {(() => {
           const hasTasks = taskCount > 0
           const homeActive = path === '/'
@@ -760,6 +771,14 @@ export function Layout({ user, photoUrl, isCore = false, isAdmin = false, isDoma
                       key={section.to}
                       type="button"
                       onClick={() => openInWorkspace({ url: section.to, label: section.label })}
+                      onContextMenu={(e) => {
+                        e.preventDefault()
+                        setSubtabMenu({
+                          x: e.clientX,
+                          y: e.clientY,
+                          req: { url: section.to, label: section.label },
+                        })
+                      }}
                       className={`flex items-center gap-2.5 px-2.5 py-1.5 rounded-md text-[13px] font-medium text-left transition-colors ${
                         section.active
                           ? 'bg-accent-coral/20 text-white'
@@ -946,6 +965,49 @@ export function Layout({ user, photoUrl, isCore = false, isAdmin = false, isDoma
           onActiveUrlChange={setFocusedTabUrl}
         />
       </main>
+
+      {/* Right-click context menu for a sidebar subtab. Rendered at the layout
+          root so it isn't clipped by the sidebar. */}
+      {subtabMenu && (
+        <>
+          <div
+            className="fixed inset-0 z-50"
+            onClick={() => setSubtabMenu(null)}
+            onContextMenu={(e) => {
+              e.preventDefault()
+              setSubtabMenu(null)
+            }}
+            aria-hidden="true"
+          />
+          <div
+            className="fixed z-50 bg-card border border-border rounded-md shadow-lg py-1 min-w-[180px] text-sm"
+            style={{ left: subtabMenu.x, top: subtabMenu.y }}
+          >
+            <button
+              type="button"
+              onClick={() => {
+                openInWorkspace(subtabMenu.req)
+                setSubtabMenu(null)
+              }}
+              className="w-full flex items-center gap-2 px-3 py-1.5 hover:bg-muted text-left text-foreground"
+            >
+              <ExternalLink className="w-3.5 h-3.5" />
+              Open
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                openToSide(subtabMenu.req)
+                setSubtabMenu(null)
+              }}
+              className="w-full flex items-center gap-2 px-3 py-1.5 hover:bg-muted text-left text-foreground"
+            >
+              <SplitSquareHorizontal className="w-3.5 h-3.5" />
+              Open to the side
+            </button>
+          </div>
+        </>
+      )}
     </div>
   )
 }

--- a/dali-api/app/components/TabWorkspace.tsx
+++ b/dali-api/app/components/TabWorkspace.tsx
@@ -9,6 +9,10 @@ export interface OpenTabRequest {
 export interface TabWorkspaceHandle {
   /** Open a tab in the focused pane, or focus it if already open anywhere. */
   openTab: (req: OpenTabRequest) => void
+  /** Open a tab in a second pane to the side (splitting if there's only one
+   *  pane), or focus it if already open there. Used by the sidebar's
+   *  right-click "Open to the side". */
+  openTabToSide: (req: OpenTabRequest) => void
   /** Rename any tab matching `url` (across all panes). Used by embedded
    *  iframes to announce their preferred label after route meta resolves. */
   setTabLabel: (url: string, label: string) => void
@@ -295,6 +299,60 @@ export function TabWorkspace({ initialTabs, apiRef, onActiveUrlChange }: TabWork
                   }
                 : p,
             ),
+          }
+        })
+      },
+      openTabToSide: (req) => {
+        setState((prev) => {
+          // Already open somewhere — just focus it (don't duplicate).
+          const existing = findTabPane(prev, req.url)
+          if (existing) {
+            return {
+              ...prev,
+              focusedPaneId: existing.paneId,
+              panes: prev.panes.map((p) =>
+                p.id === existing.paneId
+                  ? {
+                      ...p,
+                      activeTabId: existing.tabId,
+                      tabs: p.tabs.map((t) =>
+                        t.id === existing.tabId ? { ...t, lastActivatedAt: now() } : t,
+                      ),
+                    }
+                  : p,
+              ),
+            }
+          }
+          const newTab: Tab = {
+            id: newId(),
+            label: req.label,
+            url: req.url,
+            lastActivatedAt: now(),
+          }
+          // Already split — open in the pane that isn't focused.
+          if (prev.panes.length >= 2) {
+            const sidePane =
+              prev.panes.find((p) => p.id !== prev.focusedPaneId) ?? prev.panes[1]
+            return {
+              ...prev,
+              focusedPaneId: sidePane.id,
+              panes: prev.panes.map((p) =>
+                p.id === sidePane.id
+                  ? {
+                      ...p,
+                      tabs: appendWithLruCap([...p.tabs, newTab], newTab.id),
+                      activeTabId: newTab.id,
+                    }
+                  : p,
+              ),
+            }
+          }
+          // Single pane — create a second one to the right.
+          const newPaneId = newId()
+          return {
+            ...prev,
+            focusedPaneId: newPaneId,
+            panes: [...prev.panes, { id: newPaneId, tabs: [newTab], activeTabId: newTab.id }],
           }
         })
       },

--- a/dali-api/app/hiring/components/Library.tsx
+++ b/dali-api/app/hiring/components/Library.tsx
@@ -44,7 +44,7 @@ export default function Library() {
         </p>
       </header>
 
-      <div className="flex gap-1 bg-muted rounded-lg p-1 w-fit" role="tablist" aria-label="Library section">
+      <div className="flex items-center gap-2" role="tablist" aria-label="Library section">
         {TABS.map((t) => {
           const active = t.id === tab;
           return (
@@ -54,10 +54,10 @@ export default function Library() {
               role="tab"
               aria-selected={active}
               onClick={() => selectTab(t.id)}
-              className={`px-4 py-1.5 rounded-md text-sm font-medium transition ${
+              className={`px-4 py-1.5 text-sm font-semibold rounded-md transition-colors ${
                 active
-                  ? "bg-accent-coral text-white shadow-sm"
-                  : "text-muted-foreground hover:text-foreground"
+                  ? "bg-accent-coral text-white"
+                  : "text-foreground hover:bg-muted"
               }`}
             >
               {t.label}

--- a/dali-api/app/lib/__mocks__/db.ts
+++ b/dali-api/app/lib/__mocks__/db.ts
@@ -72,6 +72,7 @@ export const prisma = {
   },
   scheduledMeeting: {
     findMany: vi.fn().mockResolvedValue([]),
+    findUnique: vi.fn(),
     create: vi.fn(),
     update: vi.fn(),
   },

--- a/dali-api/app/lib/__tests__/google-calendar.test.ts
+++ b/dali-api/app/lib/__tests__/google-calendar.test.ts
@@ -36,6 +36,21 @@ function mockFetchOnce(body: unknown, ok = true, status = 200) {
   return fn;
 }
 
+// Queue several fetch responses in order (e.g. calendarList then events.list).
+function mockFetchSequence(bodies: unknown[]) {
+  const fn = vi.fn();
+  for (const body of bodies) {
+    fn.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => body,
+      text: async () => JSON.stringify(body),
+    });
+  }
+  vi.stubGlobal("fetch", fn);
+  return fn;
+}
+
 function encryptedTokens(opts: { accessToken: string; refreshToken: string; expiresAt: string | null }) {
   return encrypt(JSON.stringify(opts));
 }
@@ -85,36 +100,65 @@ describe("getValidAccessTokenForLink", () => {
 });
 
 describe("fetchBusyEvents", () => {
-  it("returns merged busy ranges from each link's primary calendar", async () => {
+  it("returns titled events from each link's primary calendar, tinted by colour", async () => {
     prismaMock.userCalendarLink.findMany.mockResolvedValueOnce([
       { id: "L1", subCalendarIds: [] },
     ]);
-    prismaMock.userCalendarLink.findUnique.mockResolvedValueOnce({
+    // getValidAccessTokenForLink is called once for the link.
+    prismaMock.userCalendarLink.findUnique.mockResolvedValue({
       oauthTokens: encryptedTokens({
         accessToken: "tok",
         refreshToken: "r",
         expiresAt: new Date(Date.now() + 10 * 60_000).toISOString(),
       }),
     });
-    mockFetchOnce({
-      calendars: {
-        primary: {
-          busy: [
-            { start: "2026-05-12T13:00:00Z", end: "2026-05-12T14:00:00Z" },
-            { start: "2026-05-12T15:00:00Z", end: "2026-05-12T16:00:00Z" },
-          ],
-        },
+    // Two fetches: calendarList (for colours) then events.list for "primary".
+    mockFetchSequence([
+      { items: [{ id: "primary", summary: "Me", primary: true, backgroundColor: "#2952A3" }] },
+      {
+        items: [
+          {
+            id: "e1",
+            summary: "Standup",
+            status: "confirmed",
+            start: { dateTime: "2026-05-12T13:00:00Z" },
+            end: { dateTime: "2026-05-12T14:00:00Z" },
+          },
+          // Declined → skipped.
+          {
+            id: "e2",
+            summary: "Declined thing",
+            status: "confirmed",
+            start: { dateTime: "2026-05-12T15:00:00Z" },
+            end: { dateTime: "2026-05-12T16:00:00Z" },
+            attendees: [{ self: true, responseStatus: "declined" }],
+          },
+          // All-day (date only) → skipped.
+          {
+            id: "e3",
+            summary: "Holiday",
+            status: "confirmed",
+            start: { date: "2026-05-12" },
+            end: { date: "2026-05-13" },
+          },
+        ],
       },
-    });
-    prismaMock.userCalendarLink.update.mockResolvedValueOnce({});
+    ]);
+    prismaMock.userCalendarLink.update.mockResolvedValue({});
 
     const out = await fetchBusyEvents(
       "userX",
       new Date("2026-05-12T00:00:00Z"),
       new Date("2026-05-13T00:00:00Z"),
     );
-    expect(out).toHaveLength(2);
-    expect(out[0]).toEqual({ start: "2026-05-12T13:00:00Z", end: "2026-05-12T14:00:00Z" });
+    expect(out).toHaveLength(1);
+    expect(out[0]).toEqual({
+      start: "2026-05-12T13:00:00Z",
+      end: "2026-05-12T14:00:00Z",
+      title: "Standup",
+      calendarId: "primary",
+      color: "#2952A3",
+    });
   });
 
   it("returns [] when no UserCalendarLink exists (Phase 2: no legacy User.google* fallback)", async () => {

--- a/dali-api/app/lib/__tests__/groups.test.ts
+++ b/dali-api/app/lib/__tests__/groups.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi } from "vitest";
+
+// groups.ts pulls in ~/lib/db at import time, which loads the generated Prisma
+// client — absent in CI before `prisma generate`. isGroupArchived is pure and
+// never touches the DB, so mock db so importing the module doesn't require the
+// real client (matches every other db-touching suite).
+vi.mock("~/lib/db");
+
+import { isGroupArchived } from "../groups";
+
+const NOW = new Date("2026-05-24T00:00:00Z");
+
+// Two terms: 26W has ended, 26S is still running as of NOW.
+const ended = new Date("2026-03-01T00:00:00Z");
+const running = new Date("2026-06-15T00:00:00Z");
+const termEnds = new Map([
+  ["26W", ended],
+  ["26S", running],
+]);
+
+describe("isGroupArchived", () => {
+  it("is archived when manually archived, regardless of terms", () => {
+    expect(
+      isGroupArchived({ archivedAt: new Date("2026-01-01"), boundTermIds: [] }, termEnds, NOW),
+    ).toBe(true);
+    // Manual archive overrides a still-running bound term.
+    expect(
+      isGroupArchived({ archivedAt: new Date("2026-01-01"), boundTermIds: ["26S"] }, termEnds, NOW),
+    ).toBe(true);
+  });
+
+  it("is not archived when ongoing (no archive, no bound terms)", () => {
+    expect(isGroupArchived({ archivedAt: null, boundTermIds: [] }, termEnds, NOW)).toBe(false);
+  });
+
+  it("auto-archives once the only bound term has ended", () => {
+    expect(isGroupArchived({ archivedAt: null, boundTermIds: ["26W"] }, termEnds, NOW)).toBe(true);
+  });
+
+  it("stays active while a bound term is still running", () => {
+    expect(isGroupArchived({ archivedAt: null, boundTermIds: ["26S"] }, termEnds, NOW)).toBe(false);
+  });
+
+  it("uses the latest bound term: active until the last term ends", () => {
+    // Bound to both an ended and a running term — the running one keeps it active.
+    expect(
+      isGroupArchived({ archivedAt: null, boundTermIds: ["26W", "26S"] }, termEnds, NOW),
+    ).toBe(false);
+  });
+
+  it("ignores unknown (deleted) term ids; falls back to not-archived if all unknown", () => {
+    expect(
+      isGroupArchived({ archivedAt: null, boundTermIds: ["gone"] }, termEnds, NOW),
+    ).toBe(false);
+    // A known-ended term still archives even alongside an unknown id.
+    expect(
+      isGroupArchived({ archivedAt: null, boundTermIds: ["gone", "26W"] }, termEnds, NOW),
+    ).toBe(true);
+  });
+});

--- a/dali-api/app/lib/__tests__/notifications.test.ts
+++ b/dali-api/app/lib/__tests__/notifications.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("~/lib/db");
+
+import { prisma } from "~/lib/db";
+import { listMyNotifications } from "~/lib/notifications";
+
+const mockPrisma = prisma as unknown as {
+  notification: {
+    findMany: ReturnType<typeof vi.fn>;
+    count: ReturnType<typeof vi.fn>;
+  };
+};
+
+// The clause that hides invites whose meeting was Cancelled — every query in
+// listMyNotifications must carry it so cancelled invites vanish everywhere.
+const NOT_CANCELLED = {
+  OR: [
+    { scheduledMeetingId: null },
+    { scheduledMeeting: { status: { not: "Cancelled" } } },
+  ],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockPrisma.notification.findMany.mockResolvedValue([]);
+  mockPrisma.notification.count.mockResolvedValue(0);
+});
+
+describe("listMyNotifications", () => {
+  it("excludes cancelled-meeting invites from the default feed", async () => {
+    await listMyNotifications("user-1");
+    expect(mockPrisma.notification.findMany).toHaveBeenCalledWith({
+      where: { recipientUserId: "user-1", ...NOT_CANCELLED },
+      orderBy: { createdAt: "desc" },
+      take: 50,
+    });
+  });
+
+  it("keeps the cancelled filter on the unread count too", async () => {
+    await listMyNotifications("user-1");
+    expect(mockPrisma.notification.count).toHaveBeenCalledWith({
+      where: { recipientUserId: "user-1", readAt: null, ...NOT_CANCELLED },
+    });
+  });
+
+  it("combines onlyUnread with the cancelled filter", async () => {
+    await listMyNotifications("user-1", { onlyUnread: true });
+    expect(mockPrisma.notification.findMany).toHaveBeenCalledWith({
+      where: { recipientUserId: "user-1", readAt: null, ...NOT_CANCELLED },
+      orderBy: { createdAt: "desc" },
+      take: 50,
+    });
+  });
+});

--- a/dali-api/app/lib/__tests__/scheduled-meeting.test.ts
+++ b/dali-api/app/lib/__tests__/scheduled-meeting.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("~/lib/db");
+
+import { prisma } from "~/lib/db";
+import { cancelScheduledMeeting } from "~/lib/scheduled-meeting";
+
+const mockPrisma = prisma as unknown as {
+  scheduledMeeting: {
+    findUnique: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+  };
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("cancelScheduledMeeting", () => {
+  it("flips a meeting to Cancelled when the organizer cancels", async () => {
+    mockPrisma.scheduledMeeting.findUnique.mockResolvedValue({
+      id: "m1",
+      organizerId: "org-1",
+      status: "Confirmed",
+    });
+    mockPrisma.scheduledMeeting.update.mockResolvedValue({});
+
+    const res = await cancelScheduledMeeting("m1", "org-1");
+
+    expect(res).toEqual({ ok: true, alreadyCancelled: false });
+    expect(mockPrisma.scheduledMeeting.update).toHaveBeenCalledWith({
+      where: { id: "m1" },
+      data: { status: "Cancelled" },
+    });
+  });
+
+  it("forbids non-organizers", async () => {
+    mockPrisma.scheduledMeeting.findUnique.mockResolvedValue({
+      id: "m1",
+      organizerId: "org-1",
+      status: "Confirmed",
+    });
+
+    const res = await cancelScheduledMeeting("m1", "someone-else");
+
+    expect(res).toEqual({ ok: false, error: "Only the organizer can cancel", status: 403 });
+    expect(mockPrisma.scheduledMeeting.update).not.toHaveBeenCalled();
+  });
+
+  it("404s a missing meeting", async () => {
+    mockPrisma.scheduledMeeting.findUnique.mockResolvedValue(null);
+
+    const res = await cancelScheduledMeeting("nope", "org-1");
+
+    expect(res).toEqual({ ok: false, error: "Not found", status: 404 });
+    expect(mockPrisma.scheduledMeeting.update).not.toHaveBeenCalled();
+  });
+
+  it("is idempotent — re-cancelling does not write again", async () => {
+    mockPrisma.scheduledMeeting.findUnique.mockResolvedValue({
+      id: "m1",
+      organizerId: "org-1",
+      status: "Cancelled",
+    });
+
+    const res = await cancelScheduledMeeting("m1", "org-1");
+
+    expect(res).toEqual({ ok: true, alreadyCancelled: true });
+    expect(mockPrisma.scheduledMeeting.update).not.toHaveBeenCalled();
+  });
+});

--- a/dali-api/app/lib/__tests__/tasks.test.ts
+++ b/dali-api/app/lib/__tests__/tasks.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("~/lib/db");
+
+import { prisma } from "~/lib/db";
+import { listOpenTasks, countOpenTasks } from "~/lib/tasks";
+
+const mockPrisma = prisma as unknown as {
+  notification: {
+    findMany: ReturnType<typeof vi.fn>;
+    count: ReturnType<typeof vi.fn>;
+  };
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockPrisma.notification.findMany.mockResolvedValue([]);
+  mockPrisma.notification.count.mockResolvedValue(0);
+});
+
+// The where clause the Tasks views filter on. Cancelled-meeting invites and
+// stale interview-assignment notifications must both be excluded.
+function expectedWhere(userId: string) {
+  return {
+    recipientUserId: userId,
+    readAt: null,
+    AND: [
+      {
+        OR: [
+          { scheduledMeetingId: null },
+          { scheduledMeeting: { status: { not: "Cancelled" } } },
+        ],
+      },
+    ],
+    OR: [
+      { interviewAssignmentId: null },
+      { interviewAssignment: { status: "Active", interview: { status: "Scheduled" } } },
+    ],
+  };
+}
+
+describe("listOpenTasks", () => {
+  it("filters out cancelled-meeting invites and stale interview tasks", async () => {
+    await listOpenTasks("user-1");
+    expect(mockPrisma.notification.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expectedWhere("user-1") }),
+    );
+  });
+
+  it("maps a meeting-invite notification to a meeting-source task", async () => {
+    mockPrisma.notification.findMany.mockResolvedValue([
+      {
+        id: "n1",
+        kind: "MeetingInvite",
+        title: "Meeting invite: Standup",
+        body: null,
+        link: "/calendar?meeting=m1",
+        dueAt: null,
+        createdAt: new Date("2026-05-20T10:00:00Z"),
+        scheduledMeeting: { selectedAt: new Date("2026-05-22T15:00:00Z") },
+        form: null,
+      },
+    ]);
+
+    const tasks = await listOpenTasks("user-1");
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0]).toMatchObject({
+      id: "n1",
+      source: "meeting",
+      dueAt: "2026-05-22T15:00:00.000Z",
+    });
+  });
+});
+
+describe("countOpenTasks", () => {
+  it("counts with the same cancelled/interview filter", async () => {
+    await countOpenTasks("user-1");
+    expect(mockPrisma.notification.count).toHaveBeenCalledWith({
+      where: expectedWhere("user-1"),
+    });
+  });
+});

--- a/dali-api/app/lib/availability.ts
+++ b/dali-api/app/lib/availability.ts
@@ -241,18 +241,7 @@ function formatDtstart(d: Date): string {
 // per-day grid bucketing; this module owns the cross-user math.
 
 const DEFAULT_BUFFER_MIN = 15;
-const DEFAULT_WORK_START_MIN = 9 * 60;
-const DEFAULT_WORK_END_MIN = 17 * 60;
 const DEFAULT_TIMEZONE = "America/New_York";
-
-function defaultWorkingHoursForDow(): WorkingHoursDayInput[] {
-  return Array.from({ length: 7 }).map((_, dow) => ({
-    dayOfWeek: dow,
-    enabled: dow >= 1 && dow <= 5,
-    startMinute: DEFAULT_WORK_START_MIN,
-    endMinute: DEFAULT_WORK_END_MIN,
-  }));
-}
 
 /**
  * Load + compute free/busy for a single user across the given window.
@@ -276,16 +265,28 @@ export async function computeUserFreeBusy(
     ),
   ]);
 
-  const persistedDows = new Set(whRows.map((r) => r.dayOfWeek));
-  const workingHours: WorkingHoursDayInput[] = [
-    ...whRows.map((r) => ({
-      dayOfWeek: r.dayOfWeek,
-      enabled: r.enabled,
-      startMinute: r.startMinute,
-      endMinute: r.endMinute,
-    })),
-    ...defaultWorkingHoursForDow().filter((d) => !persistedDows.has(d.dayOfWeek)),
-  ];
+  // Working-hours policy:
+  //   • No persisted rows at all  → feature is OFF → the user is available
+  //     all day, every day (a single 00:00–24:00 "working" segment per dow).
+  //     Free time is then simply "anything not busy".
+  //   • Any persisted rows         → feature is ON → trust the saved segments
+  //     verbatim (including enabled weekend days). Days the user never saved a
+  //     row for stay unavailable, matching what they see in the editor.
+  const timezone = settings?.timezone ?? fallbackTimezone;
+  const hasPersisted = whRows.length > 0;
+  const workingHours: WorkingHoursDayInput[] = hasPersisted
+    ? whRows.map((r) => ({
+        dayOfWeek: r.dayOfWeek,
+        enabled: r.enabled,
+        startMinute: r.startMinute,
+        endMinute: r.endMinute,
+      }))
+    : Array.from({ length: 7 }).map((_, dow) => ({
+        dayOfWeek: dow,
+        enabled: true,
+        startMinute: 0,
+        endMinute: 24 * 60,
+      }));
 
   const externalBusy: Interval[] = busyRaw.map((b) => ({
     start: new Date(b.start),
@@ -303,7 +304,7 @@ export async function computeUserFreeBusy(
     })),
     externalBusy,
     bufferMin: settings?.defaultEventBufferMin ?? DEFAULT_BUFFER_MIN,
-    timezone: settings?.timezone ?? fallbackTimezone,
+    timezone,
   });
   return { userId, free, busy };
 }

--- a/dali-api/app/lib/calendar-schemas.ts
+++ b/dali-api/app/lib/calendar-schemas.ts
@@ -30,6 +30,31 @@ export const SetWorkingSegmentsSchema = z.object({
     .max(24),
 });
 
+// Full-replace for the entire week in one transaction. Used when the user first
+// turns Working Hours on / edits a day while the state is still the in-memory
+// default, so all seven days get materialized together (otherwise the loader
+// would treat the un-persisted days as "explicitly empty"). Empty segments for a
+// day mean "unavailable", same as set-working-segments.
+export const SeedWorkingHoursSchema = z.object({
+  intent: z.literal("seed-working-hours"),
+  days: z
+    .array(
+      z.object({
+        dayOfWeek,
+        segments: z
+          .array(
+            z.object({
+              startMinute: minuteOfDay,
+              endMinute: minuteOfDay,
+              location: z.enum(["InPerson", "Remote"]),
+            }),
+          )
+          .max(24),
+      }),
+    )
+    .max(7),
+});
+
 // Copy Monday's hours to Tue–Fri. Sat/Sun untouched.
 export const CopyWeekdaysSchema = z.object({
   intent: z.literal("copy-weekdays"),
@@ -83,6 +108,7 @@ export const ToggleSubCalendarSchema = z.object({
 
 export const CalendarActionSchema = z.discriminatedUnion("intent", [
   SetWorkingSegmentsSchema,
+  SeedWorkingHoursSchema,
   CopyWeekdaysSchema,
   ResetWorkingHoursSchema,
   SetEventBufferSchema,

--- a/dali-api/app/lib/google-calendar.ts
+++ b/dali-api/app/lib/google-calendar.ts
@@ -4,6 +4,12 @@ import { decrypt, encrypt } from "~/lib/calendar-crypto";
 interface BusyEvent {
   start: string; // ISO
   end: string; // ISO
+  // Enriched from events.list so the calendar can show the real event name and
+  // colour it by source calendar. All optional: availability math only reads
+  // start/end, and a busy block with no title still renders as "Busy".
+  title?: string;
+  calendarId?: string; // the Google sub-calendar this event came from
+  color?: string; // that calendar's backgroundColor (hex), for per-calendar tint
 }
 
 interface StoredTokens {
@@ -123,6 +129,66 @@ async function extractGoogleErrorDetail(res: Response): Promise<string> {
   }
 }
 
+interface GoogleEvent {
+  id?: string;
+  summary?: string;
+  status?: string; // "confirmed" | "tentative" | "cancelled"
+  transparency?: string; // "opaque" (busy) | "transparent" (free)
+  start?: { dateTime?: string; date?: string };
+  end?: { dateTime?: string; date?: string };
+  attendees?: { self?: boolean; responseStatus?: string }[];
+}
+
+// One sub-calendar's confirmed, time-bounded, not-declined, busy events in the
+// window. Uses events.list (not freeBusy) so we get the real title; freeBusy
+// returns only opaque time ranges. `color` is the calendar's backgroundColor,
+// threaded onto every event so the grid can tint by source calendar.
+async function fetchEventsForCalendar(
+  token: string,
+  calendarId: string,
+  color: string | undefined,
+  start: Date,
+  end: Date,
+): Promise<BusyEvent[]> {
+  const params = new URLSearchParams({
+    timeMin: start.toISOString(),
+    timeMax: end.toISOString(),
+    singleEvents: "true", // expand recurring events into instances
+    orderBy: "startTime",
+    maxResults: "250",
+    fields: "items(id,summary,status,transparency,start,end,attendees(self,responseStatus))",
+  });
+  const res = await fetch(
+    `https://www.googleapis.com/calendar/v3/calendars/${encodeURIComponent(calendarId)}/events?${params}`,
+    { headers: { Authorization: `Bearer ${token}` } },
+  );
+  if (!res.ok) {
+    const detail = await extractGoogleErrorDetail(res);
+    throw new Error(`Google events.list failed (${res.status}): ${detail}`);
+  }
+  const data = (await res.json()) as { items?: GoogleEvent[] };
+  const out: BusyEvent[] = [];
+  for (const ev of data.items ?? []) {
+    // Skip cancelled, all-day (date-only, no dateTime), free/transparent, and
+    // events this user has declined — matching the old "busy" semantics.
+    if (ev.status === "cancelled") continue;
+    if (ev.transparency === "transparent") continue;
+    const startIso = ev.start?.dateTime;
+    const endIso = ev.end?.dateTime;
+    if (!startIso || !endIso) continue;
+    const self = ev.attendees?.find((a) => a.self);
+    if (self?.responseStatus === "declined") continue;
+    out.push({
+      start: startIso,
+      end: endIso,
+      title: ev.summary?.trim() || "Busy",
+      calendarId,
+      color,
+    });
+  }
+  return out;
+}
+
 async function fetchBusyForLink(
   linkId: string,
   subCalendarIds: string[],
@@ -130,33 +196,21 @@ async function fetchBusyForLink(
   end: Date,
 ): Promise<BusyEvent[]> {
   const token = await getValidAccessTokenForLink(linkId);
-  const items = subCalendarIds.length > 0
-    ? subCalendarIds.map((id) => ({ id }))
-    : [{ id: "primary" }];
-  const res = await fetch("https://www.googleapis.com/calendar/v3/freeBusy", {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${token}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      timeMin: start.toISOString(),
-      timeMax: end.toISOString(),
-      items,
-    }),
-  });
-  if (!res.ok) {
-    const detail = await extractGoogleErrorDetail(res);
-    throw new Error(`Google freebusy failed (${res.status}): ${detail}`);
+  // Map calendarId → backgroundColor so each event can be tinted by its source.
+  let colorById = new Map<string, string | undefined>();
+  try {
+    const list = await listCalendarsForLink(linkId);
+    colorById = new Map(list.map((c) => [c.id, c.backgroundColor]));
+  } catch {
+    // Colour is best-effort; events still render (untinted) without it.
   }
-  const data = (await res.json()) as {
-    calendars?: Record<string, { busy?: { start: string; end: string }[] }>;
-  };
-  const out: BusyEvent[] = [];
-  for (const cal of Object.values(data.calendars ?? {})) {
-    for (const b of cal.busy ?? []) out.push({ start: b.start, end: b.end });
-  }
-  return out;
+  const calendarIds = subCalendarIds.length > 0 ? subCalendarIds : ["primary"];
+  const perCalendar = await Promise.all(
+    calendarIds.map((id) =>
+      fetchEventsForCalendar(token, id, colorById.get(id), start, end),
+    ),
+  );
+  return perCalendar.flat();
 }
 
 /**

--- a/dali-api/app/lib/groups.ts
+++ b/dali-api/app/lib/groups.ts
@@ -118,27 +118,59 @@ export type VisibleGroup = {
   dynamicQuery: string | null;
   systemKey: string | null;
   memberIds: string[];
+  // Effective archived state, combining a manual archive (archivedAt set) with
+  // term-bound auto-archive (every bound term has ended). See isGroupArchived.
+  archived: boolean;
+  // Set only when manually archived; null otherwise. Lets the UI tell apart
+  // "archived because its term ended" from "someone archived it".
+  archivedAt: string | null;
+  boundTermIds: string[];
 };
 
-// Returns the groups the given user belongs to. Static membership is read
-// directly off the row; Dynamic groups are resolved via dynamicQuery. Use this
-// at every list site so groups stay hidden from non-members.
-export async function listVisibleGroupsForUser(
-  userId: string,
-): Promise<VisibleGroup[]> {
-  const groups = await prisma.groupDefinition.findMany({
-    orderBy: { name: "asc" },
-    select: {
-      id: true,
-      name: true,
-      type: true,
-      dynamicQuery: true,
-      staticMemberIds: true,
-      systemKey: true,
-    },
-  });
+// A static group is archived if it was manually archived (archivedAt set) OR
+// it is term-bound and every bound term has already ended. `now` is passed in
+// so callers can resolve a whole list against one consistent clock.
+export function isGroupArchived(
+  group: { archivedAt: Date | string | null; boundTermIds: string[] },
+  termEndById: Map<string, Date>,
+  now: Date,
+): boolean {
+  if (group.archivedAt) return true;
+  if (group.boundTermIds.length === 0) return false;
+  // Resolve each bound term's end; unknown ids (deleted terms) are ignored.
+  const ends = group.boundTermIds
+    .map((id) => termEndById.get(id))
+    .filter((d): d is Date => d instanceof Date);
+  if (ends.length === 0) return false;
+  const latestEnd = ends.reduce((a, b) => (a > b ? a : b));
+  return latestEnd.getTime() < now.getTime();
+}
 
-  const resolved = await Promise.all(
+// Resolves every group to a VisibleGroup (members + derived archive state),
+// without any per-viewer filtering. Shared by the membership-scoped and
+// management list functions below.
+async function resolveAllGroups(): Promise<VisibleGroup[]> {
+  const [groups, terms] = await Promise.all([
+    prisma.groupDefinition.findMany({
+      orderBy: { name: "asc" },
+      select: {
+        id: true,
+        name: true,
+        type: true,
+        dynamicQuery: true,
+        staticMemberIds: true,
+        systemKey: true,
+        archivedAt: true,
+        boundTermIds: true,
+      },
+    }),
+    prisma.term.findMany({ select: { id: true, endDate: true } }),
+  ]);
+
+  const termEndById = new Map(terms.map((t) => [t.id, t.endDate]));
+  const now = new Date();
+
+  return Promise.all(
     groups.map(async (g) => {
       const memberIds =
         g.type === "Static"
@@ -153,11 +185,30 @@ export async function listVisibleGroupsForUser(
         dynamicQuery: g.dynamicQuery,
         systemKey: g.systemKey,
         memberIds,
+        archived: isGroupArchived(g, termEndById, now),
+        archivedAt: g.archivedAt ? g.archivedAt.toISOString() : null,
+        boundTermIds: g.boundTermIds,
       };
     }),
   );
+}
 
+// Returns the groups the given user belongs to. Static membership is read
+// directly off the row; Dynamic groups are resolved via dynamicQuery. Use this
+// at consumer sites (e.g. "groups I'm in") so groups stay hidden from
+// non-members. The management page uses listAllGroups instead.
+export async function listVisibleGroupsForUser(
+  userId: string,
+): Promise<VisibleGroup[]> {
+  const resolved = await resolveAllGroups();
   return resolved.filter((g) => g.memberIds.includes(userId));
+}
+
+// Returns every group, unfiltered. For the Groups management page, where a
+// Core/Admin user manages groups they may not belong to — so a group created
+// without adding yourself still shows up.
+export async function listAllGroups(): Promise<VisibleGroup[]> {
+  return resolveAllGroups();
 }
 
 // Idempotent helpers used at entity-creation sites. Each ensures the matching

--- a/dali-api/app/lib/notifications.ts
+++ b/dali-api/app/lib/notifications.ts
@@ -2,7 +2,17 @@
 // and the MCP `list_my_notifications` tool both call into this module so the
 // "what counts as a recent notification" policy lives in one place.
 
+import type { Prisma } from "~/generated/prisma/client";
 import { prisma } from "~/lib/db";
+
+// Invites for a Cancelled meeting are hidden everywhere — inbox, bell, and
+// tasks alike. Combine this with the per-user filter on every query.
+const NOT_CANCELLED_MEETING: Prisma.NotificationWhereInput = {
+  OR: [
+    { scheduledMeetingId: null },
+    { scheduledMeeting: { status: { not: "Cancelled" } } },
+  ],
+};
 
 export interface ListNotificationsOptions {
   /** Hard cap on rows returned. */
@@ -26,9 +36,11 @@ export async function listMyNotifications(
   opts: ListNotificationsOptions = {},
 ): Promise<NotificationListResult> {
   const limit = Math.max(1, Math.min(opts.limit ?? 50, 50));
-  const where = opts.onlyUnread
-    ? { recipientUserId: userId, readAt: null }
-    : { recipientUserId: userId };
+  const where: Prisma.NotificationWhereInput = {
+    recipientUserId: userId,
+    ...(opts.onlyUnread ? { readAt: null } : {}),
+    ...NOT_CANCELLED_MEETING,
+  };
 
   const [items, unreadCount] = await Promise.all([
     prisma.notification.findMany({
@@ -37,7 +49,7 @@ export async function listMyNotifications(
       take: limit,
     }),
     prisma.notification.count({
-      where: { recipientUserId: userId, readAt: null },
+      where: { recipientUserId: userId, readAt: null, ...NOT_CANCELLED_MEETING },
     }),
   ]);
 

--- a/dali-api/app/lib/scheduled-meeting.ts
+++ b/dali-api/app/lib/scheduled-meeting.ts
@@ -150,3 +150,36 @@ export async function createScheduledMeeting(
     gcalError,
   };
 }
+
+export type CancelScheduledMeetingResult =
+  | { ok: true; alreadyCancelled: boolean }
+  | { ok: false; error: string; status: number };
+
+/**
+ * Cancel a meeting. Only the organizer may cancel. Flipping the status to
+ * Cancelled is all that's needed to pull the invite out of every recipient's
+ * todos, tasks, attention banner, and notification bell — those surfaces filter
+ * on `scheduledMeeting.status !== "Cancelled"` rather than fanning out deletes.
+ * The Google Calendar event (if any) is left in place; deleting it would need a
+ * new google-calendar helper and is out of scope here.
+ */
+export async function cancelScheduledMeeting(
+  meetingId: string,
+  actorUserId: string,
+): Promise<CancelScheduledMeetingResult> {
+  const meeting = await prisma.scheduledMeeting.findUnique({
+    where: { id: meetingId },
+    select: { id: true, organizerId: true, status: true },
+  });
+  if (!meeting) return { ok: false, error: "Not found", status: 404 };
+  if (meeting.organizerId !== actorUserId) {
+    return { ok: false, error: "Only the organizer can cancel", status: 403 };
+  }
+  if (meeting.status === "Cancelled") return { ok: true, alreadyCancelled: true };
+
+  await prisma.scheduledMeeting.update({
+    where: { id: meetingId },
+    data: { status: "Cancelled" },
+  });
+  return { ok: true, alreadyCancelled: false };
+}

--- a/dali-api/app/lib/tasks.ts
+++ b/dali-api/app/lib/tasks.ts
@@ -3,9 +3,11 @@ import { prisma } from "~/lib/db";
 
 // A "task" (todo) is any unread notification — every NotificationKind counts.
 // The Tasks sidebar, Home attention banner, and sidebar count all read this
-// single predicate so they never disagree. Reading a notification (RSVPing,
-// opening its link, submitting the attached form, or hitting "mark all read")
-// clears it from tasks.
+// single predicate so they never disagree. Reading a notification (opening its
+// link, submitting the attached form, or hitting "mark all read") clears it
+// from tasks. Meeting invites are the exception: they only clear once the
+// recipient RSVPs (Accept/Maybe/Decline), and they drop off automatically once
+// the meeting is Cancelled — see TASK_WHERE.
 //
 //   kind === MeetingInvite      → "meeting"      (carries RSVP target)
 //   kind === MeetingReminder    → "reminder"     (calendar fan-out)
@@ -38,6 +40,17 @@ export type Task = {
 const TASK_WHERE = (userId: string): Prisma.NotificationWhereInput => ({
   recipientUserId: userId,
   readAt: null,
+  // A meeting-invite notification drops off Tasks the moment its meeting is
+  // Cancelled — no fan-out delete needed. Notifications not tied to a meeting
+  // (the common case) pass via the `null` branch.
+  AND: [
+    {
+      OR: [
+        { scheduledMeetingId: null },
+        { scheduledMeeting: { status: { not: "Cancelled" } } },
+      ],
+    },
+  ],
   // A notification linked to an InterviewAssignment is only a task while
   // that assignment is still Active on a still-Scheduled interview. As
   // soon as the assignment moves to Declined/Replaced or the interview

--- a/dali-api/app/mcp/tools/__tests__/find-mutual-freebusy.test.ts
+++ b/dali-api/app/mcp/tools/__tests__/find-mutual-freebusy.test.ts
@@ -75,7 +75,9 @@ describe("find_mutual_freebusy", () => {
   });
 
   it("returns mutual free slots in a single-weekday window", async () => {
-    // Wed 2026-05-13 09:00 ET → 17:00 ET (default working hours).
+    // Wed 2026-05-13 09:00 ET → 17:00 ET. Neither user has persisted working
+    // hours (findMany → []), so each is treated as available all day; with no
+    // busy events the whole queried window is mutually free.
     const out = await runFindMutualFreebusy("user-1", {
       participantUserIds: ["user-2"],
       windowStart: "2026-05-13T13:00:00Z", // 09:00 ET

--- a/dali-api/app/mcp/tools/__tests__/list-my-notifications.test.ts
+++ b/dali-api/app/mcp/tools/__tests__/list-my-notifications.test.ts
@@ -56,7 +56,15 @@ describe("list_my_notifications", () => {
 
     await runListMyNotifications("user-1", { onlyUnread: true });
     expect(mockPrisma.notification.findMany).toHaveBeenCalledWith({
-      where: { recipientUserId: "user-1", readAt: null },
+      where: {
+        recipientUserId: "user-1",
+        readAt: null,
+        // Cancelled-meeting invites are hidden everywhere, including the MCP feed.
+        OR: [
+          { scheduledMeetingId: null },
+          { scheduledMeeting: { status: { not: "Cancelled" } } },
+        ],
+      },
       orderBy: { createdAt: "desc" },
       take: 20,
     });

--- a/dali-api/app/members/routes/members.groups.tsx
+++ b/dali-api/app/members/routes/members.groups.tsx
@@ -1,11 +1,23 @@
-import { useState } from "react";
-import { redirect, useLoaderData, useFetcher } from "react-router";
+import { useMemo, useState } from "react";
+import { Link, redirect, useLoaderData, useFetcher } from "react-router";
 import type { Route } from "./+types/members.groups";
 import { prisma } from "~/lib/db";
-import { listVisibleGroupsForUser } from "~/lib/groups";
+import { listAllGroups } from "~/lib/groups";
 import { requireAuth } from "~/lib/auth";
 import { canViewForms } from "~/lib/roles";
-import { Users, Plus, Trash2, X } from "lucide-react";
+import { resolvePhotoUrl } from "~/lib/photo";
+import { initialsFromName } from "~/lib/display";
+import { Modal } from "~/components/Modal";
+import {
+  Users,
+  Plus,
+  Trash2,
+  X,
+  ChevronRight,
+  ChevronDown,
+  Archive,
+  ArchiveRestore,
+} from "lucide-react";
 
 export const meta: Route.MetaFunction = () => [{ title: "Groups · Members · DALI OS" }];
 
@@ -15,29 +27,95 @@ type GroupRow = {
   type: "Static" | "Dynamic";
   systemKey: string | null;
   memberIds: string[];
+  archived: boolean;
+  // True when archived because someone clicked Archive (vs. term auto-archive).
+  manuallyArchived: boolean;
+  boundTermCodes: string[];
 };
 
-type UserOption = {
+// A member as shown on an expanded group card: enough to render a profile-style
+// card (photo, name, role pills) and link to the member's page.
+type MemberCardData = {
   id: string;
   firstName: string;
   lastName: string;
   daliEmail: string | null;
+  photoUrl: string | null;
+  coreTitles: string[];
+  domainRoles: { domainName: string; level: string }[];
 };
+
+type TermOption = { id: string; code: string };
 
 export async function loader({ request }: Route.LoaderArgs) {
   const auth = await requireAuth(request);
   if (!auth.ok) return redirect("/login");
   if (!(await canViewForms(auth.user.sub))) return redirect("/members");
 
-  const [groups, users] = await Promise.all([
-    listVisibleGroupsForUser(auth.user.sub),
+  const [visible, users, terms] = await Promise.all([
+    listAllGroups(),
     prisma.user.findMany({
-      select: { id: true, firstName: true, lastName: true, daliEmail: true },
+      select: {
+        id: true,
+        firstName: true,
+        lastName: true,
+        daliEmail: true,
+        photoUrl: true,
+        coreAssignments: { select: { leadTitle: true } },
+        domainEligibilities: {
+          select: { level: true, domain: { select: { displayName: true } } },
+        },
+      },
       orderBy: [{ lastName: "asc" }, { firstName: "asc" }],
+    }),
+    prisma.term.findMany({
+      orderBy: { sortKey: "desc" },
+      select: { id: true, code: true },
     }),
   ]);
 
-  return { groups, users };
+  const termCodeById = new Map(terms.map((t) => [t.id, t.code]));
+
+  const members: MemberCardData[] = await Promise.all(
+    users.map(async (u) => ({
+      id: u.id,
+      firstName: u.firstName,
+      lastName: u.lastName,
+      daliEmail: u.daliEmail,
+      photoUrl: await resolvePhotoUrl(u.photoUrl),
+      coreTitles: deriveCoreTitles(u.coreAssignments),
+      domainRoles: u.domainEligibilities.map((e) => ({
+        domainName: e.domain.displayName,
+        level: e.level,
+      })),
+    })),
+  );
+
+  const groups: GroupRow[] = visible.map((g) => ({
+    id: g.id,
+    name: g.name,
+    type: g.type,
+    systemKey: g.systemKey,
+    memberIds: g.memberIds,
+    archived: g.archived,
+    manuallyArchived: g.archivedAt !== null,
+    boundTermCodes: g.boundTermIds
+      .map((id) => termCodeById.get(id))
+      .filter((c): c is string => !!c),
+  }));
+
+  return { groups, members, terms };
+}
+
+// Distinct Core lead titles, with title-less Core assignments collapsing to a
+// single "Core" pill. Mirrors the Members directory derivation.
+function deriveCoreTitles(assignments: { leadTitle: string | null }[]): string[] {
+  if (assignments.length === 0) return [];
+  const titles = new Set(
+    assignments.map((a) => a.leadTitle).filter((t): t is string => !!t),
+  );
+  if (assignments.some((a) => !a.leadTitle)) titles.add("Core");
+  return Array.from(titles);
 }
 
 export async function action({ request }: Route.ActionArgs) {
@@ -51,14 +129,30 @@ export async function action({ request }: Route.ActionArgs) {
 
   if (intent === "create-group") {
     const name = String(formData.get("name") ?? "").trim();
-    const memberIds = String(formData.get("memberIds") ?? "")
-      .split(",")
-      .map((s) => s.trim())
-      .filter(Boolean);
+    const memberIds = parseIdList(formData.get("memberIds"));
+    const boundTermIds = parseIdList(formData.get("boundTermIds"));
     if (!name) return Response.json({ error: "Name is required" }, { status: 400 });
     if (memberIds.length === 0)
       return Response.json({ error: "At least one member is required" }, { status: 400 });
-    await prisma.groupDefinition.create({ data: { name, type: "Static", staticMemberIds: memberIds } });
+    // Only keep term ids that actually exist, so a stale form can't bind a
+    // group to a deleted term (which would make its archive state undefined).
+    const validTermIds =
+      boundTermIds.length === 0
+        ? []
+        : (
+            await prisma.term.findMany({
+              where: { id: { in: boundTermIds } },
+              select: { id: true },
+            })
+          ).map((t) => t.id);
+    await prisma.groupDefinition.create({
+      data: {
+        name,
+        type: "Static",
+        staticMemberIds: memberIds,
+        boundTermIds: validTermIds,
+      },
+    });
     return null;
   }
 
@@ -73,6 +167,22 @@ export async function action({ request }: Route.ActionArgs) {
     if (group.systemKey)
       return Response.json({ error: "System-managed groups cannot be deleted" }, { status: 400 });
     await prisma.groupDefinition.delete({ where: { id: groupId } });
+    return null;
+  }
+
+  if (intent === "archive-group" || intent === "unarchive-group") {
+    const groupId = String(formData.get("groupId") ?? "");
+    const group = await prisma.groupDefinition.findUnique({
+      where: { id: groupId },
+      select: { systemKey: true },
+    });
+    if (!group) return Response.json({ error: "Group not found" }, { status: 404 });
+    if (group.systemKey)
+      return Response.json({ error: "System-managed groups cannot be archived" }, { status: 400 });
+    await prisma.groupDefinition.update({
+      where: { id: groupId },
+      data: { archivedAt: intent === "archive-group" ? new Date() : null },
+    });
     return null;
   }
 
@@ -108,21 +218,39 @@ export async function action({ request }: Route.ActionArgs) {
   return Response.json({ error: "Unknown intent" }, { status: 400 });
 }
 
-function userLabel(u: UserOption) {
-  const name = `${u.firstName} ${u.lastName}`.trim();
-  return name || u.daliEmail || u.id;
+function parseIdList(value: FormDataEntryValue | null): string[] {
+  return String(value ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
 }
 
+function memberLabel(m: MemberCardData) {
+  const name = `${m.firstName} ${m.lastName}`.trim();
+  return name || m.daliEmail || m.id;
+}
+
+type StatusFilter = "active" | "archived" | "all";
+
 export default function AdminConsoleGroups() {
-  const { groups, users } = useLoaderData<typeof loader>();
-  const usersById = new Map(users.map((u) => [u.id, u]));
+  const { groups, members, terms } = useLoaderData<typeof loader>();
+  const membersById = useMemo(
+    () => new Map(members.map((m) => [m.id, m])),
+    [members],
+  );
   const [creating, setCreating] = useState(false);
   const [query, setQuery] = useState("");
+  const [status, setStatus] = useState<StatusFilter>("active");
 
   const q = query.trim().toLowerCase();
-  const visibleGroups = q
-    ? groups.filter((g: GroupRow) => g.name.toLowerCase().includes(q))
-    : groups;
+  const visibleGroups = groups.filter((g: GroupRow) => {
+    if (status === "active" && g.archived) return false;
+    if (status === "archived" && !g.archived) return false;
+    if (q && !g.name.toLowerCase().includes(q)) return false;
+    return true;
+  });
+
+  const activeCount = groups.filter((g: GroupRow) => !g.archived).length;
 
   return (
     <div className="space-y-6">
@@ -131,88 +259,156 @@ export default function AdminConsoleGroups() {
           <Users className="w-6 h-6 text-foreground/80" />
           <h1 className="text-2xl font-bold text-foreground">User Groups</h1>
           <span className="px-2.5 py-0.5 rounded-full text-xs font-medium bg-muted text-muted-foreground">
-            {groups.length}
+            {activeCount}
           </span>
         </div>
         <button
           type="button"
           onClick={() => setCreating(true)}
-          className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-gray-900 text-white text-sm hover:bg-gray-700"
+          className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-accent-coral text-white text-sm font-medium hover:bg-accent-coral/90 transition-colors"
         >
           <Plus className="w-4 h-4" /> New group
         </button>
       </div>
 
-      {creating && (
-        <CreateGroupForm users={users} onDone={() => setCreating(false)} />
-      )}
-
       {groups.length > 0 && (
-        <input
-          type="search"
-          value={query}
-          onChange={(e) => setQuery(e.target.value)}
-          placeholder="Search groups by name"
-          className="w-full max-w-sm px-3 py-2 text-sm border border-border rounded-md bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-accent-coral/30"
-        />
+        <div className="flex flex-wrap items-center gap-2">
+          <input
+            type="search"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search groups by name"
+            className="flex-1 min-w-[12rem] max-w-sm px-3 py-2 text-sm border border-border rounded-md bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-accent-coral/30"
+          />
+          <StatusTabs status={status} onChange={setStatus} />
+        </div>
       )}
 
       <div className="space-y-3">
-        {groups.length === 0 && !creating && (
+        {groups.length === 0 && (
           <div className="text-sm text-muted-foreground/70 px-4 py-8 text-center bg-card border border-border rounded-lg">
             No groups yet. Click "New group" to create one.
           </div>
         )}
         {groups.length > 0 && visibleGroups.length === 0 && (
           <div className="text-sm text-muted-foreground/70 px-4 py-8 text-center bg-card border border-border rounded-lg">
-            No groups match "{query.trim()}".
+            {q
+              ? `No ${status === "all" ? "" : status + " "}groups match "${query.trim()}".`
+              : `No ${status} groups.`}
           </div>
         )}
         {visibleGroups.map((g: GroupRow) => (
-          <GroupCard key={g.id} group={g} users={users} usersById={usersById} />
+          <GroupCard key={g.id} group={g} members={members} membersById={membersById} />
         ))}
       </div>
+
+      <Modal
+        open={creating}
+        onClose={() => setCreating(false)}
+        labelledBy="create-group-title"
+        containerClassName="bg-card rounded-2xl shadow-brand-2 max-w-lg w-full p-5 sm:p-6 my-auto"
+      >
+        <CreateGroupForm
+          members={members}
+          terms={terms}
+          onDone={() => setCreating(false)}
+        />
+      </Modal>
     </div>
   );
 }
 
-function CreateGroupForm({ users, onDone }: { users: UserOption[]; onDone: () => void }) {
+function StatusTabs({
+  status,
+  onChange,
+}: {
+  status: StatusFilter;
+  onChange: (s: StatusFilter) => void;
+}) {
+  const tabs: { value: StatusFilter; label: string }[] = [
+    { value: "active", label: "Active" },
+    { value: "archived", label: "Archived" },
+    { value: "all", label: "All" },
+  ];
+  return (
+    <div className="inline-flex rounded-md border border-border bg-background p-0.5">
+      {tabs.map((t) => (
+        <button
+          key={t.value}
+          type="button"
+          onClick={() => onChange(t.value)}
+          className={`px-3 py-1 text-sm rounded transition-colors ${
+            status === t.value
+              ? "bg-accent-coral text-white"
+              : "text-muted-foreground hover:text-foreground"
+          }`}
+          aria-pressed={status === t.value}
+        >
+          {t.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function CreateGroupForm({
+  members,
+  terms,
+  onDone,
+}: {
+  members: MemberCardData[];
+  terms: TermOption[];
+  onDone: () => void;
+}) {
   const fetcher = useFetcher();
   const [name, setName] = useState("");
   const [selected, setSelected] = useState<string[]>([]);
   const [query, setQuery] = useState("");
+  // "always" = never term-bound; "terms" = archive after the chosen term(s) end.
+  const [scope, setScope] = useState<"always" | "terms">("always");
+  const [boundTerms, setBoundTerms] = useState<string[]>([]);
 
-  const filtered = users.filter((u) => {
+  const filtered = members.filter((m) => {
     if (!query) return true;
-    const q = query.toLowerCase();
+    const ql = query.toLowerCase();
     return (
-      `${u.firstName} ${u.lastName}`.toLowerCase().includes(q) ||
-      (u.daliEmail ?? "").toLowerCase().includes(q)
+      `${m.firstName} ${m.lastName}`.toLowerCase().includes(ql) ||
+      (m.daliEmail ?? "").toLowerCase().includes(ql)
     );
   });
 
   const submitting = fetcher.state !== "idle";
-  const canSubmit = name.trim().length > 0 && selected.length > 0 && !submitting;
+  const termsOk = scope === "always" || boundTerms.length > 0;
+  const canSubmit =
+    name.trim().length > 0 && selected.length > 0 && termsOk && !submitting;
 
   return (
-    <div className="bg-card border border-border rounded-lg p-4 space-y-3">
+    <div className="space-y-3">
       <div className="flex items-center justify-between">
-        <h2 className="font-medium text-foreground">New group</h2>
-        <button type="button" onClick={onDone} className="text-muted-foreground hover:text-foreground" aria-label="Cancel">
+        <h2 id="create-group-title" className="font-semibold text-lg text-foreground">
+          New group
+        </h2>
+        <button
+          type="button"
+          onClick={onDone}
+          className="text-muted-foreground hover:text-foreground"
+          aria-label="Cancel"
+        >
           <X className="w-4 h-4" />
         </button>
       </div>
       <fetcher.Form
         method="post"
         onSubmit={(e) => {
-          // memberIds is stored as a hidden comma-joined string
           const fd = new FormData(e.currentTarget);
+          // memberIds and boundTermIds travel as hidden comma-joined strings.
           fd.set("memberIds", selected.join(","));
+          fd.set("boundTermIds", scope === "terms" ? boundTerms.join(",") : "");
           fetcher.submit(fd, { method: "post" });
           e.preventDefault();
           onDone();
         }}
-        className="space-y-3"
+        className="space-y-4"
       >
         <input type="hidden" name="intent" value="create-group" />
         <div>
@@ -230,23 +426,89 @@ function CreateGroupForm({ users, onDone }: { users: UserOption[]; onDone: () =>
             required
           />
         </div>
+
+        <fieldset className="space-y-2">
+          <legend className="text-sm font-medium text-foreground mb-1">Duration</legend>
+          <label className="flex items-start gap-2 text-sm">
+            <input
+              type="radio"
+              name="scope"
+              checked={scope === "always"}
+              onChange={() => setScope("always")}
+              className="mt-0.5"
+            />
+            <span>
+              <span className="text-foreground">Ongoing</span>
+              <span className="block text-xs text-muted-foreground">
+                Stays active until you archive it manually.
+              </span>
+            </span>
+          </label>
+          <label className="flex items-start gap-2 text-sm">
+            <input
+              type="radio"
+              name="scope"
+              checked={scope === "terms"}
+              onChange={() => setScope("terms")}
+              className="mt-0.5"
+            />
+            <span>
+              <span className="text-foreground">For specific term(s)</span>
+              <span className="block text-xs text-muted-foreground">
+                Auto-archives once the selected term(s) have ended.
+              </span>
+            </span>
+          </label>
+          {scope === "terms" && (
+            <div className="flex flex-wrap gap-1.5 pl-6 pt-1">
+              {terms.length === 0 && (
+                <span className="text-xs text-muted-foreground">No terms available.</span>
+              )}
+              {terms.map((t) => {
+                const on = boundTerms.includes(t.id);
+                return (
+                  <button
+                    key={t.id}
+                    type="button"
+                    onClick={() =>
+                      setBoundTerms(
+                        on ? boundTerms.filter((x) => x !== t.id) : [...boundTerms, t.id],
+                      )
+                    }
+                    aria-pressed={on}
+                    className={`px-2.5 py-1 rounded-full text-xs font-medium border transition-colors ${
+                      on
+                        ? "bg-accent-coral text-white border-accent-coral"
+                        : "bg-background text-foreground border-border hover:bg-muted/50"
+                    }`}
+                  >
+                    {t.code}
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </fieldset>
+
         <div>
-          <label className="block text-sm font-medium text-foreground mb-1">Members ({selected.length})</label>
+          <label className="block text-sm font-medium text-foreground mb-1">
+            Members ({selected.length})
+          </label>
           {selected.length > 0 && (
             <div className="flex flex-wrap gap-1.5 mb-2">
               {selected.map((id) => {
-                const u = users.find((x) => x.id === id);
-                if (!u) return null;
+                const m = findMember(members, id);
+                if (!m) return null;
                 return (
                   <span
                     key={id}
                     className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-800"
                   >
-                    {userLabel(u)}
+                    {memberLabel(m)}
                     <button
                       type="button"
                       onClick={() => setSelected(selected.filter((s) => s !== id))}
-                      aria-label={`Remove ${userLabel(u)}`}
+                      aria-label={`Remove ${memberLabel(m)}`}
                       className="hover:text-purple-600"
                     >
                       <X className="w-3 h-3" />
@@ -264,27 +526,39 @@ function CreateGroupForm({ users, onDone }: { users: UserOption[]; onDone: () =>
             className="w-full px-3 py-2 text-sm border border-border rounded-md bg-background text-foreground"
           />
           <div className="mt-2 max-h-48 overflow-y-auto border border-border rounded-md bg-background">
-            {filtered.slice(0, 50).map((u) => {
-              const isSel = selected.includes(u.id);
+            {filtered.slice(0, 50).map((m) => {
+              const isSel = selected.includes(m.id);
               return (
                 <button
-                  key={u.id}
+                  key={m.id}
                   type="button"
                   onClick={() =>
-                    setSelected(isSel ? selected.filter((s) => s !== u.id) : [...selected, u.id])
+                    setSelected(isSel ? selected.filter((s) => s !== m.id) : [...selected, m.id])
                   }
                   className={`w-full text-left px-3 py-1.5 text-sm hover:bg-muted/50 flex justify-between items-center ${
                     isSel ? "bg-muted/30" : ""
                   }`}
                 >
-                  <span>{userLabel(u)}</span>
+                  <span>{memberLabel(m)}</span>
                   {isSel && <span className="text-xs text-purple-700">Selected</span>}
                 </button>
               );
             })}
           </div>
         </div>
-        <div className="flex justify-end gap-2">
+
+        <div className="flex items-center justify-end gap-2 pt-1">
+          {!canSubmit && !submitting && (
+            <span className="mr-auto text-xs text-muted-foreground">
+              {name.trim().length === 0
+                ? "Add a name to continue."
+                : selected.length === 0
+                  ? "Select at least one member."
+                  : !termsOk
+                    ? "Pick at least one term."
+                    : ""}
+            </span>
+          )}
           <button
             type="button"
             onClick={onDone}
@@ -295,7 +569,7 @@ function CreateGroupForm({ users, onDone }: { users: UserOption[]; onDone: () =>
           <button
             type="submit"
             disabled={!canSubmit}
-            className="px-3 py-1.5 text-sm rounded-md bg-gray-900 text-white hover:bg-gray-700 disabled:opacity-50"
+            className="px-3 py-1.5 text-sm font-medium rounded-md bg-accent-coral text-white hover:bg-accent-coral/90 transition-colors disabled:opacity-60"
           >
             Create group
           </button>
@@ -305,141 +579,294 @@ function CreateGroupForm({ users, onDone }: { users: UserOption[]; onDone: () =>
   );
 }
 
+// Lookup helper used inside CreateGroupForm where we only have the array.
+function findMember(members: MemberCardData[], id: string): MemberCardData | undefined {
+  return members.find((m) => m.id === id);
+}
+
 function GroupCard({
   group,
-  users,
-  usersById,
+  members,
+  membersById,
 }: {
   group: GroupRow;
-  users: UserOption[];
-  usersById: Map<string, UserOption>;
+  members: MemberCardData[];
+  membersById: Map<string, MemberCardData>;
 }) {
   const fetcher = useFetcher();
+  const [expanded, setExpanded] = useState(false);
   const [addingMember, setAddingMember] = useState(false);
   const [query, setQuery] = useState("");
 
   const isSystem = group.systemKey !== null;
-  const available = users.filter((u) => !group.memberIds.includes(u.id));
-  const filtered = available.filter((u) => {
+  const available = members.filter((m) => !group.memberIds.includes(m.id));
+  const filtered = available.filter((m) => {
     if (!query) return true;
     const q = query.toLowerCase();
     return (
-      `${u.firstName} ${u.lastName}`.toLowerCase().includes(q) ||
-      (u.daliEmail ?? "").toLowerCase().includes(q)
+      `${m.firstName} ${m.lastName}`.toLowerCase().includes(q) ||
+      (m.daliEmail ?? "").toLowerCase().includes(q)
     );
   });
 
   return (
-    <div className="bg-card border border-border rounded-lg p-4 space-y-2">
-      <div className="flex items-center justify-between">
-        <h3 className="font-medium text-foreground">
-          {group.name}
+    <div className={`bg-card border border-border rounded-lg ${group.archived ? "opacity-75" : ""}`}>
+      {/* Collapsed header: metadata only. Clicking the row toggles expansion. */}
+      <div className="flex items-center gap-3 p-4">
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          aria-expanded={expanded}
+          aria-label={expanded ? "Collapse group" : "Expand group"}
+          className="text-muted-foreground hover:text-foreground flex-shrink-0"
+        >
+          {expanded ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
+        </button>
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          className="flex-1 min-w-0 flex items-center gap-2 flex-wrap text-left"
+        >
+          <span className="font-medium text-foreground">{group.name}</span>
           {isSystem && (
-            <span className="ml-2 px-1.5 py-0.5 rounded text-[10px] font-medium bg-blue-50 text-blue-700 border border-blue-200 uppercase tracking-wide">
+            <span className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-blue-50 text-blue-700 border border-blue-200 uppercase tracking-wide">
               Auto
             </span>
           )}
-          <span className="ml-2 text-xs font-normal text-muted-foreground">
+          {group.archived && (
+            <span className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-amber-50 text-amber-700 border border-amber-200 uppercase tracking-wide">
+              Archived
+            </span>
+          )}
+          {group.boundTermCodes.length > 0 && (
+            <span className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-muted text-muted-foreground">
+              {group.boundTermCodes.join(", ")}
+            </span>
+          )}
+          <span className="text-xs font-normal text-muted-foreground">
             {group.memberIds.length} member{group.memberIds.length === 1 ? "" : "s"}
           </span>
-        </h3>
+        </button>
         {!isSystem && (
-          <fetcher.Form method="post" onSubmit={(e) => {
-            if (!confirm(`Delete group "${group.name}"?`)) e.preventDefault();
-          }}>
-            <input type="hidden" name="intent" value="delete-group" />
-            <input type="hidden" name="groupId" value={group.id} />
-            <button
-              type="submit"
-              aria-label="Delete group"
-              className="text-muted-foreground hover:text-red-600 p-1"
-            >
-              <Trash2 className="w-4 h-4" />
-            </button>
-          </fetcher.Form>
-        )}
-      </div>
-      <div className="flex flex-wrap gap-1.5">
-        {group.memberIds.map((uid) => {
-          const u = usersById.get(uid);
-          return (
-            <span
-              key={uid}
-              className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-800"
-            >
-              {u ? userLabel(u) : uid}
-              {!isSystem && (
-                <fetcher.Form method="post" className="inline">
-                  <input type="hidden" name="intent" value="remove-member" />
-                  <input type="hidden" name="groupId" value={group.id} />
-                  <input type="hidden" name="userId" value={uid} />
-                  <button
-                    type="submit"
-                    aria-label="Remove from group"
-                    className="hover:text-purple-600"
-                  >
-                    <X className="w-3 h-3" />
-                  </button>
-                </fetcher.Form>
-              )}
-            </span>
-          );
-        })}
-        {!isSystem && !addingMember && available.length > 0 && (
-          <button
-            type="button"
-            onClick={() => setAddingMember(true)}
-            className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-muted text-muted-foreground hover:bg-muted/80"
-          >
-            <Plus className="w-3 h-3" /> Add member
-          </button>
-        )}
-      </div>
-      {!isSystem && addingMember && (
-        <div className="border border-border rounded-md bg-background p-2 space-y-2">
-          <input
-            type="text"
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            placeholder="Search…"
-            className="w-full px-2 py-1 text-sm border border-border rounded bg-background text-foreground"
-          />
-          <div className="max-h-40 overflow-y-auto">
-            {filtered.slice(0, 30).map((u) => (
-              <fetcher.Form
-                key={u.id}
-                method="post"
-                onSubmit={() => {
-                  setAddingMember(false);
-                  setQuery("");
-                }}
+          <div className="flex items-center gap-1 flex-shrink-0">
+            {/* Term-archived groups can be reactivated by clearing the manual
+                flag too; the Archive/Restore toggle keys off the effective
+                state. A manual archive overrides term state either way. */}
+            <fetcher.Form method="post">
+              <input
+                type="hidden"
+                name="intent"
+                value={group.archived ? "unarchive-group" : "archive-group"}
+              />
+              <input type="hidden" name="groupId" value={group.id} />
+              <button
+                type="submit"
+                aria-label={group.archived ? "Restore group" : "Archive group"}
+                title={group.archived ? "Restore group" : "Archive group"}
+                className="text-muted-foreground hover:text-foreground p-1"
               >
-                <input type="hidden" name="intent" value="add-member" />
-                <input type="hidden" name="groupId" value={group.id} />
-                <input type="hidden" name="userId" value={u.id} />
-                <button
-                  type="submit"
-                  className="w-full text-left px-2 py-1 text-sm hover:bg-muted/50 rounded"
-                >
-                  {userLabel(u)}
-                </button>
-              </fetcher.Form>
-            ))}
+                {group.archived ? (
+                  <ArchiveRestore className="w-4 h-4" />
+                ) : (
+                  <Archive className="w-4 h-4" />
+                )}
+              </button>
+            </fetcher.Form>
+            <fetcher.Form
+              method="post"
+              onSubmit={(e) => {
+                if (!confirm(`Delete group "${group.name}"?`)) e.preventDefault();
+              }}
+            >
+              <input type="hidden" name="intent" value="delete-group" />
+              <input type="hidden" name="groupId" value={group.id} />
+              <button
+                type="submit"
+                aria-label="Delete group"
+                className="text-muted-foreground hover:text-red-600 p-1"
+              >
+                <Trash2 className="w-4 h-4" />
+              </button>
+            </fetcher.Form>
           </div>
-          <div className="flex justify-end">
+        )}
+      </div>
+
+      {expanded && (
+        <div className="px-4 pb-4 space-y-3 border-t border-border pt-3">
+          {group.memberIds.length === 0 && (
+            <p className="text-sm text-muted-foreground/70">No members.</p>
+          )}
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2">
+            {group.memberIds.map((uid) => {
+              const m = membersById.get(uid);
+              if (!m) {
+                return (
+                  <div
+                    key={uid}
+                    className="border border-border rounded-md p-2 bg-background text-xs text-muted-foreground"
+                  >
+                    Unknown member
+                  </div>
+                );
+              }
+              return (
+                <ExpandedMemberCard
+                  key={uid}
+                  member={m}
+                  removable={!isSystem}
+                  groupId={group.id}
+                />
+              );
+            })}
+          </div>
+
+          {!isSystem && !addingMember && available.length > 0 && (
             <button
               type="button"
-              onClick={() => {
-                setAddingMember(false);
-                setQuery("");
-              }}
-              className="text-xs text-muted-foreground hover:text-foreground"
+              onClick={() => setAddingMember(true)}
+              className="inline-flex items-center gap-1 px-2.5 py-1 rounded-md text-xs font-medium bg-muted text-muted-foreground hover:bg-muted/80"
             >
-              Cancel
+              <Plus className="w-3 h-3" /> Add member
             </button>
-          </div>
+          )}
+
+          {!isSystem && addingMember && (
+            <div className="border border-border rounded-md bg-background p-2 space-y-2">
+              <input
+                type="text"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder="Search…"
+                className="w-full px-2 py-1 text-sm border border-border rounded bg-background text-foreground"
+              />
+              <div className="max-h-40 overflow-y-auto">
+                {filtered.slice(0, 30).map((m) => (
+                  <fetcher.Form
+                    key={m.id}
+                    method="post"
+                    onSubmit={() => {
+                      setAddingMember(false);
+                      setQuery("");
+                    }}
+                  >
+                    <input type="hidden" name="intent" value="add-member" />
+                    <input type="hidden" name="groupId" value={group.id} />
+                    <input type="hidden" name="userId" value={m.id} />
+                    <button
+                      type="submit"
+                      className="w-full text-left px-2 py-1 text-sm hover:bg-muted/50 rounded"
+                    >
+                      {memberLabel(m)}
+                    </button>
+                  </fetcher.Form>
+                ))}
+              </div>
+              <div className="flex justify-end">
+                <button
+                  type="button"
+                  onClick={() => {
+                    setAddingMember(false);
+                    setQuery("");
+                  }}
+                  className="text-xs text-muted-foreground hover:text-foreground"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          )}
         </div>
       )}
+    </div>
+  );
+}
+
+function ExpandedMemberCard({
+  member,
+  removable,
+  groupId,
+}: {
+  member: MemberCardData;
+  removable: boolean;
+  groupId: string;
+}) {
+  const fetcher = useFetcher();
+  const fullName = `${member.firstName} ${member.lastName}`.trim();
+  return (
+    <div className="relative border border-border rounded-md p-2 bg-background flex items-start gap-2 hover:bg-muted/10 transition-colors">
+      <Link to={`/members/${member.id}`} className="flex items-start gap-2 min-w-0 flex-1">
+        <Avatar photoUrl={member.photoUrl} name={fullName} />
+        <div className="min-w-0 flex-1">
+          <div className="text-sm font-medium text-foreground truncate">{fullName}</div>
+          <div className="mt-1">
+            <RolePills coreTitles={member.coreTitles} domainRoles={member.domainRoles} />
+          </div>
+        </div>
+      </Link>
+      {removable && (
+        <fetcher.Form method="post" className="flex-shrink-0">
+          <input type="hidden" name="intent" value="remove-member" />
+          <input type="hidden" name="groupId" value={groupId} />
+          <input type="hidden" name="userId" value={member.id} />
+          <button
+            type="submit"
+            aria-label={`Remove ${fullName} from group`}
+            className="text-muted-foreground hover:text-red-600 p-0.5"
+          >
+            <X className="w-3 h-3" />
+          </button>
+        </fetcher.Form>
+      )}
+    </div>
+  );
+}
+
+function Avatar({ photoUrl, name }: { photoUrl: string | null; name: string }) {
+  if (photoUrl) {
+    return (
+      <img
+        src={photoUrl}
+        alt=""
+        className="w-8 h-8 rounded-full object-cover flex-shrink-0"
+      />
+    );
+  }
+  return (
+    <div className="w-8 h-8 rounded-full bg-accent-coral/15 text-accent-coral flex items-center justify-center font-bold text-[11px] flex-shrink-0">
+      {initialsFromName(name)}
+    </div>
+  );
+}
+
+function RolePills({
+  coreTitles,
+  domainRoles,
+}: {
+  coreTitles: string[];
+  domainRoles: { domainName: string; level: string }[];
+}) {
+  if (coreTitles.length === 0 && domainRoles.length === 0) {
+    return <span className="text-muted-foreground text-xs">—</span>;
+  }
+  return (
+    <div className="flex flex-wrap gap-1">
+      {coreTitles.map((title) => (
+        <span
+          key={title}
+          className="inline-flex items-center px-1.5 py-0.5 text-[11px] font-medium rounded bg-muted text-foreground"
+        >
+          {title}
+        </span>
+      ))}
+      {domainRoles.map((d) => (
+        <span
+          key={`${d.domainName}-${d.level}`}
+          className="inline-flex items-center px-1.5 py-0.5 text-[11px] font-medium rounded bg-blue-50 text-blue-700 border border-blue-100"
+        >
+          {d.domainName} · {d.level}
+        </span>
+      ))}
     </div>
   );
 }

--- a/dali-api/app/partners/routes/partners.applications.tsx
+++ b/dali-api/app/partners/routes/partners.applications.tsx
@@ -592,7 +592,7 @@ function StackedBar({
 }) {
   return (
     <div
-      className="w-9 flex flex-col-reverse rounded-t overflow-hidden"
+      className="w-9 flex flex-col-reverse overflow-hidden"
       style={{
         height: `${series.total === 0 ? 2 : Math.max(8, (series.total / chartMax) * 120)}px`,
         opacity: dim ? 0.55 : 1,

--- a/dali-api/app/routes.ts
+++ b/dali-api/app/routes.ts
@@ -164,6 +164,7 @@ export default [
 
   // Scheduled meetings
   route("api/scheduled-meetings", "calendar/routes/api.scheduled-meetings.ts"),
+  route("api/scheduled-meetings/:id/cancel", "calendar/routes/api.scheduled-meetings.$id.cancel.ts"),
   route("api/calendar/group-availability", "calendar/routes/api.calendar.group-availability.ts"),
 
   // Slack bot (webhook receivers; signature-verified, no auth middleware)

--- a/dali-api/app/routes/api.notifications.$id.read.ts
+++ b/dali-api/app/routes/api.notifications.$id.read.ts
@@ -17,13 +17,20 @@ export async function action({ request, params }: Route.ActionArgs) {
   const id = params.id!;
   const existing = await prisma.notification.findUnique({
     where: { id },
-    select: { recipientUserId: true, readAt: true },
+    select: { recipientUserId: true, readAt: true, scheduledMeetingId: true },
   });
   if (!existing) {
     return withCors(request, Response.json({ error: "Not found" }, { status: 404 }));
   }
   if (existing.recipientUserId !== auth.user.sub) {
     return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
+  }
+
+  // A meeting invite only clears once the recipient RSVPs (via the rsvp
+  // endpoint, which sets readAt itself). A plain read — opening its link —
+  // must not dismiss it, so it stays a todo until an Accept/Maybe/Decline.
+  if (existing.scheduledMeetingId) {
+    return withCors(request, Response.json({ ok: true, skipped: "meeting-invite" }));
   }
 
   if (existing.readAt) {

--- a/dali-api/app/routes/api.notifications.ts
+++ b/dali-api/app/routes/api.notifications.ts
@@ -38,9 +38,15 @@ export async function action({ request }: Route.ActionArgs) {
     return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));
   }
 
-  // POST with no id = "mark all read"
+  // POST with no id = "mark all read". Meeting invites are excluded: they
+  // clear only when the recipient RSVPs (Accept/Maybe/Decline), never on a
+  // blanket read.
   await prisma.notification.updateMany({
-    where: { recipientUserId: auth.user.sub, readAt: null },
+    where: {
+      recipientUserId: auth.user.sub,
+      readAt: null,
+      scheduledMeetingId: null,
+    },
     data: { readAt: new Date() },
   });
 

--- a/dali-api/app/routes/home.tsx
+++ b/dali-api/app/routes/home.tsx
@@ -34,7 +34,15 @@ export async function loader({ request }: Route.LoaderArgs) {
   if (auth.user.type === "applicant") return redirect("/portal");
 
   const items = await prisma.notification.findMany({
-    where: { recipientUserId: auth.user.sub },
+    // Hide invites whose meeting was Cancelled — they shouldn't appear in the
+    // banner, just as they're dropped from tasks and the bell.
+    where: {
+      recipientUserId: auth.user.sub,
+      OR: [
+        { scheduledMeetingId: null },
+        { scheduledMeeting: { status: { not: "Cancelled" } } },
+      ],
+    },
     orderBy: { createdAt: "desc" },
     take: 50,
     select: {
@@ -161,6 +169,19 @@ function AttentionBanner({
             );
             const cls =
               "flex-shrink-0 w-56 bg-card border border-border rounded-md px-3 py-2";
+
+            // Meeting invites clear only on RSVP, never on a click — so they
+            // render Accept/Maybe/Decline inline instead of a read-on-click
+            // link. The RSVP revalidates, dropping the answered invite.
+            if (t.source === "meeting") {
+              return (
+                <div key={t.id} className={cls}>
+                  {inner}
+                  <RsvpButtons notificationId={t.id} />
+                </div>
+              );
+            }
+
             return t.link ? (
               <a
                 key={t.id}
@@ -231,19 +252,31 @@ function relativeTime(iso: string): string {
 }
 
 
-function NotificationCard({ notification }: { notification: HomeNotification }) {
-  const isUnread = !notification.readAt;
-  const isInvite = notification.kind === "MeetingInvite" && !!notification.scheduledMeetingId;
-  const accent = isUnread ? "border-l-accent-coral" : "border-l-accent-teal";
-  const [rsvp, setRsvp] = useState<HomeNotification["rsvp"]>(notification.rsvp);
-  const [submitting, setSubmitting] = useState<null | "accepted" | "declined" | "tentative">(null);
+/* ------------------------------------------------------------------ */
+/* RSVP buttons — shared by the meeting-invite task card and the         */
+/* notification card. On a response, POSTs to the rsvp endpoint (which   */
+/* records the RSVP and marks the notification read), then revalidates   */
+/* so the now-answered invite drops out of tasks.                        */
+/* ------------------------------------------------------------------ */
+
+function RsvpButtons({
+  notificationId,
+  onResponded,
+}: {
+  notificationId: string;
+  onResponded?: (rsvp: "Accepted" | "Declined" | "Tentative") => void;
+}) {
+  const revalidator = useRevalidator();
+  const [submitting, setSubmitting] = useState<
+    null | "accepted" | "declined" | "tentative"
+  >(null);
   const [error, setError] = useState<string | null>(null);
 
   async function sendRsvp(response: "accepted" | "declined" | "tentative") {
     setSubmitting(response);
     setError(null);
     try {
-      const res = await fetch(`/api/notifications/${notification.id}/rsvp`, {
+      const res = await fetch(`/api/notifications/${notificationId}/rsvp`, {
         method: "POST",
         credentials: "include",
         headers: { "Content-Type": "application/json" },
@@ -252,9 +285,20 @@ function NotificationCard({ notification }: { notification: HomeNotification }) 
       const json = await res.json();
       if (!res.ok) {
         setError(json.error ?? "Failed to RSVP");
+        return;
+      }
+      const enumVal =
+        response === "accepted"
+          ? "Accepted"
+          : response === "declined"
+            ? "Declined"
+            : "Tentative";
+      onResponded?.(enumVal);
+      if (json.gcalError) {
+        setError(`Recorded in-app, but Google sync failed: ${json.gcalError}`);
       } else {
-        setRsvp(response === "accepted" ? "Accepted" : response === "declined" ? "Declined" : "Tentative");
-        if (json.gcalError) setError(`Recorded in-app, but Google sync failed: ${json.gcalError}`);
+        // Drop the answered invite from tasks/banner on the next loader pass.
+        revalidator.revalidate();
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : "Network error");
@@ -262,6 +306,48 @@ function NotificationCard({ notification }: { notification: HomeNotification }) 
       setSubmitting(null);
     }
   }
+
+  return (
+    <>
+      <div className="flex items-center gap-1.5 mt-2">
+        <button
+          type="button"
+          onClick={() => sendRsvp("accepted")}
+          disabled={!!submitting}
+          className="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium rounded-md bg-green-600 text-white hover:bg-green-700 disabled:opacity-50"
+        >
+          <Check className="w-3 h-3" />
+          {submitting === "accepted" ? "Accepting…" : "Accept"}
+        </button>
+        <button
+          type="button"
+          onClick={() => sendRsvp("tentative")}
+          disabled={!!submitting}
+          className="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium rounded-md border border-border text-foreground hover:bg-muted disabled:opacity-50"
+        >
+          <HelpCircle className="w-3 h-3" />
+          {submitting === "tentative" ? "…" : "Maybe"}
+        </button>
+        <button
+          type="button"
+          onClick={() => sendRsvp("declined")}
+          disabled={!!submitting}
+          className="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium rounded-md border border-border text-foreground hover:bg-muted disabled:opacity-50"
+        >
+          <XIcon className="w-3 h-3" />
+          {submitting === "declined" ? "…" : "Decline"}
+        </button>
+      </div>
+      {error && <p className="text-[10px] text-red-700 mt-1">{error}</p>}
+    </>
+  );
+}
+
+function NotificationCard({ notification }: { notification: HomeNotification }) {
+  const isUnread = !notification.readAt;
+  const isInvite = notification.kind === "MeetingInvite" && !!notification.scheduledMeetingId;
+  const accent = isUnread ? "border-l-accent-coral" : "border-l-accent-teal";
+  const [rsvp, setRsvp] = useState<HomeNotification["rsvp"]>(notification.rsvp);
 
   return (
     <div
@@ -325,37 +411,11 @@ function NotificationCard({ notification }: { notification: HomeNotification }) 
           )}
         </div>
         {isInvite && !rsvp && (
-          <div className="flex items-center gap-1.5 mt-2">
-            <button
-              type="button"
-              onClick={() => sendRsvp("accepted")}
-              disabled={!!submitting}
-              className="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium rounded-md bg-green-600 text-white hover:bg-green-700 disabled:opacity-50"
-            >
-              <Check className="w-3 h-3" />
-              {submitting === "accepted" ? "Accepting…" : "Accept"}
-            </button>
-            <button
-              type="button"
-              onClick={() => sendRsvp("tentative")}
-              disabled={!!submitting}
-              className="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium rounded-md border border-border text-foreground hover:bg-muted disabled:opacity-50"
-            >
-              <HelpCircle className="w-3 h-3" />
-              {submitting === "tentative" ? "…" : "Maybe"}
-            </button>
-            <button
-              type="button"
-              onClick={() => sendRsvp("declined")}
-              disabled={!!submitting}
-              className="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium rounded-md border border-border text-foreground hover:bg-muted disabled:opacity-50"
-            >
-              <XIcon className="w-3 h-3" />
-              {submitting === "declined" ? "…" : "Decline"}
-            </button>
-          </div>
+          <RsvpButtons
+            notificationId={notification.id}
+            onResponded={setRsvp}
+          />
         )}
-        {error && <p className="text-[10px] text-red-700 mt-1">{error}</p>}
       </div>
     </div>
   );

--- a/dali-api/e2e/calendar-settings.spec.ts
+++ b/dali-api/e2e/calendar-settings.spec.ts
@@ -10,23 +10,29 @@ test.describe('calendar settings persistence', () => {
     await page.goto('/calendar?embed=1');
     await expect(page.getByRole('heading', { name: 'Availability' })).toBeVisible();
 
-    // Normalize: ensure Monday is enabled before the actual test.
+    // Working Hours is off by default and the per-day editor is hidden until
+    // the master switch is on. Turn it on, which seeds the Mon–Fri default so
+    // Monday's segment editor appears.
+    const masterSwitch = page.getByRole('switch', { name: /Working hours enabled/i });
     if ((await page.getByLabel('Mon segment 1 start').count()) === 0) {
-      await page.getByRole('button', { name: /Mon enabled/i }).click();
+      await masterSwitch.click();
       await expect(page.getByLabel('Mon segment 1 start')).toBeVisible();
       await page.waitForLoadState('networkidle');
     }
 
-    // Disable Monday.
+    // Disable Monday via its per-day toggle (only present while the master
+    // switch is on).
     await page.getByRole('button', { name: /Mon enabled/i }).click();
     await expect(page.getByLabel('Mon segment 1 start')).toHaveCount(0);
     await page.waitForLoadState('networkidle');
 
-    // Reload and assert state persists.
+    // Reload and assert the disabled state persists. The master switch stays on
+    // (other days still have segments), so the editor — and Monday's toggle —
+    // remain visible.
     await page.reload();
     await expect(page.getByLabel('Mon segment 1 start')).toHaveCount(0);
 
-    // Toggle back on (leaves DB in enabled state for next run).
+    // Toggle Monday back on (leaves DB in enabled state for the next run).
     await page.getByRole('button', { name: /Mon enabled/i }).click();
     await expect(page.getByLabel('Mon segment 1 start')).toBeVisible();
     await page.waitForLoadState('networkidle');
@@ -34,13 +40,13 @@ test.describe('calendar settings persistence', () => {
 
   test('event buffer selection persists', async ({ page }) => {
     await page.goto('/calendar?embed=1');
-    // Pick 45m specifically so this test doesn't collide with the 15m default
-    // or the 30m value other ad-hoc clicks tend to leave behind.
-    await page.getByRole('button', { name: '45m', exact: true }).click();
-    await expect(page.getByText(/45-minute buffer will be added/)).toBeVisible();
+    // Pick 30m (the largest offered option) so this test doesn't collide with
+    // the 15m default.
+    await page.getByRole('button', { name: '30m', exact: true }).click();
+    await expect(page.getByText(/30-minute buffer will be added/)).toBeVisible();
     await page.waitForLoadState('networkidle');
     await page.reload();
-    await expect(page.getByText(/45-minute buffer will be added/)).toBeVisible();
+    await expect(page.getByText(/30-minute buffer will be added/)).toBeVisible();
   });
 
   test('Add Google Account link is present and points at OAuth start', async ({ page }) => {

--- a/dali-api/prisma/migrations/20260523210000_add_group_archive_term_binding/migration.sql
+++ b/dali-api/prisma/migrations/20260523210000_add_group_archive_term_binding/migration.sql
@@ -1,0 +1,11 @@
+-- Static user groups can now be archived. `archivedAt` records an explicit
+-- manual archive; `boundTermIds` scopes a group to one or more terms so it can
+-- auto-archive (derived at read time) once the latest bound term has ended.
+-- System (Dynamic) groups leave both at their defaults.
+
+-- AlterTable
+ALTER TABLE "GroupDefinition" ADD COLUMN     "archivedAt" TIMESTAMP(3),
+ADD COLUMN     "boundTermIds" TEXT[] DEFAULT ARRAY[]::TEXT[];
+
+-- CreateIndex
+CREATE INDEX "GroupDefinition_archivedAt_idx" ON "GroupDefinition"("archivedAt");

--- a/dali-api/prisma/schema.prisma
+++ b/dali-api/prisma/schema.prisma
@@ -1355,8 +1355,18 @@ model GroupDefinition {
   // groups, or null for user-created groups. Used to prevent duplicate
   // backfill and block manual edits/deletes from the UI.
   systemKey       String?   @unique
+  // Set when a static group is manually archived. A group is also treated as
+  // archived once every term in boundTermIds has ended (derived at read time);
+  // archivedAt only records an explicit, term-independent archive action.
+  archivedAt      DateTime?
+  // Term ids this static group is scoped to. Empty = not term-bound (never
+  // auto-archives). When non-empty, the group auto-archives once the latest
+  // bound term's endDate has passed. System (Dynamic) groups never use this.
+  boundTermIds    String[] @default([])
 
   createdAt DateTime @default(now())
+
+  @@index([archivedAt])
 }
 
 enum GroupType {


### PR DESCRIPTION
* Calendar UX overhaul + partners/library/sidebar polish (+ in-flight group & invite work)

This branch bundles several independent workstreams that had accumulated in the tree. Calling them out explicitly since they don't all share an author or a feature.

Calendar UX (My Availability + Schedule Meeting):
- Working Hours master on/off toggle (off by default); reset re-seeds the default week; fix the Sunday-toggle bug that wiped unpersisted Mon–Fri defaults by persisting the whole week on every edit (seed-working-hours).
- Grid: 10-minute cells, 8am–10pm range, bold hour lines vs faint sub-lines.
- Drag-to-create on My Availability: block (add-manual-block) or meeting (/api/scheduled-meetings, invitees/recurrence/Google invite), solo = in-app.
- Per-participant availability hover on Schedule Meeting.
- Free time is uncolored in both on/off states (removed the green wash).
- Availability "free" now means: working hours OFF → available all day (incl. weekends); ON → inside saved segments only. Fixes weekends showing white.
- Schedule-preview gradient now lerps white → deep green (#2E7D32) for more contrast; attendee popover flips left on Fri/Sat so it isn't clipped.

UI polish:
- Partners applications: square bar-graph tops (was rounded).
- Hiring Library: Challenges/Rubrics/Agreements toggle restyled to match the calendar pill toggle.
- Sidebar subtabs: right-click context menu (Open / Open to the side), backed by a new TabWorkspaceHandle.openTabToSide.

In-flight work also present in the tree (not authored in this session), included at the requester's instruction:
- Group archive + term binding: GroupDefinition gains archivedAt + boundTermIds. MIGRATION: 20260523210000_add_group_archive_term_binding — additive only (two nullable/defaulted columns + an index), no data loss.
- Invite-todo lifecycle: meeting-invite todos, a scheduled-meeting cancel route, and notification/task changes. Touches notification flows; review for collab/notification side effects before promoting past staging.



* Mock ~/lib/db in groups.test.ts so it doesn't load the real Prisma client

The unit-test CI job runs `npm test` without `prisma generate` (that only runs in the e2e job), so the generated client at app/generated/prisma/client is absent. Every other db-touching unit suite mocks ~/lib/db, which avoids loading db.ts entirely; groups.test.ts was the only one that didn't, so importing ../groups pulled in db.ts and failed CI with "Cannot find module '../generated/prisma/client.js'". isGroupArchived is pure and never hits the DB, so the mock just satisfies the import.



* Update calendar e2e tests for the new Working Hours UX + buffer options

Two e2e specs encoded the old calendar UI and broke after the redesign:

- Monday-toggle test clicked a per-day "Mon enabled" button on load, but Working Hours is now off by default and the per-day editor is hidden until the master switch is on. Drive the master switch (role=switch, "Working hours enabled") first; it seeds the Mon–Fri default so Monday's editor appears, then exercise the per-day toggle as before.
- Buffer test clicked "45m", but the Event Buffers options were trimmed to a max of 30m. Use 30m (still distinct from the 15m default).



---------

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/680"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782192204&installation_id=133523038&pr_number=680&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F680&signature=df5185a9b9c65e8f492b5c6bd66b928058b82cd1aaf698ba218fd24b50dc85c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->