### PR TITLE
Fellowship: editable close date while Open + persistent attention-banner item

### DIFF
--- a/dali-api/app/hiring/routes/lead.intern-to-full-cycle.$id.tsx
+++ b/dali-api/app/hiring/routes/lead.intern-to-full-cycle.$id.tsx
@@ -148,6 +148,22 @@ export async function action({ request, params }: Route.ActionArgs) {
       const [y, m, d] = closeDate.split("-").map(Number);
       parsedClose = zonedDayEndUtc(y, m, d, APPLICATION_TZ);
     }
+    // While the cycle is Open, a past close date would immediately flip the
+    // cycle to UnderReview on the next loader hit (autoCloseIfExpired). That's
+    // almost never what a lead means when editing a live cycle, so reject it.
+    if (parsedClose && parsedClose.getTime() < Date.now()) {
+      const latest = await prisma.applicationCycleStatusUpdate.findFirst({
+        where: { applicationCycleId: cycleId },
+        orderBy: { createdAt: "desc" },
+        select: { newStatus: true },
+      });
+      if (latest?.newStatus === "Open") {
+        return Response.json(
+          { error: "Close date is in the past. Pick a future date, or close the cycle from the status control." },
+          { status: 400 },
+        );
+      }
+    }
     await prisma.applicationCycle.update({
       where: { id: cycleId },
       data: { closeDate: parsedClose },
@@ -342,7 +358,11 @@ export default function InternToFullCycleSetup() {
         <StatusButton cycleId={cycle.id} currentStatus={cycle.status} />
       </header>
 
-      <CloseDateSection cycleId={cycle.id} closeDate={cycle.closeDate} disabled={isOpen} />
+      <CloseDateSection
+        cycleId={cycle.id}
+        closeDate={cycle.closeDate}
+        status={cycle.status}
+      />
 
       <FormVersionSection
         cycleId={cycle.id}
@@ -370,15 +390,15 @@ export default function InternToFullCycleSetup() {
 }
 
 function CloseDateSection({
-  cycleId,
+  cycleId: _cycleId,
   closeDate,
-  disabled,
+  status,
 }: {
   cycleId: string;
   closeDate: string | null;
-  disabled: boolean;
+  status: string;
 }) {
-  const fetcher = useFetcher();
+  const fetcher = useFetcher<{ ok?: boolean; error?: string }>();
   const initial = closeDate
     ? (() => {
         const { year, month, day } = getZonedYMD(new Date(closeDate), APPLICATION_TZ);
@@ -386,6 +406,12 @@ function CloseDateSection({
       })()
     : "";
   const [value, setValue] = useState(initial);
+  // Editable in Draft (cycle setup) and Open (live extensions/shortenings).
+  // Locked once we're in UnderReview/Completed — the application window is
+  // closed and changing the date here wouldn't reopen it.
+  const disabled = status !== "Draft" && status !== "Open";
+  const isOpen = status === "Open";
+  const error = fetcher.data && "error" in fetcher.data ? fetcher.data.error : null;
   return (
     <Section title="Close date" description="When the application window closes for interns.">
       <div className="flex items-center gap-3">
@@ -407,8 +433,13 @@ function CloseDateSection({
         </button>
       </div>
       <p className="mt-2 text-xs text-muted-foreground">
-        Applications stop at 11:59 PM {APPLICATION_TZ_LABEL} on this date.
+        {isOpen
+          ? `Update to extend or shorten this active cycle. Applications stop at 11:59 PM ${APPLICATION_TZ_LABEL} on the selected date. Interns who already received the open-cycle notification may still see the old date.`
+          : `Applications stop at 11:59 PM ${APPLICATION_TZ_LABEL} on this date.`}
       </p>
+      {error && (
+        <p className="mt-2 text-xs text-red-700">{error}</p>
+      )}
     </Section>
   );
 }

--- a/dali-api/app/lib/tasks.ts
+++ b/dali-api/app/lib/tasks.ts
@@ -1,5 +1,7 @@
 import type { Prisma } from "~/generated/prisma/client";
 import { prisma } from "~/lib/db";
+import { getActiveCycle } from "~/hiring/lib/cycles";
+import { isInternToFullEligible } from "~/hiring/lib/intern-eligibility";
 
 // A "task" (todo) is any unread notification — every NotificationKind counts.
 // The Tasks sidebar, Home attention banner, and sidebar count all read this
@@ -77,31 +79,73 @@ const TASK_WHERE = (userId: string): Prisma.NotificationWhereInput => ({
 
 /** Count of open tasks for a user. Cheap — used by the sidebar poller. */
 export async function countOpenTasks(userId: string): Promise<number> {
-  return prisma.notification.count({ where: TASK_WHERE(userId) });
+  const [notifs, fellowship] = await Promise.all([
+    prisma.notification.count({ where: TASK_WHERE(userId) }),
+    getFellowshipTask(userId),
+  ]);
+  return notifs + (fellowship ? 1 : 0);
+}
+
+/**
+ * Synthetic "apply to the fellowship" task for current interns when an
+ * InternToFull cycle is Open and they haven't finished their application. This
+ * is not a Notification row — it's derived state, so it persists in the
+ * attention banner across reloads until the user submits or withdraws.
+ */
+export async function getFellowshipTask(userId: string): Promise<Task | null> {
+  if (!(await isInternToFullEligible(userId))) return null;
+  const cycle = await getActiveCycle("InternToFull");
+  if (!cycle || cycle.currentStatus !== "Open") return null;
+
+  const app = await prisma.application.findFirst({
+    where: { userId, applicationCycleId: cycle.id },
+    select: {
+      id: true,
+      statusUpdates: { orderBy: { createdAt: "desc" }, take: 1, select: { newStatus: true, createdAt: true } },
+    },
+  });
+  const status = app?.statusUpdates[0]?.newStatus ?? null;
+  if (status === "Submitted" || status === "Withdrawn") return null;
+
+  const isDraft = status === "Draft";
+  return {
+    id: `fellowship-${cycle.id}`,
+    title: isDraft ? "Continue your fellowship application" : "Apply to the fellowship",
+    body: cycle.name,
+    link: "/intern-to-full",
+    createdAt: (app?.statusUpdates[0]?.createdAt ?? new Date()).toISOString(),
+    source: "general",
+    dueAt: cycle.closeDate ? cycle.closeDate.toISOString() : null,
+    // Clears by self-action (submit / withdraw in /intern-to-full) — no Confirm button.
+    hasAction: true,
+  };
 }
 
 /** Open tasks for a user, newest first, with deadlines resolved. */
 export async function listOpenTasks(userId: string): Promise<Task[]> {
-  const rows = await prisma.notification.findMany({
-    where: TASK_WHERE(userId),
-    orderBy: { createdAt: "desc" },
-    take: 50,
-    select: {
-      id: true,
-      kind: true,
-      title: true,
-      body: true,
-      link: true,
-      dueAt: true,
-      createdAt: true,
-      scheduledMeetingId: true,
-      scheduledMeeting: { select: { selectedAt: true } },
-      // Attached published form, if any — link the recipient straight to it.
-      form: { select: { published: true, publicToken: true } },
-    },
-  });
+  const [rows, fellowship] = await Promise.all([
+    prisma.notification.findMany({
+      where: TASK_WHERE(userId),
+      orderBy: { createdAt: "desc" },
+      take: 50,
+      select: {
+        id: true,
+        kind: true,
+        title: true,
+        body: true,
+        link: true,
+        dueAt: true,
+        createdAt: true,
+        scheduledMeetingId: true,
+        scheduledMeeting: { select: { selectedAt: true } },
+        // Attached published form, if any — link the recipient straight to it.
+        form: { select: { published: true, publicToken: true } },
+      },
+    }),
+    getFellowshipTask(userId),
+  ]);
 
-  return rows.map((n) => {
+  const notifTasks = rows.map((n) => {
     const source: Task["source"] =
       n.kind === "MeetingInvite"
         ? "meeting"
@@ -138,4 +182,6 @@ export async function listOpenTasks(userId: string): Promise<Task[]> {
       hasAction,
     };
   });
+
+  return fellowship ? [fellowship, ...notifTasks] : notifTasks;
 }


### PR DESCRIPTION
## Summary

- **(A) Editable close date while Open.** Leads can now extend or shorten an InternToFull cycle's deadline after it's gone Open (previously disabled). Past dates are rejected while Open to avoid an immediate auto-flip to UnderReview; the helper copy adapts to the live-edit state so leads know applicants may still see the old date in their original "cycle is open" notification.
- **(B) Persistent fellowship task in the attention banner.** Eligible interns now see a synthetic "Apply to the fellowship" / "Continue your fellowship application" task in the home attention banner while a cycle is Open. It persists across reloads (vs. vanishing the moment the original open-cycle notification is read) and clears once they submit or withdraw. Threaded through both `listOpenTasks` and `countOpenTasks` so the sidebar count stays consistent.

No schema changes. No changes to `home.tsx`, `AttentionBanner`, or `TaskCard` — the synthetic task slots into the existing render path.

## Test plan

- [ ] Lead flow: push an InternToFull cycle to Open → close-date picker is editable; future date saves; past date returns inline 400 with clear message.
- [ ] Lead flow: bounce cycle Open → Draft → picker still editable (regression).
- [ ] Lead flow: move cycle to UnderReview → picker locked.
- [ ] Eligible intern, no draft: load `/` → fellowship task in banner with cycle name as body, deadline chip in ET.
- [ ] Eligible intern, draft saved: task title reads "Continue your fellowship application".
- [ ] Eligible intern, submitted: task is gone; sidebar count drops.
- [ ] Non-eligible member: no fellowship task surfaces.
- [ ] No active Open cycle: no fellowship task surfaces.
- [ ] `npm run typecheck` clean for changed files; `npm test` passes.

## Follow-ups (deliberately deferred)

- Notification to applicants when the close date is changed mid-cycle (their original "Apply by X" message will be stale). Likely worth doing for material shifts.
- Standard-cycle-style extension semantics (`originalCloseDate`, "extend 48h", "remove extension"). Not requested for this PR.
- Surfacing decision status as a separate "decisions inbox" task once cycle moves to UnderReview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/698"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782354446&installation_id=133523038&pr_number=698&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F698&signature=3672051af411ecfa9a7a497e7d5980c50865b114c52e1576c95a0d683ecb63f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->