### PR TITLE
Fix staffing bid resolution + wire GitHub team finalize automation

### DIFF
--- a/dali-api/.env.example
+++ b/dali-api/.env.example
@@ -49,9 +49,13 @@ SLACK_BOT_TOKEN=""
 # (e.g. "C0123ABC"). When empty, the Slack step is skipped (reported as such).
 STAFFING_SLACK_CHANNEL=""
 
-# GitHub App used to file issues from Slack bug reports.
+# GitHub App used to file issues from Slack bug reports, and (when the App has
+# org "Members: write") to provision project teams from staffing finalize.
 GITHUB_APP_ID=""
 GITHUB_APP_INSTALLATION_ID=""
 # Full PEM, newlines preserved. In Fly use a single-line literal with \n.
 GITHUB_APP_PRIVATE_KEY=""
 GITHUB_ISSUES_REPO=""
+# Org login (e.g. "dali-lab") under which the "Set up GitHub teams" staffing
+# automation creates project teams. Unset = that automation skips.
+GITHUB_ORG=""

--- a/dali-api/.gitignore
+++ b/dali-api/.gitignore
@@ -1,5 +1,9 @@
 .DS_Store
+# All env files hold secrets and must never be committed — except the tracked
+# .env.example template.
 .env
+.env.*
+!.env.example
 /node_modules/
 
 # React Router

--- a/dali-api/app/forms/lib/public-form.ts
+++ b/dali-api/app/forms/lib/public-form.ts
@@ -8,7 +8,6 @@ import { prisma } from "~/lib/db";
 import type { Question } from "~/types";
 import { resolveReferenceOptions } from "./reference-sources";
 import { currentTerm } from "~/lib/roles";
-import { ensureStaffingCycle } from "~/projects/lib/staffing-cycle";
 import { interpretBidForm } from "~/projects/lib/bid-form-interpreter";
 import { validateBids, replaceBidSet } from "~/projects/lib/bid-validation";
 import { interpretIntentForm } from "~/projects/lib/intent-form-interpreter";
@@ -18,7 +17,7 @@ import {
   validateMapping,
   type ColumnMapping,
 } from "~/projects/lib/slot-roles";
