### PR TITLE
Harden domain-lead Rubrics e2e against iframe navigation race

### DIFF
--- a/dali-api/e2e/domain-lead.spec.ts
+++ b/dali-api/e2e/domain-lead.spec.ts
@@ -53,7 +53,12 @@ test.describe('domain lead workflow', () => {
     // tab; Rubrics live behind the in-page Rubrics tab.
     await page.getByRole('button', { name: 'Library' }).click();
     const libraryFrame = page.frameLocator('iframe[title="Library"]');
-    await libraryFrame.getByRole('tab', { name: 'Rubrics' }).click();
+    // Wait for the Library route to finish loading inside the iframe before
+    // interacting — otherwise the Rubrics tab click can race the iframe's
+    // navigation and land on a not-yet-ready frame.
+    const rubricsTab = libraryFrame.getByRole('tab', { name: 'Rubrics' });
+    await expect(rubricsTab).toBeVisible();
+    await rubricsTab.click();
     await expect(libraryFrame.getByRole('heading', { name: 'Evaluation Rubrics' })).toBeVisible();
   });
 });


### PR DESCRIPTION
Follow-up to #681 — this one-line e2e hardening was pushed just after #681's squash-merge cut, so it didn't make it into `dev`. (#681's other commits, incl. the forms-data Prisma/CI fix, did land.)

`domain-lead.spec.ts` "can reach Rubrics from the sidebar" clicked the Rubrics tab immediately after framing into the Library iframe, without waiting for the route to load inside it — racing the iframe navigation, which made the test hard-fail/flake. Wait for the Rubrics tab to be visible before clicking.

The Library markup is unchanged — the `Rubrics` tab and the `Evaluation Rubrics` heading both still exist — so this is a timing fix, not a regression.

**Caveat:** the e2e suite needs the seeded Postgres CI container, so I couldn't run it locally; this is a reasoned fix verified only to parse/list correctly. No app code changes — e2e spec only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/684"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782232927&installation_id=133523038&pr_number=684&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F684&signature=c93b5d46237fbb313215c11c4000674982ff78650cfde7abbc5c4e0543865aec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->