### PR TITLE
Fix interview notes source + surface delibs prep note

### DIFF
--- a/dali-api/app/hiring/routes/applications.$domainApplicationId.tsx
+++ b/dali-api/app/hiring/routes/applications.$domainApplicationId.tsx
@@ -189,6 +189,9 @@ export async function loader({ request, params }: Route.LoaderArgs) {
         status: true,
         location: true,
         zoomJoinUrl: true,
+        // Joint outcome — synced from `interview:{id}:recommendation` doc.
+        recommendation: true,
+        recommendationNotes: true,
         assignments: {
           where: { status: "Active" },
           select: {
@@ -200,13 +203,6 @@ export async function loader({ request, params }: Route.LoaderArgs) {
                 user: { select: { firstName: true, lastName: true } },
                 domain: { select: { name: true } },
               },
-            },
-            // Latest note version per assignment. Mirrors the orderBy DESC
-            // pattern used by api.interview-assignments.$id.notes.ts.
-            noteVersions: {
-              orderBy: { createdAt: "desc" },
-              take: 1,
-              select: { id: true, content: true, createdAt: true },
             },
           },
         },
@@ -264,35 +260,83 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     submittedAt: r.submittedAt ? r.submittedAt.toISOString() : null,
   }));
 
-  const interviews = interviewRows.map((iv) => ({
-    id: iv.id,
-    startTime: iv.startTime.toISOString(),
-    endTime: iv.endTime.toISOString(),
-    status: iv.status,
-    location: iv.location,
-    zoomJoinUrl: iv.zoomJoinUrl,
-    assignments: iv.assignments.map((a) => {
-      const isViewerThisInterviewer = a.cycleInterviewer.userId === auth.user.sub;
-      const latest = a.noteVersions[0];
-      return {
-        id: a.id,
-        role: a.role,
-        interviewerName:
-          [a.cycleInterviewer.user.firstName, a.cycleInterviewer.user.lastName]
-            .filter(Boolean)
-            .join(" ")
-            .trim() || "Interviewer",
-        domainName: a.cycleInterviewer.domain.name,
-        canEditNotes: isViewerThisInterviewer,
-        latestNote: latest
-          ? {
-              content: latest.content,
-              createdAt: latest.createdAt.toISOString(),
-            }
-          : null,
-      };
-    }),
-  }));
+  // Interview notes live in CollabDocumentVersion (Yjs/Tiptap), not in the
+  // legacy InterviewNoteVersion table. There are two doc kinds per interview:
+  //   interview:{id}:notes                          — joint, shared by both
+  //                                                   interviewers
+  //   interview:{id}:rec-notes-{assignmentId}       — per-interviewer private
+  //                                                   recommendation notes
+  // Joint recommendation text is synced from `interview:{id}:recommendation`
+  // back to Interview.recommendationNotes, so we read that column directly.
+  const collabDocNames: string[] = [];
+  for (const iv of interviewRows) {
+    collabDocNames.push(`interview:${iv.id}:notes`);
+    if (canSeePreReleaseDecisions) {
+      for (const a of iv.assignments) {
+        collabDocNames.push(`interview:${iv.id}:rec-notes-${a.id}`);
+      }
+    }
+  }
+  const collabVersionRows = collabDocNames.length > 0
+    ? await prisma.collabDocumentVersion.findMany({
+        where: { name: { in: collabDocNames } },
+        orderBy: { createdAt: "desc" },
+        select: { name: true, plainText: true, createdAt: true },
+      })
+    : [];
+  // Keep only the latest snapshot per doc name.
+  const latestCollabByName = new Map<string, { plainText: string; createdAt: Date }>();
+  for (const row of collabVersionRows) {
+    if (!latestCollabByName.has(row.name)) {
+      latestCollabByName.set(row.name, {
+        plainText: row.plainText,
+        createdAt: row.createdAt,
+      });
+    }
+  }
+
+  const interviews = interviewRows.map((iv) => {
+    const jointNotes = latestCollabByName.get(`interview:${iv.id}:notes`) ?? null;
+    return {
+      id: iv.id,
+      startTime: iv.startTime.toISOString(),
+      endTime: iv.endTime.toISOString(),
+      status: iv.status,
+      location: iv.location,
+      zoomJoinUrl: iv.zoomJoinUrl,
+      recommendation: iv.recommendation,
+      recommendationNotes: iv.recommendationNotes,
+      jointNotes: jointNotes
+        ? {
+            plainText: jointNotes.plainText,
+            updatedAt: jointNotes.createdAt.toISOString(),
+          }
+        : null,
+      assignments: iv.assignments.map((a) => {
+        const isViewerThisInterviewer = a.cycleInterviewer.userId === auth.user.sub;
+        const privateNotes = canSeePreReleaseDecisions
+          ? latestCollabByName.get(`interview:${iv.id}:rec-notes-${a.id}`) ?? null
+          : null;
+        return {
+          id: a.id,
+          role: a.role,
+          interviewerName:
+            [a.cycleInterviewer.user.firstName, a.cycleInterviewer.user.lastName]
+              .filter(Boolean)
+              .join(" ")
+              .trim() || "Interviewer",
+          domainName: a.cycleInterviewer.domain.name,
+          canEditNotes: isViewerThisInterviewer,
+          privateNotes: privateNotes
+            ? {
+                plainText: privateNotes.plainText,
+                updatedAt: privateNotes.createdAt.toISOString(),
+              }
+            : null,
+        };
+      }),
+    };
+  });
 
   // Decisions: applicants never reach this page; reviewers (in-domain) see only
   // Released. Core/DomainLead see the full append-only history.
