### PR TITLE
Form drafts + calendar/Manual Blocks follow-up fixes (#681)

### DIFF
--- a/dali-api/app/calendar/routes/calendar.tsx
+++ b/dali-api/app/calendar/routes/calendar.tsx
@@ -1241,7 +1241,7 @@ function ManualBlocksCard({ blocks, timezone }: { blocks: ManualBlockDTO[]; time
           onClick={() => setAdding((v) => !v)}
           className="inline-flex items-center gap-1 px-2.5 py-1.5 text-xs font-semibold rounded-md border border-border hover:bg-muted transition-colors"
         >
-          <Plus className="w-3.5 h-3.5" />
+          {adding ? <X className="w-3.5 h-3.5" /> : <Plus className="w-3.5 h-3.5" />}
           {adding ? "Cancel" : "Add Block"}
         </button>
       </div>
@@ -1260,6 +1260,7 @@ function ManualBlocksCard({ blocks, timezone }: { blocks: ManualBlockDTO[]; time
 
 function AddManualBlockForm({ onDone }: { onDone: () => void }) {
   const fetcher = useFetcher();
+  const [repeats, setRepeats] = useState<Repeats>("none");
   return (
     <fetcher.Form
       method="post"
@@ -1277,13 +1278,13 @@ function AddManualBlockForm({ onDone }: { onDone: () => void }) {
         className="px-2 py-1 text-sm border border-border rounded-md bg-background text-foreground"
       />
       <div className="flex gap-2">
-        <label className="flex-1 text-xs text-muted-foreground flex flex-col gap-1">
+        <label className="flex-1 min-w-0 text-xs text-muted-foreground flex flex-col gap-1">
           Start
           <input
             type="datetime-local"
             name="startTimeLocal"
             required
-            className="px-2 py-1 text-sm border border-border rounded-md bg-background text-foreground"
+            className="w-full min-w-0 px-2 py-1 text-sm border border-border rounded-md bg-background text-foreground"
             onChange={(e) => {
               const dt = e.currentTarget.value ? new Date(e.currentTarget.value).toISOString() : "";
               const hidden = e.currentTarget.form?.querySelector<HTMLInputElement>('input[name="startTime"]');
@@ -1292,13 +1293,13 @@ function AddManualBlockForm({ onDone }: { onDone: () => void }) {
           />
           <input type="hidden" name="startTime" />
         </label>
-        <label className="flex-1 text-xs text-muted-foreground flex flex-col gap-1">
+        <label className="flex-1 min-w-0 text-xs text-muted-foreground flex flex-col gap-1">
           End
           <input
             type="datetime-local"
             name="endTimeLocal"
             required
-            className="px-2 py-1 text-sm border border-border rounded-md bg-background text-foreground"
+            className="w-full min-w-0 px-2 py-1 text-sm border border-border rounded-md bg-background text-foreground"
             onChange={(e) => {
               const dt = e.currentTarget.value ? new Date(e.currentTarget.value).toISOString() : "";
               const hidden = e.currentTarget.form?.querySelector<HTMLInputElement>('input[name="endTime"]');
@@ -1308,11 +1309,23 @@ function AddManualBlockForm({ onDone }: { onDone: () => void }) {
           <input type="hidden" name="endTime" />
         </label>
       </div>
-      <input
-        name="recurrenceRule"
-        placeholder="Recurrence (RRULE, optional, e.g. FREQ=WEEKLY;BYDAY=MO)"
-        className="px-2 py-1 text-xs border border-border rounded-md bg-background text-foreground"
-      />
+      <label className="text-xs text-muted-foreground flex flex-col gap-1">
+        Repeats
+        <select
+          value={repeats}
+          onChange={(e) => setRepeats(e.target.value as Repeats)}
+          className="px-2 py-1 text-sm border border-border rounded-md bg-background text-foreground"
+        >
+          {REPEATS_OPTIONS.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+      </label>
+      {/* The action reads `recurrenceRule` as an RRULE string; derive it from
+          the friendly Repeats choice so non-technical users never see RRULE. */}
+      <input type="hidden" name="recurrenceRule" value={repeatsToRRule(repeats) ?? ""} />
       <div className="flex justify-end gap-2">
         <button
           type="button"
@@ -3034,26 +3047,12 @@ function SelectedSlotBlock({
   const height = duration * HOUR_PX;
   return (
     <div
-      className="absolute left-0 right-0 z-30 cursor-help"
-      style={{
-        top,
-        height,
-        borderWidth: "2px",
-        borderStyle: "solid",
-        borderColor: "var(--color-foreground)",
-        borderRadius: "0.125rem",
-        background: "transparent",
-      }}
+      className="absolute left-0 right-0 z-30 cursor-help border-2 border-accent-coral bg-accent-coral/10 rounded-sm"
+      style={{ top, height }}
       onMouseEnter={() => setOpen(true)}
       onMouseLeave={() => setOpen(false)}
     >
-      <div
-        className="m-1 inline-flex items-center gap-1 px-1.5 py-0.5 text-[11px] font-semibold rounded-sm shadow-sm"
-        style={{
-          color: "var(--color-foreground)",
-          backgroundColor: "var(--color-card)",
-        }}
-      >
+      <div className="m-1 inline-flex items-center gap-1 px-1.5 py-0.5 text-[11px] font-semibold rounded-sm shadow-sm bg-accent-coral text-white">
         {available.length}/{total}
       </div>
       {open && (
@@ -3202,8 +3201,10 @@ function WeekGrid({
   // column the drag started in, even when the cursor strays elsewhere.
   const columnRefs = useRef<(HTMLDivElement | null)[]>([]);
   // The committed selection block element, so the portal popover can anchor to
-  // its real on-screen rect and clamp itself to the viewport.
-  const selectionRef = useRef<HTMLDivElement | null>(null);
+  // its real on-screen rect. A callback ref into state (not a plain useRef)
+  // guarantees the portal re-renders the moment the node attaches — a shared
+  // useRef read from a sibling left anchor stuck null.
+  const [anchorEl, setAnchorEl] = useState<HTMLDivElement | null>(null);
 
   const MIN_HOUR = HOURS[0];
   const MAX_HOUR = HOURS[HOURS.length - 1] + 1;
@@ -3348,13 +3349,33 @@ function WeekGrid({
               </Fragment>
             ))}
             {backgroundLayer?.(idx)}
+            {/* Redraw the grid lines above the availability tint so they stay
+                visible over the colored background — but BEFORE events, so
+                Busy blocks render on top of the lines (not the other way
+                round). Hour lines bolder than the 10-minute sub-hour lines. */}
+            {showSubHourGrid &&
+              HOURS.map((_, i) => (
+                <Fragment key={`grid-fg-${i}`}>
+                  <div
+                    className="absolute left-0 right-0 border-t-2 border-foreground/40 pointer-events-none"
+                    style={{ top: i * HOUR_PX }}
+                  />
+                  {Array.from({ length: SUBDIVISIONS_PER_HOUR - 1 }).map((_, s) => (
+                    <div
+                      key={s}
+                      className="absolute left-0 right-0 border-t border-foreground/[0.08] pointer-events-none"
+                      style={{ top: i * HOUR_PX + (HOUR_PX * (s + 1)) / SUBDIVISIONS_PER_HOUR }}
+                    />
+                  ))}
+                </Fragment>
+              ))}
             {isToday && nowLineTop != null && (
               <div
-                className="absolute left-0 right-0 h-0 border-t-2 border-accent-coral pointer-events-none z-30"
+                className="absolute left-0 right-0 h-0.5 bg-accent-coral pointer-events-none z-30"
                 style={{ top: nowLineTop }}
                 aria-label="Current time"
               >
-                <div className="absolute left-0 -top-1 w-2 h-2 rounded-full bg-accent-coral" />
+                <div className="absolute left-0 -top-[3px] w-2 h-2 rounded-full bg-accent-coral" />
               </div>
             )}
             {drag && drag.dayIdx === idx && (() => {
@@ -3386,7 +3407,7 @@ function WeekGrid({
               const resizable = !!onSelectionResize;
               return (
                 <div
-                  ref={selectionRef}
+                  ref={setAnchorEl}
                   className={`absolute left-0 right-0 border-2 border-accent-coral bg-accent-coral/15 rounded-sm z-30 ${
                     resizable ? "" : "pointer-events-none"
                   }`}
@@ -3452,24 +3473,6 @@ function WeekGrid({
               );
             })}
             {overlayLayer?.(idx)}
-            {/* Redraw the grid lines above the availability tint so they stay
-                visible. Hour lines bolder than the 10-minute sub-hour lines. */}
-            {showSubHourGrid &&
-              HOURS.map((_, i) => (
-                <Fragment key={`grid-fg-${i}`}>
-                  <div
-                    className="absolute left-0 right-0 border-t-2 border-foreground/40 pointer-events-none z-20"
-                    style={{ top: i * HOUR_PX }}
-                  />
-                  {Array.from({ length: SUBDIVISIONS_PER_HOUR - 1 }).map((_, s) => (
-                    <div
-                      key={s}
-                      className="absolute left-0 right-0 border-t border-foreground/[0.08] pointer-events-none z-20"
-                      style={{ top: i * HOUR_PX + (HOUR_PX * (s + 1)) / SUBDIVISIONS_PER_HOUR }}
-                    />
-                  ))}
-                </Fragment>
-              ))}
           </div>
         </div>
         );
@@ -3480,7 +3483,7 @@ function WeekGrid({
         is never clipped by the grid's overflow or the screen edge. */}
     {selection && selectionPopover && (
       <SelectionPopoverPortal
-        anchorRef={selectionRef}
+        anchorEl={anchorEl}
         onDismiss={() => onSelectionDismiss?.()}
       >
         {selectionPopover()}
@@ -3496,11 +3499,11 @@ function WeekGrid({
 // fully on-screen. A transparent full-viewport backdrop captures outside clicks
 // to dismiss — and, being in a portal, never lets a click reach a grid column.
 function SelectionPopoverPortal({
-  anchorRef,
+  anchorEl,
   onDismiss,
   children,
 }: {
-  anchorRef: React.RefObject<HTMLElement | null>;
+  anchorEl: HTMLElement | null;
   onDismiss: () => void;
   children: React.ReactNode;
 }) {
@@ -3508,11 +3511,11 @@ function SelectionPopoverPortal({
   const [pos, setPos] = useState<{ left: number; top: number } | null>(null);
 
   useLayoutEffect(() => {
+    if (!anchorEl) return;
     const place = () => {
-      const anchor = anchorRef.current;
       const card = cardRef.current;
-      if (!anchor || !card) return;
-      const a = anchor.getBoundingClientRect();
+      if (!card) return;
+      const a = anchorEl.getBoundingClientRect();
       const cw = card.offsetWidth;
       const ch = card.offsetHeight;
       const gap = 8;
@@ -3523,21 +3526,55 @@ function SelectionPopoverPortal({
       let left = a.right + gap;
       if (left + cw + margin > vw) left = a.left - gap - cw;
       left = Math.max(margin, Math.min(left, vw - cw - margin));
-      // Align the top with the block, then clamp within the viewport.
-      let top = a.top;
+      // Vertically hug the block: top-align if the card fits below, else
+      // bottom-align with the block (open upward) so it stays adjacent instead
+      // of being yanked far up by a viewport clamp on a late-day selection.
+      let top = a.top + ch + margin <= vh ? a.top : a.bottom - ch;
       top = Math.max(margin, Math.min(top, vh - ch - margin));
-      setPos({ left, top });
+      setPos((prev) =>
+        prev && prev.left === left && prev.top === top ? prev : { left, top },
+      );
     };
     place();
+    // Re-place when the card resizes (block→meeting grows it) or the window
+    // reflows. Deps include anchorEl so this runs the instant the block mounts.
+    const ro = new ResizeObserver(place);
+    if (cardRef.current) ro.observe(cardRef.current);
     window.addEventListener("resize", place);
     window.addEventListener("scroll", place, true);
     return () => {
+      ro.disconnect();
       window.removeEventListener("resize", place);
       window.removeEventListener("scroll", place, true);
     };
-  }, [anchorRef, children]);
+  }, [anchorEl]);
 
   if (typeof document === "undefined") return null;
+
+  // First paint (before the layout effect sets pos): derive a spot from the
+  // anchor's current rect so the popover appears NEXT TO the block, flipping
+  // left / opening upward near the edges. Falls back to centred if no anchor.
+  let left = pos?.left;
+  let top = pos?.top;
+  if (left == null || top == null) {
+    const a = anchorEl?.getBoundingClientRect();
+    if (a) {
+      const CARD_W = 320; // matches w-80
+      const CARD_H = 416; // matches max-h-[26rem]
+      const gap = 8;
+      const margin = 8;
+      left = a.right + gap + CARD_W + gap > window.innerWidth
+        ? a.left - gap - CARD_W // would overflow right → flip to the left side
+        : a.right + gap;
+      left = Math.max(margin, left);
+      const vh = window.innerHeight;
+      const rawTop = a.top + CARD_H + margin <= vh ? a.top : a.bottom - CARD_H;
+      top = Math.max(margin, Math.min(rawTop, vh - CARD_H - margin));
+    } else {
+      left = Math.max(8, window.innerWidth / 2 - 160);
+      top = 80;
+    }
+  }
 
   return createPortal(
     <div className="fixed inset-0 z-50">
@@ -3549,7 +3586,7 @@ function SelectionPopoverPortal({
       <div
         data-calendar-popover
         className="absolute"
-        style={{ left: pos?.left ?? -9999, top: pos?.top ?? -9999, visibility: pos ? "visible" : "hidden" }}
+        style={{ left, top }}
         onMouseDown={(e) => e.stopPropagation()}
       >
         {children}

--- a/dali-api/app/forms/components/FormDetail.tsx
+++ b/dali-api/app/forms/components/FormDetail.tsx
@@ -1,8 +1,9 @@
 import { useState, useEffect, useRef } from "react";
-import { Link, useLoaderData, useSubmit, useFetcher } from "react-router";
+import { Link, useLoaderData, useFetcher } from "react-router";
 import {
   ArrowLeft,
   Plus,
+  Pencil,
   FileText,
   Clock,
   UserIcon,
@@ -29,41 +30,114 @@ function formatDateTime(iso: string) {
   );
 }
 
-// Editor page for a single form. Mirrors hiring's ChallengeDetail: a versions
-// sidebar on the left, the hiring FormBuilderTab on the right when creating a
-// version, and a read-only preview of the selected version otherwise. Saving
-// appends a new immutable version (handled by the route action).
+// Compact one-line form for the narrow versions sidebar, e.g. "May 24, 11:49 AM".
+function formatDateShort(iso: string) {
+  const d = new Date(iso);
+  return (
+    d.toLocaleDateString(undefined, { month: "short", day: "numeric" }) +
+    ", " +
+    d.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" })
+  );
+}
+
+// Editor page for a single form. A versions sidebar on the left; on the right,
+// the builder when editing the draft, or a read-only preview of a selected
+// version otherwise.
+//
+// Two save actions (see FormBuilderTab):
+//   - "Save"            → persists the editable draft (save-draft). The draft
+//                         is NOT usable: published fills always serve the
+//                         latest frozen version, never the draft.
+//   - "Save as version" → freezes the draft into an immutable version
+//                         (save-version) and clears the draft. Frozen versions
+//                         are read-only and are what publishing serves.
 export function FormDetail() {
   const { form, terms, backTo } = useLoaderData<typeof loader>();
-  const submit = useSubmit();
+  // A dedicated fetcher for saves so the builder's buttons can reflect
+  // request state ("Saving…"/"Saved ✓"). The submitted intent tells us which
+  // button is in flight; fetcher.state + a brief post-success window drive the
+  // "Saved" confirmation.
+  const saveFetcher = useFetcher<{ ok?: boolean; error?: string }>();
+  const savingIntent = saveFetcher.formData?.get("intent") as
+    | "save-draft"
+    | "save-version"
+    | null;
+  const [justSaved, setJustSaved] = useState<null | "draft" | "version">(null);
+  const saveError =
+    saveFetcher.data && "error" in saveFetcher.data ? saveFetcher.data.error : null;
+
+  const latestVersion = form.versions.length
+    ? form.versions[form.versions.length - 1]
+    : null;
+  const hasDraft = form.draft != null;
 
   const [selectedVersionId, setSelectedVersionId] = useState<string | null>(
-    () =>
-      form.versions.length
-        ? form.versions[form.versions.length - 1].id
-        : null,
+    () => latestVersion?.id ?? null,
   );
-  const [isCreatingVersion, setIsCreatingVersion] = useState(
-    form.versions.length === 0,
-  );
+  // Open straight into the builder when there's a draft to resume or no
+  // version exists yet; otherwise land on the latest version's preview.
+  const [isEditing, setIsEditing] = useState(hasDraft || form.versions.length === 0);
 
   const selectedVersion = form.versions.find(
     (v) => v.id === selectedVersionId,
   );
   const nextVersionNumber = form.versions.length + 1;
 
-  // After a save round-trips and the loader re-runs, select the new version
-  // and leave create mode.
+  // Seed the builder: resume the draft if present, else duplicate the version
+  // the user chose to branch from, else start blank.
+  const [seed, setSeed] = useState<{
+    questions: Question[];
+    description: unknown;
+  }>(() =>
+    form.draft
+      ? { questions: form.draft.questions, description: form.draft.description }
+      : latestVersion
+        ? { questions: latestVersion.questions, description: latestVersion.description }
+        : { questions: [], description: null },
+  );
+
+  // After a save-version round-trips and the loader re-runs (version count
+  // grows, draft cleared), select the new version and leave edit mode.
   const prevCount = useRef(form.versions.length);
   useEffect(() => {
     if (form.versions.length > prevCount.current) {
       setSelectedVersionId(form.versions[form.versions.length - 1].id);
-      setIsCreatingVersion(false);
+      setIsEditing(false);
     }
     prevCount.current = form.versions.length;
   }, [form.versions.length]);
 
-  function handleSave({
+  // A monotonic key for the builder. Bumped only when we deliberately re-seed
+  // (startEditing) so the builder remounts then — NOT on every loader
+  // revalidation (e.g. after a draft save flips hasDraft), which would wipe the
+  // user's in-progress edits and the "Saved" flash.
+  const [editKey, setEditKey] = useState(0);
+
+  // Open the builder seeded from a given version (or blank) and switch to it.
+  function startEditing(from?: { questions: Question[]; description: unknown }) {
+    setSeed(
+      from ?? form.draft ?? { questions: [], description: null },
+    );
+    setEditKey((k) => k + 1);
+    setIsEditing(true);
+  }
+
+  function handleSaveDraft({
+    questions,
+    description,
+  }: {
+    questions: Question[];
+    description: unknown;
+  }) {
+    const fd = new FormData();
+    fd.set("intent", "save-draft");
+    fd.set("id", form.id);
+    fd.set("questions", JSON.stringify(questions));
+    fd.set("description", description ? JSON.stringify(description) : "");
+    saveFetcher.submit(fd, { method: "post" });
+  }
+
+  function handleSaveVersion({
     questions,
     description,
   }: {
@@ -75,8 +149,45 @@ export function FormDetail() {
     fd.set("id", form.id);
     fd.set("questions", JSON.stringify(questions));
     fd.set("description", description ? JSON.stringify(description) : "");
-    submit(fd, { method: "post" });
+    saveFetcher.submit(fd, { method: "post" });
   }
+
+  // Remember the intent of the in-flight save so the post-success flash knows
+  // which button to mark (fetcher.formData is gone by the time it's idle).
+  const lastIntentRef = useRef<"save-draft" | "save-version" | null>(null);
+  if (savingIntent) lastIntentRef.current = savingIntent;
+
+  // When a save finishes (fetcher leaves "submitting", data ok), flash "Saved"
+  // on the button for ~2s. The draft save stays in the editor, so this
+  // transient checkmark is the main "it worked" signal; the version save also
+  // leaves edit mode (the version-count effect above), so the user sees the
+  // new read-only version.
+  const wasSubmitting = useRef(false);
+  useEffect(() => {
+    const submitting = saveFetcher.state === "submitting";
+    if (wasSubmitting.current && !submitting) {
+      const data = saveFetcher.data;
+      if (data && data.ok) {
+        setJustSaved(lastIntentRef.current === "save-version" ? "version" : "draft");
+        const t = setTimeout(() => setJustSaved(null), 2000);
+        wasSubmitting.current = submitting;
+        return () => clearTimeout(t);
+      }
+    }
+    wasSubmitting.current = submitting;
+  }, [saveFetcher.state, saveFetcher.data]);
+
+  // Roll up the fetcher state into the builder's saveStatus prop.
+  const saveStatus =
+    savingIntent === "save-draft"
+      ? ("saving-draft" as const)
+      : savingIntent === "save-version"
+        ? ("saving-version" as const)
+        : justSaved === "draft"
+          ? ("saved-draft" as const)
+          : justSaved === "version"
+            ? ("saved-version" as const)
+            : ("idle" as const);
 
   return (
     <div className="space-y-6">
@@ -94,13 +205,13 @@ export function FormDetail() {
               Created {new Date(form.createdAt).toLocaleDateString()}
             </p>
           </div>
-          {!isCreatingVersion && (
+          {!isEditing && (
             <button
-              onClick={() => setIsCreatingVersion(true)}
-              className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-lg text-white bg-blue-600 hover:bg-blue-700 shadow-sm"
+              onClick={() => startEditing()}
+              className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-lg text-white bg-accent-coral hover:bg-accent-coral/90 shadow-sm"
             >
               <Plus className="w-4 h-4 mr-2" />
-              New Version
+              {hasDraft ? "Continue editing draft" : "New version"}
             </button>
           )}
         </div>
@@ -114,8 +225,36 @@ export function FormDetail() {
       </div>
 
       <div className="flex flex-col lg:flex-row gap-8">
-        {/* Left: versions list */}
+        {/* Left: draft + versions list */}
         <div className="w-full lg:w-64 flex-shrink-0 space-y-4">
+          {/* Unsaved working copy — editable, not usable until saved as a
+              version. Highlighted so it's clearly distinct from frozen ones. */}
+          {hasDraft && (
+            <div className="space-y-2">
+              <h3 className="text-sm font-bold text-foreground uppercase tracking-wider">
+                Draft
+              </h3>
+              <button
+                onClick={() => startEditing(form.draft ?? undefined)}
+                className={`w-full text-left p-4 rounded-xl border transition-colors ${
+                  isEditing
+                    ? "border-accent-coral bg-accent-coral/10 ring-1 ring-accent-coral"
+                    : "border-dashed border-accent-coral/50 bg-card hover:bg-muted/50"
+                }`}
+              >
+                <div className="flex items-center gap-2">
+                  <Pencil className="w-3.5 h-3.5 text-accent-coral flex-shrink-0" />
+                  <span className="font-medium text-foreground">
+                    Unsaved draft
+                  </span>
+                </div>
+                <p className="text-sm text-muted-foreground mt-1">
+                  {form.draft?.questions.length ?? 0} questions · not yet usable
+                </p>
+              </button>
+            </div>
+          )}
+
           <h3 className="text-sm font-bold text-foreground uppercase tracking-wider">
             Versions
           </h3>
@@ -123,90 +262,118 @@ export function FormDetail() {
             <p className="text-sm text-muted-foreground">No versions yet.</p>
           ) : (
             <div className="space-y-2">
-              {[...form.versions].reverse().map((version) => (
-                <button
-                  key={version.id}
-                  onClick={() => {
-                    setSelectedVersionId(version.id);
-                    setIsCreatingVersion(false);
-                  }}
-                  className={`w-full text-left p-4 rounded-xl border transition-colors ${
-                    selectedVersionId === version.id && !isCreatingVersion
-                      ? "border-blue-500 bg-blue-50 ring-1 ring-blue-500"
-                      : "border-border bg-card hover:bg-muted/50"
-                  }`}
-                >
-                  <div className="flex items-center justify-between mb-2">
-                    <div>
-                      <span className="font-medium text-foreground">
+              {[...form.versions].reverse().map((version, i) => {
+                const isLatest = i === 0;
+                return (
+                  <button
+                    key={version.id}
+                    onClick={() => {
+                      setSelectedVersionId(version.id);
+                      setIsEditing(false);
+                    }}
+                    className={`w-full text-left p-3 rounded-xl border transition-colors ${
+                      selectedVersionId === version.id && !isEditing
+                        ? "border-accent-teal bg-accent-teal/10 ring-1 ring-accent-teal"
+                        : "border-border bg-card hover:bg-muted/50"
+                    }`}
+                  >
+                    {/* Title row: version number, the "Live" badge on the
+                        latest frozen version (what published fills serve), and
+                        the question count — all on one line. */}
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <span className="font-semibold text-foreground">
                         v{version.versionNumber}
                       </span>
-                      <p className="text-sm text-muted-foreground">
-                        {version.questions.length} questions
-                      </p>
+                      {isLatest && (
+                        <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold bg-accent-teal/15 text-accent-teal">
+                          Live
+                        </span>
+                      )}
+                      <span className="text-xs text-muted-foreground">
+                        · {version.questions.length}{" "}
+                        {version.questions.length === 1 ? "question" : "questions"}
+                      </span>
                     </div>
-                    <div className="text-right">
-                      <div className="flex items-center justify-end text-xs text-muted-foreground mb-0.5">
-                        <Clock className="w-3 h-3 mr-1 flex-shrink-0" />
-                        {formatDateTime(version.createdAt)}
+                    {/* Metadata: each on its own full-width line so the
+                        timestamp never wraps mid-value. */}
+                    <div className="mt-2 space-y-1 text-xs text-muted-foreground">
+                      <div className="flex items-center gap-1.5">
+                        <Clock className="w-3 h-3 flex-shrink-0" />
+                        <span className="truncate">{formatDateShort(version.createdAt)}</span>
                       </div>
-                      <div className="flex items-center justify-end text-xs text-muted-foreground">
-                        <UserIcon className="w-3 h-3 mr-1 flex-shrink-0" />
-                        {version.createdByName}
+                      <div className="flex items-center gap-1.5">
+                        <UserIcon className="w-3 h-3 flex-shrink-0" />
+                        <span className="truncate">{version.createdByName}</span>
                       </div>
                     </div>
-                  </div>
-                </button>
-              ))}
+                  </button>
+                );
+              })}
             </div>
           )}
         </div>
 
         {/* Right: builder or preview */}
         <div className="flex-1">
-          {isCreatingVersion ? (
+          {isEditing ? (
             <div className="bg-card rounded-xl border border-border shadow-sm p-6">
               <div className="mb-6 pb-6 border-b border-border">
                 <h2 className="text-lg font-bold text-foreground">
                   {form.versions.length === 0
                     ? "Build this form"
-                    : "Create New Version"}
+                    : "Edit draft"}
                 </h2>
                 <p className="text-sm text-muted-foreground mt-1">
-                  It will be saved as v{nextVersionNumber}. Anyone filling this
-                  out sees the latest version.
+                  <strong className="font-medium text-foreground">Save</strong>{" "}
+                  keeps an editable draft — it isn't usable yet.{" "}
+                  <strong className="font-medium text-foreground">
+                    Save as version
+                  </strong>{" "}
+                  freezes it as v{nextVersionNumber}; published forms always
+                  serve the latest saved version.
                 </p>
               </div>
               <FormBuilderTab
-                initialQuestions={selectedVersion?.questions ?? []}
-                initialDescription={selectedVersion?.description ?? null}
+                // Remount only on a deliberate re-seed (startEditing bumps
+                // editKey), so a draft save's revalidation doesn't blow away
+                // in-progress edits. FormBuilderTab reads its initial* props
+                // only on mount.
+                key={editKey}
+                initialQuestions={seed.questions}
+                initialDescription={seed.description}
                 terms={terms}
-                onSave={handleSave}
+                onSaveDraft={handleSaveDraft}
+                onSave={handleSaveVersion}
+                saveLabel="Save as version"
+                saveStatus={saveStatus}
                 onCancel={
-                  form.versions.length === 0
+                  form.versions.length === 0 && !hasDraft
                     ? undefined
-                    : () => setIsCreatingVersion(false)
+                    : () => setIsEditing(false)
                 }
               />
+              {saveError && (
+                <p className="mt-3 text-sm text-destructive">{saveError}</p>
+              )}
             </div>
           ) : selectedVersion ? (
             <div className="bg-card rounded-xl border border-border shadow-sm overflow-hidden">
+              {/* A saved version is immutable — no edit affordance here. Make a
+                  new version with the header's "New version" button instead. */}
               <div className="px-6 py-5 border-b border-border bg-muted/50 flex justify-between items-center">
                 <div>
                   <h2 className="text-lg font-semibold text-foreground">
-                    Version {selectedVersion.versionNumber} Preview
+                    Version {selectedVersion.versionNumber} · read-only
                   </h2>
                   <p className="text-sm text-muted-foreground mt-1">
                     Created by {selectedVersion.createdByName} on{" "}
                     {formatDateTime(selectedVersion.createdAt)}
                   </p>
                 </div>
-                <button
-                  onClick={() => setIsCreatingVersion(true)}
-                  className="text-sm text-blue-600 hover:text-blue-700 font-medium"
-                >
-                  Duplicate to New Version
-                </button>
+                <span className="inline-flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+                  <Lock className="w-3.5 h-3.5" />
+                  Read-only
+                </span>
               </div>
 
               <div className="p-6 space-y-4">
@@ -248,7 +415,7 @@ export function FormDetail() {
                             {q.data.options.map((opt) => (
                               <span
                                 key={opt}
-                                className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-50 text-blue-700 border border-blue-100"
+                                className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-accent-teal/10 text-accent-teal border border-accent-teal/20"
                               >
                                 {opt}
                               </span>
@@ -276,8 +443,8 @@ export function FormDetail() {
               </p>
               <div className="mt-6">
                 <button
-                  onClick={() => setIsCreatingVersion(true)}
-                  className="inline-flex items-center px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700"
+                  onClick={() => startEditing()}
+                  className="inline-flex items-center px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-accent-coral hover:bg-accent-coral/90"
                 >
                   <Plus className="w-4 h-4 mr-2" />
                   Build form

--- a/dali-api/app/forms/lib/__tests__/forms-data.draft.test.ts
+++ b/dali-api/app/forms/lib/__tests__/forms-data.draft.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("~/lib/db");
+
+// `Prisma` comes from the mocked ~/lib/db (which re-exports the namespace), so
+// the test and forms-data.ts share the same DbNull sentinel — and neither
+// touches the generated client, which isn't built in the unit-test CI job.
+import { prisma, Prisma } from "~/lib/db";
+import { runFormsAction } from "~/forms/lib/forms-data";
+
+const mockPrisma = prisma as unknown as {
+  form: {
+    findUnique: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+  };
+  formVersion: {
+    findFirst: ReturnType<typeof vi.fn>;
+    create: ReturnType<typeof vi.fn>;
+  };
+  $transaction: ReturnType<typeof vi.fn>;
+};
+
+// Build a FormData the way the editor's submit() does.
+function fd(entries: Record<string, string>): FormData {
+  const f = new FormData();
+  for (const [k, v] of Object.entries(entries)) f.set(k, v);
+  return f;
+}
+
+const ONE_QUESTION = JSON.stringify([
+  { key: "q1", type: "text", required: false, data: { label: "Name" } },
+]);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // The array form of $transaction just needs to resolve.
+  mockPrisma.$transaction.mockResolvedValue([]);
+});
+
+describe("runFormsAction save-draft", () => {
+  it("persists the working copy to the Form, not a FormVersion", async () => {
+    mockPrisma.form.findUnique.mockResolvedValue({ id: "form-1" });
+
+    const res = await runFormsAction(
+      fd({ intent: "save-draft", id: "form-1", questions: ONE_QUESTION, description: "" }),
+      "user-1",
+    );
+
+    expect(res).toEqual({ ok: true });
+    expect(mockPrisma.form.update).toHaveBeenCalledWith({
+      where: { id: "form-1" },
+      data: { draftQuestions: expect.any(Array), draftIntro: null },
+    });
+    // A draft must NOT create a version.
+    expect(mockPrisma.formVersion.create).not.toHaveBeenCalled();
+  });
+
+  it("accepts a half-finished draft (no label) — leniency is the point", async () => {
+    mockPrisma.form.findUnique.mockResolvedValue({ id: "form-1" });
+    const draftish = JSON.stringify([
+      { key: "q1", type: "text", required: false, data: { label: "" } },
+    ]);
+
+    const res = await runFormsAction(
+      fd({ intent: "save-draft", id: "form-1", questions: draftish }),
+      "user-1",
+    );
+
+    expect(res).toEqual({ ok: true });
+    expect(mockPrisma.form.update).toHaveBeenCalled();
+  });
+
+  it("404s when the form is missing", async () => {
+    mockPrisma.form.findUnique.mockResolvedValue(null);
+
+    const res = await runFormsAction(
+      fd({ intent: "save-draft", id: "nope", questions: ONE_QUESTION }),
+      "user-1",
+    );
+
+    expect(res).toEqual({ error: "Not found", status: 404 });
+    expect(mockPrisma.form.update).not.toHaveBeenCalled();
+  });
+});
+
+describe("runFormsAction save-version", () => {
+  it("freezes a version and clears the draft in one transaction", async () => {
+    mockPrisma.form.findUnique.mockResolvedValue({ id: "form-1" });
+    mockPrisma.formVersion.findFirst.mockResolvedValue({ versionNumber: 2 });
+
+    const res = await runFormsAction(
+      fd({ intent: "save-version", id: "form-1", questions: ONE_QUESTION, description: "" }),
+      "user-1",
+    );
+
+    expect(res).toEqual({ ok: true });
+    // Both the version create and the draft clear go through $transaction.
+    expect(mockPrisma.$transaction).toHaveBeenCalledOnce();
+
+    // The version create is numbered after the latest (2 → 3).
+    expect(mockPrisma.formVersion.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ formId: "form-1", versionNumber: 3 }),
+      }),
+    );
+    // The draft is nulled out (JSON column → Prisma.DbNull).
+    expect(mockPrisma.form.update).toHaveBeenCalledWith({
+      where: { id: "form-1" },
+      data: { draftQuestions: Prisma.DbNull, draftIntro: null },
+    });
+  });
+
+  it("rejects a version with no questions (validation still enforced)", async () => {
+    mockPrisma.form.findUnique.mockResolvedValue({ id: "form-1" });
+
+    const res = await runFormsAction(
+      fd({ intent: "save-version", id: "form-1", questions: "[]" }),
+      "user-1",
+    );
+
+    expect(res).toEqual({ error: "Add at least one valid question.", status: 400 });
+    expect(mockPrisma.$transaction).not.toHaveBeenCalled();
+  });
+
+  it("rejects a version whose question has no label", async () => {
+    mockPrisma.form.findUnique.mockResolvedValue({ id: "form-1" });
+    const noLabel = JSON.stringify([
+      { key: "q1", type: "text", required: false, data: { label: "  " } },
+    ]);
+
+    const res = await runFormsAction(
+      fd({ intent: "save-version", id: "form-1", questions: noLabel }),
+      "user-1",
+    );
+
+    expect(res).toEqual({ error: "Every question needs a label.", status: 400 });
+    expect(mockPrisma.$transaction).not.toHaveBeenCalled();
+  });
+});

--- a/dali-api/app/forms/lib/forms-data.ts
+++ b/dali-api/app/forms/lib/forms-data.ts
@@ -9,7 +9,7 @@
 // as serialized ProseMirror JSON.
 
 import { z } from "zod";
-import { prisma } from "~/lib/db";
+import { prisma, Prisma } from "~/lib/db";
 import type { Question } from "~/types";
 import { isReferenceSourceKey, referenceSourceNeedsTerm } from "./reference-sources.shared";
 
@@ -79,6 +79,10 @@ export type FormDetail = {
   published: boolean;
   publicToken: string | null;
   versions: FormVersionDetail[];
+  // Editable working copy, if one exists. The editor seeds the builder from
+  // this; null means start from the latest version (or blank). Never served
+  // to fillers.
+  draft: { questions: Question[]; description: unknown } | null;
 };
 
 // The full form + every version (newest last), for the dedicated editor page.
@@ -96,6 +100,9 @@ export async function loadFormForEdit(
     },
   });
   if (!form) return null;
+  const draftQuestions = form.draftQuestions
+    ? (form.draftQuestions as unknown as Question[])
+    : null;
   return {
     id: form.id,
     name: form.name,
@@ -112,6 +119,13 @@ export async function loadFormForEdit(
       // intro holds serialized ProseMirror JSON (see module note).
       description: v.intro ? safeParse(v.intro) : null,
     })),
+    draft: draftQuestions
+      ? {
+          questions: draftQuestions,
+          // draftIntro mirrors FormVersion.intro (serialized ProseMirror JSON).
+          description: form.draftIntro ? safeParse(form.draftIntro) : null,
+        }
+      : null,
   };
 }
 
@@ -251,6 +265,14 @@ export const ActionSchema = z.discriminatedUnion("intent", [
     folderId: z.string().optional(), // "" = top level
   }),
   z.object({
+    // "Save" — persist the editable working copy. Lenient: a draft may hold a
+    // work-in-progress question set, so it isn't held to save-version's rules.
+    intent: z.literal("save-draft"),
+    id: z.string().min(1),
+    questions: z.string(), // JSON-encoded Question[]
+    description: z.string().optional(), // JSON-encoded ProseMirror doc
+  }),
+  z.object({
     intent: z.literal("save-version"),
     id: z.string().min(1),
     questions: z.string(), // JSON-encoded Question[]
@@ -343,6 +365,34 @@ export async function runFormsAction(
       await prisma.form.delete({ where: { id: input.id } });
       return { ok: true };
     }
+    case "save-draft": {
+      const exists = await prisma.form.findUnique({
+        where: { id: input.id },
+        select: { id: true },
+      });
+      if (!exists) return { error: "Not found", status: 404 };
+
+      // The draft is a working copy — parse it but don't enforce save-version's
+      // completeness rules (labels, valid reference sources, non-empty). It's
+      // never served to fillers, so a half-finished draft is fine to store.
+      let questions: unknown;
+      try {
+        questions = JSON.parse(input.questions);
+      } catch {
+        return { error: "Could not parse questions.", status: 400 };
+      }
+      if (!isQuestionArray(questions))
+        return { error: "Could not parse questions.", status: 400 };
+
+      await prisma.form.update({
+        where: { id: input.id },
+        data: {
+          draftQuestions: questions as object,
+          draftIntro: input.description?.trim() || null,
+        },
+      });
+      return { ok: true };
+    }
     case "save-version": {
       const exists = await prisma.form.findUnique({
         where: { id: input.id },
@@ -382,16 +432,25 @@ export async function runFormsAction(
         orderBy: { versionNumber: "desc" },
         select: { versionNumber: true },
       });
-      await prisma.formVersion.create({
-        data: {
-          formId: input.id,
-          versionNumber: (last?.versionNumber ?? 0) + 1,
-          questions: questions as object,
-          // Reuse the intro column to store the rich-text description JSON.
-          intro: input.description?.trim() || null,
-          createdById: userId,
-        },
-      });
+      // Freeze the working copy into an immutable, fillable version and clear
+      // the draft — the two happen together so the editor never shows a stale
+      // draft alongside the version it just became.
+      await prisma.$transaction([
+        prisma.formVersion.create({
+          data: {
+            formId: input.id,
+            versionNumber: (last?.versionNumber ?? 0) + 1,
+            questions: questions as object,
+            // Reuse the intro column to store the rich-text description JSON.
+            intro: input.description?.trim() || null,
+            createdById: userId,
+          },
+        }),
+        prisma.form.update({
+          where: { id: input.id },
+          data: { draftQuestions: Prisma.DbNull, draftIntro: null },
+        }),
+      ]);
       return { ok: true };
     }
     case "create-folder": {

--- a/dali-api/app/hiring/components/ChallengeBuilder.tsx
+++ b/dali-api/app/hiring/components/ChallengeBuilder.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react'
-import { GripVertical, Plus, Pencil, Trash2, Save } from 'lucide-react'
+import React, { useState, useEffect } from 'react'
+import { GripVertical, Plus, Pencil, Trash2, Save, Check, Loader2 } from 'lucide-react'
 import type { Question } from '~/types'
 import { RichTextEditor } from '~/components/RichTextEditor'
 import { referenceSourceChoices, referenceSourceNeedsTerm } from '~/forms/lib/reference-sources.shared'
@@ -105,6 +105,17 @@ interface FormBuilderTabProps {
   initialQuestions?: Question[]
   initialDescription?: unknown
   onSave?: (payload: { questions: Question[]; description: unknown }) => void
+  // Optional secondary "Save" (draft) action. When provided, a secondary
+  // button is rendered alongside the primary one; the primary then becomes the
+  // freeze-to-version action. Forms use this; hiring doesn't pass it.
+  onSaveDraft?: (payload: { questions: Question[]; description: unknown }) => void
+  // Label for the primary save button. Defaults to "Save Version" (hiring's
+  // wording); Forms passes "Save as version".
+  saveLabel?: string
+  // Live save feedback for the two save buttons. The owner drives this from its
+  // request state so the buttons can show "Saving…"/"Saved ✓" and disable while
+  // a save is in flight. Omitted by hiring (buttons stay plain).
+  saveStatus?: 'idle' | 'saving-draft' | 'saving-version' | 'saved-draft' | 'saved-version'
   onCancel?: () => void
   isGeneralForm?: boolean
   // Terms offered for term-scoped reference sources (e.g. projects active in a
@@ -115,6 +126,9 @@ export function FormBuilderTab({
   initialQuestions = [],
   initialDescription,
   onSave,
+  onSaveDraft,
+  saveLabel = 'Save Version',
+  saveStatus = 'idle',
   onCancel,
   isGeneralForm = false,
   terms = [],
@@ -122,7 +136,6 @@ export function FormBuilderTab({
   const [questions, setQuestions] = useState<Question[]>(initialQuestions)
   const [description, setDescription] = useState<unknown>(initialDescription ?? null)
   const [editingKey, setEditingKey] = useState<string | null>(null)
-  const [isAdding, setIsAdding] = useState(false)
   const [editForm, setEditForm] = useState<Partial<Question>>({})
   const [optionsText, setOptionsText] = useState('')
   const [maxWordsEnabled, setMaxWordsEnabled] = useState(false)
@@ -164,7 +177,6 @@ export function FormBuilderTab({
   }
   const resetEditState = () => {
     setEditingKey(null)
-    setIsAdding(false)
     setEditForm({})
     setOptionsText('')
     setMaxWordsEnabled(false)
@@ -178,7 +190,6 @@ export function FormBuilderTab({
     setOptionsText(q.data.options?.join('\n') || '')
     setMaxWordsEnabled(q.data.maxWords !== undefined)
     setMaxWordsValue(q.data.maxWords !== undefined ? String(q.data.maxWords) : '')
-    setIsAdding(false)
     if (q.type === 'file' && q.data.accept) {
       const { presets, custom } = parseAcceptIntoPresets(q.data.accept)
       setAcceptPresets(presets)
@@ -190,56 +201,65 @@ export function FormBuilderTab({
   }
   const handleDelete = (key: string) => {
     setQuestions(questions.filter((q) => q.key !== key))
+    if (editingKey === key) resetEditState()
   }
-  const handleSaveEdit = () => {
-    if (!editForm.key || !editForm.data?.label) return
-    const updatedQuestion = buildQuestion({
+
+  // Auto-commit: edits to the inline form flow straight into the question list,
+  // so there's no separate "Save Question" step — the question is part of the
+  // form the moment it's added, and the top-level Save / Save as version is the
+  // only thing that persists. The buffer (editForm + per-type field state) is
+  // rebuilt into its list entry whenever any of it changes.
+  useEffect(() => {
+    if (!editingKey || !editForm.key) return
+    const rebuilt = buildQuestion({
       key: editForm.key,
       type: editForm.type || 'text',
       required: editForm.required || false,
-      label: editForm.data.label,
-      description: editForm.data.description,
+      label: editForm.data?.label || '',
+      description: editForm.data?.description,
       optionsText,
       accept: buildAcceptFromPresets(acceptPresets, acceptCustom),
-      afterDomains: editForm.data.afterDomains,
+      afterDomains: editForm.data?.afterDomains,
       isGeneralForm,
       maxWordsEnabled,
       maxWordsValue,
-      referenceSource: editForm.data.referenceSource,
-      referenceTermId: editForm.data.referenceTermId,
+      referenceSource: editForm.data?.referenceSource,
+      referenceTermId: editForm.data?.referenceTermId,
     })
-    if (isAdding) {
-      setQuestions([...questions, updatedQuestion])
-    } else {
-      setQuestions(
-        questions.map((q) => (q.key === editingKey ? updatedQuestion : q)),
-      )
-    }
+    setQuestions((prev) =>
+      prev.map((q) => (q.key === editForm.key ? rebuilt : q)),
+    )
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [editForm, optionsText, acceptPresets, acceptCustom, maxWordsEnabled, maxWordsValue])
+
+  // Collapse the inline editor. The data is already in the list (auto-commit),
+  // so this just closes the form — no save needed.
+  const handleDoneEditing = () => {
     resetEditState()
   }
-  const handleCancelEdit = () => {
-    resetEditState()
-  }
+
   const handleAddQuestion = () => {
-    setIsAdding(true)
-    setEditingKey('new')
-    setEditForm({
-      key: `q-${Date.now()}`,
+    const key = `q-${Date.now()}`
+    const newQuestion = buildQuestion({
+      key,
       type: 'text',
       required: true,
-      data: {
-        label: '',
-      },
+      label: '',
+      isGeneralForm,
     })
+    // Append immediately and open it for inline editing — no staging step.
+    setQuestions((prev) => [...prev, newQuestion])
+    setEditingKey(key)
+    setEditForm({ key, type: 'text', required: true, data: { label: '' } })
     setOptionsText('')
     setMaxWordsEnabled(false)
     setMaxWordsValue('')
     setAcceptPresets(new Set())
     setAcceptCustom('')
   }
-  const renderEditForm = (isNew: boolean) => {
+  const renderEditForm = () => {
     return (
-      <div className="bg-blue-50 border border-blue-200 rounded-lg p-5 space-y-4">
+      <div className="bg-accent-coral/5 border border-accent-coral/30 rounded-lg p-5 space-y-4">
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
           <div className="col-span-2">
             <label className="block text-sm font-medium text-foreground/80 mb-1">
@@ -394,7 +414,7 @@ export function FormBuilderTab({
                 rows={4}
                 value={optionsText}
                 onChange={(e) => setOptionsText(e.target.value)}
-                className="block w-full rounded-md border border-gray-300 bg-white text-gray-900 placeholder:text-gray-400 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm p-2"
+                className="block w-full rounded-md border border-border bg-card text-foreground placeholder:text-muted-foreground/70 shadow-sm focus:border-accent-coral focus:ring-accent-coral sm:text-sm p-2"
                 placeholder="JavaScript&#10;Python&#10;React.js&#10;Figma"
               />
               <p className="text-xs text-gray-500 mt-1">Applicants will rate each skill from 0-5.</p>
@@ -485,7 +505,7 @@ export function FormBuilderTab({
                     className={`px-3 py-1 rounded-full text-xs font-medium border transition-colors ${
                       acceptPresets.has(value)
                         ? 'bg-accent-coral/15 text-accent-coral border-accent-coral/30'
-                        : 'bg-white text-gray-700 border-gray-300 hover:border-accent-coral/50'
+                        : 'bg-card text-foreground/80 border-border hover:border-accent-coral/50 hover:bg-muted/50'
                     }`}
                   >
                     {label}
@@ -496,7 +516,7 @@ export function FormBuilderTab({
                 type="text"
                 value={acceptCustom}
                 onChange={(e) => setAcceptCustom(e.target.value)}
-                className="block w-full rounded-md border border-gray-300 bg-white text-gray-900 placeholder:text-gray-400 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm p-2"
+                className="block w-full rounded-md border border-border bg-card text-foreground placeholder:text-muted-foreground/70 shadow-sm focus:border-accent-coral focus:ring-accent-coral sm:text-sm p-2"
                 placeholder="Additional types, e.g. .f3z, text/plain"
               />
               <p className="text-xs text-gray-500 mt-1">
@@ -506,18 +526,19 @@ export function FormBuilderTab({
           )}
         </div>
 
-        <div className="flex justify-end gap-3 pt-2">
+        <div className="flex justify-between items-center gap-3 pt-2">
           <button
-            onClick={handleCancelEdit}
-            className="px-3 py-1.5 border border-gray-300 shadow-sm text-sm font-medium rounded-md text-foreground/80 bg-card hover:bg-muted/50"
+            onClick={() => editForm.key && handleDelete(editForm.key)}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-md text-red-600 hover:bg-red-50"
           >
-            Cancel
+            <Trash2 className="w-4 h-4" />
+            Remove question
           </button>
           <button
-            onClick={handleSaveEdit}
+            onClick={handleDoneEditing}
             className="px-3 py-1.5 border border-transparent text-sm font-medium rounded-md text-white bg-accent-coral hover:bg-accent-coral/90 shadow-sm"
           >
-            Save Question
+            Done
           </button>
         </div>
       </div>
@@ -550,7 +571,7 @@ export function FormBuilderTab({
             className={`rounded-xl ${dragKey === q.key ? 'opacity-40' : ''}`}
           >
             {editingKey === q.key ? (
-              renderEditForm(false)
+              renderEditForm()
             ) : (
               <div
                 className={`flex items-start gap-4 bg-card p-4 rounded-xl border shadow-sm group transition-colors duration-150 ${dragKey ? 'border-gray-300' : 'border-border'}`}
@@ -630,37 +651,62 @@ export function FormBuilderTab({
           </div>
         ))}
 
-        {isAdding ? (
-          renderEditForm(true)
-        ) : (
-          <button
-            onClick={handleAddQuestion}
-            className="w-full py-4 border-2 border-dashed border-gray-300 rounded-xl text-muted-foreground hover:text-blue-600 hover:border-blue-400 hover:bg-blue-50 transition-colors flex items-center justify-center gap-2 font-medium"
-          >
-            <Plus className="w-5 h-5" />
-            Add Question
-          </button>
-        )}
+        <button
+          onClick={handleAddQuestion}
+          className="w-full py-4 border-2 border-dashed border-border rounded-xl text-muted-foreground hover:text-accent-coral hover:border-accent-coral/50 hover:bg-muted/40 transition-colors flex items-center justify-center gap-2 font-medium"
+        >
+          <Plus className="w-5 h-5" />
+          Add Question
+        </button>
       </div>
 
       <div className="flex justify-end gap-3 pt-4 border-t border-border">
-        {onCancel && (
-          <button
-            onClick={onCancel}
-            className="px-4 py-2 border border-gray-300 shadow-sm text-sm font-medium rounded-lg text-foreground/80 bg-card hover:bg-muted/50"
-          >
-            Cancel
-          </button>
-        )}
-        {onSave && (
-          <button
-            onClick={() => onSave({ questions, description })}
-            className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-lg text-white bg-green-600 hover:bg-green-700 shadow-sm"
-          >
-            <Save className="w-4 h-4 mr-2" />
-            Save Version
-          </button>
-        )}
+        {(() => {
+          const busy = saveStatus === 'saving-draft' || saveStatus === 'saving-version'
+          return (
+            <>
+              {onCancel && (
+                <button
+                  onClick={onCancel}
+                  disabled={busy}
+                  className="px-4 py-2 border border-border shadow-sm text-sm font-medium rounded-lg text-foreground/80 bg-card hover:bg-muted/50 disabled:opacity-50"
+                >
+                  Cancel
+                </button>
+              )}
+              {onSaveDraft && (
+                <button
+                  onClick={() => onSaveDraft({ questions, description })}
+                  disabled={busy}
+                  className="inline-flex items-center px-4 py-2 border border-border text-sm font-medium rounded-lg text-foreground bg-card hover:bg-muted/50 shadow-sm disabled:opacity-60"
+                >
+                  {saveStatus === 'saving-draft' ? (
+                    <><Loader2 className="w-4 h-4 mr-2 animate-spin" /> Saving…</>
+                  ) : saveStatus === 'saved-draft' ? (
+                    <><Check className="w-4 h-4 mr-2 text-green-600" /> Saved</>
+                  ) : (
+                    <><Save className="w-4 h-4 mr-2" /> Save</>
+                  )}
+                </button>
+              )}
+              {onSave && (
+                <button
+                  onClick={() => onSave({ questions, description })}
+                  disabled={busy}
+                  className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-lg text-white bg-green-600 hover:bg-green-700 shadow-sm disabled:opacity-60"
+                >
+                  {saveStatus === 'saving-version' ? (
+                    <><Loader2 className="w-4 h-4 mr-2 animate-spin" /> Saving…</>
+                  ) : saveStatus === 'saved-version' ? (
+                    <><Check className="w-4 h-4 mr-2" /> Saved</>
+                  ) : (
+                    <><Save className="w-4 h-4 mr-2" /> {saveLabel}</>
+                  )}
+                </button>
+              )}
+            </>
+          )
+        })()}
       </div>
     </div>
   )

--- a/dali-api/app/hiring/components/Library.tsx
+++ b/dali-api/app/hiring/components/Library.tsx
@@ -36,15 +36,11 @@ export default function Library() {
 
   return (
     <div className="space-y-8">
-      <header>
-        <h1 className="text-2xl font-bold text-foreground">Library</h1>
-        <p className="mt-1 text-muted-foreground">
-          Reusable hiring artifacts — challenges, rubrics, and confidentiality
-          agreements — versioned independently of any cycle.
-        </p>
-      </header>
-
-      <div className="flex items-center gap-2" role="tablist" aria-label="Library section">
+      <div
+        className="inline-flex self-start rounded-lg border border-border bg-muted/40 p-0.5"
+        role="tablist"
+        aria-label="Library section"
+      >
         {TABS.map((t) => {
           const active = t.id === tab;
           return (
@@ -56,8 +52,8 @@ export default function Library() {
               onClick={() => selectTab(t.id)}
               className={`px-4 py-1.5 text-sm font-semibold rounded-md transition-colors ${
                 active
-                  ? "bg-accent-coral text-white"
-                  : "text-foreground hover:bg-muted"
+                  ? "bg-accent-coral text-white shadow-sm"
+                  : "text-muted-foreground hover:text-foreground hover:bg-background/60"
               }`}
             >
               {t.label}

--- a/dali-api/app/lib/__mocks__/db.ts
+++ b/dali-api/app/lib/__mocks__/db.ts
@@ -1,5 +1,13 @@
 import { vi } from "vitest";
 
+// Stub of the Prisma namespace re-exported from the real ~/lib/db. Only the
+// JSON-null sentinels are referenced by callers (e.g. forms-data clearing a
+// Json? column); they're identity-compared, so a stable stub object suffices.
+export const Prisma = {
+  DbNull: Symbol.for("Prisma.DbNull"),
+  JsonNull: Symbol.for("Prisma.JsonNull"),
+};
+
 export const prisma = {
   user: {
     findUnique: vi.fn(),
@@ -75,6 +83,24 @@ export const prisma = {
     findUnique: vi.fn(),
     create: vi.fn(),
     update: vi.fn(),
+  },
+  form: {
+    findUnique: vi.fn(),
+    findMany: vi.fn().mockResolvedValue([]),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  },
+  formVersion: {
+    findFirst: vi.fn(),
+    create: vi.fn(),
+  },
+  formFolder: {
+    findUnique: vi.fn(),
+    findMany: vi.fn().mockResolvedValue([]),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
   },
   userAvailabilitySettings: {
     findUnique: vi.fn().mockResolvedValue(null),

--- a/dali-api/app/lib/db.ts
+++ b/dali-api/app/lib/db.ts
@@ -1,6 +1,13 @@
 import { PrismaClient } from "../generated/prisma/client.js";
 import { PrismaPg } from "@prisma/adapter-pg";
 
+// Re-export the Prisma namespace through this module so callers can reach
+// runtime values like `Prisma.DbNull` without a direct value-import of the
+// generated client. The unit-test job doesn't run `prisma generate`, but tests
+// mock `~/lib/db` (resolvable) — so routing the namespace through here keeps
+// those modules loadable in CI. See app/lib/__mocks__/db.ts for the stub.
+export { Prisma } from "../generated/prisma/client.js";
+
 const globalForPrisma = global as unknown as { prisma: PrismaClient };
 
 function createPrismaClient() {

--- a/dali-api/app/projects/components/SlotColumnMapper.tsx
+++ b/dali-api/app/projects/components/SlotColumnMapper.tsx
@@ -391,9 +391,11 @@ export function SlotColumnMapper({
                 }`}
               />
               <div
-                className={`py-2 flex flex-col lg:flex-row lg:items-center gap-2 border-b border-border last:border-b-0 ${
-                  isDragging ? "opacity-50" : ""
-                }`}
+                className={`py-2 flex flex-col gap-2 border-b border-border last:border-b-0 lg:grid lg:items-center ${
+                  canManage
+                    ? "lg:grid-cols-[auto_14rem_minmax(0,1fr)_auto]"
+                    : "lg:grid-cols-[14rem_minmax(0,1fr)]"
+                } ${isDragging ? "opacity-50" : ""}`}
                 onDragOver={(e) => {
                   if (!dragSourceRef.current) return;
                   e.preventDefault();
@@ -451,10 +453,10 @@ export function SlotColumnMapper({
                     disabled={saving}
                     onChange={(e) => patch(c.uid, { label: e.target.value })}
                     placeholder="Column name"
-                    className="lg:w-56 px-2 py-1.5 text-sm border border-border rounded-md bg-background text-foreground"
+                    className="min-w-0 lg:w-full px-2 py-1.5 text-sm border border-border rounded-md bg-background text-foreground"
                   />
                 ) : (
-                  <div className="lg:w-56 shrink-0 text-sm font-medium text-foreground">
+                  <div className="min-w-0 text-sm font-medium text-foreground truncate" title={c.label}>
                     {c.label}
                     {isBuiltin && (
                       <span className="ml-1 text-xs font-normal text-muted-foreground">
@@ -467,7 +469,7 @@ export function SlotColumnMapper({
                 {/* Backing question — builtins resolve server-side, role and
                     display columns both pick a form question. */}
                 {isBuiltin ? (
-                  <div className="flex-1 text-sm text-muted-foreground italic">
+                  <div className="min-w-0 text-sm text-muted-foreground italic truncate">
                     Resolved automatically
                   </div>
                 ) : canManage ? (
@@ -478,7 +480,7 @@ export function SlotColumnMapper({
                     onChange={(e) =>
                       patch(c.uid, { questionKey: e.target.value })
                     }
-                    className="flex-1 px-2 py-1.5 text-sm border border-border rounded-md bg-background text-foreground"
+                    className="min-w-0 w-full px-2 py-1.5 text-sm border border-border rounded-md bg-background text-foreground"
                   >
                     <option value="">— Pick a question —</option>
                     {questions.map((q) => (
@@ -488,7 +490,14 @@ export function SlotColumnMapper({
                     ))}
                   </select>
                 ) : (
-                  <div className="flex-1 text-sm text-foreground">
+                  <div
+                    className="min-w-0 text-sm text-foreground truncate"
+                    title={
+                      questions.find((q) => q.key === c.questionKey)?.label ??
+                      c.questionKey ??
+                      undefined
+                    }
+                  >
                     {questions.find((q) => q.key === c.questionKey)?.label ??
                       c.questionKey ??
                       "—"}
@@ -496,7 +505,7 @@ export function SlotColumnMapper({
                 )}
 
                 {canManage && (
-                  <div className="flex items-center gap-1 shrink-0">
+                  <div className="flex items-center gap-1 shrink-0 lg:justify-self-end">
                     <label className="flex items-center gap-1 text-xs text-muted-foreground mr-1 select-none">
                       <input
                         type="checkbox"

--- a/dali-api/app/projects/components/SubmissionDatabase.tsx
+++ b/dali-api/app/projects/components/SubmissionDatabase.tsx
@@ -61,11 +61,6 @@ export function SubmissionDatabase({
             >
               <td className="px-4 py-2">
                 <span className="text-foreground">{r.name}</span>
-                {r.email && (
-                  <div className="text-xs text-muted-foreground">
-                    {r.email}
-                  </div>
-                )}
               </td>
               {columns.map((c) => {
                 const v = r.cells[c.key] ?? "";

--- a/dali-api/app/projects/routes/projects.intent-to-work.$userId.tsx
+++ b/dali-api/app/projects/routes/projects.intent-to-work.$userId.tsx
@@ -78,11 +78,7 @@ export default function IntentSubmissionDetail() {
         <h1 className="font-heading text-2xl font-bold text-foreground mt-2">
           {data.record.name}
         </h1>
-        {data.record.email && (
-          <p className="text-sm text-muted-foreground">
-            {data.record.email} · {data.cycleName}
-          </p>
-        )}
+        <p className="text-sm text-muted-foreground">{data.cycleName}</p>
       </div>
 
       {data.fields.length === 0 ? (

--- a/dali-api/app/projects/routes/projects.project-bids.$userId.tsx
+++ b/dali-api/app/projects/routes/projects.project-bids.$userId.tsx
@@ -81,11 +81,7 @@ export default function ProjectBidSubmissionDetail() {
         <h1 className="font-heading text-2xl font-bold text-foreground mt-2">
           {data.record.name}
         </h1>
-        {data.record.email && (
-          <p className="text-sm text-muted-foreground">
-            {data.record.email} · {data.cycleName}
-          </p>
-        )}
+        <p className="text-sm text-muted-foreground">{data.cycleName}</p>
       </div>
 
       {data.fields.length === 0 ? (

--- a/dali-api/prisma/migrations/20260524120000_add_form_draft_columns/migration.sql
+++ b/dali-api/prisma/migrations/20260524120000_add_form_draft_columns/migration.sql
@@ -1,0 +1,8 @@
+-- A form now keeps an editable working copy ("Save") separate from its frozen,
+-- usable versions ("Save as version"). The draft is never served to fillers;
+-- published fills always read the latest FormVersion. Both columns are
+-- nullable and default to NULL (no draft), so existing forms are unaffected.
+
+-- AlterTable
+ALTER TABLE "Form" ADD COLUMN     "draftQuestions" JSONB,
+ADD COLUMN     "draftIntro" TEXT;

--- a/dali-api/prisma/schema.prisma
+++ b/dali-api/prisma/schema.prisma
@@ -2300,6 +2300,15 @@ model Form {
   published   Boolean @default(false)
   publicToken String? @unique
 
+  // Editable working copy. "Save" writes here; the draft is mutable and is
+  // NEVER served to fillers. "Save as version" freezes the draft into an
+  // immutable FormVersion and clears these back to null. Published fills
+  // always read the latest FormVersion, so a draft is unusable until it's
+  // saved as a version. `draftIntro` mirrors FormVersion.intro (serialized
+  // ProseMirror description JSON).
+  draftQuestions Json?
+  draftIntro     String?
+
   versions      FormVersion[]
   submissions   FormSubmission[]
   notifications Notification[]


### PR DESCRIPTION
* Render calendar grid lines beneath events, not on top

The foreground grid-line redraw (added so lines stay visible over the availability gradient tint) was drawn AFTER events with z-20, so it painted hour/sub-hour lines over Busy blocks in My Availability. Move the redraw to right after the background tint and before events, and drop the z-20: lines still cover the tint, but events now stack above them in normal flow. The now-line and drag/selection overlays keep their z-30 and stay on top.



* Manual Blocks: fix "+ Cancel" icon and replace raw RRULE field with Repeats dropdown

- The Add Block toggle showed a Plus icon even when its label was "Cancel" (so "+ Cancel"). Swap to an X icon when the form is open.
- The recurrence input was a raw RRULE text field ("FREQ=WEEKLY;BYDAY=MO") — unusable for non-technical members. Replace it with the same friendly Repeats dropdown (Does not repeat / Daily / Weekly / Monthly) used by the meeting form, deriving the RRULE into a hidden field via repeatsToRRule(). The backend still accepts arbitrary RRULEs; only this UI surface is simplified.



* Fix Manual Blocks Start/End datetime inputs overflowing the form

The two-column Start/End row used flex-1 labels but the datetime-local inputs kept their large intrinsic width, so the End field ran past the card edge. Add min-w-0 to the flex labels and w-full + min-w-0 to the inputs so they shrink to fit the column instead of overflowing.



* Form drafts + reference-source/library work + calendar popover refinements

Batch of in-progress work added since the last push:

- Form drafts: Form gains draftQuestions/draftIntro (editable working copy separate from frozen FormVersions). MIGRATION 20260524120000_add_form_draft _columns — additive only (two nullable columns on Form, default NULL), no data loss. Editable via FormDetail/ChallengeBuilder; drafts are never served to fillers (published fills always read the latest FormVersion).
- Reference-source / project-mapping touch-ups across forms-data, SlotColumn Mapper, SubmissionDatabase, and the intent-to-work / project-bids routes.
- Hiring Library section toggle restyled to a bordered segmented control.
- Calendar: drag-create popover now anchors via a callback-ref-into-state (a shared useRef left the left-flipped anchor null); now-line restyled.

Typecheck clean; 943 unit tests pass (incl. new forms-data.draft.test.ts).



* Route Prisma.DbNull through ~/lib/db so forms-data is loadable in unit-test CI

forms-data.ts value-imported `Prisma` from the generated client for the `Prisma.DbNull` JSON-null sentinel (clearing the draft column on save-version). The unit-test CI job doesn't run `prisma generate`, so that module — and its new test — couldn't even load: "Cannot find module '~/generated/prisma/client'". A vi.mock can't rescue it because Vitest must resolve the path first, and in CI the path doesn't exist.

Re-export the Prisma namespace from ~/lib/db (which tests already mock and which always resolves), stub Prisma.DbNull/JsonNull in __mocks__/db.ts, and have forms-data import Prisma from ~/lib/db instead of the generated client. Verified by running the draft test with the generated client physically removed — all 6 pass; full suite stays green (968).



---------

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/682"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782231818&installation_id=133523038&pr_number=682&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F682&signature=68514f303f3f5e41c37bb80ebbd5c4ad1f82fb8f54b3492b61e63c738af7d4d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->