-import type { Slot } from "~/projects/lib/form-slots";
+import { pickStaffingBinding, type Slot } from "~/projects/lib/form-slots";
 
 export type PublicForm = {
   formId: string;
@@ -179,6 +178,7 @@ export async function submitMemberForm(args: {
         select: {
           slot: true,
           columnMapping: true,
+          updatedAt: true,
           staffingCycle: {
             select: { id: true, termId: true, maxPreferencesPerMember: true },
           },
@@ -215,18 +215,14 @@ export async function submitMemberForm(args: {
   const bad = await validateAnswers(questions, args.answers, args.userId);
   if (bad) return bad;
 
-  // Is this form bound to a staffing slot for the *current* term's cycle?
-  // The binding rows list every cycle it's bound to; we only act on the live
-  // cycle so a stale binding to an old term doesn't fire.
+  // Which staffing cycle (if any) this submission feeds is decided by the
+  // form's own bindings, not the calendar's current term — see
+  // pickStaffingBinding. currentTerm only breaks ties when a form is reused
+  // across cycles.
   const term = await currentTerm();
-  const liveCycle = term
-    ? await ensureStaffingCycle(term.id, term.code)
-    : null;
-  const staffingBinding = form.cycleBindings.find(
-    (b) =>
-      (b.slot === "project-bids" || b.slot === "intent-to-work") &&
-      liveCycle != null &&
-      b.staffingCycle.id === liveCycle.id,
+  const staffingBinding = pickStaffingBinding(
+    form.cycleBindings,
+    term?.id ?? null,
   );
 
   if (!staffingBinding) {

--- a/dali-api/app/forms/lib/reference-sources.ts
+++ b/dali-api/app/forms/lib/reference-sources.ts
@@ -37,19 +37,20 @@ export type ReferenceContext = {
 };
 
 const LOADERS = {
-  // Projects with at least one open role this term — mirrors the projects a
-  // member can actually bid on (see api.project-bids.ts role-request gate).
+  // Projects a member can bid on this term: non-archived projects that run
+  // this term (ProjectTerm) AND declare at least one domain (ProjectDomain).
+  // Biddability is domain-driven now, not gated on ProjectRoleRequest — a
+  // project with declared scope is biddable even without manually-entered role
+  // requests (see bid-validation.ts).
   "projects:open-this-term": async () => {
     const term = await currentTerm();
     if (!term) return [];
-    const roleRequests = await prisma.projectRoleRequest.findMany({
-      where: { termId: term.id },
-      select: { projectId: true },
-    });
-    const projectIds = [...new Set(roleRequests.map((r) => r.projectId))];
-    if (projectIds.length === 0) return [];
     const projects = await prisma.project.findMany({
-      where: { id: { in: projectIds } },
+      where: {
+        status: { not: "Archived" },
+        projectTerms: { some: { termId: term.id } },
+        domains: { some: {} },
+      },
       orderBy: { name: "asc" },
       select: { id: true, name: true },
     });

--- a/dali-api/app/members/routes/members.$id.tsx
+++ b/dali-api/app/members/routes/members.$id.tsx
@@ -35,6 +35,7 @@ const TEXT_FIELDS = [
   "hometown",
   "linkedinUrl",
   "githubUrl",
+  "githubUsername",
   "personalSite",
   "timeZone",
 ] as const;
@@ -58,6 +59,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
       hometown: true,
       linkedinUrl: true,
       githubUrl: true,
+      githubUsername: true,
       personalSite: true,
       photoUrl: true,
       timeZone: true,
@@ -200,6 +202,7 @@ const FIELD_LABELS: Record<string, string> = {
   hometown: "Hometown",
   linkedinUrl: "LinkedIn URL",
   githubUrl: "GitHub URL",
+  githubUsername: "GitHub username",
   personalSite: "Personal site",
   timeZone: "Time zone (IANA, e.g. America/New_York)",
 };

--- a/dali-api/app/partners/routes/partners.applications.$id.tsx
+++ b/dali-api/app/partners/routes/partners.applications.$id.tsx
@@ -230,6 +230,14 @@ export async function action({ request, params }: Route.ActionArgs) {
             slots: d.expectedMembers,
           }))
       : [];
+    // The project's declared domains are INHERITED from the role requests: the
+    // distinct domains the project needs people in. No role requests → no
+    // domains inherited. After promotion these stay editable the usual way
+    // (the `domains` intent on the project page), so this is just the initial
+    // seed, not a binding.
+    const inheritedDomainIds = Array.from(
+      new Set(roleRequestRows.map((r) => r.domainId)),
+    );
 
     const project = await prisma.$transaction(async (tx) => {
       const created = await tx.project.create({
@@ -242,6 +250,13 @@ export async function action({ request, params }: Route.ActionArgs) {
           partners: { create: { partnerOrgId: app.partnerOrgId } },
           ...(roleRequestRows.length > 0
             ? { roleRequests: { create: roleRequestRows } }
+            : {}),
+          ...(inheritedDomainIds.length > 0
+            ? {
+                domains: {
+                  create: inheritedDomainIds.map((domainId) => ({ domainId })),
+                },
+              }
             : {}),
         },
         select: { id: true },

--- a/dali-api/app/projects/components/FinalizeModal.tsx
+++ b/dali-api/app/projects/components/FinalizeModal.tsx
@@ -10,7 +10,10 @@ const AUTOMATIONS: {
   id: Automation;
   label: string;
   description: string;
-  // Stubs render disabled with a "Not configured" note.
+  // `configured: false` renders disabled with a "Not configured" note. A
+  // `true` automation is wired end-to-end; runtime gaps (e.g. a missing env var
+  // or unset project field) are reported by the server as a per-step "skipped"
+  // result rather than disabling the control here.
   configured: boolean;
 }[] = [
   {
@@ -27,15 +30,15 @@ const AUTOMATIONS: {
     configured: true,
   },
   {
+    id: "github",
+    label: "Set up GitHub teams",
+    description: "Create the project's GitHub team and add the confirmed roster.",
+    configured: true,
+  },
+  {
     id: "gmail",
     label: "Create Gmail accounts",
     description: "Provision project Google Workspace accounts.",
-    configured: false,
-  },
-  {
-    id: "github",
-    label: "Set up GitHub teams",
-    description: "Create the project's GitHub team and add members.",
     configured: false,
   },
 ];

--- a/dali-api/app/projects/components/MemberCard.tsx
+++ b/dali-api/app/projects/components/MemberCard.tsx
@@ -65,6 +65,14 @@ export function MemberCard({ card, columnId, projectNames, onOpenBid, draggable 
             <span className="text-sm font-semibold text-foreground truncate text-left">
               {fullName}
             </span>
+            {card.unresolvedBid && (
+              <span
+                className="inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium rounded bg-amber-100 text-amber-800"
+                title="Submitted a bid, but none of their picks matched an open role for this term — needs a staffing lead's attention."
+              >
+                Bid unresolved
+              </span>
+            )}
           </div>
           <RoleStrip card={card} />
         </div>
@@ -140,7 +148,15 @@ function BidStrip({
   // Always show the member's top 3 project preferences in rank order,
   // regardless of which column the card is in.
   if (card.topPreferences.length === 0) {
-    return <p className="text-[11px] text-muted-foreground italic">No project bids</p>;
+    // Distinguish "submitted a bid that resolved to nothing" from "never bid" —
+    // the former needs a lead to fix open roles, the latter is just empty.
+    return (
+      <p className="text-[11px] text-muted-foreground italic">
+        {card.unresolvedBid
+          ? "Bid submitted — no picks matched an open role"
+          : "No project bids"}
+      </p>
+    );
   }
   return (
     <ol className="text-[11px] text-muted-foreground flex flex-col gap-0.5">

--- a/dali-api/app/projects/components/StaffingBoard.tsx
+++ b/dali-api/app/projects/components/StaffingBoard.tsx
@@ -32,7 +32,7 @@ export type DomainDemand = { domainId: string; domainName: string; slots: number
 
 type Props = {
   cycleId: string;
-  termCode: string;
+  termId: string;
   terms: { id: string; code: string }[];
   projects: ProjectMeta[];
   members: MemberInput[];
@@ -45,7 +45,7 @@ type Props = {
 
 export function StaffingBoard({
   cycleId,
-  termCode,
+  termId,
   terms,
   projects,
   members,
@@ -151,7 +151,7 @@ export function StaffingBoard({
           </label>
           <select
             id="staffing-term"
-            value={termCode}
+            value={termId}
             onChange={(e) => {
               setSearchParams(
                 (prev) => {
@@ -164,7 +164,7 @@ export function StaffingBoard({
             className="text-sm px-2 py-1 border border-border rounded-md bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-accent-coral/30"
           >
             {terms.map((t) => (
-              <option key={t.id} value={t.code}>
+              <option key={t.id} value={t.id}>
                 {t.code}
               </option>
             ))}

--- a/dali-api/app/projects/lib/__tests__/bid-validation.test.ts
+++ b/dali-api/app/projects/lib/__tests__/bid-validation.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("~/lib/db");
+
+import { prisma } from "~/lib/db";
+import { validateBids, type BidCycle } from "~/projects/lib/bid-validation";
+
+// The shared db mock doesn't define these models; attach vi.fns so this file
+// can drive them. Cast through unknown since they're not on the shared stub.
+const mockPrisma = prisma as unknown as {
+  domainEligibility: { findMany: ReturnType<typeof vi.fn> };
+  projectDomain: { findMany: ReturnType<typeof vi.fn> };
+};
+
+beforeEach(() => {
+  mockPrisma.domainEligibility = { findMany: vi.fn() };
+  mockPrisma.projectDomain = { findMany: vi.fn() };
+});
+
+const cycle: BidCycle = {
+  id: "cyc1",
+  termId: "term-26X",
+  maxPreferencesPerMember: 3,
+};
+
+describe("validateBids — domain-driven biddability", () => {
+  it("resolves a bid when the project declares the member's eligibility domain (no role request needed)", async () => {
+    mockPrisma.domainEligibility.findMany.mockResolvedValue([
+      { domainId: "eng", level: "P3" },
+    ]);
+    // Project works in Engineering — biddable, even with zero ProjectRoleRequest.
+    mockPrisma.projectDomain.findMany.mockResolvedValue([
+      { projectId: "p1", domainId: "eng" },
+    ]);
+
+    const res = await validateBids("u1", cycle, [{ projectId: "p1" }]);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.bids).toEqual([
+      { projectId: "p1", domainId: "eng", level: "P3", preferenceRank: 1, notes: null },
+    ]);
+    // Biddability must come from ProjectDomain, not ProjectRoleRequest.
+    expect(mockPrisma.projectDomain.findMany).toHaveBeenCalled();
+  });
+
+  it("drops a bid on a project that doesn't work in any eligibility domain", async () => {
+    mockPrisma.domainEligibility.findMany.mockResolvedValue([
+      { domainId: "eng", level: "P3" },
+    ]);
+    // Project only works in Design; member is Engineering-only → no rows.
+    mockPrisma.projectDomain.findMany.mockResolvedValue([]);
+
+    const res = await validateBids("u1", cycle, [{ projectId: "p1" }]);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.bids).toEqual([]);
+  });
+
+  it("uses the member's eligibility level, and ranks bids by submission order", async () => {
+    mockPrisma.domainEligibility.findMany.mockResolvedValue([
+      { domainId: "eng", level: "P2" },
+    ]);
+    mockPrisma.projectDomain.findMany.mockResolvedValue([
+      { projectId: "p1", domainId: "eng" },
+      { projectId: "p2", domainId: "eng" },
+    ]);
+
+    const res = await validateBids("u1", cycle, [
+      { projectId: "p2" },
+      { projectId: "p1" },
+    ]);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.bids).toEqual([
+      { projectId: "p2", domainId: "eng", level: "P2", preferenceRank: 1, notes: null },
+      { projectId: "p1", domainId: "eng", level: "P2", preferenceRank: 2, notes: null },
+    ]);
+  });
+
+  it("records zero bids (not an error) when the member has no eligibility — they still appear, flagged", async () => {
+    mockPrisma.domainEligibility.findMany.mockResolvedValue([]);
+    const res = await validateBids("u1", cycle, [{ projectId: "p1" }]);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.bids).toEqual([]);
+  });
+
+  it("de-duplicates the same project picked twice, keeping the highest rank", async () => {
+    // Real case (Alexander): same project in all 3 slots. Must not reject the
+    // whole submission — collapse to one bid at rank 1.
+    mockPrisma.domainEligibility.findMany.mockResolvedValue([
+      { domainId: "eng", level: "P3" },
+    ]);
+    mockPrisma.projectDomain.findMany.mockResolvedValue([
+      { projectId: "p1", domainId: "eng" },
+    ]);
+
+    const res = await validateBids("u1", cycle, [
+      { projectId: "p1" },
+      { projectId: "p1" },
+      { projectId: "p1" },
+    ]);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.bids).toEqual([
+      { projectId: "p1", domainId: "eng", level: "P3", preferenceRank: 1, notes: null },
+    ]);
+  });
+
+  it("caps at maxBids, keeping the top-ranked picks (no rejection)", async () => {
+    mockPrisma.domainEligibility.findMany.mockResolvedValue([
+      { domainId: "eng", level: "P3" },
+    ]);
+    mockPrisma.projectDomain.findMany.mockResolvedValue([
+      { projectId: "p1", domainId: "eng" },
+      { projectId: "p2", domainId: "eng" },
+      { projectId: "p3", domainId: "eng" },
+      { projectId: "p4", domainId: "eng" },
+    ]);
+
+    // 4 distinct picks, maxBids = 3 → keep p1,p2,p3.
+    const res = await validateBids("u1", cycle, [
+      { projectId: "p1" },
+      { projectId: "p2" },
+      { projectId: "p3" },
+      { projectId: "p4" },
+    ]);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.bids.map((b) => b.projectId)).toEqual(["p1", "p2", "p3"]);
+    expect(res.bids.map((b) => b.preferenceRank)).toEqual([1, 2, 3]);
+  });
+});

--- a/dali-api/app/projects/lib/__tests__/form-slots.test.ts
+++ b/dali-api/app/projects/lib/__tests__/form-slots.test.ts
@@ -1,4 +1,9 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
+// form-slots.ts imports the real ~/lib/db at module load (for other helpers);
+// stub it so importing this pure function doesn't pull in the generated Prisma
+// client, which isn't built during the unit-test CI job. pickStaffingBinding
+// never touches prisma, so the mock is inert.
+vi.mock("~/lib/db");
 import { pickStaffingBinding } from "~/projects/lib/form-slots";
 
 // Shape mirrors the subset of StaffingCycleFormBinding that submitMemberForm

--- a/dali-api/app/projects/lib/__tests__/form-slots.test.ts
+++ b/dali-api/app/projects/lib/__tests__/form-slots.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { pickStaffingBinding } from "~/projects/lib/form-slots";
+
+// Shape mirrors the subset of StaffingCycleFormBinding that submitMemberForm
+// selects on. Dates are explicit so the tie-break order is unambiguous.
+function binding(opts: {
+  slot: string;
+  termId: string;
+  updatedAt: string;
+  id?: string;
+}) {
+  return {
+    id: opts.id ?? `${opts.slot}-${opts.termId}`,
+    slot: opts.slot,
+    termId: opts.termId,
+    updatedAt: new Date(opts.updatedAt),
+    staffingCycle: { termId: opts.termId },
+  };
+}
+
+describe("pickStaffingBinding", () => {
+  it("returns undefined when the form drives no staffing slot", () => {
+    const bindings = [
+      binding({ slot: "some-other-slot", termId: "t-26S", updatedAt: "2026-01-01" }),
+    ];
+    expect(pickStaffingBinding(bindings, "t-26S")).toBeUndefined();
+  });
+
+  it("picks the form's bound cycle even when it isn't the current term", () => {
+    // The regression: a 26S bid form submitted while the calendar's current
+    // term is 26W must still feed 26S, not get dropped for a missing live
+    // binding.
+    const bindings = [
+      binding({ slot: "project-bids", termId: "t-26S", updatedAt: "2026-01-01" }),
+    ];
+    const picked = pickStaffingBinding(bindings, "t-26W");
+    expect(picked?.termId).toBe("t-26S");
+  });
+
+  it("prefers the live term's binding when a form is reused across cycles", () => {
+    const bindings = [
+      binding({ slot: "project-bids", termId: "t-26S", updatedAt: "2026-03-01" }),
+      binding({ slot: "project-bids", termId: "t-26W", updatedAt: "2026-01-01" }),
+    ];
+    // 26S is newer, but 26W is live — live wins.
+    const picked = pickStaffingBinding(bindings, "t-26W");
+    expect(picked?.termId).toBe("t-26W");
+  });
+
+  it("falls back to the most recently updated binding when none is live", () => {
+    const bindings = [
+      binding({ slot: "project-bids", termId: "t-26S", updatedAt: "2026-03-01" }),
+      binding({ slot: "project-bids", termId: "t-26W", updatedAt: "2026-01-01" }),
+    ];
+    // currentTerm() is null (between terms) → newest binding wins.
+    const picked = pickStaffingBinding(bindings, null);
+    expect(picked?.termId).toBe("t-26S");
+  });
+
+  it("considers intent-to-work bindings too, ignoring unrelated slots", () => {
+    const bindings = [
+      binding({ slot: "some-other-slot", termId: "t-26S", updatedAt: "2026-05-01" }),
+      binding({ slot: "intent-to-work", termId: "t-26W", updatedAt: "2026-01-01" }),
+    ];
+    const picked = pickStaffingBinding(bindings, null);
+    expect(picked?.slot).toBe("intent-to-work");
+  });
+});

--- a/dali-api/app/projects/lib/__tests__/staffing-board.test.ts
+++ b/dali-api/app/projects/lib/__tests__/staffing-board.test.ts
@@ -94,6 +94,29 @@ describe("buildBoard", () => {
     expect(board[UNASSIGNED].map((c) => c.userId)).toEqual(["u-a", "u-c", "u-b"]);
   });
 
+  it("defaults unresolvedBid to false for an ordinary member", () => {
+    const board = buildBoard({
+      projectIds: ["p1"],
+      members: [member()],
+      assignments: [],
+    });
+    expect(board[UNASSIGNED][0].unresolvedBid).toBe(false);
+  });
+
+  it("carries an unresolved-bid flag through to the Unassigned card", () => {
+    // A member who bid but produced no preference: no project picks, flagged.
+    const board = buildBoard({
+      projectIds: ["p1"],
+      members: [member({ preferences: [], unresolvedBid: true })],
+      assignments: [],
+    });
+    expect(board[UNASSIGNED]).toHaveLength(1);
+    const card = board[UNASSIGNED][0];
+    expect(card.unresolvedBid).toBe(true);
+    expect(card.topPreferences).toEqual([]);
+    expect(card.level).toBeNull();
+  });
+
   it("carries every domainLevel through to the card", () => {
     const board = buildBoard({
       projectIds: ["p1"],

--- a/dali-api/app/projects/lib/bid-validation.ts
+++ b/dali-api/app/projects/lib/bid-validation.ts
@@ -51,57 +51,71 @@ export async function validateBids(
   cycle: BidCycle,
   bids: RawBid[],
 ): Promise<BidValidationResult> {
+  // The form is live and self-served, so a member can submit picks that don't
+  // form a clean ranked set — the same project in two slots, more slots filled
+  // than maxBids, or no eligibility yet. None of these should reject the whole
+  // submission and make the member vanish from the board; we normalize what we
+  // can and record what's left. (Genuine interpretation failures upstream
+  // already produce no bids; this guards the validate step.)
   const maxBids = Math.min(3, cycle.maxPreferencesPerMember);
-  if (bids.length > maxBids) {
-    return { ok: false, error: `You can bid on at most ${maxBids} projects.` };
-  }
 
-  // No duplicate projects — a member ranks distinct projects, not the same
-  // project twice.
-  const seen = new Set(bids.map((b) => b.projectId));
-  if (seen.size !== bids.length) {
-    return { ok: false, error: "Duplicate bid" };
+  // De-duplicate by project, keeping the highest (lowest-numbered) rank — i.e.
+  // the first occurrence, since `bids` is in rank order. Picking the same
+  // project twice collapses to one bid rather than rejecting the submission.
+  const dedupedBids: RawBid[] = [];
+  const seenProjects = new Set<string>();
+  for (const b of bids) {
+    if (seenProjects.has(b.projectId)) continue;
+    seenProjects.add(b.projectId);
+    dedupedBids.push(b);
   }
+  // Then cap at maxBids, keeping the top-ranked ones.
+  const effectiveBids = dedupedBids.slice(0, maxBids);
 
   // The member's eligibility map: domainId -> level. Each bid expands into
-  // one row per eligibility (where the project has an open role).
+  // one row per eligibility (where the project works in that domain). No
+  // eligibility yet → nothing to expand into, so record zero bids rather than
+  // erroring (the member still appears on the board, flagged).
   const eligibilities = await prisma.domainEligibility.findMany({
     where: { userId },
     select: { domainId: true, level: true },
   });
   if (eligibilities.length === 0) {
-    return {
-      ok: false,
-      error: "You have no domain eligibility — no bids can be recorded.",
-    };
+    return { ok: true, bids: [] };
   }
   const levelByDomain = new Map(
     eligibilities.map((e) => [e.domainId, e.level]),
   );
 
-  // Open roles for this term, restricted to the member's eligibility
-  // domains. Keyed (project,domain) for O(1) cross-check.
-  const roleRequests = await prisma.projectRoleRequest.findMany({
+  // Biddability is driven by the project's DECLARED DOMAINS (ProjectDomain),
+  // not by per-term ProjectRoleRequest rows. A project is biddable in a domain
+  // if it works in that domain at all; level comes from the member's
+  // eligibility. (ProjectRoleRequest still exists for headcount display on the
+  // board, but no longer gates whether a bid resolves — a project with scope
+  // but no manually-entered role requests is still biddable.) Restricted to
+  // the bid projects ∩ the member's eligibility domains, keyed (project,domain)
+  // for O(1) cross-check.
+  const projectDomains = await prisma.projectDomain.findMany({
     where: {
-      termId: cycle.termId,
+      projectId: { in: effectiveBids.map((b) => b.projectId) },
       domainId: { in: [...levelByDomain.keys()] },
     },
     select: { projectId: true, domainId: true },
   });
-  const openRoles = new Set(
-    roleRequests.map((r) => `${r.projectId}:${r.domainId}`),
+  const biddable = new Set(
+    projectDomains.map((d) => `${d.projectId}:${d.domainId}`),
   );
 
   const validated: ValidatedBid[] = [];
-  for (let i = 0; i < bids.length; i++) {
-    const b = bids[i];
+  for (let i = 0; i < effectiveBids.length; i++) {
+    const b = effectiveBids[i];
     const rank = i + 1;
-    // Each eligibility the project has an open role in becomes a row. If
-    // the project has no open role in any eligibility domain, the bid
+    // Each eligibility domain the project works in becomes a row. If the
+    // project doesn't work in any of the member's eligibility domains, the bid
     // contributes nothing — silently dropped so the rest of the submission
-    // still records (eligibility/open-role drift shouldn't reject the form).
+    // still records (eligibility/domain drift shouldn't reject the form).
     for (const [domainId, level] of levelByDomain) {
-      if (!openRoles.has(`${b.projectId}:${domainId}`)) continue;
+      if (!biddable.has(`${b.projectId}:${domainId}`)) continue;
       validated.push({
         projectId: b.projectId,
         domainId,

--- a/dali-api/app/projects/lib/form-slots.ts
+++ b/dali-api/app/projects/lib/form-slots.ts
@@ -17,6 +17,32 @@ export function isSlot(value: string): value is Slot {
   return value in SLOTS;
 }
 
+// Which of a form's cycle bindings a submission should feed. A form is bound
+// per-cycle (one binding per cycle+slot), so the binding names the cycle — we
+// pick from the form's own bindings rather than re-deriving the cycle from the
+// calendar's current term, which would silently drop submissions for any term
+// that isn't "live" today. Normally a form drives one staffing slot for one
+// cycle; if it's reused across cycles we prefer the live term's binding, else
+// the most recently updated one, so the choice is always deterministic.
+export function pickStaffingBinding<
+  B extends {
+    slot: string;
+    updatedAt: Date;
+    staffingCycle: { termId: string };
+  },
+>(bindings: B[], currentTermId: string | null): B | undefined {
+  return bindings
+    .filter((b) => b.slot === "project-bids" || b.slot === "intent-to-work")
+    .sort((a, b) => {
+      if (currentTermId) {
+        const aLive = a.staffingCycle.termId === currentTermId;
+        const bLive = b.staffingCycle.termId === currentTermId;
+        if (aLive !== bLive) return aLive ? -1 : 1;
+      }
+      return b.updatedAt.getTime() - a.updatedAt.getTime();
+    })[0];
+}
+
 // The form bound to a slot for a cycle, with just enough of its latest
 // version to surface it to members. `null` when no form is bound.
 export type SlotBinding = {

--- a/dali-api/app/projects/lib/staffing-board.ts
+++ b/dali-api/app/projects/lib/staffing-board.ts
@@ -29,6 +29,12 @@ export type MemberInput = {
   coreTitles: string[];
   preferences: Preference[];
   domainLevels: DomainLevel[];
+  // True when the member submitted a project-bids form for this cycle but it
+  // produced no usable preference (e.g. the bid projects have no open role in
+  // an eligibility domain). They still belong on the board — flagged — so a
+  // staffing lead notices, rather than vanishing. Derived in the loader; never
+  // set for members whose preferences resolved normally.
+  unresolvedBid?: boolean;
 };
 
 export type Assignment = {
@@ -54,6 +60,9 @@ export type MemberCardModel = {
   level: Level | null;
   // Member's top 3 project preferences in rank order. Always shown on the card.
   topPreferences: { projectId: string; rank: number }[];
+  // Mirrors MemberInput.unresolvedBid — the card renders a badge so the member
+  // is visibly distinguished from one who simply hasn't been placed yet.
+  unresolvedBid: boolean;
 };
 
 export const UNASSIGNED = "__unassigned__";
@@ -129,6 +138,7 @@ function toCard(
       .sort((a, b) => a.preferenceRank - b.preferenceRank)
       .slice(0, 3)
       .map((p) => ({ projectId: p.projectId, rank: p.preferenceRank })),
+    unresolvedBid: member.unresolvedBid ?? false,
   };
 }
 

--- a/dali-api/app/projects/routes/api.staffing.finalize.ts
+++ b/dali-api/app/projects/routes/api.staffing.finalize.ts
@@ -4,6 +4,7 @@ import { requireAuth } from "~/lib/auth";
 import { canManageStaffing } from "~/lib/roles";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { postMessage } from "~/slack/lib/slack-client";
+import { ensureTeam, addTeamMember } from "~/slack/lib/github-app";
 import { logAuditEvent } from "~/lib/audit";
 
 // POST /api/staffing/finalize
@@ -17,7 +18,8 @@ import { logAuditEvent } from "~/lib/audit";
 //     Confirmed, and upsert canonical ProjectAssignment + DomainEligibility.
 //   - slack:       post the confirmed roster to STAFFING_SLACK_CHANNEL.
 //   - gmail:       STUB — no Google Admin SDK wired up yet.
-//   - github:      STUB — GitHub App lacks org-team scope.
+//   - github:      get-or-create the project's GITHUB_ORG team (from
+//                  Project.githubTeamSlug) and add the confirmed roster.
 
 const AUTOMATIONS = ["assignments", "slack", "gmail", "github"] as const;
 type Automation = (typeof AUTOMATIONS)[number];
@@ -79,7 +81,7 @@ export async function action({ request }: Route.ActionArgs) {
   }
   const project = await prisma.project.findUnique({
     where: { id: body.projectId },
-    select: { id: true, name: true },
+    select: { id: true, name: true, githubTeamSlug: true },
   });
   if (!project) {
     return withCors(request, Response.json({ error: "Project not found" }, { status: 404 }));
@@ -196,12 +198,56 @@ export async function action({ request }: Route.ActionArgs) {
     };
   }
 
-  // ── github (stub) ──────────────────────────────────────────────────────────
+  // ── github ───────────────────────────────────────────────────────────────
+  // Get-or-create the project's org team (Project.githubTeamSlug, persistent
+  // across terms) and add the confirmed roster. Re-runnable: ensureTeam and the
+  // membership PUT are both idempotent, and we never remove anyone. Roster
+  // members without a stored githubUsername are skipped and reported.
   if (selected.has("github")) {
-    results.github = {
-      status: "skipped",
-      message: "GitHub team provisioning is not configured.",
-    };
+    if (!process.env.GITHUB_ORG) {
+      results.github = { status: "skipped", message: "GITHUB_ORG not set." };
+    } else if (!project.githubTeamSlug) {
+      results.github = {
+        status: "skipped",
+        message: "No GitHub team configured for this project — set one on the project page.",
+      };
+    } else {
+      try {
+        const roster = await prisma.staffingAssignment.findMany({
+          where: { staffingCycleId: cycle.id, projectId: project.id, status: "Confirmed" },
+          select: {
+            user: {
+              select: { firstName: true, lastName: true, githubUsername: true },
+            },
+          },
+        });
+        // Distinct usernames among the roster; collect those missing a handle
+        // so the lead knows who to follow up with.
+        const withHandle = new Set<string>();
+        const missing: string[] = [];
+        for (const r of roster) {
+          const handle = r.user.githubUsername?.trim();
+          if (handle) withHandle.add(handle);
+          else missing.push(`${r.user.firstName} ${r.user.lastName}`);
+        }
+
+        const team = await ensureTeam(project.githubTeamSlug);
+        for (const username of withHandle) {
+          await addTeamMember(team.slug, username);
+        }
+
+        const parts = [
+          `${team.created ? "Created" : "Updated"} team "${team.slug}"`,
+          `added ${withHandle.size} member${withHandle.size === 1 ? "" : "s"}`,
+        ];
+        if (missing.length > 0) {
+          parts.push(`skipped ${missing.length} with no GitHub username (${missing.join(", ")})`);
+        }
+        results.github = { status: "ok", message: `${parts.join("; ")}.` };
+      } catch (err) {
+        results.github = { status: "error", message: errMsg(err) };
+      }
+    }
   }
 
   await logAuditEvent({

--- a/dali-api/app/projects/routes/projects.$id.tsx
+++ b/dali-api/app/projects/routes/projects.$id.tsx
@@ -84,6 +84,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
       calendarEmail: true,
       imageUrl: true,
       repoUrls: true,
+      githubTeamSlug: true,
       overviewPageId: true,
       prdPageId: true,
       projectTerms: {
@@ -430,6 +431,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
       calendarEmail: project.calendarEmail,
       imageUrl: project.imageUrl,
       repoUrls: project.repoUrls,
+      githubTeamSlug: project.githubTeamSlug,
       overviewPageId: project.overviewPageId,
       prdPageId: project.prdPageId,
       startTerm,
@@ -610,6 +612,17 @@ export async function action({ request, params }: Route.ActionArgs) {
   const imageUrlRaw = (form.get("imageUrl") as string | null)?.trim() ?? "";
   const repoUrlsRaw = (form.get("repoUrls") as string | null) ?? "";
   const termCountRaw = (form.get("termCount") as string | null) ?? "";
+  const githubTeamRaw = (form.get("githubTeamSlug") as string | null)?.trim() ?? "";
+
+  // Normalize to a GitHub-safe team slug: lowercase, non-alphanumerics → single
+  // hyphens, trimmed. Empty clears the field (automation then skips).
+  const githubTeamSlug =
+    githubTeamRaw === ""
+      ? null
+      : githubTeamRaw
+          .toLowerCase()
+          .replace(/[^a-z0-9]+/g, "-")
+          .replace(/^-+|-+$/g, "");
 
   // repoUrls textarea: one URL per line, blanks dropped.
   const repoUrls = repoUrlsRaw
@@ -629,6 +642,7 @@ export async function action({ request, params }: Route.ActionArgs) {
       imageUrl: imageUrlRaw === "" ? null : imageUrlRaw,
       repoUrls,
       termCount,
+      githubTeamSlug,
     },
   });
   return redirect(`/projects/${params.id}`);
@@ -1244,6 +1258,23 @@ function DetailsSegment({
               ) : (
                 <span className="px-2 py-1.5 text-sm text-foreground">
                   {project.imageUrl ?? "—"}
+                </span>
+              )}
+            </label>
+
+            <label className="flex flex-col gap-1 text-xs">
+              <span className="text-muted-foreground">GitHub team</span>
+              {editing ? (
+                <input
+                  name="githubTeamSlug"
+                  type="text"
+                  defaultValue={project.githubTeamSlug ?? ""}
+                  placeholder="project-team-name"
+                  className="px-2 py-1.5 text-sm border border-border rounded-md bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-accent-coral/30"
+                />
+              ) : (
+                <span className="px-2 py-1.5 text-sm text-foreground">
+                  {project.githubTeamSlug ?? "—"}
                 </span>
               )}
             </label>

--- a/dali-api/app/projects/routes/projects.intent-to-work.tsx
+++ b/dali-api/app/projects/routes/projects.intent-to-work.tsx
@@ -174,10 +174,21 @@ export async function action({ request }: Route.ActionArgs) {
   if (!(await canManageStaffing(auth.user.sub)))
     return Response.json({ error: "Forbidden" }, { status: 403 });
 
-  const term = await currentTerm();
-  if (!term)
+  // Bind to the cycle for the term the page is VIEWING (?term=), not whatever
+  // term is live today — mirrors the loader's resolution so a binding saved
+  // while viewing a non-live term lands on that term's cycle instead of being
+  // silently written to the current one. Falls back to the current term.
+  const { terms: termOptions, termId: filterTermId } =
+    await resolveTermFilter(request);
+  const fallbackTerm = await currentTerm();
+  const selected =
+    termOptions.find((o) => o.id === filterTermId) ??
+    (fallbackTerm
+      ? { id: fallbackTerm.id, code: fallbackTerm.code }
+      : termOptions[0]);
+  if (!selected)
     return Response.json({ error: "No active staffing term." }, { status: 400 });
-  const cycle = await ensureStaffingCycle(term.id, term.code);
+  const cycle = await ensureStaffingCycle(selected.id, selected.code);
 
   const form = await request.formData();
   const intent = String(form.get("intent"));

--- a/dali-api/app/projects/routes/projects.project-bids.tsx
+++ b/dali-api/app/projects/routes/projects.project-bids.tsx
@@ -171,10 +171,22 @@ export async function action({ request }: Route.ActionArgs) {
   if (!(await canManageStaffing(auth.user.sub)))
     return Response.json({ error: "Forbidden" }, { status: 403 });
 
-  const term = await currentTerm();
-  if (!term)
+  // Bind to the cycle for the term the page is VIEWING (?term=), not whatever
+  // term is live today — the loader resolves the cycle the same way, so a
+  // binding saved while viewing 26X must land on 26X, else the picker reloads
+  // empty and the save looks lost. Falls back to the current term when no term
+  // is selected.
+  const { terms: termOptions, termId: filterTermId } =
+    await resolveTermFilter(request);
+  const fallbackTerm = await currentTerm();
+  const selected =
+    termOptions.find((o) => o.id === filterTermId) ??
+    (fallbackTerm
+      ? { id: fallbackTerm.id, code: fallbackTerm.code }
+      : termOptions[0]);
+  if (!selected)
     return Response.json({ error: "No active staffing term." }, { status: 400 });
-  const cycle = await ensureStaffingCycle(term.id, term.code);
+  const cycle = await ensureStaffingCycle(selected.id, selected.code);
 
   const form = await request.formData();
   const intent = String(form.get("intent"));

--- a/dali-api/app/projects/routes/projects.staffing.tsx
+++ b/dali-api/app/projects/routes/projects.staffing.tsx
@@ -58,9 +58,13 @@ export async function loader({ request }: Route.LoaderArgs) {
       .find((t) => t.startDate.getTime() > now) ??
     null;
 
-  const requestedCode = new URL(request.url).searchParams.get("term");
+  // The term is addressed by id, matching the shared TermFilter convention
+  // used by every other term-scoped page (?term=<id>). Honouring a bare code
+  // here would silently miss id-based links from the rest of the app and fall
+  // back to the current term, so a chosen term (e.g. 26S) wouldn't stick.
+  const requestedId = new URL(request.url).searchParams.get("term");
   const selectedTerm =
-    (requestedCode && terms.find((t) => t.code === requestedCode)) ||
+    (requestedId && terms.find((t) => t.id === requestedId)) ||
     currentTermRow ||
     terms[0];
 
@@ -68,7 +72,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     selectedTerm.id,
     selectedTerm.code,
   );
-  const cycleTermCode = selectedTerm.code;
+  const selectedTermId = selectedTerm.id;
 
   // The pool of members on the board is everyone who submitted at least one
   // StaffingPreference for this cycle. Members who didn't bid don't show up.
@@ -139,7 +143,14 @@ export async function loader({ request }: Route.LoaderArgs) {
     prefsByUser.set(p.userId, list);
   }
 
-  const members: MemberInput[] = await Promise.all(users.map(async (u) => ({
+  // Same shape for both pools (members with preferences, and bid-submitters
+  // whose bids resolved to none). preferences/unresolvedBid are passed in
+  // because they differ between the two.
+  const toMemberInput = async (
+    u: (typeof users)[number],
+    preferences: Preference[],
+    unresolvedBid: boolean,
+  ): Promise<MemberInput> => ({
     userId: u.id,
     firstName: u.firstName,
     lastName: u.lastName,
@@ -152,8 +163,51 @@ export async function loader({ request }: Route.LoaderArgs) {
     domainLevels: u.domainEligibilities
       .map((e) => ({ domainName: e.domain.displayName, level: e.level as Level }))
       .sort((a, b) => a.domainName.localeCompare(b.domainName)),
-    preferences: prefsByUser.get(u.id) ?? [],
-  })));
+    preferences,
+    unresolvedBid,
+  });
+
+  const members: MemberInput[] = await Promise.all(
+    users.map((u) => toMemberInput(u, prefsByUser.get(u.id) ?? [], false)),
+  );
+
+  // A member who submitted this cycle's Project Bids form but produced no
+  // StaffingPreference (their picks had no open role in an eligibility domain)
+  // would otherwise vanish — the pool above is preference-derived. Surface them
+  // as flagged Unassigned cards so a staffing lead can act. Only users not
+  // already in the preference pool need adding.
+  const bidSubmitterIds = (
+    await prisma.formSubmission.findMany({
+      where: { staffingCycleId: cycle.id, slot: "project-bids" },
+      select: { userId: true },
+      distinct: ["userId"],
+    })
+  )
+    .map((s) => s.userId)
+    .filter((id): id is string => !!id && !memberUserIds.includes(id));
+
+  if (bidSubmitterIds.length > 0) {
+    const flaggedUsers = await prisma.user.findMany({
+      where: { id: { in: bidSubmitterIds } },
+      select: {
+        id: true,
+        firstName: true,
+        lastName: true,
+        daliEmail: true,
+        dartmouthEmail: true,
+        photoUrl: true,
+        adminMembership: { select: { id: true } },
+        coreAssignments: { select: { leadTitle: true } },
+        domainEligibilities: {
+          select: { level: true, domain: { select: { displayName: true } } },
+        },
+      },
+    });
+    const flagged = await Promise.all(
+      flaggedUsers.map((u) => toMemberInput(u, [], true)),
+    );
+    members.push(...flagged);
+  }
 
   const initialAssignments: Assignment[] = assignmentRows.map((a) => ({
     userId: a.userId,
@@ -198,7 +252,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   return {
     cycle: {
       id: cycle.id,
-      termCode: cycleTermCode,
+      termId: selectedTermId,
     },
     terms: terms.map((t) => ({ id: t.id, code: t.code })),
     canManage,
@@ -248,7 +302,7 @@ export default function StaffingPage() {
 
       <StaffingBoard
         cycleId={data.cycle.id}
-        termCode={data.cycle.termCode}
+        termId={data.cycle.termId}
         terms={data.terms}
         projects={data.projects}
         members={data.members}

--- a/dali-api/app/routes/home.tsx
+++ b/dali-api/app/routes/home.tsx
@@ -39,12 +39,21 @@ export async function loader({ request }: Route.LoaderArgs) {
 
   const items = await prisma.notification.findMany({
     // Hide invites whose meeting was Cancelled — they shouldn't appear in the
-    // banner, just as they're dropped from tasks and the bell.
+    // banner, just as they're dropped from tasks and the bell. Also hide
+    // already-answered invites (Accepted/Declined/Tentative): once the user has
+    // RSVP'd, the card has served its purpose and shouldn't linger.
     where: {
       recipientUserId: auth.user.sub,
-      OR: [
-        { scheduledMeetingId: null },
-        { scheduledMeeting: { status: { not: "Cancelled" } } },
+      AND: [
+        {
+          OR: [
+            { scheduledMeetingId: null },
+            { scheduledMeeting: { status: { not: "Cancelled" } } },
+          ],
+        },
+        {
+          OR: [{ scheduledMeetingId: null }, { rsvp: null }],
+        },
       ],
     },
     orderBy: { createdAt: "desc" },
@@ -143,9 +152,7 @@ export default function Home() {
         </p>
       </header>
 
-      {(tasks.length > 0 || notifications.length > 0) && (
-        <AttentionBanner tasks={tasks} notifications={notifications} />
-      )}
+      <AttentionBanner tasks={tasks} notifications={notifications} />
 
       <div className="flex flex-col gap-6">
         <WeekCalendarPanel days={weekDays} events={weekEvents} />
@@ -182,7 +189,22 @@ function AttentionBanner({
   // list. Drop those duplicates — the task card is the richer rendering
   // (deadline + form link) — so each item shows once.
   const taskIds = new Set(tasks.map((t) => t.id));
-  const extraNotifications = notifications.filter((n) => !taskIds.has(n.id));
+  const extraNotifications = notifications.filter((n) => {
+    if (taskIds.has(n.id)) return false;
+    // A read notification still belongs on the banner only when it's a meeting
+    // invite: we keep those so the RSVP/status badge stays reachable. Every
+    // other read notification (e.g. an interview assignment already opened, so
+    // it's no longer a task) is finished business — its Dismiss can't change
+    // anything server-side, so the card would just sit here un-clearable. Drop
+    // it so Dismiss actually removes it for good on revalidate.
+    if (n.readAt && n.kind !== "MeetingInvite") return false;
+    return true;
+  });
+
+  // Nothing to surface once duplicates and finished (read, non-invite)
+  // notifications are filtered out — render nothing rather than an empty
+  // banner with a bare header.
+  if (tasks.length === 0 && extraNotifications.length === 0) return null;
 
   // "Needs attention" = open tasks + unread non-task notifications. Read
   // notifications still render below (so RSVP stays reachable) but don't
@@ -476,10 +498,29 @@ function RsvpButtons({
 }
 
 function NotificationCard({ notification }: { notification: HomeNotification }) {
+  const revalidator = useRevalidator();
   const isUnread = !notification.readAt;
   const isInvite = notification.kind === "MeetingInvite" && !!notification.scheduledMeetingId;
   const accent = isUnread ? "border-l-accent-coral" : "border-l-accent-teal";
   const [rsvp, setRsvp] = useState<HomeNotification["rsvp"]>(notification.rsvp);
+  const [dismissing, setDismissing] = useState(false);
+
+  // Invites clear by RSVP, never by dismiss (the /read endpoint exempts them),
+  // so the Dismiss control is offered for every other notification. It marks
+  // the row read and revalidates, dropping the card from the banner.
+  async function dismiss() {
+    setDismissing(true);
+    try {
+      await fetch(`/api/notifications/${notification.id}/read`, {
+        method: "POST",
+        credentials: "include",
+      });
+      revalidator.revalidate();
+      notifyTasksChanged();
+    } catch {
+      setDismissing(false);
+    }
+  }
 
   return (
     <div
@@ -488,38 +529,52 @@ function NotificationCard({ notification }: { notification: HomeNotification }) 
       <div className="min-w-0 flex-1">
         <div className="flex items-center justify-between gap-2">
           <span className="text-sm font-semibold text-foreground truncate">{notification.title}</span>
-          {notification.link && (
-            <a
-              href={notification.link}
-              onClick={(e) => {
-                if (!notification.readAt) {
-                  // keepalive: true so the POST survives the navigation
-                  // that the anchor's default action is about to start.
-                  fetch(`/api/notifications/${notification.id}/read`, {
-                    method: "POST",
-                    credentials: "include",
-                    keepalive: true,
-                  });
-                }
-                // If we're inside a TabWorkspace iframe, ask the parent to
-                // open the link as a new tab instead of letting it navigate
-                // the iframe (which strands the user in chrome-less embed
-                // mode with no way back).
-                const link = notification.link!;
-                if (link.startsWith("/") && window.self !== window.top) {
-                  e.preventDefault();
-                  window.parent.postMessage(
-                    { type: "dali:openTab", url: link, label: notification.title },
-                    window.location.origin,
-                  );
-                }
-              }}
-              className="text-muted-foreground hover:text-foreground"
-              aria-label="Open linked page"
-            >
-              <ExternalLink className="w-3.5 h-3.5" />
-            </a>
-          )}
+          <div className="flex items-center gap-1.5 flex-shrink-0">
+            {notification.link && (
+              <a
+                href={notification.link}
+                onClick={(e) => {
+                  if (!notification.readAt) {
+                    // keepalive: true so the POST survives the navigation
+                    // that the anchor's default action is about to start.
+                    fetch(`/api/notifications/${notification.id}/read`, {
+                      method: "POST",
+                      credentials: "include",
+                      keepalive: true,
+                    });
+                  }
+                  // If we're inside a TabWorkspace iframe, ask the parent to
+                  // open the link as a new tab instead of letting it navigate
+                  // the iframe (which strands the user in chrome-less embed
+                  // mode with no way back).
+                  const link = notification.link!;
+                  if (link.startsWith("/") && window.self !== window.top) {
+                    e.preventDefault();
+                    window.parent.postMessage(
+                      { type: "dali:openTab", url: link, label: notification.title },
+                      window.location.origin,
+                    );
+                  }
+                }}
+                className="text-muted-foreground hover:text-foreground"
+                aria-label="Open linked page"
+              >
+                <ExternalLink className="w-3.5 h-3.5" />
+              </a>
+            )}
+            {!isInvite && (
+              <button
+                type="button"
+                onClick={dismiss}
+                disabled={dismissing}
+                className="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium rounded-md border border-border text-foreground hover:bg-muted disabled:opacity-50"
+                aria-label="Dismiss notification"
+              >
+                <Check className="w-3 h-3" />
+                {dismissing ? "Dismissing…" : "Dismiss"}
+              </button>
+            )}
+          </div>
         </div>
         {notification.body && (
           <p className="text-xs text-muted-foreground mt-0.5 line-clamp-2">{notification.body}</p>

--- a/dali-api/app/slack/lib/__tests__/github-teams.test.ts
+++ b/dali-api/app/slack/lib/__tests__/github-teams.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  ensureTeam,
+  addTeamMember,
+  __setGitHubClientForTests,
+} from "~/slack/lib/github-app";
+import type { Octokit } from "@octokit/rest";
+
+// Minimal fake of the Octokit surface the team helpers touch.
+function fakeOctokit(overrides: {
+  getByName?: ReturnType<typeof vi.fn>;
+  create?: ReturnType<typeof vi.fn>;
+  addMembership?: ReturnType<typeof vi.fn>;
+}) {
+  return {
+    rest: {
+      teams: {
+        getByName: overrides.getByName ?? vi.fn(),
+        create: overrides.create ?? vi.fn(),
+        addOrUpdateMembershipForUserInOrg: overrides.addMembership ?? vi.fn(),
+      },
+    },
+  } as unknown as Octokit;
+}
+
+const notFound = Object.assign(new Error("Not Found"), { status: 404 });
+
+beforeEach(() => {
+  process.env.GITHUB_ORG = "dali-test-org";
+});
+afterEach(() => {
+  __setGitHubClientForTests(null);
+  delete process.env.GITHUB_ORG;
+});
+
+describe("ensureTeam", () => {
+  it("returns an existing team without recreating it (idempotent re-run)", async () => {
+    const getByName = vi.fn().mockResolvedValue({ data: { slug: "alpha" } });
+    const create = vi.fn();
+    __setGitHubClientForTests(fakeOctokit({ getByName, create }));
+
+    const res = await ensureTeam("alpha");
+    expect(res).toEqual({ slug: "alpha", created: false });
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it("creates a closed team when none exists (404 → create)", async () => {
+    const getByName = vi.fn().mockRejectedValue(notFound);
+    const create = vi.fn().mockResolvedValue({ data: { slug: "beta" } });
+    __setGitHubClientForTests(fakeOctokit({ getByName, create }));
+
+    const res = await ensureTeam("beta");
+    expect(res).toEqual({ slug: "beta", created: true });
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({ org: "dali-test-org", name: "beta", privacy: "closed" }),
+    );
+  });
+
+  it("propagates non-404 errors instead of creating", async () => {
+    const getByName = vi.fn().mockRejectedValue(
+      Object.assign(new Error("boom"), { status: 500 }),
+    );
+    const create = vi.fn();
+    __setGitHubClientForTests(fakeOctokit({ getByName, create }));
+
+    await expect(ensureTeam("gamma")).rejects.toThrow("boom");
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it("throws when GITHUB_ORG is unset", async () => {
+    delete process.env.GITHUB_ORG;
+    __setGitHubClientForTests(fakeOctokit({}));
+    await expect(ensureTeam("delta")).rejects.toThrow("GITHUB_ORG");
+  });
+});
+
+describe("addTeamMember", () => {
+  it("adds a member with role 'member' (PUT is idempotent)", async () => {
+    const addMembership = vi.fn().mockResolvedValue({});
+    __setGitHubClientForTests(fakeOctokit({ addMembership }));
+
+    await addTeamMember("alpha", "octocat");
+    expect(addMembership).toHaveBeenCalledWith({
+      org: "dali-test-org",
+      team_slug: "alpha",
+      username: "octocat",
+      role: "member",
+    });
+  });
+});

--- a/dali-api/app/slack/lib/github-app.ts
+++ b/dali-api/app/slack/lib/github-app.ts
@@ -55,3 +55,57 @@ export async function createIssue(args: { title: string; body: string }): Promis
   return { number: res.data.number, htmlUrl: res.data.html_url };
 }
 
+// ─── Org teams (staffing finalize) ───────────────────────────────────────────
+// These require the GitHub App to have org "Members: write" and to be installed
+// on GITHUB_ORG. The org login is read here (not passed in) so callers can't
+// target an arbitrary org.
+
+function requireOrg(): string {
+  const org = process.env.GITHUB_ORG;
+  if (!org) throw new Error("GITHUB_ORG is not set");
+  return org;
+}
+
+// Get-or-create a team by slug under GITHUB_ORG. Idempotent: an existing team
+// is returned untouched (we never recreate or modify its settings on re-run).
+// New teams are created `closed` (visible to the org, membership controlled).
+export async function ensureTeam(slug: string): Promise<{ slug: string; created: boolean }> {
+  const org = requireOrg();
+  const gh = githubAppClient();
+  try {
+    const existing = await gh.rest.teams.getByName({ org, team_slug: slug });
+    return { slug: existing.data.slug, created: false };
+  } catch (err) {
+    if (!isNotFound(err)) throw err;
+  }
+  // `name` is what GitHub slugifies; passing the slug as the name keeps the
+  // resulting slug stable for a simple input.
+  const created = await gh.rest.teams.create({
+    org,
+    name: slug,
+    privacy: "closed",
+  });
+  return { slug: created.data.slug, created: true };
+}
+
+// Add (or confirm) a member on a team. PUT is idempotent — re-adding an
+// existing member is a no-op that returns 200. Role defaults to "member".
+export async function addTeamMember(teamSlug: string, username: string): Promise<void> {
+  const org = requireOrg();
+  await githubAppClient().rest.teams.addOrUpdateMembershipForUserInOrg({
+    org,
+    team_slug: teamSlug,
+    username,
+    role: "member",
+  });
+}
+
+function isNotFound(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "status" in err &&
+    (err as { status?: number }).status === 404
+  );
+}
+

--- a/dali-api/prisma/migrations/20260525180000_add_github_team_and_username/migration.sql
+++ b/dali-api/prisma/migrations/20260525180000_add_github_team_and_username/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Project" ADD COLUMN "githubTeamSlug" TEXT;
+
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN "githubUsername" TEXT;

--- a/dali-api/prisma/schema.prisma
+++ b/dali-api/prisma/schema.prisma
@@ -56,6 +56,11 @@ model User {
   hometown     String?
   linkedinUrl  String?
   githubUrl    String?
+  // Bare GitHub login (e.g. "octocat"), distinct from githubUrl (a display
+  // link). Used to add the member to their project's GitHub team during
+  // staffing finalize. Editable in member details; nullable — a member with no
+  // username is silently skipped (and reported) by that automation.
+  githubUsername String?
   personalSite String?
 
   // ─── Relations: existing ──────────────────────────────────────────────────
@@ -1822,6 +1827,12 @@ model Project {
 
   // Git repositories for this project (URLs). Empty by default.
   repoUrls String[] @default([])
+
+  // GitHub team slug for this project's org team, persistent across terms.
+  // Set on the project detail page. When present, the staffing "Set up GitHub
+  // teams" finalize automation get-or-creates a team with this slug under
+  // GITHUB_ORG and adds the confirmed roster. Null = automation skips.
+  githubTeamSlug String?
 
   overviewPage Page? @relation("ProjectOverview", fields: [overviewPageId], references: [id])
   prdPage      Page? @relation("ProjectPRD", fields: [prdPageId], references: [id])


### PR DESCRIPTION
## Summary

Staffing project bids were silently resolving to zero `StaffingPreference` rows, so members who submitted bids never appeared on the staffing board. This fixes the root causes and finishes the GitHub-team finalize automation.

### Bid resolution fixes
- **Wrong-cycle writes:** bid/intent submissions and slot-binding saves used `currentTerm()` instead of the term being viewed, landing on the wrong (or no) cycle. Submissions now feed the cycle the form is *bound* to (`pickStaffingBinding`); the project-bids / intent-to-work route **actions** resolve the cycle from `?term=` like their loaders do.
- **Biddability is now domain-driven:** `validateBids` matches a bid against a project's declared domains (`ProjectDomain`) ∩ the member's eligibility, with level from `DomainEligibility`. `ProjectRoleRequest` had no creation UI (only partner promotion, earliest-term-only) and is now headcount-**display** only — it no longer gates whether a bid resolves.
- **No more silent hard-rejects:** duplicate project picks de-duplicate (keep highest rank), too many bids cap at `maxBids`, and no-eligibility records zero bids instead of erroring. These previously erased the member entirely.
- **Flagged cards:** bid-submitters who still produce no preference surface as "Bid unresolved" Unassigned cards (derived at load — no schema change).
- Partner-app promotion now inherits a project's `ProjectDomain` set from the role requests it creates.

### GitHub team finalize automation (was a stub)
- New `Project.githubTeamSlug` (editable on the project detail page) and `User.githubUsername` (editable in member details).
- `github-app.ts` gains idempotent `ensureTeam` (privacy `closed`) + `addTeamMember`.
- `/api/staffing/finalize` get-or-creates the project's team under `GITHUB_ORG` and adds the confirmed roster — never removing anyone, skipping + reporting members with no stored handle. Gated on `GITHUB_ORG`.
- **Gmail / Google Workspace provisioning stays an explicit stub** (needs an Admin SDK service account with domain-wide delegation that doesn't exist yet).

### Hygiene
- `.gitignore` now ignores all `.env*` except `.env.example` — prod secrets were previously committable.
- `GITHUB_ORG` documented in `.env.example`.

## Migration
`20260525180000_add_github_team_and_username` — two **nullable** columns (`Project.githubTeamSlug`, `User.githubUsername`). No data loss. Applied + verified against a local dev DB; `prisma migrate status` reports no drift.

## Operational note (done separately, not in this PR)
A one-off backfill recovered already-submitted bids for Tuna Ozturk and Alexander Carney in prod under the new rules (the script is intentionally **not** included here).

## Reviewer notes / live prerequisites
- The GitHub automation's live path is unit-tested against a fake Octokit but has **not** hit the real org. Before relying on it: the GitHub App needs org **`Members: write`** and must be installed on `GITHUB_ORG`. Suggest a dry run on one project post-deploy.
- `app/routes/home.tsx` (notification-dismiss) is pre-existing work bundled in at the author's request.

## Test plan
- `npm run typecheck` — clean (25 pre-existing `scripts/` errors only; zero new).
- `npm test` — **1008 passing** (117 files), incl. new `bid-validation`, `form-slots`, and `github-teams` suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/696"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782339359&installation_id=133523038&pr_number=696&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F696&signature=6dc06e3936c6d28679181b41439c20f85dbf28b2bd97c488a1cb4c6396ae7f33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->