@@ -581,48 +625,89 @@ function InterviewsSection({ interviews }: { interviews: InterviewRow[] }) {
                           .join(", ")}
                   </span>
                 </div>
-                {iv.assignments.length > 0 && (
+                <div className="rounded-md border border-border bg-background/50 p-3">
+                  <div className="flex items-center justify-between gap-2">
+                    <div className="text-xs font-bold text-muted-foreground uppercase tracking-wider">
+                      Joint notes
+                    </div>
+                    {iv.assignments.some((a) => a.canEditNotes) && (
+                      <Link
+                        to={`/hiring/interviewer/interview/${iv.id}`}
+                        className="text-xs text-blue-600 hover:underline"
+                      >
+                        Open in interviewer view
+                      </Link>
+                    )}
+                  </div>
+                  {iv.jointNotes && iv.jointNotes.plainText.trim().length > 0 ? (
+                    <>
+                      <p className="mt-2 text-sm text-foreground whitespace-pre-wrap">
+                        {iv.jointNotes.plainText}
+                      </p>
+                      <p className="mt-1 text-[11px] text-muted-foreground/80">
+                        Last edit{" "}
+                        {new Date(iv.jointNotes.updatedAt).toLocaleString(undefined, {
+                          month: "short",
+                          day: "numeric",
+                          hour: "numeric",
+                          minute: "2-digit",
+                        })}
+                      </p>
+                    </>
+                  ) : (
+                    <p className="mt-2 text-xs text-muted-foreground/70 italic">
+                      No notes yet.
+                    </p>
+                  )}
+                </div>
+                {(iv.recommendation || iv.recommendationNotes) && (
+                  <div className="rounded-md border border-border bg-background/50 p-3">
+                    <div className="text-xs font-bold text-muted-foreground uppercase tracking-wider">
+                      Joint recommendation
+                    </div>
+                    {iv.recommendation && (
+                      <div className="mt-2">
+                        <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-bold bg-muted text-foreground/80">
+                          {iv.recommendation}
+                        </span>
+                      </div>
+                    )}
+                    {iv.recommendationNotes && iv.recommendationNotes.trim().length > 0 && (
+                      <p className="mt-2 text-sm text-foreground whitespace-pre-wrap">
+                        {iv.recommendationNotes}
+                      </p>
+                    )}
+                  </div>
+                )}
+                {iv.assignments.some((a) => a.privateNotes) && (
                   <div className="space-y-2 pl-1">
-                    {iv.assignments.map((a) => (
-                      <div key={a.id} className="rounded-md border border-border bg-background/50 p-3">
-                        <div className="flex items-center justify-between gap-2">
+                    <div className="text-xs font-bold text-muted-foreground uppercase tracking-wider">
+                      Per-interviewer notes
+                    </div>
+                    {iv.assignments
+                      .filter((a) => a.privateNotes && a.privateNotes.plainText.trim().length > 0)
+                      .map((a) => (
+                        <div key={a.id} className="rounded-md border border-border bg-background/50 p-3">
                           <div className="text-sm font-medium text-foreground">
                             {a.interviewerName}{" "}
                             <span className="text-xs font-normal text-muted-foreground">
                               · {a.role === "InDomain" ? a.domainName : `Cross (${a.domainName})`}
                             </span>
                           </div>
-                          {a.canEditNotes && (
-                            <Link
-                              to={`/hiring/interviewer/interview/${iv.id}`}
-                              className="text-xs text-blue-600 hover:underline"
-                            >
-                              Open in interviewer view
-                            </Link>
-                          )}
-                        </div>
-                        {a.latestNote ? (
-                          <>
-                            <p className="mt-2 text-sm text-foreground whitespace-pre-wrap">
-                              {a.latestNote.content}
-                            </p>
-                            <p className="mt-1 text-[11px] text-muted-foreground/80">
-                              Latest version saved{" "}
-                              {new Date(a.latestNote.createdAt).toLocaleString(undefined, {
-                                month: "short",
-                                day: "numeric",
-                                hour: "numeric",
-                                minute: "2-digit",
-                              })}
-                            </p>
-                          </>
-                        ) : (
-                          <p className="mt-2 text-xs text-muted-foreground/70 italic">
-                            No notes yet.
+                          <p className="mt-2 text-sm text-foreground whitespace-pre-wrap">
+                            {a.privateNotes!.plainText}
                           </p>
-                        )}
-                      </div>
-                    ))}
+                          <p className="mt-1 text-[11px] text-muted-foreground/80">
+                            Last edit{" "}
+                            {new Date(a.privateNotes!.updatedAt).toLocaleString(undefined, {
+                              month: "short",
+                              day: "numeric",
+                              hour: "numeric",
+                              minute: "2-digit",
+                            })}
+                          </p>
+                        </div>
+                      ))}
                   </div>
                 )}
               </li>

--- a/dali-api/app/hiring/routes/applications.$domainApplicationId.tsx
+++ b/dali-api/app/hiring/routes/applications.$domainApplicationId.tsx
@@ -66,6 +66,10 @@ export async function loader({ request, params }: Route.LoaderArgs) {
       id: true,
       domainId: true,
       answers: true,
+      // Free-form note leads write during Initial delibs as interview prep.
+      // The collab layer keeps this column in sync with the live Yjs doc, so
+      // reading it directly is safe. Lead-only on the UI.
+      interviewPrepNote: true,
       domain: { select: { displayName: true } },
       challengeVersion: {
         select: {
@@ -436,6 +440,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     interviews,
     decisions: visibleDecisions,
     delibs,
+    interviewPrepNote: canSeeDelibs ? da.interviewPrepNote : null,
     canSeePreReleaseDecisions,
     canSeeDelibs,
     selectedReviewId,
@@ -551,7 +556,10 @@ export default function ApplicationReadOnlyDetail() {
         </div>
       </div>
 
-      <InterviewsSection interviews={data.interviews} />
+      <InterviewsSection
+        interviews={data.interviews}
+        interviewPrepNote={data.interviewPrepNote}
+      />
       <DecisionsSection
         decisions={data.decisions}
         canSeePreReleaseDecisions={data.canSeePreReleaseDecisions}
@@ -566,7 +574,14 @@ type InterviewRow = LoaderData["interviews"][number];
 type DecisionRow = LoaderData["decisions"][number];
 type DelibsRef = LoaderData["delibs"][number];
 
-function InterviewsSection({ interviews }: { interviews: InterviewRow[] }) {
+function InterviewsSection({
+  interviews,
+  interviewPrepNote,
+}: {
+  interviews: InterviewRow[];
+  interviewPrepNote: string | null;
+}) {
+  const hasPrepNote = interviewPrepNote != null && interviewPrepNote.trim().length > 0;
   return (
     <section className="bg-card rounded-xl border border-border shadow-sm">
       <div className="px-6 py-4 border-b border-border bg-muted/50">
@@ -577,6 +592,19 @@ function InterviewsSection({ interviews }: { interviews: InterviewRow[] }) {
             : `${interviews.length} ${interviews.length === 1 ? "interview" : "interviews"}`}
         </p>
       </div>
+      {hasPrepNote && (
+        <div className="px-6 py-3 border-b border-border bg-amber-50/40">
+          <div className="text-xs font-bold text-amber-900 uppercase tracking-wider">
+            Interview prep note
+          </div>
+          <p className="mt-1 text-sm text-foreground whitespace-pre-wrap">
+            {interviewPrepNote}
+          </p>
+          <p className="mt-1 text-[11px] text-muted-foreground/80">
+            Set by leads during Initial delibs.
+          </p>
+        </div>
+      )}
       {interviews.length > 0 && (
         <ul className="divide-y divide-border">
           {interviews.map((iv) => {


### PR DESCRIPTION
## Summary

Two follow-ups to the unified applicant detail page from PR #688, both isolated to `applications.$domainApplicationId.tsx`.

### 1. Interview notes read from the wrong table

Notes were querying `InterviewNoteVersion` — a legacy/orphaned model that the live interviewer UI doesn't write to. In production every completed interview showed "No notes yet."

The actual notes live in `CollabDocumentVersion` (Yjs/Tiptap snapshots). Three docs per interview now feed the page:

| Doc name | Source | Visibility |
|---|---|---|
| `interview:{id}:notes` | joint notes — both interviewers edit together | anyone with page access |
| `interview:{id}:rec-notes-{assignmentId}` | per-interviewer private rec notes | Core / DomainLead |
| `interview:{id}:recommendation` → `Interview.recommendationNotes` | joint recommendation rationale | anyone with page access |

The UI section was rebuilt accordingly:
- One **Joint notes** block per interview (not nested under each interviewer).
- A **Joint recommendation** block with the recommendation pill + notes when set.
- A **Per-interviewer notes** list, lead-only.

### 2. Interview prep note (Initial delibs)

`DomainApplication.interviewPrepNote` is a free-form note leads write during Initial delibs ("ask about X in the interview") — it bridges delibs → interviews but was never surfaced. Now rendered as a lead-only callout at the top of the Interviews section. The column is synced from the live collab doc by the persistence layer, so reading it directly is safe.

## Audit of the rest of the loader

While debugging the notes issue I also audited the other queries against the collab persistence layer. No additional staleness:

- `ApplicationReview.feedback` / `rejectionRationale` — collab-backed but synced back to the row on every save.
- Scores, annotations — plain JSON, no collab path.
- Decision notes — written directly to the row.
- Delibs columnOrder — plain JSON.

`Decision.parentDecisionId` (Draft→Final→Released lineage) was flagged but skipped — the chronological timeline already conveys this.

## Test plan

- [ ] Open an applicant who completed an interview with notes — confirm "Joint notes" shows the latest content, not "No notes yet"
- [ ] Verify joint recommendation pill + notes show when interviewers marked complete
- [ ] As Core/DomainLead: confirm per-interviewer private rec notes render in the "Per-interviewer notes" list
- [ ] As a plain reviewer in-domain: confirm the per-interviewer notes section is omitted
- [ ] As Core/DomainLead: confirm the amber "Interview prep note" callout shows when a prep note exists; absent when it doesn't
- [ ] As a plain reviewer: confirm the prep note callout is hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/693"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782323834&installation_id=133523038&pr_number=693&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F693&signature=40dfa3537132e93eeddb5ae9bcabe39aee2872a3b40372afecf5bbbf03f321ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->