### PR TITLE
Harden domain-lead Rubrics e2e against iframe navigation race (#684)

### DIFF
--- a/dali-api/e2e/domain-lead.spec.ts
+++ b/dali-api/e2e/domain-lead.spec.ts
@@ -53,7 +53,12 @@ test.describe('domain lead workflow', () => {
     // tab; Rubrics live behind the in-page Rubrics tab.
     await page.getByRole('button', { name: 'Library' }).click();
     const libraryFrame = page.frameLocator('iframe[title="Library"]');
-    await libraryFrame.getByRole('tab', { name: 'Rubrics' }).click();
+    // Wait for the Library route to finish loading inside the iframe before
+    // interacting — otherwise the Rubrics tab click can race the iframe's
+    // navigation and land on a not-yet-ready frame.
+    const rubricsTab = libraryFrame.getByRole('tab', { name: 'Rubrics' });
+    await expect(rubricsTab).toBeVisible();
+    await rubricsTab.click();
     await expect(libraryFrame.getByRole('heading', { name: 'Evaluation Rubrics' })).toBeVisible();
   });
 });


### PR DESCRIPTION
The test clicked the Rubrics tab immediately after framing into the Library iframe, without waiting for the Library route to load inside it — so the click could race the iframe navigation and hit a not-yet-ready frame, leaving the panel on Challenges and the "Evaluation Rubrics" heading absent. Wait for the Rubrics tab to be visible (i.e. the Library has rendered) before clicking. The Library markup is unchanged — the tab and heading both still exist; this is a timing fix, consistent with sibling nav specs flaking in the same run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/685"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782233018&installation_id=133523038&pr_number=685&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F685&signature=761993308c154b74ad56a1ae58e72b523be9029234516972189dca809dcec4fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->