### PR TITLE
Fix interview dashboard duplicates + unify applicant detail view (#688)

### DIFF
--- a/dali-api/app/components/workspace-link.ts
+++ b/dali-api/app/components/workspace-link.ts
@@ -1,0 +1,16 @@
+// When a page is rendered inside a TabWorkspace iframe, a regular Link click
+// would navigate the iframe itself — replacing the source view (dashboard,
+// list, etc.) with the destination. Instead, ask the parent shell to open a
+// new workspace tab so the source view stays put.
+//
+// Returns true if the request was sent (caller should preventDefault). Returns
+// false when we're at top-level (no iframe) — let the normal Link navigate.
+export function requestOpenTabIfEmbedded(url: string, label: string): boolean {
+  if (typeof window === "undefined") return false;
+  if (window.self === window.top) return false;
+  window.parent.postMessage(
+    { type: "dali:openTab", url, label },
+    window.location.origin,
+  );
+  return true;
+}

--- a/dali-api/app/hiring/components/analytics/ApplicationList.tsx
+++ b/dali-api/app/hiring/components/analytics/ApplicationList.tsx
@@ -1,4 +1,5 @@
 import { useNavigate } from "react-router";
+import { requestOpenTabIfEmbedded } from "~/components/workspace-link";
 
 export interface ApplicationRow {
   id: string;
@@ -49,7 +50,12 @@ export function ApplicationList({ rows, selectedStatusLabel }: Props) {
               {rows.map((r) => (
                 <tr
                   key={r.id}
-                  onClick={() => navigate(`/hiring/applications/${r.id}`)}
+                  onClick={() => {
+                    const url = `/hiring/applications/${r.id}`;
+                    if (!requestOpenTabIfEmbedded(url, r.applicantName)) {
+                      navigate(url);
+                    }
+                  }}
                   className="border-t border-border hover:bg-muted/20 cursor-pointer"
                 >
                   <td className="px-4 py-2 text-accent-coral">{r.applicantName}</td>

--- a/dali-api/app/hiring/routes/api.cycles.$cycleId.interviews.ts
+++ b/dali-api/app/hiring/routes/api.cycles.$cycleId.interviews.ts
@@ -46,10 +46,11 @@ export async function loader({ request, params }: Route.LoaderArgs) {
       orderBy: { startTime: "asc" },
     }),
     // Pre-filter: DAs in this cycle with at least one Released
-    // InvitedToInterview decision and no Scheduled interview. We confirm the
-    // *latest* Released decision is InvitedToInterview in JS — a follow-up
-    // Rejected/Waitlisted would override and the candidate is no longer
-    // awaiting scheduling.
+    // InvitedToInterview decision and no Scheduled or Completed interview. We
+    // confirm the *latest* Released decision is InvitedToInterview in JS — a
+    // follow-up Rejected/Waitlisted would override and the candidate is no
+    // longer awaiting scheduling. Cancelled interviews stay pending so they
+    // can be rescheduled.
     prisma.domainApplication.findMany({
       where: {
         selected: true,
@@ -57,7 +58,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
         decisions: {
           some: { type: "InvitedToInterview", stage: "Released" },
         },
-        interviews: { none: { status: "Scheduled" } },
+        interviews: { none: { status: { in: ["Scheduled", "Completed"] } } },
       },
       include: {
         application: {

--- a/dali-api/app/hiring/routes/applications.$domainApplicationId.tsx
+++ b/dali-api/app/hiring/routes/applications.$domainApplicationId.tsx
@@ -1,5 +1,5 @@
 import { Link, redirect, useLoaderData, useSearchParams } from "react-router";
-import { ArrowLeft } from "lucide-react";
+import { ArrowLeft, Calendar, MapPin, Users } from "lucide-react";
 import type { Route } from "./+types/applications.$domainApplicationId";
 import { prisma } from "~/lib/db";
 import { requireAuth } from "~/lib/auth";
@@ -9,6 +9,37 @@ import { presignAnswers } from "~/hiring/lib/presign";
 import { ApplicationViewer } from "~/hiring/components/ApplicationViewer";
 import { ReviewSummary } from "~/hiring/components/ReviewSummary";
 import type { Question, RubricCriterion } from "~/types";
+
+const INTERVIEW_STATUS_COLORS: Record<string, string> = {
+  Scheduled: "bg-blue-100 text-blue-700",
+  Completed: "bg-green-100 text-green-700",
+  CancelledByApplicant: "bg-red-100 text-red-700",
+  CancelledByAdmin: "bg-muted text-foreground/80",
+};
+
+const INTERVIEW_STATUS_LABELS: Record<string, string> = {
+  CancelledByApplicant: "Cancelled (applicant)",
+  CancelledByAdmin: "Cancelled (admin)",
+};
+
+const DECISION_COLORS: Record<string, string> = {
+  Rejected: "bg-red-100 text-red-700",
+  InvitedToInterview: "bg-blue-100 text-blue-700",
+  Accepted: "bg-green-100 text-green-700",
+  Waitlisted: "bg-yellow-100 text-yellow-700",
+};
+
+const STAGE_LABELS: Record<string, string> = {
+  Draft: "Draft",
+  Final: "Finalized",
+  Released: "Released",
+};
+
+const LOCATION_LABELS: Record<string, string> = {
+  PodAppa: "Pod Appa",
+  PodMomo: "Pod Momo",
+  Online: "Online",
+};
 
 export const meta: Route.MetaFunction = ({ data }) => {
   const name = (data as { applicantName?: string } | undefined)?.applicantName;
@@ -125,21 +156,101 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     criterionLabels[c.key] = c.label;
   }
 
-  // Submitted reviews for THIS domain application, with reviewer identity.
-  const reviewRows = await prisma.applicationReview.findMany({
-    where: { domainApplicationId: da.id, submittedAt: { not: null } },
-    orderBy: { submittedAt: "asc" },
-    select: {
-      id: true,
-      scores: true,
-      feedback: true,
-      rejectionRationale: true,
-      overallRecommendation: true,
-      annotations: true,
-      submittedAt: true,
-      submittedBy: { select: { firstName: true, lastName: true } },
-    },
-  });
+  // Per-section role flags. Page-level access (above) already restricts plain
+  // reviewers to DAs in their own domain; these flags further gate
+  // pre-Released decisions and delibs context to leads only.
+  const canSeePreReleaseDecisions = roles.isCore || roles.isDomainLead;
+  const canSeeDelibs = roles.isCore || roles.isDomainLead;
+
+  // Submitted reviews, interviews (+ assignments + latest note per assignment),
+  // decisions, and delibs sessions for this DA — all in parallel.
+  const [reviewRows, interviewRows, decisionRows, delibsSessions] = await Promise.all([
+    prisma.applicationReview.findMany({
+      where: { domainApplicationId: da.id, submittedAt: { not: null } },
+      orderBy: { submittedAt: "asc" },
+      select: {
+        id: true,
+        scores: true,
+        feedback: true,
+        rejectionRationale: true,
+        overallRecommendation: true,
+        annotations: true,
+        submittedAt: true,
+        submittedBy: { select: { firstName: true, lastName: true } },
+      },
+    }),
+    prisma.interview.findMany({
+      where: { domainApplicationId: da.id },
+      orderBy: { startTime: "asc" },
+      select: {
+        id: true,
+        startTime: true,
+        endTime: true,
+        status: true,
+        location: true,
+        zoomJoinUrl: true,
+        assignments: {
+          where: { status: "Active" },
+          select: {
+            id: true,
+            role: true,
+            cycleInterviewer: {
+              select: {
+                userId: true,
+                user: { select: { firstName: true, lastName: true } },
+                domain: { select: { name: true } },
+              },
+            },
+            // Latest note version per assignment. Mirrors the orderBy DESC
+            // pattern used by api.interview-assignments.$id.notes.ts.
+            noteVersions: {
+              orderBy: { createdAt: "desc" },
+              take: 1,
+              select: { id: true, content: true, createdAt: true },
+            },
+          },
+        },
+      },
+    }),
+    // Decisions are append-only. We fetch all rows; visibility per stage is
+    // gated in the response shaping below.
+    prisma.decision.findMany({
+      where: { domainApplicationId: da.id },
+      orderBy: { createdAt: "asc" },
+      select: {
+        id: true,
+        type: true,
+        stage: true,
+        notes: true,
+        waitlistRank: true,
+        createdAt: true,
+        madeBy: { select: { firstName: true, lastName: true } },
+      },
+    }),
+    // Delibs sessions reference DAs by id inside columnOrder JSON, not by FK.
+    // There's at most one Initial + one Final session per (domain, cycle), so
+    // this is bounded.
+    canSeeDelibs
+      ? prisma.delibsSession.findMany({
+          where: { domainId: effectiveDomainId, applicationCycleId: cycleId },
+          select: {
+            id: true,
+            type: true,
+            status: true,
+            columnOrder: true,
+            createdAt: true,
+            updatedAt: true,
+          },
+        })
+      : Promise.resolve([] as Array<{
+          id: string;
+          type: "Initial" | "Final";
+          status: "Active" | "Closed";
+          columnOrder: unknown;
+          createdAt: Date;
+          updatedAt: Date;
+        }>),
+  ]);
   const reviews = reviewRows.map((r) => ({
     id: r.id,
     reviewerName:
@@ -152,6 +263,85 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     annotations: (r.annotations as object[]) ?? [],
     submittedAt: r.submittedAt ? r.submittedAt.toISOString() : null,
   }));
+
+  const interviews = interviewRows.map((iv) => ({
+    id: iv.id,
+    startTime: iv.startTime.toISOString(),
+    endTime: iv.endTime.toISOString(),
+    status: iv.status,
+    location: iv.location,
+    zoomJoinUrl: iv.zoomJoinUrl,
+    assignments: iv.assignments.map((a) => {
+      const isViewerThisInterviewer = a.cycleInterviewer.userId === auth.user.sub;
+      const latest = a.noteVersions[0];
+      return {
+        id: a.id,
+        role: a.role,
+        interviewerName:
+          [a.cycleInterviewer.user.firstName, a.cycleInterviewer.user.lastName]
+            .filter(Boolean)
+            .join(" ")
+            .trim() || "Interviewer",
+        domainName: a.cycleInterviewer.domain.name,
+        canEditNotes: isViewerThisInterviewer,
+        latestNote: latest
+          ? {
+              content: latest.content,
+              createdAt: latest.createdAt.toISOString(),
+            }
+          : null,
+      };
+    }),
+  }));
+
+  // Decisions: applicants never reach this page; reviewers (in-domain) see only
+  // Released. Core/DomainLead see the full append-only history.
+  const visibleDecisions = decisionRows
+    .filter((d) => canSeePreReleaseDecisions || d.stage === "Released")
+    .map((d) => ({
+      id: d.id,
+      type: d.type,
+      stage: d.stage,
+      notes: d.notes,
+      waitlistRank: d.waitlistRank,
+      createdAt: d.createdAt.toISOString(),
+      madeByName:
+        [d.madeBy?.firstName, d.madeBy?.lastName].filter(Boolean).join(" ").trim() || null,
+    }));
+
+  // For each delibs session, find which column this DA sits in (if any). Some
+  // closed sessions may not contain the DA at all — exclude those.
+  type DelibsRef = {
+    id: string;
+    type: "Initial" | "Final";
+    status: "Active" | "Closed";
+    column: string | null;
+    updatedAt: string;
+  };
+  const delibs: DelibsRef[] = canSeeDelibs
+    ? delibsSessions
+        .map((s): DelibsRef | null => {
+          const cols = (s.columnOrder ?? {}) as Record<string, unknown>;
+          let column: string | null = null;
+          for (const [name, ids] of Object.entries(cols)) {
+            if (Array.isArray(ids) && ids.includes(da.id)) {
+              column = name;
+              break;
+            }
+          }
+          // Only surface sessions that actually reference this DA. An active
+          // session for the domain doesn't necessarily contain every DA.
+          if (column === null) return null;
+          return {
+            id: s.id,
+            type: s.type,
+            status: s.status,
+            column,
+            updatedAt: s.updatedAt.toISOString(),
+          };
+        })
+        .filter((s): s is DelibsRef => s !== null)
+    : [];
 
   // Selected review = ?review= if valid, else the first.
   const url = new URL(request.url);
@@ -199,6 +389,11 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     questionLabels,
     criterionLabels,
     reviews,
+    interviews,
+    decisions: visibleDecisions,
+    delibs,
+    canSeePreReleaseDecisions,
+    canSeeDelibs,
     selectedReviewId,
   };
 }
@@ -311,6 +506,233 @@ export default function ApplicationReadOnlyDetail() {
           </div>
         </div>
       </div>
+
+      <InterviewsSection interviews={data.interviews} />
+      <DecisionsSection
+        decisions={data.decisions}
+        canSeePreReleaseDecisions={data.canSeePreReleaseDecisions}
+      />
+      {data.canSeeDelibs && <DelibsSection delibs={data.delibs} />}
     </div>
+  );
+}
+
+type LoaderData = Exclude<Awaited<ReturnType<typeof loader>>, Response>;
+type InterviewRow = LoaderData["interviews"][number];
+type DecisionRow = LoaderData["decisions"][number];
+type DelibsRef = LoaderData["delibs"][number];
+
+function InterviewsSection({ interviews }: { interviews: InterviewRow[] }) {
+  return (
+    <section className="bg-card rounded-xl border border-border shadow-sm">
+      <div className="px-6 py-4 border-b border-border bg-muted/50">
+        <h2 className="text-lg font-bold text-foreground">Interviews</h2>
+        <p className="text-xs text-muted-foreground mt-0.5">
+          {interviews.length === 0
+            ? "No interviews yet."
+            : `${interviews.length} ${interviews.length === 1 ? "interview" : "interviews"}`}
+        </p>
+      </div>
+      {interviews.length > 0 && (
+        <ul className="divide-y divide-border">
+          {interviews.map((iv) => {
+            const start = new Date(iv.startTime);
+            const end = new Date(iv.endTime);
+            const statusLabel = INTERVIEW_STATUS_LABELS[iv.status] ?? iv.status;
+            const statusClass =
+              INTERVIEW_STATUS_COLORS[iv.status] ?? "bg-muted text-foreground/80";
+            const locationLabel = LOCATION_LABELS[iv.location] ?? iv.location;
+            return (
+              <li key={iv.id} className="px-6 py-4 space-y-3">
+                <div className="flex flex-wrap items-center gap-3">
+                  <span
+                    className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-bold ${statusClass}`}
+                  >
+                    {statusLabel}
+                  </span>
+                  <span className="inline-flex items-center gap-1.5 text-sm text-foreground">
+                    <Calendar className="w-3.5 h-3.5 text-muted-foreground" aria-hidden />
+                    {start.toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" })}
+                    {" · "}
+                    {start.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" })}
+                    {" – "}
+                    {end.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" })}
+                  </span>
+                  <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
+                    <MapPin className="w-3.5 h-3.5" aria-hidden />
+                    {locationLabel}
+                    {iv.location === "Online" && iv.zoomJoinUrl && (
+                      <a
+                        href={iv.zoomJoinUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-blue-600 hover:underline ml-1"
+                      >
+                        link
+                      </a>
+                    )}
+                  </span>
+                  <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
+                    <Users className="w-3.5 h-3.5" aria-hidden />
+                    {iv.assignments.length === 0
+                      ? "No interviewers assigned"
+                      : iv.assignments
+                          .map((a) => `${a.interviewerName} (${a.role === "InDomain" ? a.domainName : "Cross"})`)
+                          .join(", ")}
+                  </span>
+                </div>
+                {iv.assignments.length > 0 && (
+                  <div className="space-y-2 pl-1">
+                    {iv.assignments.map((a) => (
+                      <div key={a.id} className="rounded-md border border-border bg-background/50 p-3">
+                        <div className="flex items-center justify-between gap-2">
+                          <div className="text-sm font-medium text-foreground">
+                            {a.interviewerName}{" "}
+                            <span className="text-xs font-normal text-muted-foreground">
+                              · {a.role === "InDomain" ? a.domainName : `Cross (${a.domainName})`}
+                            </span>
+                          </div>
+                          {a.canEditNotes && (
+                            <Link
+                              to={`/hiring/interviewer/interview/${iv.id}`}
+                              className="text-xs text-blue-600 hover:underline"
+                            >
+                              Open in interviewer view
+                            </Link>
+                          )}
+                        </div>
+                        {a.latestNote ? (
+                          <>
+                            <p className="mt-2 text-sm text-foreground whitespace-pre-wrap">
+                              {a.latestNote.content}
+                            </p>
+                            <p className="mt-1 text-[11px] text-muted-foreground/80">
+                              Latest version saved{" "}
+                              {new Date(a.latestNote.createdAt).toLocaleString(undefined, {
+                                month: "short",
+                                day: "numeric",
+                                hour: "numeric",
+                                minute: "2-digit",
+                              })}
+                            </p>
+                          </>
+                        ) : (
+                          <p className="mt-2 text-xs text-muted-foreground/70 italic">
+                            No notes yet.
+                          </p>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function DecisionsSection({
+  decisions,
+  canSeePreReleaseDecisions,
+}: {
+  decisions: DecisionRow[];
+  canSeePreReleaseDecisions: boolean;
+}) {
+  return (
+    <section className="bg-card rounded-xl border border-border shadow-sm">
+      <div className="px-6 py-4 border-b border-border bg-muted/50">
+        <h2 className="text-lg font-bold text-foreground">Decisions</h2>
+        <p className="text-xs text-muted-foreground mt-0.5">
+          {decisions.length === 0
+            ? canSeePreReleaseDecisions
+              ? "No decisions recorded."
+              : "No released decisions yet."
+            : `${decisions.length} ${decisions.length === 1 ? "record" : "records"}`}
+          {!canSeePreReleaseDecisions && decisions.length > 0 && " (released only)"}
+        </p>
+      </div>
+      {decisions.length > 0 && (
+        <ol className="divide-y divide-border">
+          {decisions.map((d) => (
+            <li key={d.id} className="px-6 py-3 flex items-start gap-3">
+              <span
+                className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-bold flex-shrink-0 ${
+                  DECISION_COLORS[d.type] ?? "bg-muted text-foreground/80"
+                }`}
+              >
+                {d.type}
+                {d.waitlistRank != null && ` #${d.waitlistRank}`}
+              </span>
+              <span className="text-xs text-muted-foreground flex-shrink-0 mt-0.5">
+                {STAGE_LABELS[d.stage] ?? d.stage}
+              </span>
+              <div className="flex-1 min-w-0">
+                {d.notes && (
+                  <p className="text-sm text-foreground whitespace-pre-wrap">{d.notes}</p>
+                )}
+              </div>
+              <div className="text-xs text-muted-foreground/80 text-right flex-shrink-0">
+                <div>
+                  {new Date(d.createdAt).toLocaleDateString(undefined, {
+                    month: "short",
+                    day: "numeric",
+                    year: "numeric",
+                  })}
+                </div>
+                {d.madeByName && (
+                  <div className="text-[11px] text-muted-foreground/70">by {d.madeByName}</div>
+                )}
+              </div>
+            </li>
+          ))}
+        </ol>
+      )}
+    </section>
+  );
+}
+
+function DelibsSection({ delibs }: { delibs: DelibsRef[] }) {
+  return (
+    <section className="bg-card rounded-xl border border-border shadow-sm">
+      <div className="px-6 py-4 border-b border-border bg-muted/50">
+        <h2 className="text-lg font-bold text-foreground">Delibs</h2>
+        <p className="text-xs text-muted-foreground mt-0.5">
+          {delibs.length === 0
+            ? "Not part of any delibs session."
+            : `${delibs.length} ${delibs.length === 1 ? "session" : "sessions"}`}
+        </p>
+      </div>
+      {delibs.length > 0 && (
+        <ul className="divide-y divide-border">
+          {delibs.map((s) => (
+            <li key={s.id} className="px-6 py-3 flex items-center gap-3">
+              <span className="text-sm font-medium text-foreground">{s.type} delibs</span>
+              <span
+                className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-bold ${
+                  s.status === "Active"
+                    ? "bg-amber-100 text-amber-800"
+                    : "bg-muted text-foreground/80"
+                }`}
+              >
+                {s.status}
+              </span>
+              {s.column && (
+                <span className="text-xs text-muted-foreground">in “{s.column}”</span>
+              )}
+              <span className="ml-auto text-xs text-muted-foreground/70">
+                Updated{" "}
+                {new Date(s.updatedAt).toLocaleDateString(undefined, {
+                  month: "short",
+                  day: "numeric",
+                })}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
   );
 }

--- a/dali-api/app/hiring/routes/domain-lead.tsx
+++ b/dali-api/app/hiring/routes/domain-lead.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import { Form, Link, useLoaderData, useSearchParams, useRevalidator, useSubmit } from "react-router";
+import { requestOpenTabIfEmbedded } from "~/components/workspace-link";
 import { redirect } from "react-router";
 import type { Route } from "./+types/domain-lead";
 import { prisma } from "~/lib/db";
@@ -2373,6 +2374,12 @@ function ApplicationsTable({ apps, draftDecisions, cycleReviewersForDomain, cycl
                   )}
                   <Link
                     to={`/hiring/domain-lead/application/${da?.id}`}
+                    onClick={(e) => {
+                      if (!da?.id) return
+                      const url = `/hiring/domain-lead/application/${da.id}`
+                      const label = `${app.user.firstName ?? ''} ${app.user.lastName ?? ''}`.trim() || 'Applicant'
+                      if (requestOpenTabIfEmbedded(url, label)) e.preventDefault()
+                    }}
                     className="text-blue-600 hover:text-blue-800 font-medium"
                   >
                     Review →
@@ -2469,6 +2476,12 @@ function ApplicationsTable({ apps, draftDecisions, cycleReviewersForDomain, cycl
                 )}
                 <Link
                   to={`/hiring/domain-lead/application/${da?.id}`}
+                  onClick={(e) => {
+                    if (!da?.id) return
+                    const url = `/hiring/domain-lead/application/${da.id}`
+                    const label = `${app.user.firstName ?? ''} ${app.user.lastName ?? ''}`.trim() || 'Applicant'
+                    if (requestOpenTabIfEmbedded(url, label)) e.preventDefault()
+                  }}
                   className="text-blue-600 hover:text-blue-800 text-sm font-medium"
                 >
                   Review →

--- a/dali-api/app/hiring/routes/lead.cycle.$id.tsx
+++ b/dali-api/app/hiring/routes/lead.cycle.$id.tsx
@@ -15,6 +15,7 @@ import {
   type NotificationSlotType,
 } from "~/hiring/lib/email-variables";
 import { Modal } from "~/components/Modal";
+import { requestOpenTabIfEmbedded } from "~/components/workspace-link";
 import { ChallengePreviewModal } from "~/hiring/components/ChallengePreviewModal";
 import { Settings, Users, Calendar, AlertTriangle, Trash2, Plus, CheckCircle, ArrowRight, Circle, ChevronRight, X, LayoutDashboard, Eye, Mail } from 'lucide-react'
 import { formatVersionLabel, buildVersionNumberMap } from "~/lib/formatVersion";
@@ -61,6 +62,7 @@ interface InterviewRow {
   location: string
   zoomJoinUrl: string | null
   domainApplication: {
+    id: string
     challengeVersion: { domain: { name: string } }
     application: { user: { firstName: string; lastName: string } }
   }
@@ -1187,6 +1189,10 @@ export default function HiringLeadCycleDetails() {
   // Filters for the interviews table — domain + status. "all" disables.
   const [interviewDomainFilter, setInterviewDomainFilter] = useState<string>('all')
   const [interviewStatusFilter, setInterviewStatusFilter] = useState<string>('all')
+  // Cancelled interviews are hidden by default — they duplicate the
+  // "Awaiting Schedule" row for the same applicant and clutter the
+  // "what comes next" view.
+  const [showCancelledInterviews, setShowCancelledInterviews] = useState<boolean>(false)
 
   // ── Coverage heatmap state ──
   const [coverage, setCoverage] = useState<{
@@ -1998,16 +2004,25 @@ export default function HiringLeadCycleDetails() {
       ) : tab === 'interviews' && (() => {
         // Filter inputs derived from current data so empty options never show.
         const domainFor = (p: PendingInviteRow) => p.domainApplication.challengeVersion?.domain.name ?? p.domainApplication.domain.name
+        const isCancelled = (status: string) =>
+          status === 'CancelledByApplicant' || status === 'CancelledByAdmin'
+        // Hide cancelled interviews unless the user opted in. A cancelled-only
+        // applicant still surfaces via the pending list ("Awaiting Schedule"),
+        // so the dashboard keeps 1 row per applicant.
+        const visibleInterviews = showCancelledInterviews
+          ? interviews
+          : interviews.filter(i => !isCancelled(i.status))
+        const hiddenCancelledCount = interviews.length - visibleInterviews.length
         const availableDomains = Array.from(new Set<string>([
-          ...interviews.map(i => i.domainApplication.challengeVersion.domain.name).filter(Boolean),
+          ...visibleInterviews.map(i => i.domainApplication.challengeVersion.domain.name).filter(Boolean),
           ...pendingInvites.map(domainFor).filter(Boolean),
         ])).sort()
         const availableStatuses = Array.from(new Set<string>([
           ...(pendingInvites.length > 0 ? ['Awaiting Schedule'] : []),
-          ...interviews.map(i => i.status),
+          ...visibleInterviews.map(i => i.status),
         ]))
         const filtersActive = interviewDomainFilter !== 'all' || interviewStatusFilter !== 'all'
-        const filteredInterviews = interviews.filter(i => {
+        const filteredInterviews = visibleInterviews.filter(i => {
           if (interviewDomainFilter !== 'all' && i.domainApplication.challengeVersion.domain.name !== interviewDomainFilter) return false
           if (interviewStatusFilter !== 'all' && i.status !== interviewStatusFilter) return false
           return true
@@ -2018,7 +2033,10 @@ export default function HiringLeadCycleDetails() {
           return true
         })
         const totalRows = filteredInterviews.length + filteredPending.length
-        const totalAll = interviews.length + pendingInvites.length
+        const totalAll = visibleInterviews.length + pendingInvites.length
+        // Show the filter bar whenever there's any data — including cancelled
+        // interviews that are currently hidden — so the toggle stays reachable.
+        const hasAnyRows = interviews.length + pendingInvites.length > 0
         const tableEmpty = totalRows === 0
         // "Resend invite" needs a CycleNotificationEmail bound to
         // InterviewInviteReminder. Without one the button has no template
@@ -2047,7 +2065,7 @@ export default function HiringLeadCycleDetails() {
             <span>Controls marked with <Mail className="w-3 h-3 inline-block align-middle text-blue-600" /> send an email when committed. Hover the icon to see who receives it.</span>
           </div>
           <div className="bg-card rounded-xl border border-border shadow-sm overflow-hidden">
-            {totalAll > 0 && (
+            {hasAnyRows && (
               <div className="px-4 sm:px-6 py-3 border-b border-border bg-card flex flex-wrap items-center gap-3">
                 <label className="inline-flex items-center gap-2 text-xs text-muted-foreground">
                   <span className="font-medium">Domain</span>
@@ -2085,6 +2103,15 @@ export default function HiringLeadCycleDetails() {
                     Clear filters
                   </button>
                 )}
+                <label className="inline-flex items-center gap-1.5 text-xs text-muted-foreground cursor-pointer select-none">
+                  <input
+                    type="checkbox"
+                    checked={showCancelledInterviews}
+                    onChange={(e) => setShowCancelledInterviews(e.target.checked)}
+                    className="w-3.5 h-3.5 rounded border-border accent-accent-coral"
+                  />
+                  <span>Show cancelled{hiddenCancelledCount > 0 && !showCancelledInterviews ? ` (${hiddenCancelledCount})` : ''}</span>
+                </label>
                 <span className="ml-auto text-xs text-muted-foreground">
                   Showing {totalRows} of {totalAll}
                 </span>
@@ -2111,7 +2138,17 @@ export default function HiringLeadCycleDetails() {
                   return (
                     <tr key={`pending-${p.id}`} className="bg-amber-50/40 hover:bg-amber-50 transition">
                       <td className="px-4 py-3 font-medium text-foreground">
-                        {u.firstName} {u.lastName}
+                        <Link
+                          to={`/hiring/applications/${p.domainApplication.id}`}
+                          onClick={(e) => {
+                            const url = `/hiring/applications/${p.domainApplication.id}`
+                            const label = `${u.firstName ?? ''} ${u.lastName ?? ''}`.trim() || 'Applicant'
+                            if (requestOpenTabIfEmbedded(url, label)) e.preventDefault()
+                          }}
+                          className="hover:underline focus:outline-none focus:ring-2 focus:ring-accent-coral/40 rounded"
+                        >
+                          {u.firstName} {u.lastName}
+                        </Link>
                       </td>
                       <td className="px-4 py-3 text-muted-foreground">{domainName || '—'}</td>
                       <td className="px-4 py-3 text-muted-foreground text-xs italic">
@@ -2152,7 +2189,18 @@ export default function HiringLeadCycleDetails() {
                   return (
                     <tr key={interview.id} className="hover:bg-muted/50 transition">
                       <td className="px-4 py-3 font-medium text-foreground">
-                        {interview.domainApplication.application.user.firstName} {interview.domainApplication.application.user.lastName}
+                        <Link
+                          to={`/hiring/applications/${interview.domainApplication.id}`}
+                          onClick={(e) => {
+                            const u = interview.domainApplication.application.user
+                            const url = `/hiring/applications/${interview.domainApplication.id}`
+                            const label = `${u.firstName ?? ''} ${u.lastName ?? ''}`.trim() || 'Applicant'
+                            if (requestOpenTabIfEmbedded(url, label)) e.preventDefault()
+                          }}
+                          className="hover:underline focus:outline-none focus:ring-2 focus:ring-accent-coral/40 rounded"
+                        >
+                          {interview.domainApplication.application.user.firstName} {interview.domainApplication.application.user.lastName}
+                        </Link>
                       </td>
                       <td className="px-4 py-3 text-muted-foreground">{domainName || '—'}</td>
                       <td className="px-4 py-3 text-muted-foreground">
@@ -2308,9 +2356,17 @@ export default function HiringLeadCycleDetails() {
                   <li key={`pending-${p.id}`} className="px-4 py-3 space-y-1 bg-amber-50/40">
                     <div className="flex items-start justify-between gap-2">
                       <div className="min-w-0">
-                        <div className="font-medium text-foreground truncate">
+                        <Link
+                          to={`/hiring/applications/${p.domainApplication.id}`}
+                          onClick={(e) => {
+                            const url = `/hiring/applications/${p.domainApplication.id}`
+                            const label = `${u.firstName ?? ''} ${u.lastName ?? ''}`.trim() || 'Applicant'
+                            if (requestOpenTabIfEmbedded(url, label)) e.preventDefault()
+                          }}
+                          className="block font-medium text-foreground truncate hover:underline"
+                        >
                           {u.firstName} {u.lastName}
-                        </div>
+                        </Link>
                         <div className="text-xs text-muted-foreground mt-0.5">{domainName || '—'}</div>
                       </div>
                       <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-bold flex-shrink-0 bg-amber-100 text-amber-800">
@@ -2347,9 +2403,18 @@ export default function HiringLeadCycleDetails() {
                   <li key={interview.id} className="px-4 py-3 space-y-2">
                     <div className="flex items-start justify-between gap-2">
                       <div className="min-w-0">
-                        <div className="font-medium text-foreground truncate">
+                        <Link
+                          to={`/hiring/applications/${interview.domainApplication.id}`}
+                          onClick={(e) => {
+                            const u = interview.domainApplication.application.user
+                            const url = `/hiring/applications/${interview.domainApplication.id}`
+                            const label = `${u.firstName ?? ''} ${u.lastName ?? ''}`.trim() || 'Applicant'
+                            if (requestOpenTabIfEmbedded(url, label)) e.preventDefault()
+                          }}
+                          className="block font-medium text-foreground truncate hover:underline"
+                        >
                           {interview.domainApplication.application.user.firstName} {interview.domainApplication.application.user.lastName}
-                        </div>
+                        </Link>
                         <div className="text-xs text-muted-foreground mt-0.5">{domainName || '—'}</div>
                       </div>
                       <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-bold flex-shrink-0 ${

--- a/dali-api/app/hiring/routes/reviewer.tsx
+++ b/dali-api/app/hiring/routes/reviewer.tsx
@@ -11,6 +11,7 @@ import {
   ListOrdered,
 } from 'lucide-react'
 import { getReviewStatus } from '~/hiring/lib/review-status'
+import { requestOpenTabIfEmbedded } from '~/components/workspace-link'
 import { CycleSelector } from '~/hiring/components/CycleSelector'
 import { getActiveCycle, cycleStatusToStage, inferUnderReviewStage } from '~/hiring/lib/cycles'
 import { getCycleConfidentialityState } from '~/hiring/lib/confidentiality'
@@ -635,6 +636,13 @@ export default function ReviewerDashboard() {
                       )}
                       <Link
                         to={`/hiring/reviewer/application/${interview.domainApplication?.application?.id}`}
+                        onClick={(e) => {
+                          const url = `/hiring/reviewer/application/${interview.domainApplication?.application?.id}`
+                          const label = applicant
+                            ? `${applicant.firstName ?? ''} ${applicant.lastName ?? ''}`.trim() || 'Applicant'
+                            : 'Applicant'
+                          if (requestOpenTabIfEmbedded(url, label)) e.preventDefault()
+                        }}
                         className="text-sm text-blue-600 hover:text-blue-800 font-medium flex items-center mt-1"
                       >
                         View Application{' '}

--- a/dali-api/app/members/routes/members.tsx
+++ b/dali-api/app/members/routes/members.tsx
@@ -11,6 +11,7 @@ import {
 import type { Route } from "./+types/members";
 import { requireAuth } from "~/lib/auth";
 import { isCore } from "~/lib/roles";
+import { requestOpenTabIfEmbedded } from "~/components/workspace-link";
 import { prisma } from "~/lib/db";
 import { initialsFromName } from "~/lib/display";
 import { resolvePhotoUrl } from "~/lib/photo";
@@ -449,7 +450,11 @@ function MembersTable({ rows }: { rows: MemberRow[] }) {
           {rows.map((m) => (
             <tr
               key={m.id}
-              onClick={() => navigate(`/members/${m.id}`)}
+              onClick={() => {
+                const url = `/members/${m.id}`;
+                const label = `${m.firstName ?? ""} ${m.lastName ?? ""}`.trim() || "Member";
+                if (!requestOpenTabIfEmbedded(url, label)) navigate(url);
+              }}
               className="border-t border-border hover:bg-muted/20 cursor-pointer"
             >
               <td className="px-4 py-2 text-foreground">

--- a/dali-api/app/partners/routes/partners.applications.tsx
+++ b/dali-api/app/partners/routes/partners.applications.tsx
@@ -14,6 +14,7 @@ import {
 } from "@dnd-kit/core";
 import type { Route } from "./+types/partners.applications";
 import { requireAuth } from "~/lib/auth";
+import { requestOpenTabIfEmbedded } from "~/components/workspace-link";
 import { prisma } from "~/lib/db";
 import { canViewStaffing, isCore } from "~/lib/roles";
 import {
@@ -727,7 +728,10 @@ function ApplicationsTable({ rows }: { rows: ApplicationRow[] }) {
           {rows.map((a) => (
             <tr
               key={a.id}
-              onClick={() => navigate(`/partners/applications/${a.id}`)}
+              onClick={() => {
+                const url = `/partners/applications/${a.id}`;
+                if (!requestOpenTabIfEmbedded(url, a.title)) navigate(url);
+              }}
               className="border-t border-border hover:bg-muted/20 cursor-pointer"
             >
               <td className="px-4 py-2 text-foreground">{a.title}</td>
@@ -911,7 +915,10 @@ function ApplicationCard({
       ref={setNodeRef}
       style={style}
       {...dragProps}
-      onClick={() => navigate(`/partners/applications/${app.id}`)}
+      onClick={() => {
+        const url = `/partners/applications/${app.id}`;
+        if (!requestOpenTabIfEmbedded(url, app.title)) navigate(url);
+      }}
       className={`border border-border rounded-md bg-background p-2.5 text-sm flex flex-col gap-2 ${
         draggable ? "cursor-grab active:cursor-grabbing" : "cursor-pointer"
       } ${isDragging ? "opacity-60 shadow-lg" : "hover:bg-muted/20"}`}

--- a/dali-api/app/projects/components/SubmissionDatabase.tsx
+++ b/dali-api/app/projects/components/SubmissionDatabase.tsx
@@ -5,6 +5,7 @@
 // page, where hidden (not-in-table) columns are also shown.
 
 import { useNavigate } from "react-router";
+import { requestOpenTabIfEmbedded } from "~/components/workspace-link";
 
 export type DbColumn = { key: string; label: string };
 
@@ -56,7 +57,10 @@ export function SubmissionDatabase({
           {rows.map((r) => (
             <tr
               key={r.userId}
-              onClick={() => navigate(`${detailBase}/${r.userId}`)}
+              onClick={() => {
+                const url = `${detailBase}/${r.userId}`;
+                if (!requestOpenTabIfEmbedded(url, r.name)) navigate(url);
+              }}
               className="border-t border-border hover:bg-muted/20 cursor-pointer"
             >
               <td className="px-4 py-2">

--- a/dali-api/app/projects/routes/projects.list.tsx
+++ b/dali-api/app/projects/routes/projects.list.tsx
@@ -10,6 +10,7 @@ import {
 import type { Route } from "./+types/projects.list";
 import { requireAuth } from "~/lib/auth";
 import { isCore } from "~/lib/roles";
+import { requestOpenTabIfEmbedded } from "~/components/workspace-link";
 import { prisma } from "~/lib/db";
 import { ensureProjectGroup } from "~/lib/groups";
 import { ViewToggle, useViewPreference } from "~/components/ViewToggle";
@@ -334,7 +335,10 @@ function ProjectsTable({ rows }: { rows: ProjectRow[] }) {
           {rows.map((p) => (
             <tr
               key={p.id}
-              onClick={() => navigate(`/projects/${p.id}`)}
+              onClick={() => {
+                const url = `/projects/${p.id}`;
+                if (!requestOpenTabIfEmbedded(url, p.name)) navigate(url);
+              }}
               className="border-t border-border hover:bg-muted/20 cursor-pointer"
             >
               <td className="px-4 py-2 text-foreground">{p.name}</td>


### PR DESCRIPTION
* Fix interview dashboard duplicates and unify applicant detail view

The lead interview dashboard double-counted applications whose interview was already Completed: they appeared both in the interview list and in the "Awaiting Schedule" pending list, because the pending query only excluded Scheduled interviews. Tightened the filter to also exclude Completed; Cancelled interviews still surface as pending so they can be rescheduled.

Cancelled interviews now hide by default with a "Show cancelled (N)" toggle, so the dashboard keeps one row per applicant for the "what comes next" view. Applicant names on the dashboard link to the applicant detail page.

The applicant detail page (/hiring/applications/{daId}) now surfaces the full context for one DA: existing application + reviews, plus interviews with per-assignment notes, the decision timeline, and any delibs sessions referencing the DA. Per-section access follows existing conventions — Released decisions are visible to all readers of the page; Draft/Final decisions and delibs are lead-only.



* Open applicant detail in a new tab from dashboard surfaces

The unified applicant detail page is reference context, not workflow, so opening it in a new tab preserves the source view (interview dashboard, analytics list, delibs board, reviewer interview card) instead of swapping it out and leaving a misleading "Back to Applications" link.

Workflow links into authoring pages (reviewer queue's Start/Continue Review, Open Interview, etc.) stay same-tab — those are tasks the user navigates into and out of, not glance views.



* Open applicant detail as a workspace tab, not a browser tab

Dashboards and lists already render inside TabWorkspace iframes, so a plain Link click was navigating the iframe itself and stranding the user. A browser new tab fixed that but loses the in-app tab model.

Reuse the existing dali:openTab postMessage convention (already used by notifications and home tiles) so clicking an applicant name from the interview dashboard, analytics list, reviewer dashboard, or delibs view opens a new TabWorkspace tab next to the source view instead of replacing it. At top-level (no iframe) the Link falls through to a normal navigation.

Factored into a small requestOpenTabIfEmbedded helper so the 5 call sites stay readable.



* Apply embed-aware navigation to remaining list/table click handlers

Audit found five more table/card rows whose onClick handlers called navigate() directly without checking for iframe embedding, so clicking a row from the projects/members/partners lists or the partners kanban would replace the dashboard view with the detail page instead of opening a workspace tab next to it.

Reuse requestOpenTabIfEmbedded so each surface behaves the same way as the hiring dashboards updated in the previous commit. Tab labels use the entity's display name (project name, member name, partner app title) so the new workspace tab is identifiable.



---------

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/690"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782318232&installation_id=133523038&pr_number=690&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F690&signature=02221d4a6778e55c76b958ff8ba97e4e29509f810e82b28b24efa8637daa2987"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->