### PR TITLE
Hiring/staffing UX fixes + bid resolution (+ WIP rubric versioning)

### DIFF
--- a/dali-api/app/components/CollaborativeEditor.tsx
+++ b/dali-api/app/components/CollaborativeEditor.tsx
@@ -69,6 +69,33 @@ export type InlineCommentOpts = {
 
 const commentDecoKey = new PluginKey("inlineCommentDecorations");
 
+// In a contenteditable ProseMirror editor, Tab is not bound by default, so the
+// browser treats it as focus traversal and moves focus out of the editor — to
+// the user it looks like Tab "can't be typed." Bind it: inside a list, Tab/
+// Shift-Tab indent/outdent the item (the Notion/Docs behavior); anywhere else
+// Tab inserts a literal tab character. Returning true in every branch stops the
+// focus-escape default.
+const TabKeymap = Extension.create({
+  name: "tabKeymap",
+  addKeyboardShortcuts() {
+    return {
+      Tab: ({ editor }) => {
+        if (editor.can().sinkListItem("listItem")) {
+          return editor.chain().focus().sinkListItem("listItem").run();
+        }
+        return editor.chain().focus().insertContent("\t").run();
+      },
+      "Shift-Tab": ({ editor }) => {
+        if (editor.can().liftListItem("listItem")) {
+          return editor.chain().focus().liftListItem("listItem").run();
+        }
+        // Nothing to outdent outside a list; swallow it so focus stays put.
+        return true;
+      },
+    };
+  },
+});
+
 // Custom cursor/selection builders so we can add an `.idle` class — the
 // default builders don't know about our `idle` flag.
 function buildCursor(user: AwarenessUser, _clientId: number): HTMLElement {
@@ -349,6 +376,7 @@ function CollaborativeEditorInner({
         undoRedo: false,
       }),
       Placeholder.configure({ placeholder }),
+      TabKeymap,
       createCollabExtension(entry.fragment, entry.provider),
       ...(inlineComments?.enabled
         ? [

--- a/dali-api/app/components/NavigationProgress.tsx
+++ b/dali-api/app/components/NavigationProgress.tsx
@@ -1,0 +1,91 @@
+import { useEffect, useRef, useState } from "react";
+import { useNavigation } from "react-router";
+
+// A slim top-of-viewport progress bar shown during client-side route
+// transitions. Mounted once at the document root (root.tsx), so it covers
+// every page — the applicant portal, the main shell, and the pages loaded
+// inside each workspace iframe (each iframe is its own document and runs its
+// own copy of this bar).
+//
+// The bar eases toward — but never reaches — 100% while loading (real
+// completion time is unknown), then snaps to full and fades out once the
+// navigation settles. A short entry delay avoids flashing the bar for
+// instant transitions.
+export function NavigationProgress() {
+  const navigation = useNavigation();
+  const isLoading = navigation.state !== "idle";
+
+  // visible drives mount + fade; progress is the width %.
+  const [visible, setVisible] = useState(false);
+  const [progress, setProgress] = useState(0);
+  const trickleRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const showTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    const clearTrickle = () => {
+      if (trickleRef.current) {
+        clearInterval(trickleRef.current);
+        trickleRef.current = null;
+      }
+    };
+
+    if (isLoading) {
+      if (hideTimerRef.current) clearTimeout(hideTimerRef.current);
+      // Don't flash for transitions that resolve almost immediately.
+      showTimerRef.current = setTimeout(() => {
+        setVisible(true);
+        setProgress(8);
+        clearTrickle();
+        // Trickle toward 90% with diminishing steps so it always looks like
+        // progress without ever completing on its own.
+        trickleRef.current = setInterval(() => {
+          setProgress((p) => (p >= 90 ? p : p + (90 - p) * 0.12));
+        }, 200);
+      }, 120);
+
+      return () => {
+        if (showTimerRef.current) clearTimeout(showTimerRef.current);
+      };
+    }
+
+    // Settled. Cancel a pending show; if the bar is up, complete and fade it.
+    if (showTimerRef.current) clearTimeout(showTimerRef.current);
+    clearTrickle();
+    setVisible((wasVisible) => {
+      if (!wasVisible) return false;
+      setProgress(100);
+      hideTimerRef.current = setTimeout(() => {
+        setVisible(false);
+        setProgress(0);
+      }, 280);
+      return true;
+    });
+  }, [isLoading]);
+
+  useEffect(
+    () => () => {
+      if (trickleRef.current) clearInterval(trickleRef.current);
+      if (showTimerRef.current) clearTimeout(showTimerRef.current);
+      if (hideTimerRef.current) clearTimeout(hideTimerRef.current);
+    },
+    [],
+  );
+
+  if (!visible && progress === 0) return null;
+
+  return (
+    <div
+      aria-hidden
+      className="fixed inset-x-0 top-0 z-[100] h-0.5 pointer-events-none"
+    >
+      <div
+        className="h-full bg-grad-teal shadow-[0_0_8px_var(--color-accent-teal)] transition-[width,opacity] duration-200 ease-out motion-reduce:transition-none"
+        style={{
+          width: `${progress}%`,
+          opacity: visible ? 1 : 0,
+        }}
+      />
+    </div>
+  );
+}

--- a/dali-api/app/components/TabWorkspace.tsx
+++ b/dali-api/app/components/TabWorkspace.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { X, Maximize2, SplitSquareHorizontal } from 'lucide-react'
+import { X, Maximize2, SplitSquareHorizontal, Loader2 } from 'lucide-react'
 
 export interface OpenTabRequest {
   url: string
@@ -21,7 +21,16 @@ export interface TabWorkspaceHandle {
 interface Tab {
   id: string
   label: string
+  // Where the tab's iframe currently is. Drifts as the user navigates links
+  // inside the iframe (kept in sync via the `dali:tabNavigated` message), and
+  // is persisted so reopening the workspace restores the last page viewed.
+  // NOT fed back into the live iframe's src — see `seedUrlsRef` — so updating
+  // it never reloads the iframe and loses its back/forward history.
   url: string
+  // The section URL the tab was opened from (e.g. /hiring/reviewer). Stable
+  // for the tab's life. Used to dedupe sidebar clicks so re-clicking a section
+  // focuses the already-open tab even after it has drifted to a sub-page.
+  origin: string
   lastActivatedAt: number
 }
 
@@ -36,7 +45,7 @@ interface WorkspaceState {
   focusedPaneId: string
 }
 
-const STORAGE_KEY = 'dali:tabworkspace:v2'
+const STORAGE_KEY = 'dali:tabworkspace:v3'
 const MAX_TABS_PER_PANE = 10
 
 function newId() {
@@ -79,7 +88,15 @@ function loadState(): WorkspaceState {
     if (!raw) return emptyState()
     const parsed = JSON.parse(raw)
     if (!isValidState(parsed)) return emptyState()
-    return parsed
+    // `origin` was added after `url`; backfill it from `url` for any tab
+    // persisted before the field existed so dedup/highlighting keep working.
+    return {
+      ...parsed,
+      panes: parsed.panes.map((p) => ({
+        ...p,
+        tabs: p.tabs.map((t) => (t.origin ? t : { ...t, origin: t.url })),
+      })),
+    }
   } catch {
     return emptyState()
   }
@@ -102,9 +119,12 @@ function appendWithLruCap(tabs: Tab[], protectedTabId: string): Tab[] {
   return [...tabs.slice(0, victimIdx), ...tabs.slice(victimIdx + 1)]
 }
 
+// Locate an open tab for `url`, matching on either its origin (so re-clicking
+// a sidebar section focuses a tab that has since drifted to a sub-page) or its
+// current url (so re-opening the exact deep link focuses it too).
 function findTabPane(state: WorkspaceState, url: string): { paneId: string; tabId: string } | null {
   for (const pane of state.panes) {
-    const tab = pane.tabs.find((t) => t.url === url)
+    const tab = pane.tabs.find((t) => t.origin === url || t.url === url)
     if (tab) return { paneId: pane.id, tabId: tab.id }
   }
   return null
@@ -159,6 +179,28 @@ export function TabWorkspace({ initialTabs, apiRef, onActiveUrlChange }: TabWork
   // Lazy-mount on first activation — avoids slamming the server on hydrate
   // when many tabs were persisted across sessions.
   const [mountedTabIds, setMountedTabIds] = useState<Set<string>>(() => new Set())
+  // Tab ids whose iframe document has finished its initial load. Drives the
+  // per-pane loading overlay: a mounted-but-not-yet-loaded tab shows a spinner
+  // until its iframe's onLoad fires. (In-iframe React Router navigations are
+  // covered separately by the root NavigationProgress bar.)
+  const [loadedTabIds, setLoadedTabIds] = useState<Set<string>>(() => new Set())
+
+  // The URL each iframe was mounted with. Captured once per tab (the first
+  // time it mounts) and used as the iframe `src`, so updating the tab's live
+  // `url` as the user navigates inside the iframe never re-points `src` and
+  // reloads the frame (which would wipe its back/forward history). A fresh
+  // page load re-seeds from the persisted `url`, restoring the last page.
+  const seedUrlsRef = useRef<Map<string, string>>(new Map())
+  const seedFor = (tab: Tab): string => {
+    const existing = seedUrlsRef.current.get(tab.id)
+    if (existing !== undefined) return existing
+    seedUrlsRef.current.set(tab.id, tab.url)
+    return tab.url
+  }
+
+  // tabId → its <iframe>, so a `dali:tabNavigated` message can be attributed
+  // to the right tab by matching the message's source window.
+  const iframeElsRef = useRef<Map<string, HTMLIFrameElement>>(new Map())
 
   // Hydrate from localStorage on first client render.
   useEffect(() => {
@@ -171,6 +213,7 @@ export function TabWorkspace({ initialTabs, apiRef, onActiveUrlChange }: TabWork
         id: newId(),
         label: t.label,
         url: t.url,
+        origin: t.url,
         // Stagger so the last seeded tab is the most recent (it's the active
         // one). The caller orders initial tabs from "anchor" (Home) to
         // "most specific" (the section the user actually navigated to), so
@@ -210,6 +253,7 @@ export function TabWorkspace({ initialTabs, apiRef, onActiveUrlChange }: TabWork
           id: newId(),
           label: target.label,
           url: target.url,
+          origin: target.url,
           lastActivatedAt: now(),
         }
         setState({
@@ -242,6 +286,44 @@ export function TabWorkspace({ initialTabs, apiRef, onActiveUrlChange }: TabWork
     }
   }, [state])
 
+  // Track where each iframe navigates. Embedded pages post `dali:tabNavigated`
+  // with their current location on every in-iframe route change; we attribute
+  // it to a tab by matching the message's source window to that tab's iframe,
+  // then update the tab's live `url` (for persistence + sidebar highlight).
+  // The iframe's `src` is pinned to its mount seed, so this never reloads it.
+  useEffect(() => {
+    function handler(e: MessageEvent) {
+      if (e.origin !== window.location.origin) return
+      const data = e.data
+      if (!data || data.type !== 'dali:tabNavigated' || typeof data.url !== 'string') return
+      let tabId: string | null = null
+      for (const [id, el] of iframeElsRef.current) {
+        if (el.contentWindow === e.source) {
+          tabId = id
+          break
+        }
+      }
+      if (!tabId) return
+      const nextUrl = data.url as string
+      setState((prev) => {
+        let changed = false
+        const panes = prev.panes.map((p) => ({
+          ...p,
+          tabs: p.tabs.map((t) => {
+            if (t.id === tabId && t.url !== nextUrl) {
+              changed = true
+              return { ...t, url: nextUrl }
+            }
+            return t
+          }),
+        }))
+        return changed ? { ...prev, panes } : prev
+      })
+    }
+    window.addEventListener('message', handler)
+    return () => window.removeEventListener('message', handler)
+  }, [])
+
   // Whenever a tab becomes the active tab in any pane, ensure its iframe is
   // mounted. Tabs only mount when actually viewed; persisted-but-unvisited
   // tabs stay dormant until clicked.
@@ -252,6 +334,21 @@ export function TabWorkspace({ initialTabs, apiRef, onActiveUrlChange }: TabWork
         if (pane.activeTabId && !prev.has(pane.activeTabId)) {
           if (!next) next = new Set(prev)
           next.add(pane.activeTabId)
+        }
+      }
+      return next ?? prev
+    })
+  }, [state])
+
+  // Drop loaded-state for tabs that have been closed so the set stays bounded.
+  useEffect(() => {
+    const liveIds = new Set(state.panes.flatMap((p) => p.tabs.map((t) => t.id)))
+    setLoadedTabIds((prev) => {
+      let next: Set<string> | null = null
+      for (const id of prev) {
+        if (!liveIds.has(id)) {
+          if (!next) next = new Set(prev)
+          next.delete(id)
         }
       }
       return next ?? prev
@@ -286,6 +383,7 @@ export function TabWorkspace({ initialTabs, apiRef, onActiveUrlChange }: TabWork
             id: newId(),
             label: req.label,
             url: req.url,
+            origin: req.url,
             lastActivatedAt: now(),
           }
           return {
@@ -327,6 +425,7 @@ export function TabWorkspace({ initialTabs, apiRef, onActiveUrlChange }: TabWork
             id: newId(),
             label: req.label,
             url: req.url,
+            origin: req.url,
             lastActivatedAt: now(),
           }
           // Already split — open in the pane that isn't focused.
@@ -362,7 +461,7 @@ export function TabWorkspace({ initialTabs, apiRef, onActiveUrlChange }: TabWork
           const panes = prev.panes.map((p) => ({
             ...p,
             tabs: p.tabs.map((t) => {
-              if (t.url === url && t.label !== label) {
+              if ((t.url === url || t.origin === url) && t.label !== label) {
                 changed = true
                 return { ...t, label }
               }
@@ -496,7 +595,8 @@ export function TabWorkspace({ initialTabs, apiRef, onActiveUrlChange }: TabWork
   // contentDocument so shortcuts work when focus is inside the embedded page.
   // Re-runs on each iframe load (e.g., when the user navigates a link inside
   // the iframe), at which point contentDocument is a fresh Document object.
-  const onIframeLoad = (e: React.SyntheticEvent<HTMLIFrameElement>) => {
+  const onIframeLoad = (tabId: string) => (e: React.SyntheticEvent<HTMLIFrameElement>) => {
+    setLoadedTabIds((prev) => (prev.has(tabId) ? prev : new Set(prev).add(tabId)))
     const doc = e.currentTarget.contentDocument
     if (!doc) return
     const handler = (ev: Event) => handlersRef.current?.onShortcut(ev as KeyboardEvent)
@@ -913,14 +1013,25 @@ export function TabWorkspace({ initialTabs, apiRef, onActiveUrlChange }: TabWork
                 return (
                   <iframe
                     key={tab.id}
-                    src={addEmbedParam(tab.url)}
+                    ref={(el) => {
+                      if (el) iframeElsRef.current.set(tab.id, el)
+                      else iframeElsRef.current.delete(tab.id)
+                    }}
+                    src={addEmbedParam(seedFor(tab))}
                     title={tab.label}
                     className="absolute inset-0 w-full h-full border-0"
                     style={{ display: isActive ? 'block' : 'none' }}
-                    onLoad={onIframeLoad}
+                    onLoad={onIframeLoad(tab.id)}
                   />
                 )
               })}
+              {/* Spinner over the active tab while its iframe document is
+                  still doing its initial load (before onLoad fires). */}
+              {activeTab && mountedTabIds.has(activeTab.id) && !loadedTabIds.has(activeTab.id) && (
+                <div className="absolute inset-0 flex items-center justify-center bg-section-bg">
+                  <Loader2 className="w-6 h-6 text-accent-teal animate-spin motion-reduce:animate-none" />
+                </div>
+              )}
               {!activeTab && (
                 <div className="absolute inset-0 flex items-center justify-center text-muted-foreground/60 text-sm">
                   No content

--- a/dali-api/app/components/TabWorkspace.tsx
+++ b/dali-api/app/components/TabWorkspace.tsx
@@ -198,9 +198,40 @@ export function TabWorkspace({ initialTabs, apiRef, onActiveUrlChange }: TabWork
     return tab.url
   }
 
+  // Stable `title` for each iframe, captured at first mount. The visible tab
+  // label can be refined by `setTabLabel` as the iframe navigates, but the
+  // iframe's `title` attribute is the section's identity (e.g. "Cycles") and
+  // must NOT shift under it — both so it reads consistently and so anything
+  // addressing the frame by title stays valid across in-tab navigation.
+  const seedTitlesRef = useRef<Map<string, string>>(new Map())
+  const titleFor = (tab: Tab): string => {
+    const existing = seedTitlesRef.current.get(tab.id)
+    if (existing !== undefined) return existing
+    seedTitlesRef.current.set(tab.id, tab.label)
+    return tab.label
+  }
+
   // tabId → its <iframe>, so a `dali:tabNavigated` message can be attributed
   // to the right tab by matching the message's source window.
   const iframeElsRef = useRef<Map<string, HTMLIFrameElement>>(new Map())
+  // Stable ref callback PER tab id. The iframe's ref MUST keep the same
+  // function identity across renders: an inline `ref={(el) => …}` is a new
+  // function every render, so React detaches (ref(null)) and reattaches the
+  // iframe node — and re-attaching an iframe reloads it from `src` (the mount
+  // seed), snapping an in-iframe navigation back to the section root. Caching
+  // one callback per id keeps the node attached so in-tab navigation sticks.
+  const iframeRefCbs = useRef<Map<string, (el: HTMLIFrameElement | null) => void>>(new Map())
+  const registerIframe = (tabId: string) => {
+    let cb = iframeRefCbs.current.get(tabId)
+    if (!cb) {
+      cb = (el: HTMLIFrameElement | null) => {
+        if (el) iframeElsRef.current.set(tabId, el)
+        else iframeElsRef.current.delete(tabId)
+      }
+      iframeRefCbs.current.set(tabId, cb)
+    }
+    return cb
+  }
 
   // Hydrate from localStorage on first client render.
   useEffect(() => {
@@ -1013,12 +1044,9 @@ export function TabWorkspace({ initialTabs, apiRef, onActiveUrlChange }: TabWork
                 return (
                   <iframe
                     key={tab.id}
-                    ref={(el) => {
-                      if (el) iframeElsRef.current.set(tab.id, el)
-                      else iframeElsRef.current.delete(tab.id)
-                    }}
+                    ref={registerIframe(tab.id)}
                     src={addEmbedParam(seedFor(tab))}
-                    title={tab.label}
+                    title={titleFor(tab)}
                     className="absolute inset-0 w-full h-full border-0"
                     style={{ display: isActive ? 'block' : 'none' }}
                     onLoad={onIframeLoad(tab.id)}

--- a/dali-api/app/hiring/components/CalendarGrid.tsx
+++ b/dali-api/app/hiring/components/CalendarGrid.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef, useCallback, useEffect } from 'react'
 import { ChevronLeft, ChevronRight, Calendar } from 'lucide-react'
+import { APPLICATION_TZ, zonedWallTimeUtc, getZonedParts } from '~/lib/timezone'
 
 // ─── Types ─���─────────────────────────────────────────────────────────────────
 
@@ -63,31 +64,36 @@ function formatHour(hour: number): string {
   return `${hour - 12} PM`
 }
 
-/** Create a block key from a date — "YYYY-MM-DD-HH-mm" */
-function blockKey(d: Date): string {
-  const y = d.getFullYear()
-  const m = String(d.getMonth() + 1).padStart(2, '0')
-  const day = String(d.getDate()).padStart(2, '0')
-  const h = String(d.getHours()).padStart(2, '0')
-  const min = String(d.getMinutes()).padStart(2, '0')
-  return `${y}-${m}-${day}-${h}-${min}`
+// A block key is "YYYY-MM-DD-HH-mm" wall time in the *interview* timezone
+// (`tz`), NOT the browser's. All key↔instant conversions route through `tz` so
+// a "9:00 AM" cell means 9:00 AM in the configured zone for every interviewer,
+// and the UTC instants we save line up with the server's window clip.
+
+/** Build a key from config-timezone wall-clock parts. */
+function partsToKey(year: number, month: number, day: number, hour: number, minute: number): string {
+  const m = String(month).padStart(2, '0')
+  const d = String(day).padStart(2, '0')
+  const h = String(hour).padStart(2, '0')
+  const min = String(minute).padStart(2, '0')
+  return `${year}-${m}-${d}-${h}-${min}`
 }
 
-function blockKeyToDate(key: string): Date {
+/** The UTC instant a block key represents, given the interview timezone. */
+function keyToUtc(key: string, tz: string): Date {
   const [y, m, d, h, min] = key.split('-').map(Number)
-  return new Date(y, m - 1, d, h, min)
+  return zonedWallTimeUtc(y, m, d, h, min, tz)
 }
 
-/** Merge adjacent 15-min blocks into contiguous ranges */
-function mergeBlocks(keys: string[]): { startTime: string; endTime: string }[] {
+/** Merge adjacent 15-min blocks into contiguous UTC ranges. */
+function mergeBlocks(keys: string[], tz: string): { startTime: string; endTime: string }[] {
   if (keys.length === 0) return []
   const sorted = [...keys].sort()
   const ranges: { startTime: string; endTime: string }[] = []
-  let rangeStart = blockKeyToDate(sorted[0])
+  let rangeStart = keyToUtc(sorted[0], tz)
   let rangeEnd = new Date(rangeStart.getTime() + BLOCK_MINUTES * 60_000)
 
   for (let i = 1; i < sorted.length; i++) {
-    const blockStart = blockKeyToDate(sorted[i])
+    const blockStart = keyToUtc(sorted[i], tz)
     const blockEnd = new Date(blockStart.getTime() + BLOCK_MINUTES * 60_000)
     if (blockStart.getTime() === rangeEnd.getTime()) {
       // Extend current range
@@ -102,15 +108,15 @@ function mergeBlocks(keys: string[]): { startTime: string; endTime: string }[] {
   return ranges
 }
 
-/** Expand saved availability ranges into individual block keys */
-function expandBlocks(ranges: { startTime: string; endTime: string }[]): Set<string> {
+/** Expand saved UTC ranges into individual config-timezone block keys. */
+function expandBlocks(ranges: { startTime: string; endTime: string }[], tz: string): Set<string> {
   const keys = new Set<string>()
   for (const r of ranges) {
-    const start = new Date(r.startTime)
     const end = new Date(r.endTime)
-    let cursor = new Date(start)
+    let cursor = new Date(r.startTime)
     while (cursor < end) {
-      keys.add(blockKey(cursor))
+      const p = getZonedParts(cursor, tz)
+      keys.add(partsToKey(p.year, p.month, p.day, p.hour, p.minute))
       cursor = new Date(cursor.getTime() + BLOCK_MINUTES * 60_000)
     }
   }
@@ -129,34 +135,36 @@ export default function CalendarGrid({
   interviewBlocks = [],
   onSave,
   saving = false,
+  timezone = APPLICATION_TZ,
   onImportFromGoogle,
   importing = false,
   pendingPrefill,
 }: CalendarGridProps) {
+  const tz = timezone
   const [weekStart, setWeekStart] = useState(() =>
     getMonday(initialWeekStart ?? rangeStart),
   )
   const [selected, setSelected] = useState<Set<string>>(() =>
-    expandBlocks(savedBlocks),
+    expandBlocks(savedBlocks, tz),
   )
   const [dirty, setDirty] = useState(false)
 
   // Rebuild selection when savedBlocks change (e.g. after save round-trip)
   useEffect(() => {
-    setSelected(expandBlocks(savedBlocks))
+    setSelected(expandBlocks(savedBlocks, tz))
     setDirty(false)
-  }, [savedBlocks])
+  }, [savedBlocks, tz])
 
   // When the parent provides a prefill (e.g. from Google Calendar import),
   // replace the current selection and mark dirty so the user can review/save.
   useEffect(() => {
     if (pendingPrefill) {
-      setSelected(expandBlocks(pendingPrefill))
+      setSelected(expandBlocks(pendingPrefill, tz))
       setDirty(true)
     }
-  }, [pendingPrefill])
+  }, [pendingPrefill, tz])
 
-  const interviewKeys = expandBlocks(interviewBlocks)
+  const interviewKeys = expandBlocks(interviewBlocks, tz)
 
   // Drag state
   const dragging = useRef(false)
@@ -279,7 +287,7 @@ export default function CalendarGrid({
   }, [applyToCell, cellAtPoint])
 
   const handleSave = () => {
-    const merged = mergeBlocks(Array.from(selected))
+    const merged = mergeBlocks(Array.from(selected), tz)
     onSave(merged)
   }
 
@@ -361,12 +369,20 @@ export default function CalendarGrid({
 
                 {/* Day cells */}
                 {weekDays.map((dayDate, colIdx) => {
-                  const cellDate = new Date(dayDate)
-                  cellDate.setHours(hour, minute, 0, 0)
-                  const key = blockKey(cellDate)
+                  // The day cell's calendar date drives the key (config-tz wall
+                  // time); its real instant comes from `keyToUtc` for past-test.
+                  const key = partsToKey(
+                    dayDate.getFullYear(),
+                    dayDate.getMonth() + 1,
+                    dayDate.getDate(),
+                    hour,
+                    minute,
+                  )
                   const isSelected = selected.has(key)
                   const isInterview = interviewKeys.has(key)
-                  const isPast = cellDate < new Date()
+                  const isPast = keyToUtc(key, tz) < new Date()
+                  const cellDate = new Date(dayDate)
+                  cellDate.setHours(0, 0, 0, 0)
                   const isOutOfRange = cellDate < rangeStartDay || cellDate >= dayAfterRangeEnd
                   const isLocked = isInterview || isPast || isOutOfRange
 

--- a/dali-api/app/hiring/components/delibs/ApplicantContextModal.tsx
+++ b/dali-api/app/hiring/components/delibs/ApplicantContextModal.tsx
@@ -140,10 +140,7 @@ export function ApplicantContextModal({
               />
               <ReviewsSection
                 reviews={data.reviews ?? []}
-                criteria={[
-                  ...(data.rubric.generalCriteria ?? []),
-                  ...(data.rubric.domainCriteria ?? []),
-                ]}
+                criteriaByKey={data.criteriaByKey ?? {}}
                 fieldContext={buildFieldContext(data)}
               />
               <DecisionsSection decisions={data.decisions ?? []} />
@@ -355,11 +352,11 @@ function ReviewAnnotations({
 
 export function ReviewsSection({
   reviews,
-  criteria,
+  criteriaByKey,
   fieldContext,
 }: {
   reviews: any[];
-  criteria: any[];
+  criteriaByKey: Record<string, { label: string; maxScore?: number }>;
   fieldContext: FieldContext;
 }) {
   return (
@@ -409,16 +406,18 @@ export function ReviewsSection({
 
                 {Object.keys(scores).length > 0 && (
                   <div className="mt-2 flex flex-wrap gap-1">
-                    {criteria.map((c: any) => {
-                      const score = scores[c.key];
+                    {Object.entries(scores).map(([key, score]) => {
                       if (score == null) return null;
+                      const meta = criteriaByKey[key];
+                      const label = meta?.label ?? key;
                       return (
                         <span
-                          key={c.key}
+                          key={key}
                           className="text-xs bg-muted text-foreground/80 px-1.5 py-0.5 rounded"
-                          title={c.label}
+                          title={label}
                         >
-                          {c.label?.split(" ")[0] ?? c.key}: {score}/{c.maxScore}
+                          {label.split(" ")[0]}: {score}
+                          {meta?.maxScore != null ? `/${meta.maxScore}` : ""}
                         </span>
                       );
                     })}

--- a/dali-api/app/hiring/components/delibs/__tests__/ApplicantContextModal.test.tsx
+++ b/dali-api/app/hiring/components/delibs/__tests__/ApplicantContextModal.test.tsx
@@ -3,11 +3,14 @@ import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { ReviewsSection, InterviewPrepNoteSection } from "../ApplicantContextModal";
 
-function render(reviews: any[]) {
+function render(
+  reviews: any[],
+  criteriaByKey: Record<string, { label: string; maxScore?: number }> = {},
+) {
   return renderToStaticMarkup(
     createElement(ReviewsSection, {
       reviews,
-      criteria: [],
+      criteriaByKey,
       fieldContext: {},
     }),
   );
@@ -59,6 +62,50 @@ describe("ReviewsSection — Internal Feedback / Rejection Rationale", () => {
   it("shows the empty state when no reviewers are assigned", () => {
     const html = render([]);
     expect(html).toContain("No reviewers assigned yet.");
+  });
+
+  it("renders scores by iterating the review's own keys, resolving labels via the map", () => {
+    const html = render(
+      [
+        {
+          id: "rev-1",
+          scores: { "crit-aaa": 5, "crit-bbb": 3 },
+          feedback: "",
+          rejectionRationale: "",
+          overallRecommendation: "Hire",
+          submittedAt: new Date("2026-04-01T00:00:00Z"),
+          cycleReviewer: { user: { firstName: "Rev", lastName: "Iewer" } },
+        },
+      ],
+      {
+        "crit-aaa": { label: "Excitement towards learning", maxScore: 5 },
+        "crit-bbb": { label: "Desire to collaborate", maxScore: 5 },
+      },
+    );
+    // First word of the label + n/max, not the raw key.
+    expect(html).toContain("Excitement: 5/5");
+    expect(html).toContain("Desire: 3/5");
+    expect(html).not.toContain("crit-aaa");
+  });
+
+  it("falls back to the raw key only when the map has no entry (orphaned criterion)", () => {
+    const html = render(
+      [
+        {
+          id: "rev-1",
+          scores: { "crit-1778609863899": 4 },
+          feedback: "",
+          rejectionRationale: "",
+          overallRecommendation: "Hire",
+          submittedAt: new Date("2026-04-01T00:00:00Z"),
+          cycleReviewer: { user: { firstName: "Rev", lastName: "Iewer" } },
+        },
+      ],
+      {},
+    );
+    // No maxScore is appended when the criterion is unknown.
+    expect(html).toContain("crit-1778609863899: 4");
+    expect(html).not.toContain("crit-1778609863899: 4/");
   });
 });
 

--- a/dali-api/app/hiring/lib/__tests__/api.my-interview.reschedule.test.ts
+++ b/dali-api/app/hiring/lib/__tests__/api.my-interview.reschedule.test.ts
@@ -26,6 +26,9 @@ const mockTx: any = {
     findFirst: vi.fn(),
     update: vi.fn(),
   },
+  interviewAssignment: {
+    updateMany: vi.fn(),
+  },
   interviewConfig: {
     findUnique: vi.fn(),
   },
@@ -40,6 +43,7 @@ beforeEach(() => {
 
   mockTx.interview.findFirst = vi.fn();
   mockTx.interview.update = vi.fn();
+  mockTx.interviewAssignment.updateMany = vi.fn();
   mockTx.interviewConfig.findUnique = vi.fn().mockResolvedValue({ rescheduleNoticeHours: 12, bookingNoticeHours: 0 });
 
   // $transaction receives (callback, options); invoke the callback with mockTx
@@ -144,6 +148,12 @@ describe("POST /api/hiring/my-interview/reschedule", () => {
     expect(mockTx.interview.update).toHaveBeenCalledWith({
       where: { id: "int-design" },
       data: { status: "CancelledByApplicant" },
+    });
+
+    // Old slot's assignments released so it leaves interviewer dashboards
+    expect(mockTx.interviewAssignment.updateMany).toHaveBeenCalledWith({
+      where: { interviewId: "int-design", status: "Active" },
+      data: { status: "Declined" },
     });
 
     // New interview assigned to correct DA

--- a/dali-api/app/hiring/lib/__tests__/rubric-criteria.test.ts
+++ b/dali-api/app/hiring/lib/__tests__/rubric-criteria.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("~/lib/db");
+
+import { prisma } from "~/lib/db";
+import { buildCriteriaLabelMap, buildCriteriaList } from "../rubric-criteria";
+
+const mockPrisma = prisma as unknown as Record<string, any>;
+
+beforeEach(() => {
+  (mockPrisma as any).rubricVersion = { findMany: vi.fn() };
+});
+
+describe("buildCriteriaLabelMap", () => {
+  it("returns only the general criteria when there is no domain/pinned version", async () => {
+    const map = await buildCriteriaLabelMap({
+      domainRubricVersionId: null,
+      generalCriteria: [{ key: "g1", label: "Communication", maxScore: 5 }],
+      pinnedVersionIds: [],
+    });
+    expect(map).toEqual({ g1: { label: "Communication", maxScore: 5, description: undefined } });
+    expect(mockPrisma.rubricVersion.findMany).not.toHaveBeenCalled();
+  });
+
+  it("prefers the current domain rubric label over older history for the same key", async () => {
+    mockPrisma.rubricVersion.findMany
+      // directVersions (current + pinned)
+      .mockResolvedValueOnce([
+        {
+          id: "rv-current",
+          rubricId: "rub-1",
+          versionNumber: 2,
+          criteria: [{ key: "crit-a", label: "New Label", maxScore: 5 }],
+        },
+      ])
+      // history scan
+      .mockResolvedValueOnce([
+        { criteria: [{ key: "crit-a", label: "New Label", maxScore: 5 }] },
+        { criteria: [{ key: "crit-a", label: "Old Label", maxScore: 4 }] },
+      ]);
+
+    const map = await buildCriteriaLabelMap({
+      domainRubricVersionId: "rv-current",
+      pinnedVersionIds: [],
+    });
+
+    expect(map["crit-a"].label).toBe("New Label");
+  });
+
+  it("recovers an orphaned key from rubric history when the current version dropped it", async () => {
+    mockPrisma.rubricVersion.findMany
+      .mockResolvedValueOnce([
+        {
+          id: "rv-current",
+          rubricId: "rub-1",
+          versionNumber: 3,
+          criteria: [{ key: "crit-kept", label: "Kept Criterion", maxScore: 5 }],
+        },
+      ])
+      .mockResolvedValueOnce([
+        { criteria: [{ key: "crit-kept", label: "Kept Criterion", maxScore: 5 }] },
+        // An older version still carried the now-removed criterion.
+        { criteria: [{ key: "crit-1778609863899", label: "Sound architecture", maxScore: 5 }] },
+      ]);
+
+    const map = await buildCriteriaLabelMap({
+      domainRubricVersionId: "rv-current",
+      pinnedVersionIds: [],
+    });
+
+    expect(map["crit-1778609863899"].label).toBe("Sound architecture");
+    expect(map["crit-kept"].label).toBe("Kept Criterion");
+  });
+
+  it("fills in keys from a pinned version that the current version lacks", async () => {
+    mockPrisma.rubricVersion.findMany
+      .mockResolvedValueOnce([
+        {
+          id: "rv-current",
+          rubricId: "rub-1",
+          versionNumber: 2,
+          criteria: [{ key: "crit-a", label: "Current A" }],
+        },
+        {
+          id: "rv-pinned",
+          rubricId: "rub-1",
+          versionNumber: 1,
+          criteria: [{ key: "crit-b", label: "Pinned B" }],
+        },
+      ])
+      .mockResolvedValueOnce([]); // history empty for this assertion
+
+    const map = await buildCriteriaLabelMap({
+      domainRubricVersionId: "rv-current",
+      pinnedVersionIds: ["rv-pinned"],
+    });
+
+    expect(map["crit-a"].label).toBe("Current A");
+    expect(map["crit-b"].label).toBe("Pinned B");
+  });
+
+  it("buildCriteriaList returns the map as a flat array with keys", async () => {
+    const list = await buildCriteriaList({
+      domainRubricVersionId: null,
+      generalCriteria: [{ key: "g1", label: "Communication", maxScore: 5 }],
+      pinnedVersionIds: [],
+    });
+    expect(list).toEqual([
+      { key: "g1", label: "Communication", maxScore: 5, description: undefined },
+    ]);
+  });
+});

--- a/dali-api/app/hiring/lib/rubric-criteria.ts
+++ b/dali-api/app/hiring/lib/rubric-criteria.ts
@@ -1,0 +1,137 @@
+// Resolves rubric-criterion keys (stored in ApplicationReview.scores) to their
+// human labels for read-only display.
+//
+// The problem this solves: editing a rubric creates a NEW immutable
+// RubricVersion, and newly-added criteria get fresh `crit-<timestamp>` keys.
+// Reviews scored against an older version keep those older keys in their
+// `scores` JSON. If a consumer only looks at the *current* cycle rubric, any
+// key that was added/changed by a later edit no longer resolves and the raw
+// `crit-<timestamp>` key leaks into the UI.
+//
+// Going forward, ApplicationReview.rubricVersionId pins the exact version a
+// review's keys belong to (see the review write paths). For reviews written
+// before that column existed — or any straggler key — we reconstruct the label
+// by scanning the full version history of the relevant rubric(s): every
+// RubricVersion sharing the same rubricId is a sibling, so newest-first across
+// all of them recovers the label for any key that ever existed.
+
+import { prisma } from "~/lib/db";
+
+export type CriterionMeta = { label: string; maxScore?: number; description?: string };
+
+type RawCriterion = {
+  key?: unknown;
+  label?: unknown;
+  maxScore?: unknown;
+  description?: unknown;
+};
+
+function coerceCriteria(criteria: unknown): RawCriterion[] {
+  return Array.isArray(criteria) ? (criteria as RawCriterion[]) : [];
+}
+
+function addCriteria(
+  map: Map<string, CriterionMeta>,
+  criteria: unknown,
+  { overwrite }: { overwrite: boolean },
+): void {
+  for (const c of coerceCriteria(criteria)) {
+    if (typeof c?.key !== "string" || c.key.length === 0) continue;
+    if (!overwrite && map.has(c.key)) continue;
+    map.set(c.key, {
+      label: typeof c.label === "string" && c.label.length > 0 ? c.label : c.key,
+      maxScore: typeof c.maxScore === "number" ? c.maxScore : undefined,
+      description: typeof c.description === "string" ? c.description : undefined,
+    });
+  }
+}
+
+/**
+ * Build a `criterionKey -> { label, maxScore }` map for rendering review
+ * scores, resilient to rubric edits.
+ *
+ * Resolution order (later wins for the "current" layer, earlier wins for
+ * history so the most recent label is preferred without being clobbered by
+ * older versions):
+ *  1. The current cycle rubric criteria (domain + optional general) — the
+ *     common case, and the labels we prefer to show.
+ *  2. Criteria from any RubricVersion explicitly pinned on a review.
+ *  3. A fallback scan of every historical version of the same rubric(s),
+ *     newest-first, to recover keys that only the current layer is missing.
+ *
+ * @param opts.domainRubricVersionId  current domain rubric version for the
+ *        cycle (from DomainApplicationCycle.rubricVersionId), if any.
+ * @param opts.generalCriteria        general-form rubric criteria array, if any.
+ * @param opts.pinnedVersionIds       rubricVersionIds pinned on the reviews
+ *        being rendered (ApplicationReview.rubricVersionId).
+ */
+export async function buildCriteriaLabelMap(opts: {
+  domainRubricVersionId?: string | null;
+  generalCriteria?: unknown;
+  pinnedVersionIds?: (string | null | undefined)[];
+}): Promise<Record<string, CriterionMeta>> {
+  const map = new Map<string, CriterionMeta>();
+
+  // Layer 1 (preferred): the general-form rubric criteria.
+  addCriteria(map, opts.generalCriteria, { overwrite: true });
+
+  // Collect the version ids we want to load directly: the current domain
+  // version plus any pinned versions.
+  const directIds = new Set<string>();
+  if (opts.domainRubricVersionId) directIds.add(opts.domainRubricVersionId);
+  for (const id of opts.pinnedVersionIds ?? []) {
+    if (id) directIds.add(id);
+  }
+  if (directIds.size === 0) {
+    return Object.fromEntries(map);
+  }
+
+  const directVersions = await prisma.rubricVersion.findMany({
+    where: { id: { in: Array.from(directIds) } },
+    select: { id: true, rubricId: true, versionNumber: true, criteria: true },
+  });
+
+  // Layer 1 (preferred, cont.): the current domain version's criteria win over
+  // history; pinned versions fill in keys the current version doesn't have.
+  const currentVersion = directVersions.find(
+    (v) => v.id === opts.domainRubricVersionId,
+  );
+  if (currentVersion) addCriteria(map, currentVersion.criteria, { overwrite: true });
+  for (const v of directVersions) {
+    if (v.id === currentVersion?.id) continue;
+    addCriteria(map, v.criteria, { overwrite: false });
+  }
+
+  // Layer 3 (fallback): scan the full history of the same rubric(s), newest
+  // first, to recover any key still unresolved. `overwrite: false` ensures the
+  // preferred labels above are never clobbered by older versions.
+  const rubricIds = Array.from(new Set(directVersions.map((v) => v.rubricId)));
+  if (rubricIds.length > 0) {
+    const history = await prisma.rubricVersion.findMany({
+      where: { rubricId: { in: rubricIds } },
+      orderBy: { versionNumber: "desc" },
+      select: { criteria: true },
+    });
+    for (const v of history) {
+      addCriteria(map, v.criteria, { overwrite: false });
+    }
+  }
+
+  return Object.fromEntries(map);
+}
+
+/**
+ * Array form of {@link buildCriteriaLabelMap}, for consumers that thread a flat
+ * `{ key, label, maxScore, description }[]` (e.g. domain-lead's ReviewModal,
+ * which builds its own key map). Same edit-resilient resolution, returned as an
+ * array (current/general criteria first, then any extra keys recovered from
+ * history).
+ */
+export async function buildCriteriaList(opts: {
+  domainRubricVersionId?: string | null;
+  generalCriteria?: unknown;
+  pinnedVersionIds?: (string | null | undefined)[];
+}): Promise<Array<{ key: string } & CriterionMeta>> {
+  const map = await buildCriteriaLabelMap(opts);
+  return Object.entries(map).map(([key, meta]) => ({ key, ...meta }));
+}

--- a/dali-api/app/hiring/routes/__tests__/api.cycles.my-availability.test.ts
+++ b/dali-api/app/hiring/routes/__tests__/api.cycles.my-availability.test.ts
@@ -128,3 +128,64 @@ describe("PUT /api/hiring/cycles/:cycleId/my-availability — input validation",
     expect(res.status).toBe(200);
   });
 });
+
+describe("PUT /api/hiring/cycles/:cycleId/my-availability — window clip", () => {
+  // Regression: the window bounds were derived by reading the stored
+  // UTC-midnight date through the config timezone, which shifted the whole
+  // window back a day. Every block an interviewer submitted then fell outside
+  // it and was silently discarded — availability saved as empty.
+  it("keeps blocks on the configured start day (ET config, no day-shift)", async () => {
+    (mockPrisma as any).interviewConfig.findUnique = vi.fn().mockResolvedValue({
+      // Stored as UTC midnight; stands for the calendar date 2026-06-01.
+      interviewStartDate: new Date("2026-06-01T00:00:00.000Z"),
+      interviewEndDate: new Date("2026-06-01T00:00:00.000Z"),
+      timezone: "America/New_York",
+    });
+
+    // 9:00–9:30 AM ET on 2026-06-01 (ET is UTC-4 in June).
+    const res = await action({
+      request: makeRequest({
+        blocks: [
+          {
+            startTime: "2026-06-01T13:00:00.000Z",
+            endTime: "2026-06-01T13:30:00.000Z",
+          },
+        ],
+      }),
+      params: { cycleId: CYCLE_ID },
+      context: {},
+    } as any);
+
+    expect(res.status).toBe(200);
+    expect(mockPrisma.interviewerAvailability.createMany).toHaveBeenCalledTimes(1);
+    const arg = mockPrisma.interviewerAvailability.createMany.mock.calls[0][0];
+    expect(arg.data).toHaveLength(1);
+    expect(arg.data[0].startTime.toISOString()).toBe("2026-06-01T13:00:00.000Z");
+  });
+
+  it("still clips blocks genuinely outside the window", async () => {
+    (mockPrisma as any).interviewConfig.findUnique = vi.fn().mockResolvedValue({
+      interviewStartDate: new Date("2026-06-01T00:00:00.000Z"),
+      interviewEndDate: new Date("2026-06-01T00:00:00.000Z"),
+      timezone: "America/New_York",
+    });
+
+    // 9:00 AM ET on 2026-06-05 — four days past the one-day window.
+    const res = await action({
+      request: makeRequest({
+        blocks: [
+          {
+            startTime: "2026-06-05T13:00:00.000Z",
+            endTime: "2026-06-05T13:30:00.000Z",
+          },
+        ],
+      }),
+      params: { cycleId: CYCLE_ID },
+      context: {},
+    } as any);
+
+    expect(res.status).toBe(200);
+    // Nothing valid to write → createMany is skipped (deleteMany still clears).
+    expect(mockPrisma.interviewerAvailability.createMany).not.toHaveBeenCalled();
+  });
+});

--- a/dali-api/app/hiring/routes/__tests__/api.domain-applications.full-context.test.ts
+++ b/dali-api/app/hiring/routes/__tests__/api.domain-applications.full-context.test.ts
@@ -14,7 +14,10 @@ import { loader } from "~/hiring/routes/api.domain-applications.$id.full-context
 const mockPrisma = prisma as unknown as {
   domainApplication: { findUnique: ReturnType<typeof vi.fn> };
   domainApplicationCycle: { findUnique: ReturnType<typeof vi.fn> };
-  rubricVersion: { findUnique: ReturnType<typeof vi.fn> };
+  rubricVersion: {
+    findUnique: ReturnType<typeof vi.fn>;
+    findMany: ReturnType<typeof vi.fn>;
+  };
 };
 
 const USER_ID = "user-1";
@@ -25,7 +28,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   (mockPrisma as any).domainApplication = { findUnique: vi.fn() };
   (mockPrisma as any).domainApplicationCycle = { findUnique: vi.fn() };
-  (mockPrisma as any).rubricVersion = { findUnique: vi.fn() };
+  (mockPrisma as any).rubricVersion = { findUnique: vi.fn(), findMany: vi.fn() };
   vi.mocked(requireAuth).mockResolvedValue({
     ok: true,
     user: { sub: USER_ID },
@@ -58,6 +61,7 @@ function setupHappyPathDomainApp() {
       {
         id: "rev-1",
         scores: { c1: 4 },
+        rubricVersionId: "drv-1",
         feedback: "good",
         rejectionRationale: "",
         overallRecommendation: "Hire",
@@ -78,12 +82,28 @@ function setupHappyPathDomainApp() {
       },
     ],
   });
+  // Current domain rubric version for the cycle.
   mockPrisma.domainApplicationCycle.findUnique.mockResolvedValue({
-    rubricVersion: { criteria: [{ key: "c1", label: "Craft", maxScore: 5 }] },
+    rubricVersionId: "drv-1",
   });
+  // General-form rubric criteria (fetched directly by the endpoint).
   mockPrisma.rubricVersion.findUnique.mockResolvedValue({
     criteria: [{ key: "g1c", label: "General", maxScore: 5 }],
   });
+  // Resolver queries: first the direct versions (current + pinned), then the
+  // history scan over the same rubricId.
+  mockPrisma.rubricVersion.findMany
+    .mockResolvedValueOnce([
+      {
+        id: "drv-1",
+        rubricId: "rub-1",
+        versionNumber: 1,
+        criteria: [{ key: "c1", label: "Craft", maxScore: 5 }],
+      },
+    ])
+    .mockResolvedValueOnce([
+      { criteria: [{ key: "c1", label: "Craft", maxScore: 5 }] },
+    ]);
 }
 
 describe("GET /api/hiring/domain-applications/:id/full-context", () => {
@@ -114,8 +134,10 @@ describe("GET /api/hiring/domain-applications/:id/full-context", () => {
     expect(json.reviews[0].rejectionRationale).toBe("");
     expect(json.decisions).toHaveLength(1);
     expect(json.decisions[0].notes).toBe("moved from Initial delibs");
-    expect(json.rubric.generalCriteria).toEqual([{ key: "g1c", label: "General", maxScore: 5 }]);
-    expect(json.rubric.domainCriteria).toEqual([{ key: "c1", label: "Craft", maxScore: 5 }]);
+    // Criteria are now returned as a resolved key -> meta map (resilient to
+    // rubric edits) rather than separate general/domain arrays.
+    expect(json.criteriaByKey.g1c).toEqual({ label: "General", maxScore: 5, description: undefined });
+    expect(json.criteriaByKey.c1).toEqual({ label: "Craft", maxScore: 5, description: undefined });
     expect(hasCycleAccess).toHaveBeenCalledWith(USER_ID, CYCLE_ID);
   });
 

--- a/dali-api/app/hiring/routes/api.cycles.$cycleId.my-availability.ts
+++ b/dali-api/app/hiring/routes/api.cycles.$cycleId.my-availability.ts
@@ -4,7 +4,7 @@ import { prisma } from "~/lib/db";
 import { requireAuth } from "~/lib/auth";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { parseJson } from "~/lib/validate";
-import { getZonedYMD, zonedDayStartUtc } from "~/lib/timezone";
+import { zonedDayStartUtc } from "~/lib/timezone";
 
 const AvailabilitySchema = z.object({
   blocks: z
@@ -23,20 +23,27 @@ const AvailabilitySchema = z.object({
 });
 
 /** UTC bounds [start, end) of the configured interview window in `timezone`.
- * The stored `interviewStartDate`/`interviewEndDate` are nominally UTC midnight
- * but represent calendar dates; we derive the actual day in the configured
- * timezone, then take midnight-on-that-day and midnight-on-(endDate+1) in that
- * timezone as UTC instants. */
+ * The stored `interviewStartDate`/`interviewEndDate` are UTC-midnight stamps
+ * that stand for plain calendar dates (the picker sends a date-only value), so
+ * we read their Y/M/D in UTC — NOT in `timezone`, which would shift the date to
+ * the previous day for any zone west of UTC and slide the whole window off by a
+ * day. We then anchor midnight-on-startDate and midnight-on-(endDate+1) in the
+ * configured timezone. */
 function interviewWindowUtcBounds(config: {
   interviewStartDate: Date;
   interviewEndDate: Date;
   timezone: string;
 }): { start: Date; end: Date } {
-  const startYMD = getZonedYMD(config.interviewStartDate, config.timezone);
-  const endYMD = getZonedYMD(config.interviewEndDate, config.timezone);
-  const start = zonedDayStartUtc(startYMD.year, startYMD.month, startYMD.day, config.timezone);
+  const s = config.interviewStartDate;
+  const e = config.interviewEndDate;
+  const start = zonedDayStartUtc(
+    s.getUTCFullYear(),
+    s.getUTCMonth() + 1,
+    s.getUTCDate(),
+    config.timezone,
+  );
   // End is exclusive — the day after `interviewEndDate`.
-  const endNext = new Date(Date.UTC(endYMD.year, endYMD.month - 1, endYMD.day));
+  const endNext = new Date(Date.UTC(e.getUTCFullYear(), e.getUTCMonth(), e.getUTCDate()));
   endNext.setUTCDate(endNext.getUTCDate() + 1);
   const end = zonedDayStartUtc(
     endNext.getUTCFullYear(),

--- a/dali-api/app/hiring/routes/api.cycles.$cycleId.my-interviews.ts
+++ b/dali-api/app/hiring/routes/api.cycles.$cycleId.my-interviews.ts
@@ -30,6 +30,11 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     where: {
       cycleInterviewerId: { in: interviewerRows.map((r) => r.id) },
       status: "Active",
+      // An Active assignment can still hang off a cancelled interview when a
+      // cancel path forgot to decline its assignments (the reschedule path
+      // historically did). Gate on the interview itself so the dashboard
+      // never surfaces a cancelled slot regardless of assignment bookkeeping.
+      interview: { status: "Scheduled" },
     },
     include: {
       interview: {

--- a/dali-api/app/hiring/routes/api.domain-applications.$id.full-context.ts
+++ b/dali-api/app/hiring/routes/api.domain-applications.$id.full-context.ts
@@ -3,6 +3,7 @@ import { prisma } from "~/lib/db";
 import { requireAuth } from "~/lib/auth";
 import { hasCycleAccess } from "~/lib/roles";
 import { requireApiSignedOrForbidden } from "~/hiring/lib/confidentiality";
+import { buildCriteriaLabelMap } from "~/hiring/lib/rubric-criteria";
 
 export async function loader({ request, params }: Route.LoaderArgs) {
   const auth = await requireAuth(request);
@@ -64,7 +65,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
               applicationCycleId: da.application.applicationCycleId,
             },
           },
-          select: { rubricVersion: { select: { criteria: true } } },
+          select: { rubricVersionId: true },
         })
       : Promise.resolve(null),
     da.application.applicationCycle.generalRubricVersionId
@@ -74,6 +75,14 @@ export async function loader({ request, params }: Route.LoaderArgs) {
         })
       : Promise.resolve(null),
   ]);
+
+  // Criterion key -> label map resilient to rubric edits (prefers the current
+  // rubric, falls back to each review's pinned version + rubric history).
+  const criteriaByKey = await buildCriteriaLabelMap({
+    domainRubricVersionId: domainCycle?.rubricVersionId ?? null,
+    generalCriteria: generalRubric?.criteria,
+    pinnedVersionIds: da.reviews.map((r) => r.rubricVersionId),
+  });
 
   return Response.json({
       domainApplication: {
@@ -94,9 +103,6 @@ export async function loader({ request, params }: Route.LoaderArgs) {
       },
       reviews: da.reviews,
       decisions: da.decisions,
-      rubric: {
-        generalCriteria: generalRubric?.criteria ?? [],
-        domainCriteria: domainCycle?.rubricVersion?.criteria ?? [],
-      },
+      criteriaByKey,
     });
 }

--- a/dali-api/app/hiring/routes/api.interviews.$id.complete.ts
+++ b/dali-api/app/hiring/routes/api.interviews.$id.complete.ts
@@ -82,9 +82,12 @@ export async function action({ request, params }: Route.ActionArgs) {
   if (body instanceof Response) return body;
   const { recommendation, recommendationNotes } = body;
 
-  if (interview.status === "Completed") {
-    return Response.json({ error: "Interview is already completed" }, { status: 409 });
-  }
+  // The recommendation is joint: a single shared outcome for the interview, set
+  // by either interviewer on behalf of both. So completing an already-completed
+  // interview is idempotent, not an error — the co-interviewer may submit the
+  // same (live-synced) value, or update it to the agreed value. We only record
+  // an audit event on the first transition into Completed.
+  const wasCompleted = interview.status === "Completed";
 
   const updated = await prisma.interview.update({
     where: { id: params.id },
@@ -95,17 +98,19 @@ export async function action({ request, params }: Route.ActionArgs) {
     },
   });
 
-  await logAuditEvent({
-    action: "interview.complete",
-    userId: auth.user.sub,
-    targetId: interview.id,
-    metadata: {
-      cycleId: interview.applicationCycleId,
-      domainApplicationId: interview.domainApplicationId,
-      recommendation,
-    },
-    request,
-  });
+  if (!wasCompleted) {
+    await logAuditEvent({
+      action: "interview.complete",
+      userId: auth.user.sub,
+      targetId: interview.id,
+      metadata: {
+        cycleId: interview.applicationCycleId,
+        domainApplicationId: interview.domainApplicationId,
+        recommendation,
+      },
+      request,
+    });
+  }
 
   return Response.json(updated);
 }

--- a/dali-api/app/hiring/routes/api.my-interview.reschedule.ts
+++ b/dali-api/app/hiring/routes/api.my-interview.reschedule.ts
@@ -89,6 +89,13 @@ export async function action({ request }: Route.ActionArgs) {
           where: { id: current.id },
           data: { status: "CancelledByApplicant" },
         });
+        // Release the old slot's assignments so it stops showing as an
+        // active interview on interviewer dashboards — mirrors the cancel
+        // and withdraw paths.
+        await tx.interviewAssignment.updateMany({
+          where: { interviewId: current.id, status: "Active" },
+          data: { status: "Declined" },
+        });
 
         const created = await assignInterviewers(
           current.applicationCycleId,

--- a/dali-api/app/hiring/routes/api.reviews.$id.ts
+++ b/dali-api/app/hiring/routes/api.reviews.$id.ts
@@ -150,7 +150,16 @@ export async function action({ request, params }: Route.ActionArgs) {
 
   const review = await prisma.applicationReview.findUnique({
     where: { id: params.id },
-    include: { cycleReviewer: true },
+    include: {
+      cycleReviewer: true,
+      domainApplication: {
+        select: {
+          domainId: true,
+          challengeVersion: { select: { domainId: true } },
+          application: { select: { applicationCycleId: true } },
+        },
+      },
+    },
   });
   if (!review) {
     return Response.json({ error: "Review not found" }, { status: 404 });
@@ -187,9 +196,30 @@ export async function action({ request, params }: Route.ActionArgs) {
     if (!result.ok) {
       return Response.json({ error: result.error }, { status: 400 });
     }
+
+    // When scores are written, pin the domain rubric version those keys belong
+    // to so a later rubric edit can't orphan them at render time. Only the
+    // domain rubric is pinned (its criteria are the crit-<ts> keys that drift);
+    // the general-form rubric is resolved separately by consumers.
+    const patch: typeof result.data & { rubricVersionId?: string } = { ...result.data };
+    const da = review.domainApplication;
+    if (result.data.scores !== undefined && !review.rubricVersionId && da) {
+      const domainId = da.domainId ?? da.challengeVersion?.domainId ?? null;
+      const applicationCycleId = da.application?.applicationCycleId ?? null;
+      if (domainId && applicationCycleId) {
+        const dac = await prisma.domainApplicationCycle.findUnique({
+          where: {
+            domainId_applicationCycleId: { domainId, applicationCycleId },
+          },
+          select: { rubricVersionId: true },
+        });
+        if (dac?.rubricVersionId) patch.rubricVersionId = dac.rubricVersionId;
+      }
+    }
+
     const updated = await prisma.applicationReview.update({
       where: { id: params.id },
-      data: result.data,
+      data: patch,
     });
 
     return Response.json(updated);

--- a/dali-api/app/hiring/routes/applications.tsx
+++ b/dali-api/app/hiring/routes/applications.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from "react";
 import { redirect, useLoaderData, useNavigate, useSearchParams } from "react-router";
+import { Search } from "lucide-react";
 import type { Route } from "./+types/applications";
 import { requireAuth } from "~/lib/auth";
 import { getUserRoles } from "~/lib/roles";
@@ -195,16 +196,23 @@ export default function ApplicationsDatabase() {
   const data = useLoaderData<typeof loader>();
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
-  // Client-side domain filter. "" = all visible domains. Reset when the
-  // cycle changes (different cycle = different domain set) by keying off the
-  // selected cycle id in the dependency below.
+  // Client-side filters. "" = all. Reset when the cycle changes (different
+  // cycle = different domain set) by keying off the selected cycle below.
   const [domainId, setDomainId] = useState("");
+  const [status, setStatus] = useState("");
+  const [query, setQuery] = useState("");
 
   const rows = data.gate === "ok" ? data.rows : [];
-  const filteredRows = useMemo(
-    () => (domainId ? rows.filter((r) => r.domainId === domainId) : rows),
-    [rows, domainId],
-  );
+  const filteredRows = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return rows.filter((r) => {
+      if (domainId && r.domainId !== domainId) return false;
+      if (status && r.status !== status) return false;
+      if (q && !`${r.name} ${r.email ?? ""}`.toLowerCase().includes(q))
+        return false;
+      return true;
+    });
+  }, [rows, domainId, status, query]);
 
   if (data.gate === "empty") {
     return (
@@ -239,6 +247,8 @@ export default function ApplicationsDatabase() {
           value={data.selectedCycleId}
           onChange={(e) => {
             setDomainId("");
+            setStatus("");
+            setQuery("");
             const next = new URLSearchParams(searchParams);
             next.set("cycle", e.target.value);
             setSearchParams(next);
@@ -266,27 +276,56 @@ export default function ApplicationsDatabase() {
             ))}
           </select>
         )}
-        <span className="text-xs text-muted-foreground sm:ml-auto">
-          {filteredRows.length}
-          {filteredRows.length === data.rows.length
-            ? ""
-            : ` of ${data.rows.length}`}{" "}
-          {filteredRows.length === 1 ? "submission" : "submissions"}
-        </span>
+        <select
+          aria-label="Filter by status"
+          value={status}
+          onChange={(e) => setStatus(e.target.value)}
+          className="px-3 py-1.5 text-sm border border-border rounded-md bg-background text-foreground sm:w-40"
+        >
+          <option value="">All statuses</option>
+          {Object.keys(STATUS_TONE).map((s) => (
+            <option key={s} value={s}>
+              {s}
+            </option>
+          ))}
+        </select>
+        <div className="relative w-full sm:ml-auto sm:w-64 min-w-[12rem]">
+          <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground/70 pointer-events-none" />
+          <input
+            type="search"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search by name or email"
+            aria-label="Search applicants by name or email"
+            className="w-full pl-8 pr-3 py-1.5 text-sm border border-border rounded-md bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-accent-coral/30"
+          />
+        </div>
       </div>
 
       <div className="bg-card border border-border rounded-lg overflow-hidden">
         {filteredRows.length === 0 ? (
           <div className="px-4 py-8 text-center text-sm text-muted-foreground">
-            No submissions for {data.selectedCycleName}
-            {data.isCore ? "" : " in your domains"}.
+            {rows.length === 0 ? (
+              <>
+                No submissions for {data.selectedCycleName}
+                {data.isCore ? "" : " in your domains"}.
+              </>
+            ) : (
+              "No applicants match the current filters."
+            )}
           </div>
         ) : (
           <div className="overflow-x-auto">
             <table className="w-full text-sm min-w-[640px]">
               <thead className="bg-muted/30 text-muted-foreground text-xs uppercase tracking-wide">
                 <tr>
-                  <th className="text-left font-medium px-4 py-2">Applicant</th>
+                  <th className="text-left font-medium px-4 py-2">
+                    Applicant ({filteredRows.length}
+                    {filteredRows.length === data.rows.length
+                      ? ""
+                      : ` of ${data.rows.length}`}
+                    )
+                  </th>
                   <th className="text-left font-medium px-4 py-2">Domain</th>
                   <th className="text-left font-medium px-4 py-2">Status</th>
                   <th className="text-left font-medium px-4 py-2">Submitted</th>

--- a/dali-api/app/hiring/routes/domain-lead.application.$id.tsx
+++ b/dali-api/app/hiring/routes/domain-lead.application.$id.tsx
@@ -8,6 +8,7 @@ import { presignAnswers } from "~/hiring/lib/presign";
 import { ArrowLeft, ChevronDown } from "lucide-react";
 import { ApplicationViewer } from "~/hiring/components/ApplicationViewer";
 import { ReviewSummary } from "~/hiring/components/ReviewSummary";
+import { buildCriteriaLabelMap } from "~/hiring/lib/rubric-criteria";
 import {
   inferDomainApplicationStatus,
   domainApplicationStatusInclude,
@@ -128,7 +129,9 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   );
   if (confRedirect) return confRedirect;
 
-  // Load rubric criteria for score labels
+  // Resolve criterion-key -> label for score display. Prefers the current
+  // domain rubric, but falls back to the version pinned on each review (and
+  // rubric history) so scores keyed by an older rubric version still resolve.
   const dac = daDomainId
     ? await prisma.domainApplicationCycle.findUnique({
         where: {
@@ -137,13 +140,19 @@ export async function loader({ request, params }: Route.LoaderArgs) {
             applicationCycleId: da.application.applicationCycleId,
           },
         },
-        include: { rubricVersion: true },
+        select: { rubricVersionId: true },
       })
     : null;
 
   const generalRubric = await prisma.applicationCycle.findUnique({
     where: { id: da.application.applicationCycleId },
-    select: { generalRubricVersion: true },
+    select: { generalRubricVersion: { select: { criteria: true } } },
+  });
+
+  const criteriaByKey = await buildCriteriaLabelMap({
+    domainRubricVersionId: dac?.rubricVersionId ?? null,
+    generalCriteria: generalRubric?.generalRubricVersion?.criteria,
+    pinnedVersionIds: (da.reviews ?? []).map((r: any) => r.rubricVersionId),
   });
 
   const cycleStatus = (da.application.applicationCycle.statusUpdates[0]?.newStatus ?? "Draft") as ApplicationCycleStatus;
@@ -171,13 +180,12 @@ export async function loader({ request, params }: Route.LoaderArgs) {
       domainApplication: { ...da, answers: presignedChallengeAnswers },
       application: { ...da.application, answers: presignedGeneralAnswers },
       inferredStatus,
-      domainRubricCriteria: (dac?.rubricVersion?.criteria as any[]) ?? [],
-      generalRubricCriteria: (generalRubric?.generalRubricVersion?.criteria as any[]) ?? [],
+      criteriaByKey,
     };
 }
 
 export default function DomainLeadApplicationView() {
-  const { domainApplication: da, application, inferredStatus, domainRubricCriteria, generalRubricCriteria } =
+  const { domainApplication: da, application, inferredStatus, criteriaByKey } =
     useLoaderData<typeof loader>() as any;
 
   const generalQuestions: any[] = application.generalChallengeVersion?.questions ?? [];
@@ -186,7 +194,6 @@ export default function DomainLeadApplicationView() {
   const decisions: any[] = da.decisions ?? [];
   const interview = da.interviews?.[0] ?? null;
   const statusInfo = STATUS_BADGE[inferredStatus] ?? STATUS_BADGE.Pending;
-  const allCriteria = [...(generalRubricCriteria ?? []), ...(domainRubricCriteria ?? [])];
 
   const questionLabels: Record<string, string> = {};
   for (const q of [...generalQuestions, ...challengeQuestions]) {
@@ -266,7 +273,7 @@ export default function DomainLeadApplicationView() {
             {reviews.length > 0 && (
               <div className="divide-y divide-gray-100">
                 {reviews.map((review: any) => (
-                  <ReviewCard key={review.id} review={review} criteria={allCriteria} />
+                  <ReviewCard key={review.id} review={review} criteriaByKey={criteriaByKey} />
                 ))}
               </div>
             )}
@@ -340,7 +347,13 @@ export default function DomainLeadApplicationView() {
   );
 }
 
-function ReviewCard({ review, criteria }: { review: any; criteria: any[] }) {
+function ReviewCard({
+  review,
+  criteriaByKey,
+}: {
+  review: any;
+  criteriaByKey: Record<string, { label: string; maxScore?: number }>;
+}) {
   const [expanded, setExpanded] = useState(false);
   const reviewer = review.cycleReviewer?.user;
   const name = reviewer ? `${reviewer.firstName} ${reviewer.lastName}` : "Unknown";
@@ -365,15 +378,19 @@ function ReviewCard({ review, criteria }: { review: any; criteria: any[] }) {
         )}
       </div>
 
-      {/* Scores summary */}
+      {/* Scores summary — iterate the review's own score keys so a score
+          survives even if its criterion was edited out of the current rubric;
+          the resolver supplies the label from the pinned/historical version. */}
       {Object.keys(scores).length > 0 && (
         <div className="mt-2 flex flex-wrap gap-1">
-          {criteria.map((c: any) => {
-            const score = scores[c.key];
+          {Object.entries(scores).map(([key, score]) => {
             if (score == null) return null;
+            const meta = criteriaByKey[key];
+            const label = meta?.label ?? key;
             return (
-              <span key={c.key} className="text-xs bg-muted text-foreground/80 px-1.5 py-0.5 rounded" title={c.label}>
-                {c.label?.split(" ")[0]}: {score}/{c.maxScore}
+              <span key={key} className="text-xs bg-muted text-foreground/80 px-1.5 py-0.5 rounded" title={label}>
+                {label.split(" ")[0]}: {score}
+                {meta?.maxScore != null ? `/${meta.maxScore}` : ""}
               </span>
             );
           })}

--- a/dali-api/app/hiring/routes/domain-lead.tsx
+++ b/dali-api/app/hiring/routes/domain-lead.tsx
@@ -9,6 +9,7 @@ import { CheckCircle, Plus, Trash2, Check, Clock, X, CircleDashed, ChevronDown, 
 import { inferDomainApplicationStatus } from "~/hiring/lib/domain-application-status";
 import { inReviewPipelineFilter } from "~/hiring/lib/application-pipeline-filter";
 import { getReviewStatus } from "~/hiring/lib/review-status";
+import { buildCriteriaList } from "~/hiring/lib/rubric-criteria";
 import { getCycleConfidentialityState } from "~/hiring/lib/confidentiality";
 import { ConfidentialityGate } from "~/hiring/components/ConfidentialityGate";
 import { RichTextViewer, isEmptyDoc } from "~/components/RichTextViewer";
@@ -331,7 +332,34 @@ export async function loader({ request }: Route.LoaderArgs) {
         orderBy: { createdAt: "desc" },
       });
       const currentRubricVersionId = cycle?.domains[0]?.rubricVersionId ?? null;
-      const rubricCriteria = (rubricVersionOptions.find((rv) => rv.id === currentRubricVersionId)?.criteria as any[] | null) ?? [];
+      // Flat criteria list for the ReviewModal's score labels, resilient to
+      // rubric edits: current domain rubric + general rubric + any versions
+      // pinned on this domain's reviews (and their history), so scores keyed by
+      // an older rubric version still resolve instead of leaking raw crit-<ts>.
+      const domainReviewVersionIds = cycle
+        ? (
+            await prisma.applicationReview.findMany({
+              where: {
+                domainApplication: {
+                  ...daDomainMatch,
+                  application: { applicationCycleId: cycle.id },
+                },
+                rubricVersionId: { not: null },
+              },
+              select: { rubricVersionId: true },
+              distinct: ["rubricVersionId"],
+            })
+          ).map((r) => r.rubricVersionId)
+        : [];
+      const generalCriteria = cycle?.generalRubricVersionId
+        ? ((rubricVersionOptions.find((rv) => rv.id === cycle.generalRubricVersionId)
+            ?.criteria as any[] | null) ?? undefined)
+        : undefined;
+      const rubricCriteria = await buildCriteriaList({
+        domainRubricVersionId: currentRubricVersionId,
+        generalCriteria,
+        pinnedVersionIds: domainReviewVersionIds,
+      });
 
       // Interviewers for this domain in this cycle (with availability blocks —
       // the component sums their durations to show total hours offered).

--- a/dali-api/app/hiring/routes/interviewer.interview.$interviewId.tsx
+++ b/dali-api/app/hiring/routes/interviewer.interview.$interviewId.tsx
@@ -6,7 +6,6 @@ import {
   Clock,
   Check,
   Video,
-  AlertTriangle,
   ChevronDown,
   FileText,
   MapPin,
@@ -24,6 +23,7 @@ import { PresenceBar } from '~/components/collab/PresenceBar'
 import { useSharedString } from '~/components/collab/useSharedString'
 import { ApplicationViewer } from '~/hiring/components/ApplicationViewer'
 import { ReviewSummary } from '~/hiring/components/ReviewSummary'
+import { buildCriteriaLabelMap } from '~/hiring/lib/rubric-criteria'
 import type { Route } from './+types/interviewer.interview.$interviewId'
 import type { Question } from '~/types'
 
@@ -113,7 +113,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   // Standard cycles where challengeVersion is always set; the optional chain
   // is just to satisfy TS now that the column is nullable.
   const domainId = interview.domainApplication.challengeVersion?.domainId ?? null
-  let rubricCriteria: any[] = []
+  let domainRubricVersionId: string | null = null
   if (domainId) {
     const domainAppCycle = await prisma.domainApplicationCycle.findUnique({
       where: {
@@ -122,14 +122,20 @@ export async function loader({ request, params }: Route.LoaderArgs) {
           applicationCycleId: interview.applicationCycleId,
         },
       },
+      select: { rubricVersionId: true },
     })
-    if (domainAppCycle?.rubricVersionId) {
-      const rv = await prisma.rubricVersion.findUnique({
-        where: { id: domainAppCycle.rubricVersionId },
-      })
-      rubricCriteria = (rv?.criteria as any[] | null) ?? []
-    }
+    domainRubricVersionId = domainAppCycle?.rubricVersionId ?? null
   }
+  // Criterion key -> label map for the submitted reviews' scores. Resilient to
+  // rubric edits: prefers the current domain rubric but falls back to the
+  // versions pinned on each review (and their history) so keys from older
+  // rubric versions still resolve instead of leaking as raw crit-<ts> keys.
+  const criteriaByKey = await buildCriteriaLabelMap({
+    domainRubricVersionId,
+    pinnedVersionIds: interview.domainApplication.reviews.map(
+      (r: any) => r.rubricVersionId,
+    ),
+  })
 
   const collabToken = parseSessionCookie(request)
 
@@ -165,14 +171,14 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   return {
       interview: interviewWithPresignedAnswers,
       myAssignment,
-      rubricCriteria,
+      criteriaByKey,
       collabToken,
       userName,
     }
 }
 
 export default function InterviewDetailPage() {
-  const { interview, myAssignment, rubricCriteria, collabToken, userName } =
+  const { interview, myAssignment, criteriaByKey, collabToken, userName } =
     useLoaderData<typeof loader>() as any
 
   const applicant = interview.domainApplication?.application?.user
@@ -203,10 +209,6 @@ export default function InterviewDetailPage() {
   const domainQuestions: any[] =
     interview.domainApplication?.challengeVersion?.questions ?? []
   const submittedReviews: any[] = interview.domainApplication?.reviews ?? []
-  const criteriaByKey: Record<string, { label: string }> = {}
-  for (const c of rubricCriteria as any[]) {
-    if (c?.key) criteriaByKey[c.key] = { label: c.label ?? c.key }
-  }
 
   const questionLabels: Record<string, string> = {}
   for (const q of [...generalQuestions, ...domainQuestions]) {
@@ -248,14 +250,23 @@ export default function InterviewDetailPage() {
     interview.recommendation ?? '',
   )
 
-  // Completed state
-  const [isCompleted, setIsCompleted] = useState(
-    interview.status === 'Completed',
+  // Completed state — also shared live so that when one interviewer marks the
+  // joint recommendation complete, the co-interviewer's open page flips to the
+  // Completed view immediately (rather than only after a manual reload). The
+  // DB write is still the source of truth on next load; this flag mirrors it
+  // for the live session. Seeded from interview.status.
+  const {
+    value: completedFlag,
+    setValue: setCompletedFlag,
+  } = useSharedString(
+    `interview:${interview.id}:rec-status`,
+    collabToken,
+    interview.status === 'Completed' ? 'completed' : '',
   )
+  const isCompleted = completedFlag === 'completed'
+  const setIsCompleted = (next: boolean) =>
+    setCompletedFlag(next ? 'completed' : '')
   const [completing, setCompleting] = useState(false)
-
-  // Decline state
-  const [declining, setDeclining] = useState(false)
 
   // Mark complete
   const handleMarkComplete = useCallback(async () => {
@@ -268,7 +279,9 @@ export default function InterviewDetailPage() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ recommendation }),
       })
-      if (res.ok) {
+      // 409 = the co-interviewer already submitted this joint recommendation.
+      // That's the success case here, not an error: flip to Completed anyway.
+      if (res.ok || res.status === 409) {
         setIsCompleted(true)
       }
     } finally {
@@ -291,48 +304,6 @@ export default function InterviewDetailPage() {
       setCompleting(false)
     }
   }, [interview.id])
-
-  // Mark unavailable (decline)
-  const handleDecline = useCallback(async () => {
-    if (
-      !confirm(
-        'Are you sure you want to mark yourself as unavailable for this interview?',
-      )
-    )
-      return
-    setDeclining(true)
-    try {
-      const res = await fetch(
-        `/api/hiring/cycles/${interview.applicationCycleId}/my-interviews/${interview.id}/decline`,
-        {
-          method: 'POST',
-          credentials: 'include',
-        },
-      )
-      if (res.ok) {
-        window.location.href = '/hiring/reviewer'
-        return
-      }
-      if (res.status === 409) {
-        const body = (await res.json().catch(() => ({}))) as { error?: string }
-        alert(
-          body.error ??
-            'No replacement interviewer is available. Please contact the hiring lead.',
-        )
-        return
-      }
-      const body = (await res.json().catch(() => ({}))) as { error?: string }
-      alert(`Failed to mark unavailable: ${body.error ?? res.statusText}`)
-    } catch (e) {
-      alert(
-        `Failed to mark unavailable: ${
-          e instanceof Error ? e.message : String(e)
-        }`,
-      )
-    } finally {
-      setDeclining(false)
-    }
-  }, [interview.id, interview.applicationCycleId])
 
   return (
     <PresenceProvider
@@ -433,16 +404,6 @@ export default function InterviewDetailPage() {
               </span>
             </div>
           </div>
-          {!isCompleted && (
-            <button
-              onClick={handleDecline}
-              disabled={declining}
-              className="inline-flex items-center px-3 py-2 text-sm font-medium text-red-600 bg-red-50 border border-red-200 rounded-lg hover:bg-red-100 disabled:opacity-50"
-            >
-              <AlertTriangle className="w-4 h-4 mr-1.5" />
-              {declining ? 'Declining...' : 'Mark Unavailable'}
-            </button>
-          )}
         </div>
       </div>
 
@@ -564,9 +525,14 @@ export default function InterviewDetailPage() {
 
       {/* Joint Recommendation */}
       <div className="bg-card rounded-xl border border-border shadow-sm p-6">
-        <h2 className="text-lg font-semibold text-foreground mb-4">
+        <h2 className="text-lg font-semibold text-foreground mb-1">
           Joint Recommendation
         </h2>
+        <p className="text-xs text-muted-foreground mb-4">
+          One shared recommendation for this interview. Either interviewer
+          submits it on behalf of both — only one of you needs to mark it
+          complete.
+        </p>
 
         {isCompleted ? (
           <div className="p-4 bg-green-50 rounded-lg border border-green-200">
@@ -613,28 +579,6 @@ export default function InterviewDetailPage() {
                   </option>
                 ))}
               </select>
-            </div>
-
-            <div>
-              <label className="block text-sm font-medium text-foreground/80 mb-1">
-                Your Notes
-              </label>
-              <p className="text-xs text-muted-foreground mb-2">
-                Private — only you can see these notes. Autosaved.
-              </p>
-              {collabToken ? (
-                <CollaborativeEditor
-                  editorId="recommendation"
-                  documentName={`interview:${interview.id}:rec-notes-${myAssignment.id}`}
-                  token={collabToken}
-                  userName={userName}
-                  placeholder="Your notes on the recommendation..."
-                />
-              ) : (
-                <div className="p-4 bg-yellow-50 rounded-lg border border-yellow-200 text-sm text-yellow-800">
-                  Session expired — please refresh.
-                </div>
-              )}
             </div>
 
             <div className="flex items-center gap-3">

--- a/dali-api/app/hiring/routes/reviewer.application.$id.tsx
+++ b/dali-api/app/hiring/routes/reviewer.application.$id.tsx
@@ -187,12 +187,40 @@ export async function action({ request, params }: Route.ActionArgs) {
         domainApplication: { applicationId: params.id },
         cycleReviewer: { userId: auth.user.sub },
       },
+      include: {
+        domainApplication: {
+          select: {
+            domainId: true,
+            challengeVersion: { select: { domainId: true } },
+            application: { select: { applicationCycleId: true } },
+          },
+        },
+      },
     })
 
     if (existing) {
+      // Pin the domain rubric version these score keys belong to, so a later
+      // rubric edit (which mints new crit-<ts> keys) doesn't orphan them at
+      // render time. Resolve the domain from the review's domain application.
+      const da = existing.domainApplication
+      const domainId = da.domainId ?? da.challengeVersion?.domainId ?? null
+      let rubricVersionId: string | null = existing.rubricVersionId ?? null
+      if (domainId) {
+        const dac = await prisma.domainApplicationCycle.findUnique({
+          where: {
+            domainId_applicationCycleId: {
+              domainId,
+              applicationCycleId: da.application.applicationCycleId,
+            },
+          },
+          select: { rubricVersionId: true },
+        })
+        if (dac?.rubricVersionId) rubricVersionId = dac.rubricVersionId
+      }
+
       await prisma.applicationReview.update({
         where: { id: existing.id },
-        data: { scores, overallRecommendation, annotations },
+        data: { scores, overallRecommendation, annotations, rubricVersionId },
       })
     }
   }

--- a/dali-api/app/hiring/routes/reviewer.tsx
+++ b/dali-api/app/hiring/routes/reviewer.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react'
 import { Link, useLoaderData, useRevalidator, useSearchParams } from 'react-router'
 import {
-  ChevronRight,
   ChevronDown,
   CheckCircle,
   FileText,
@@ -11,7 +10,6 @@ import {
   ListOrdered,
 } from 'lucide-react'
 import { getReviewStatus } from '~/hiring/lib/review-status'
-import { requestOpenTabIfEmbedded } from '~/components/workspace-link'
 import { CycleSelector } from '~/hiring/components/CycleSelector'
 import { getActiveCycle, cycleStatusToStage, inferUnderReviewStage } from '~/hiring/lib/cycles'
 import { getCycleConfidentialityState } from '~/hiring/lib/confidentiality'
@@ -19,15 +17,16 @@ import { ConfidentialityGate } from '~/hiring/components/ConfidentialityGate'
 import { INITIAL_COLUMNS, FINAL_COLUMNS } from '~/hiring/lib/delibs'
 import { ApplicantContextModal } from '~/hiring/components/delibs/ApplicantContextModal'
 import CalendarGrid from '~/hiring/components/CalendarGrid'
-import { getZonedYMD } from '~/lib/timezone'
+import { zonedWallTimeUtc } from '~/lib/timezone'
 
-/** Convert a UTC ISO timestamp to a local-time Date at midnight on the calendar
- * day that the timestamp falls on in `timezone`. The CalendarGrid's date math
- * runs in the browser's local time, so feeding it raw UTC midnight pushes the
- * grid back a day in any timezone west of UTC. */
-function isoToLocalMidnightInTz(iso: string, timezone: string): Date {
-  const { year, month, day } = getZonedYMD(new Date(iso), timezone)
-  return new Date(year, month - 1, day)
+/** The interview-window bound dates are stored as UTC-midnight stamps that
+ * stand for plain calendar dates. Return a browser-local midnight Date on that
+ * same calendar day so CalendarGrid's day-range gating lines up with the
+ * server's window (which also reads these bounds as UTC calendar dates).
+ * Reading the day in a timezone instead would shift it back a day west of UTC. */
+function isoToCalendarDayLocalMidnight(iso: string): Date {
+  const d = new Date(iso)
+  return new Date(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate())
 }
 import { prisma } from '~/lib/db'
 import { requireAuth } from "~/lib/auth";
@@ -377,8 +376,9 @@ export default function ReviewerDashboard() {
   }, [isCycleInterviewer, activeCycle?.id])
 
   // Fetch scheduled interviews (single call populates both the calendar overlay
-  // and the Assigned Interviews section).
-  useEffect(() => {
+  // and the Assigned Interviews section). Exposed as a callback so declining an
+  // interview from a card can refresh the list in place.
+  const loadScheduledInterviews = useCallback(() => {
     if (!activeCycle) return
     fetch(`/api/hiring/cycles/${activeCycle.id}/my-interviews`, { credentials: 'include' })
       .then(r => r.ok ? r.json() : [])
@@ -393,6 +393,55 @@ export default function ReviewerDashboard() {
       })
       .catch(() => {})
   }, [activeCycle?.id])
+
+  useEffect(() => {
+    loadScheduledInterviews()
+  }, [loadScheduledInterviews])
+
+  // Mark unavailable for an assigned interview, straight from its card.
+  // Mirrors the decline action on the interview detail page, but refreshes the
+  // list in place instead of navigating away.
+  const [decliningId, setDecliningId] = useState<string | null>(null)
+  const handleDeclineInterview = useCallback(
+    async (interviewId: string) => {
+      if (!activeCycle) return
+      if (
+        !confirm(
+          'Are you sure you want to mark yourself as unavailable for this interview?',
+        )
+      )
+        return
+      setDecliningId(interviewId)
+      try {
+        const res = await fetch(
+          `/api/hiring/cycles/${activeCycle.id}/my-interviews/${interviewId}/decline`,
+          { method: 'POST', credentials: 'include' },
+        )
+        if (res.ok) {
+          loadScheduledInterviews()
+          return
+        }
+        const body = (await res.json().catch(() => ({}))) as { error?: string }
+        if (res.status === 409) {
+          alert(
+            body.error ??
+              'No replacement interviewer is available. Please contact the hiring lead.',
+          )
+          return
+        }
+        alert(`Failed to mark unavailable: ${body.error ?? res.statusText}`)
+      } catch (e) {
+        alert(
+          `Failed to mark unavailable: ${
+            e instanceof Error ? e.message : String(e)
+          }`,
+        )
+      } finally {
+        setDecliningId(null)
+      }
+    },
+    [activeCycle?.id, loadScheduledInterviews],
+  )
 
   const handleSaveAvailability = useCallback(
     async (blocks: { startTime: string; endTime: string }[]) => {
@@ -424,9 +473,16 @@ export default function ReviewerDashboard() {
     setImporting(true)
     setImportError(null)
     try {
-      const start = new Date(interviewConfig.interviewStartDate)
-      const end = new Date(interviewConfig.interviewEndDate)
-      const params = new URLSearchParams({ start: start.toISOString(), end: end.toISOString() })
+      const tz = interviewConfig.timezone
+      // The stored bounds are UTC-midnight stamps standing for calendar dates;
+      // read them in UTC and walk day-by-day. Working-hour blocks are built at
+      // wall-clock time in the interview timezone so they line up with the grid
+      // and survive the server's window clip regardless of the browser's zone.
+      const startBound = new Date(interviewConfig.interviewStartDate)
+      const endBound = new Date(interviewConfig.interviewEndDate)
+      const windowStart = zonedWallTimeUtc(startBound.getUTCFullYear(), startBound.getUTCMonth() + 1, startBound.getUTCDate(), 0, 0, tz)
+      const windowEnd = zonedWallTimeUtc(endBound.getUTCFullYear(), endBound.getUTCMonth() + 1, endBound.getUTCDate() + 1, 0, 0, tz)
+      const params = new URLSearchParams({ start: windowStart.toISOString(), end: windowEnd.toISOString() })
       const res = await fetch(`/api/google-calendar/busy?${params}`, { credentials: 'include' })
       if (!res.ok) {
         const err = await res.json().catch(() => ({}))
@@ -439,17 +495,25 @@ export default function ReviewerDashboard() {
       // hours on weekdays in the range, skip any that overlap a busy event.
       const BLOCK_MS = 15 * 60 * 1000
       const available: { startTime: string; endTime: string }[] = []
-      const cursor = new Date(start)
-      cursor.setHours(0, 0, 0, 0)
-      while (cursor <= end) {
-        const day = cursor.getDay()
-        if (day !== 0 && day !== 6) {
+      // Iterate calendar days from the start bound through the end bound by
+      // UTC date; the block instants themselves are resolved in `tz`.
+      const dayCursor = new Date(Date.UTC(startBound.getUTCFullYear(), startBound.getUTCMonth(), startBound.getUTCDate()))
+      const lastDay = new Date(Date.UTC(endBound.getUTCFullYear(), endBound.getUTCMonth(), endBound.getUTCDate()))
+      while (dayCursor <= lastDay) {
+        const y = dayCursor.getUTCFullYear()
+        const mo = dayCursor.getUTCMonth() + 1
+        const d = dayCursor.getUTCDate()
+        // Weekday as seen in the interview timezone (skip Sat/Sun). Resolved
+        // from the day's noon instant so it can't tip into an adjacent day.
+        const weekday = new Intl.DateTimeFormat('en-US', { timeZone: tz, weekday: 'short' })
+          .format(zonedWallTimeUtc(y, mo, d, 12, 0, tz))
+        const isWeekend = weekday === 'Sat' || weekday === 'Sun'
+        if (!isWeekend) {
           for (let h = interviewConfig.dayStartHour; h < interviewConfig.dayEndHour; h++) {
             for (let m = 0; m < 60; m += 15) {
-              const blockStart = new Date(cursor)
-              blockStart.setHours(h, m, 0, 0)
+              const blockStart = zonedWallTimeUtc(y, mo, d, h, m, tz)
               const blockEnd = new Date(blockStart.getTime() + BLOCK_MS)
-              if (blockStart < start || blockEnd > end) continue
+              if (blockStart < windowStart || blockEnd > windowEnd) continue
               const overlaps = busyEvents.some(b => {
                 const bs = new Date(b.start)
                 const be = new Date(b.end)
@@ -464,7 +528,7 @@ export default function ReviewerDashboard() {
             }
           }
         }
-        cursor.setDate(cursor.getDate() + 1)
+        dayCursor.setUTCDate(dayCursor.getUTCDate() + 1)
       }
 
       setPendingPrefill(available)
@@ -634,20 +698,6 @@ export default function ReviewerDashboard() {
                       {domains && (
                         <p className="text-xs text-gray-500">{domains}</p>
                       )}
-                      <Link
-                        to={`/hiring/reviewer/application/${interview.domainApplication?.application?.id}`}
-                        onClick={(e) => {
-                          const url = `/hiring/reviewer/application/${interview.domainApplication?.application?.id}`
-                          const label = applicant
-                            ? `${applicant.firstName ?? ''} ${applicant.lastName ?? ''}`.trim() || 'Applicant'
-                            : 'Applicant'
-                          if (requestOpenTabIfEmbedded(url, label)) e.preventDefault()
-                        }}
-                        className="text-sm text-blue-600 hover:text-blue-800 font-medium flex items-center mt-1"
-                      >
-                        View Application{' '}
-                        <ChevronRight className="w-3 h-3 ml-0.5" />
-                      </Link>
                     </div>
                     <div className="text-right bg-white px-3 py-2 rounded-lg border shadow-sm">
                       <p className="text-sm font-bold text-gray-900">
@@ -670,14 +720,21 @@ export default function ReviewerDashboard() {
                       </p>
                     </div>
                   </div>
-                  <div className="p-6 flex-1 flex flex-col justify-end">
+                  <div className="p-6 flex-1 flex items-end gap-3">
                     <Link
                       to={`/hiring/interviewer/interview/${interview.id}`}
                       className="inline-flex items-center justify-center px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-lg text-white bg-accent-coral hover:bg-accent-coral/90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
                     >
-                      <Video className="w-4 h-4 mr-2" />
                       Open Interview
                     </Link>
+                    <button
+                      type="button"
+                      onClick={() => handleDeclineInterview(interview.id)}
+                      disabled={decliningId === interview.id}
+                      className="inline-flex items-center justify-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-lg text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+                    >
+                      {decliningId === interview.id ? 'Marking…' : 'Mark Unavailable'}
+                    </button>
                   </div>
                 </div>
               )
@@ -715,14 +772,15 @@ export default function ReviewerDashboard() {
                 interviews. 15-minute blocks.
               </p>
               <CalendarGrid
-                rangeStart={isoToLocalMidnightInTz(interviewConfig.interviewStartDate, interviewConfig.timezone)}
-                rangeEnd={isoToLocalMidnightInTz(interviewConfig.interviewEndDate, interviewConfig.timezone)}
+                rangeStart={isoToCalendarDayLocalMidnight(interviewConfig.interviewStartDate)}
+                rangeEnd={isoToCalendarDayLocalMidnight(interviewConfig.interviewEndDate)}
                 dayStartHour={interviewConfig.dayStartHour}
                 dayEndHour={interviewConfig.dayEndHour}
                 savedBlocks={savedAvailability}
                 interviewBlocks={interviewBlocks}
                 onSave={handleSaveAvailability}
                 saving={availabilitySaving}
+                timezone={interviewConfig.timezone}
                 onImportFromGoogle={handleImportFromGoogle}
                 importing={importing}
                 pendingPrefill={pendingPrefill}

--- a/dali-api/app/lib/timezone.ts
+++ b/dali-api/app/lib/timezone.ts
@@ -31,6 +31,31 @@ export function getZonedYMD(
   };
 }
 
+/** Wall-clock parts of `date` interpreted in `timezone` (month 1-indexed). */
+export function getZonedParts(
+  date: Date,
+  timezone: string,
+): { year: number; month: number; day: number; hour: number; minute: number } {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: timezone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  }).formatToParts(date);
+  const get = (t: string) =>
+    Number(parts.find((p) => p.type === t)?.value ?? "0");
+  return {
+    year: get("year"),
+    month: get("month"),
+    day: get("day"),
+    hour: get("hour") % 24,
+    minute: get("minute"),
+  };
+}
+
 /**
  * Hour-of-day of `date` interpreted in `timezone`, as a fraction in [0, 24)
  * (e.g. 2:30 PM → 14.5). Used to position the calendar's "current time" line.
@@ -69,13 +94,22 @@ export function zonedDayEndUtc(
 }
 
 /** UTC instant corresponding to local midnight on `year-month-day` in `timezone`. */
-export function zonedDayStartUtc(
+/**
+ * UTC instant corresponding to a wall-clock time `year-month-day hour:minute`
+ * in `timezone`. DST-correct: probes the zone's offset at the guessed instant
+ * and corrects, which resolves transition days the same way the rest of this
+ * module does. The single source of truth for "this local time means this UTC
+ * instant" — `zonedDayStartUtc` is the hour=0, minute=0 case.
+ */
+export function zonedWallTimeUtc(
   year: number,
   month: number,
   day: number,
+  hour: number,
+  minute: number,
   timezone: string,
 ): Date {
-  const utcGuess = new Date(Date.UTC(year, month - 1, day));
+  const utcGuess = new Date(Date.UTC(year, month - 1, day, hour, minute));
   const formatter = new Intl.DateTimeFormat("en-US", {
     timeZone: timezone,
     year: "numeric",
@@ -99,4 +133,13 @@ export function zonedDayStartUtc(
   );
   const offsetMs = localAtUtcMs - utcGuess.getTime();
   return new Date(utcGuess.getTime() - offsetMs);
+}
+
+export function zonedDayStartUtc(
+  year: number,
+  month: number,
+  day: number,
+  timezone: string,
+): Date {
+  return zonedWallTimeUtc(year, month, day, 0, 0, timezone);
 }

--- a/dali-api/app/projects/lib/__tests__/bid-validation.test.ts
+++ b/dali-api/app/projects/lib/__tests__/bid-validation.test.ts
@@ -43,11 +43,31 @@ describe("validateBids — domain-driven biddability", () => {
     expect(mockPrisma.projectDomain.findMany).toHaveBeenCalled();
   });
 
-  it("drops a bid on a project that doesn't work in any eligibility domain", async () => {
+  it("records a bid on a project OUTSIDE the member's eligibility domains, at the default level", async () => {
+    // Member is Engineering-only, but bids a Design-only project. The bid must
+    // still resolve (product intent: every bid shows), labeled with the
+    // project's domain at the baseline P1 since the member has no level there.
     mockPrisma.domainEligibility.findMany.mockResolvedValue([
       { domainId: "eng", level: "P3" },
     ]);
-    // Project only works in Design; member is Engineering-only → no rows.
+    mockPrisma.projectDomain.findMany.mockResolvedValue([
+      { projectId: "p1", domainId: "design" },
+    ]);
+
+    const res = await validateBids("u1", cycle, [{ projectId: "p1" }]);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.bids).toEqual([
+      { projectId: "p1", domainId: "design", level: "P1", preferenceRank: 1, notes: null },
+    ]);
+  });
+
+  it("produces no rows only when the project declares no domains at all", async () => {
+    // Nothing to do with eligibility — a project with zero ProjectDomain rows
+    // has no column to place a bid in, so it contributes nothing.
+    mockPrisma.domainEligibility.findMany.mockResolvedValue([
+      { domainId: "eng", level: "P3" },
+    ]);
     mockPrisma.projectDomain.findMany.mockResolvedValue([]);
 
     const res = await validateBids("u1", cycle, [{ projectId: "p1" }]);
@@ -77,12 +97,58 @@ describe("validateBids — domain-driven biddability", () => {
     ]);
   });
 
-  it("records zero bids (not an error) when the member has no eligibility — they still appear, flagged", async () => {
+  it("resolves a bid even when the member has NO eligibility at all, at the default level", async () => {
+    // No eligibility no longer drops bids. The project's declared domains drive
+    // the rows; level falls back to P1 since the member has none.
     mockPrisma.domainEligibility.findMany.mockResolvedValue([]);
+    mockPrisma.projectDomain.findMany.mockResolvedValue([
+      { projectId: "p1", domainId: "eng" },
+    ]);
     const res = await validateBids("u1", cycle, [{ projectId: "p1" }]);
     expect(res.ok).toBe(true);
     if (!res.ok) return;
-    expect(res.bids).toEqual([]);
+    expect(res.bids).toEqual([
+      { projectId: "p1", domainId: "eng", level: "P1", preferenceRank: 1, notes: null },
+    ]);
+  });
+
+  it("lands a bid only in the member's eligibility domain when the project overlaps it", async () => {
+    // Member eligible in eng (P2) only; project declares eng + design. The bid
+    // lands ONLY in eng (the overlap) at P2 — design is dropped because the
+    // member is eligible somewhere in this project, so we don't spill into
+    // domains they have nothing to do with.
+    mockPrisma.domainEligibility.findMany.mockResolvedValue([
+      { domainId: "eng", level: "P2" },
+    ]);
+    mockPrisma.projectDomain.findMany.mockResolvedValue([
+      { projectId: "p1", domainId: "eng" },
+      { projectId: "p1", domainId: "design" },
+    ]);
+    const res = await validateBids("u1", cycle, [{ projectId: "p1" }]);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.bids).toEqual([
+      { projectId: "p1", domainId: "eng", level: "P2", preferenceRank: 1, notes: null },
+    ]);
+  });
+
+  it("expands across ALL project domains only when there's no eligibility overlap", async () => {
+    // Member eligible in eng; project declares design + uiux (no overlap). The
+    // bid falls back to every project domain at the default level so it shows.
+    mockPrisma.domainEligibility.findMany.mockResolvedValue([
+      { domainId: "eng", level: "P3" },
+    ]);
+    mockPrisma.projectDomain.findMany.mockResolvedValue([
+      { projectId: "p1", domainId: "design" },
+      { projectId: "p1", domainId: "uiux" },
+    ]);
+    const res = await validateBids("u1", cycle, [{ projectId: "p1" }]);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.bids).toEqual([
+      { projectId: "p1", domainId: "design", level: "P1", preferenceRank: 1, notes: null },
+      { projectId: "p1", domainId: "uiux", level: "P1", preferenceRank: 1, notes: null },
+    ]);
   });
 
   it("de-duplicates the same project picked twice, keeping the highest rank", async () => {

--- a/dali-api/app/projects/lib/bid-validation.ts
+++ b/dali-api/app/projects/lib/bid-validation.ts
@@ -1,17 +1,16 @@
 // Shared validation + level-resolution for a member's project bids, used by
 // the form-driven submission path (bid-form-interpreter.ts → public-form.ts).
 //
-// A bid is now JUST a projectId (rank = array index). Domain is no longer
-// asked on the form — instead, each bid expands server-side into one
-// StaffingPreference per (project, eligibility) the member has, with that
-// eligibility's level. Anything outside that eligibility set is silently
-// dropped; anything inside it is recorded so the staffing board can see
-// every (project, domain) combination the member is eligible to fill.
-//
-// Bids must still match an open ProjectRoleRequest for (term, domain) — a
-// project with no open roles in any of the member's eligibility domains is
-// rejected. preferenceRank carries the bid's rank, so all expansions of bid
-// N share rank N.
+// A bid is JUST a projectId (rank = array index). Domain is not asked on the
+// form — instead, each bid expands server-side into StaffingPreference rows:
+// one per domain the PROJECT declares (ProjectDomain) that the member is also
+// eligible in, so a bid normally lands in the member's own domain columns at
+// their eligibility level. Eligibility does NOT gate the bid, though — when the
+// project shares no domain with the member's eligibility, the bid falls back to
+// the project's declared domains (at the default level) so it still shows on
+// the board instead of vanishing. preferenceRank carries the bid's rank, shared
+// across all expansions of bid N. (ProjectRoleRequest is headcount display
+// only; it never gates bids.)
 
 import { prisma } from "~/lib/db";
 
@@ -72,54 +71,55 @@ export async function validateBids(
   // Then cap at maxBids, keeping the top-ranked ones.
   const effectiveBids = dedupedBids.slice(0, maxBids);
 
-  // The member's eligibility map: domainId -> level. Each bid expands into
-  // one row per eligibility (where the project works in that domain). No
-  // eligibility yet → nothing to expand into, so record zero bids rather than
-  // erroring (the member still appears on the board, flagged).
+  // The member's eligibility map: domainId -> level. Used ONLY to label a bid
+  // row with the member's level in that domain — it does NOT gate whether a
+  // bid resolves. A member with no eligibility (or none in the project's
+  // domains) still produces bid rows; they're just marked at the default
+  // level. This keeps every bid visible on the board, per product intent.
   const eligibilities = await prisma.domainEligibility.findMany({
     where: { userId },
     select: { domainId: true, level: true },
   });
-  if (eligibilities.length === 0) {
-    return { ok: true, bids: [] };
-  }
   const levelByDomain = new Map(
     eligibilities.map((e) => [e.domainId, e.level]),
   );
 
-  // Biddability is driven by the project's DECLARED DOMAINS (ProjectDomain),
-  // not by per-term ProjectRoleRequest rows. A project is biddable in a domain
-  // if it works in that domain at all; level comes from the member's
-  // eligibility. (ProjectRoleRequest still exists for headcount display on the
-  // board, but no longer gates whether a bid resolves — a project with scope
-  // but no manually-entered role requests is still biddable.) Restricted to
-  // the bid projects ∩ the member's eligibility domains, keyed (project,domain)
-  // for O(1) cross-check.
+  // Biddability is driven by the project's DECLARED DOMAINS (ProjectDomain) —
+  // never by per-term ProjectRoleRequest rows. A bid expands to a row per
+  // domain the project declares that the member is ALSO eligible in (so a
+  // member's bid normally lands in their own domain columns). Eligibility no
+  // longer GATES the bid, though: when the project shares NO domain with the
+  // member's eligibility, the bid falls back to the project's declared domains
+  // so it still shows on the board instead of vanishing.
   const projectDomains = await prisma.projectDomain.findMany({
-    where: {
-      projectId: { in: effectiveBids.map((b) => b.projectId) },
-      domainId: { in: [...levelByDomain.keys()] },
-    },
+    where: { projectId: { in: effectiveBids.map((b) => b.projectId) } },
     select: { projectId: true, domainId: true },
   });
-  const biddable = new Set(
-    projectDomains.map((d) => `${d.projectId}:${d.domainId}`),
-  );
+  const domainsByProject = new Map<string, string[]>();
+  for (const d of projectDomains) {
+    const list = domainsByProject.get(d.projectId) ?? [];
+    list.push(d.domainId);
+    domainsByProject.set(d.projectId, list);
+  }
+
+  // Level shown on a bid row: the member's eligibility level in that domain if
+  // they have one, else the baseline P1 (Learner). Level never blocks a bid.
+  const DEFAULT_LEVEL: BidLevel = "P1";
 
   const validated: ValidatedBid[] = [];
   for (let i = 0; i < effectiveBids.length; i++) {
     const b = effectiveBids[i];
     const rank = i + 1;
-    // Each eligibility domain the project works in becomes a row. If the
-    // project doesn't work in any of the member's eligibility domains, the bid
-    // contributes nothing — silently dropped so the rest of the submission
-    // still records (eligibility/domain drift shouldn't reject the form).
-    for (const [domainId, level] of levelByDomain) {
-      if (!biddable.has(`${b.projectId}:${domainId}`)) continue;
+    const projDomains = domainsByProject.get(b.projectId) ?? [];
+    // Prefer the project domains the member is eligible in; if there's no
+    // overlap, fall back to all the project's domains so the bid still records.
+    const eligibleOverlap = projDomains.filter((d) => levelByDomain.has(d));
+    const targetDomains = eligibleOverlap.length > 0 ? eligibleOverlap : projDomains;
+    for (const domainId of targetDomains) {
       validated.push({
         projectId: b.projectId,
         domainId,
-        level: level as BidLevel,
+        level: (levelByDomain.get(domainId) ?? DEFAULT_LEVEL) as BidLevel,
         preferenceRank: rank,
         notes: null,
       });

--- a/dali-api/app/root.tsx
+++ b/dali-api/app/root.tsx
@@ -14,6 +14,7 @@ import {
   AnalyticsErrorReporter,
   reportBoundaryError,
 } from "~/components/AnalyticsErrorReporter";
+import { NavigationProgress } from "~/components/NavigationProgress";
 
 export const links: Route.LinksFunction = () => [
   { rel: "preconnect", href: "https://fonts.googleapis.com" },
@@ -70,6 +71,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
         <Links />
       </head>
       <body>
+        <NavigationProgress />
         {children}
         <AnalyticsErrorReporter />
         <ScrollRestoration />

--- a/dali-api/app/routes/layout.tsx
+++ b/dali-api/app/routes/layout.tsx
@@ -82,11 +82,16 @@ export default function AppLayoutRoute() {
 
   // When embedded, keep the parent workspace in sync with this iframe on every
   // in-iframe navigation:
-  //  - `dali:tabNavigated` updates the tab's stored URL so the sidebar
-  //    highlight tracks the current page and a reload restores it (the iframe
-  //    src is pinned to its mount seed, so this never reloads the frame).
-  //  - `dali:setTabLabel` refreshes the tab label from document.title.
-  // The reported URL drops `embed=1` so it matches how tabs are stored/opened.
+  //  - `dali:tabNavigated` updates the tab's stored URL (with `embed=1`
+  //    stripped, matching how tabs are stored) so the sidebar highlight tracks
+  //    the current page and a reload restores it. The iframe src is pinned to
+  //    its mount seed, so this never reloads the frame.
+  //  - `dali:setTabLabel` refreshes the tab label from document.title, keyed by
+  //    the iframe's RAW location (still carrying `embed=1` on first load). A
+  //    sidebar-opened section root is stored without `embed`, so its raw URL
+  //    won't match and its friendly sidebar label ("Cycles", "Domain", …) is
+  //    preserved; only a deeper client-side navigation (where `embed` has been
+  //    dropped from the URL) matches and refines the label.
   // setTimeout gives React Router a tick to write the title from meta.
   useEffect(() => {
     if (!embedded) return
@@ -95,10 +100,10 @@ export default function AppLayoutRoute() {
     const params = new URLSearchParams(location.search)
     params.delete('embed')
     const query = params.toString()
-    const url = location.pathname + (query ? `?${query}` : '')
+    const cleanUrl = location.pathname + (query ? `?${query}` : '')
 
     window.parent.postMessage(
-      { type: 'dali:tabNavigated', url },
+      { type: 'dali:tabNavigated', url: cleanUrl },
       window.location.origin,
     )
 
@@ -107,7 +112,11 @@ export default function AppLayoutRoute() {
       const label = raw.replace(/\s*·\s*DALI OS\s*$/, '').trim() || raw
       if (!label) return
       window.parent.postMessage(
-        { type: 'dali:setTabLabel', url, label },
+        {
+          type: 'dali:setTabLabel',
+          url: window.location.pathname + window.location.search,
+          label,
+        },
         window.location.origin,
       )
     }, 50)

--- a/dali-api/app/routes/layout.tsx
+++ b/dali-api/app/routes/layout.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { Outlet, redirect, useLoaderData, useSearchParams } from 'react-router'
+import { Outlet, redirect, useLoaderData, useLocation, useSearchParams } from 'react-router'
 import { Layout } from '~/components/Layout'
 import { requireAuth } from "~/lib/auth";
 import { getUserRoles } from '~/lib/roles'
@@ -60,6 +60,7 @@ export async function loader({ request }: Route.LoaderArgs) {
 export default function AppLayoutRoute() {
   const { user, photoUrl, isCore, isAdmin, isDomainLead, canViewForms, canViewStaffing, isInterviewer, isEmbedded } = useLoaderData<typeof loader>()
   const [searchParams] = useSearchParams()
+  const location = useLocation()
 
   // After a client-side navigation inside the workspace iframe, the loader
   // re-runs via fetch — which carries `Sec-Fetch-Dest: empty`, not `iframe` —
@@ -79,28 +80,39 @@ export default function AppLayoutRoute() {
 
   const embedded = isEmbedded || isClientEmbedded || searchParams.get('embed') === '1'
 
-  // When embedded, announce our preferred tab label to the parent workspace.
-  // Source: document.title (set by each route's Route.MetaFunction), with the
-  // shared `· DALI OS` suffix stripped. setTimeout(0) gives React Router a
-  // tick to write the title from meta before we read it.
+  // When embedded, keep the parent workspace in sync with this iframe on every
+  // in-iframe navigation:
+  //  - `dali:tabNavigated` updates the tab's stored URL so the sidebar
+  //    highlight tracks the current page and a reload restores it (the iframe
+  //    src is pinned to its mount seed, so this never reloads the frame).
+  //  - `dali:setTabLabel` refreshes the tab label from document.title.
+  // The reported URL drops `embed=1` so it matches how tabs are stored/opened.
+  // setTimeout gives React Router a tick to write the title from meta.
   useEffect(() => {
     if (!embedded) return
     if (typeof window === 'undefined') return
+
+    const params = new URLSearchParams(location.search)
+    params.delete('embed')
+    const query = params.toString()
+    const url = location.pathname + (query ? `?${query}` : '')
+
+    window.parent.postMessage(
+      { type: 'dali:tabNavigated', url },
+      window.location.origin,
+    )
+
     const id = window.setTimeout(() => {
       const raw = document.title
       const label = raw.replace(/\s*·\s*DALI OS\s*$/, '').trim() || raw
       if (!label) return
       window.parent.postMessage(
-        {
-          type: 'dali:setTabLabel',
-          url: window.location.pathname + window.location.search,
-          label,
-        },
+        { type: 'dali:setTabLabel', url, label },
         window.location.origin,
       )
     }, 50)
     return () => window.clearTimeout(id)
-  }, [embedded])
+  }, [embedded, location.pathname, location.search])
 
   // Skip the sidebar shell when rendered inside a TabWorkspace iframe.
   if (embedded) {

--- a/dali-api/prisma/migrations/20260525210000_add_review_rubric_version/migration.sql
+++ b/dali-api/prisma/migrations/20260525210000_add_review_rubric_version/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "ApplicationReview" ADD COLUMN "rubricVersionId" TEXT;
+
+-- AddForeignKey
+ALTER TABLE "ApplicationReview" ADD CONSTRAINT "ApplicationReview_rubricVersionId_fkey" FOREIGN KEY ("rubricVersionId") REFERENCES "RubricVersion"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/dali-api/prisma/schema.prisma
+++ b/dali-api/prisma/schema.prisma
@@ -729,6 +729,15 @@ model ApplicationReview {
   cycleReviewerId String
   cycleReviewer   CycleReviewer @relation(fields: [cycleReviewerId], references: [id])
 
+  // The domain rubric version this review's score keys belong to, pinned at
+  // submit time. Rubric edits create a NEW RubricVersion (with fresh
+  // crit-<ts> keys for added criteria), so without this pin a later edit
+  // orphans old score keys and labels render as raw keys. Nullable: reviews
+  // created before this column existed have no pin (resolver falls back to
+  // scanning version history).
+  rubricVersionId String?
+  rubricVersion   RubricVersion? @relation(fields: [rubricVersionId], references: [id])
+
   scores                Json    @default("{}") // { [criterionKey]: number }
   feedback              String  @default("")
   rejectionRationale    String  @default("")
@@ -812,6 +821,8 @@ model RubricVersion {
   domainApplicationCycles DomainApplicationCycle[]
   // Back-ref: cycles using this as the general form rubric
   cyclesAsGeneralRubric   ApplicationCycle[]       @relation("CycleGeneralRubric")
+  // Back-ref: reviews pinned to this version's criteria at submit time
+  applicationReviews      ApplicationReview[]
 }
 
 // ─── Collaborative Editing ───────────────────────────────────────────────────

--- a/dali-api/scripts/backfill-staffing-submissions.ts
+++ b/dali-api/scripts/backfill-staffing-submissions.ts
@@ -1,0 +1,337 @@
+/**
+ * Backfill StaffingPreference / IntentToWork rows for project-bids and
+ * intent-to-work form submissions that should have produced them but didn't.
+ * Two cases are handled:
+ *
+ *  (A) ORPHANED — the submission was saved with staffingCycleId = null / slot =
+ *      null. Before the pickStaffingBinding fix, submitMemberForm derived the
+ *      cycle from currentTerm() and only acted on a binding matching the live
+ *      cycle, so a submission for a non-live term fell through to the plain
+ *      branch and wrote no staffing rows. The cycle is re-derived from the
+ *      form's own binding.
+ *
+ *  (B) STAMPED-BUT-EMPTY — the submission IS stamped with a cycle+slot, but the
+ *      member currently has NO StaffingPreference / IntentToWork for that cycle.
+ *      This happens when validation dropped every row under the old rules (e.g.
+ *      bids on projects with no matching ProjectRoleRequest, before biddability
+ *      became domain-driven). Re-running validation under the current rules
+ *      recovers them. The cycle is the one already on the row.
+ *
+ * In both cases we replay the exact interpret → validate → replace path the
+ * live code uses, so recovered rows match a fresh submission.
+ *
+ * SAFETY — never clobbers good data:
+ *  - Case B only touches submissions whose member has ZERO existing rows for
+ *    the cycle, so there's nothing to overwrite.
+ *  - Only the LATEST submission per (user, form) is replayed; older ones are
+ *    left (replace-whole-set would otherwise wipe newer data).
+ *  - Orphans are also stamped so they drop out of the candidate set on re-run.
+ *
+ * Dry-run by default — prints what it WOULD do and writes nothing. Pass
+ * --commit to actually write.
+ *
+ * Usage:
+ *   npx tsx --env-file .env scripts/backfill-staffing-submissions.ts          # dry run
+ *   npx tsx --env-file .env scripts/backfill-staffing-submissions.ts --commit # write
+ */
+import { PrismaClient } from "../app/generated/prisma/client.js";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { interpretBidForm } from "../app/projects/lib/bid-form-interpreter.js";
+import { validateBids, replaceBidSet } from "../app/projects/lib/bid-validation.js";
+import { interpretIntentForm } from "../app/projects/lib/intent-form-interpreter.js";
+import { replaceIntentSet } from "../app/projects/lib/intent-validation.js";
+import {
+  parseColumnMapping,
+  validateMapping,
+} from "../app/projects/lib/slot-roles.js";
+
+const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL! });
+const prisma = new PrismaClient({ adapter });
+
+const COMMIT = process.argv.includes("--commit");
+
+type Question = Parameters<typeof validateMapping>[1][number];
+type Slot = "project-bids" | "intent-to-work";
+
+// One unit of work, normalized so the two source cases share a code path.
+type Candidate = {
+  id: string;
+  userId: string;
+  createdAt: Date;
+  formId: string;
+  formName: string;
+  answers: Record<string, unknown>;
+  questions: Question[];
+  slot: Slot;
+  cycle: { id: string; termId: string; maxPreferencesPerMember: number };
+  columnMapping: unknown;
+  source: "orphan" | "stamped-empty";
+};
+
+async function main() {
+  console.log(
+    COMMIT
+      ? "▶ COMMIT mode — changes WILL be written.\n"
+      : "▶ DRY RUN — no changes will be written. Re-run with --commit to apply.\n",
+  );
+
+  const candidates: Candidate[] = [];
+  let skipped = 0;
+
+  // ── Case A: orphaned submissions (null cycle) on a staffing-bound form ──
+  const orphans = await prisma.formSubmission.findMany({
+    where: {
+      staffingCycleId: null,
+      userId: { not: null },
+      form: {
+        cycleBindings: { some: { slot: { in: ["project-bids", "intent-to-work"] } } },
+      },
+    },
+    orderBy: { createdAt: "asc" },
+    select: {
+      id: true,
+      userId: true,
+      createdAt: true,
+      answers: true,
+      formVersion: { select: { questions: true } },
+      form: {
+        select: {
+          id: true,
+          name: true,
+          cycleBindings: {
+            where: { slot: { in: ["project-bids", "intent-to-work"] } },
+            select: {
+              slot: true,
+              columnMapping: true,
+              staffingCycle: {
+                select: { id: true, termId: true, maxPreferencesPerMember: true },
+              },
+            },
+          },
+        },
+      },
+    },
+  });
+
+  for (const sub of orphans) {
+    const slotBindings = sub.form.cycleBindings.filter(
+      (b) => b.slot === "project-bids" || b.slot === "intent-to-work",
+    );
+    // A form bound to one slot for one cycle is the normal case. If it's bound
+    // to a slot for several cycles we can't attribute an orphan answer set;
+    // skip for a human rather than guess.
+    if (slotBindings.length !== 1) {
+      console.log(
+        `  ⊘ orphan ${sub.id} (form "${sub.form.name}"): ambiguous — ` +
+          `${slotBindings.length} staffing binding(s); skipping.`,
+      );
+      skipped++;
+      continue;
+    }
+    const b = slotBindings[0];
+    candidates.push({
+      id: sub.id,
+      userId: sub.userId!,
+      createdAt: sub.createdAt,
+      formId: sub.form.id,
+      formName: sub.form.name,
+      answers: (sub.answers as Record<string, unknown>) ?? {},
+      questions: (sub.formVersion.questions as unknown as Question[]) ?? [],
+      slot: b.slot as Slot,
+      cycle: b.staffingCycle,
+      columnMapping: b.columnMapping,
+      source: "orphan",
+    });
+  }
+
+  // ── Case B: stamped submissions whose member has no rows for that cycle ──
+  const stamped = await prisma.formSubmission.findMany({
+    where: {
+      staffingCycleId: { not: null },
+      userId: { not: null },
+      slot: { in: ["project-bids", "intent-to-work"] },
+    },
+    orderBy: { createdAt: "asc" },
+    select: {
+      id: true,
+      userId: true,
+      createdAt: true,
+      slot: true,
+      answers: true,
+      staffingCycleId: true,
+      formVersion: { select: { questions: true } },
+      form: {
+        select: {
+          id: true,
+          name: true,
+          cycleBindings: {
+            select: { slot: true, columnMapping: true, staffingCycle: { select: { id: true } } },
+          },
+        },
+      },
+      staffingCycle: {
+        select: { id: true, termId: true, maxPreferencesPerMember: true },
+      },
+    },
+  });
+
+  for (const sub of stamped) {
+    const slot = sub.slot as Slot;
+    const userId = sub.userId!;
+    const cycleId = sub.staffingCycleId!;
+    // Only re-validate when the member currently has NOTHING for this cycle —
+    // that's the "dropped to empty" case. If they already have rows, leave them
+    // alone (never clobber good data).
+    const existing =
+      slot === "project-bids"
+        ? await prisma.staffingPreference.count({
+            where: { userId, staffingCycleId: cycleId },
+          })
+        : await prisma.intentToWork.count({
+            where: { userId, staffingCycleId: cycleId },
+          });
+    if (existing > 0) continue;
+
+    // The mapping for a stamped submission comes from the binding on the SAME
+    // cycle+slot (that's how the live submit interpreted it).
+    const binding = sub.form.cycleBindings.find(
+      (cb) => cb.slot === slot && cb.staffingCycle.id === cycleId,
+    );
+    if (!binding) {
+      console.log(
+        `  ⊘ stamped ${sub.id} (form "${sub.form.name}", ${slot}): no binding for its own ` +
+          `cycle+slot; skipping (can't re-interpret).`,
+      );
+      skipped++;
+      continue;
+    }
+    candidates.push({
+      id: sub.id,
+      userId,
+      createdAt: sub.createdAt,
+      formId: sub.form.id,
+      formName: sub.form.name,
+      answers: (sub.answers as Record<string, unknown>) ?? {},
+      questions: (sub.formVersion.questions as unknown as Question[]) ?? [],
+      slot,
+      cycle: sub.staffingCycle!,
+      columnMapping: binding.columnMapping,
+      source: "stamped-empty",
+    });
+  }
+
+  console.log(
+    `Found ${candidates.length} candidate submission(s) ` +
+      `(${candidates.filter((c) => c.source === "orphan").length} orphaned, ` +
+      `${candidates.filter((c) => c.source === "stamped-empty").length} stamped-but-empty).\n`,
+  );
+
+  let recovered = 0;
+
+  // oldest-first within each (user, form) bucket: process so the newest wins.
+  candidates.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+
+  for (const c of candidates) {
+    // replace*Set is whole-set per (user, cycle), so only the LATEST submission
+    // for this (user, form) may write. An older one would wipe newer data.
+    const newer = await prisma.formSubmission.findFirst({
+      where: { userId: c.userId, formId: c.formId, createdAt: { gt: c.createdAt } },
+      select: { id: true },
+    });
+    if (newer) {
+      console.log(
+        `  ↩ ${c.source} ${c.id} (form "${c.formName}", ${c.slot}): superseded by a newer ` +
+          `submission; ${c.source === "orphan" ? "stamping cycle only" : "leaving as-is"}.`,
+      );
+      if (COMMIT && c.source === "orphan") {
+        await prisma.formSubmission.update({
+          where: { id: c.id },
+          data: { staffingCycleId: c.cycle.id, slot: c.slot },
+        });
+      }
+      recovered++;
+      continue;
+    }
+
+    const mapping = parseColumnMapping(c.columnMapping);
+    const mapCheck = validateMapping(c.slot, c.questions, mapping);
+    if (!mapCheck.ok || mapping == null) {
+      const why = mapCheck.ok ? "no mapping" : mapCheck.reason;
+      console.log(
+        `  ~ ${c.source} ${c.id} (form "${c.formName}", ${c.slot}): mapping not usable (${why}); ` +
+          `${c.source === "orphan" ? "stamping cycle only, no staffing rows" : "no rows to recover"}.`,
+      );
+      if (COMMIT && c.source === "orphan") {
+        await prisma.formSubmission.update({
+          where: { id: c.id },
+          data: { staffingCycleId: c.cycle.id, slot: c.slot },
+        });
+      }
+      recovered++;
+      continue;
+    }
+
+    if (c.slot === "project-bids") {
+      const interpreted = interpretBidForm(c.answers, mapping);
+      const rawBids = interpreted.ok ? interpreted.bids : [];
+      const validated =
+        rawBids.length > 0
+          ? await validateBids(c.userId, c.cycle, rawBids)
+          : { ok: true as const, bids: [] };
+      const bids = validated.ok ? validated.bids : [];
+
+      console.log(
+        `  ✓ ${c.source} ${c.id} (form "${c.formName}", project-bids → ${c.cycle.id}): ` +
+          `${bids.length} preference row(s) for user ${c.userId}.`,
+      );
+      if (COMMIT) {
+        await prisma.$transaction(async (tx) => {
+          await replaceBidSet(tx, c.userId, c.cycle.id, bids);
+          await tx.formSubmission.update({
+            where: { id: c.id },
+            data: { staffingCycleId: c.cycle.id, slot: "project-bids" },
+          });
+        });
+      }
+      recovered++;
+    } else {
+      const termRows = await prisma.term.findMany({ select: { id: true } });
+      const interpreted = interpretIntentForm(
+        c.answers,
+        mapping,
+        termRows.map((t) => t.id),
+      );
+      const rows = interpreted.ok ? interpreted.rows : [];
+
+      console.log(
+        `  ✓ ${c.source} ${c.id} (form "${c.formName}", intent-to-work → ${c.cycle.id}): ` +
+          `${rows.length} intent row(s) for user ${c.userId}.`,
+      );
+      if (COMMIT) {
+        await prisma.$transaction(async (tx) => {
+          await replaceIntentSet(tx, c.userId, c.cycle.id, rows);
+          await tx.formSubmission.update({
+            where: { id: c.id },
+            data: { staffingCycleId: c.cycle.id, slot: "intent-to-work" },
+          });
+        });
+      }
+      recovered++;
+    }
+  }
+
+  console.log(
+    `\nDone. ${recovered} submission(s) ${COMMIT ? "processed" : "would be processed"}, ` +
+      `${skipped} skipped (ambiguous / no binding).`,
+  );
+  if (!COMMIT && recovered > 0) {
+    console.log("Re-run with --commit to apply.");
+  }
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());


### PR DESCRIPTION
## Summary

Bundles several independent hiring/staffing fixes plus an in-progress review rubric-versioning feature that was already present in the working tree.

### Authored in this branch
- **Page-load animation** — `NavigationProgress` top bar (mounted in `root.tsx`, covers every document incl. embedded iframe pages) + per-iframe loading spinner in `TabWorkspace`.
- **Tab history** — workspace tabs track their live URL, decoupled from the iframe `src` seed, so back/forward and reload restore the last page; sidebar re-click refocuses an open tab by its origin.
- **Cancelled-interview leak** — reschedule now declines the old interview's `Active` assignments (matching cancel/withdraw); the my-interviews dashboard query gates on `interview.status: "Scheduled"` so a cancelled slot can't surface.
- **Applications tab** — status filter + search bar (name/email); submission count moved into the Applicant column header.
- **Mark Unavailable** — moved onto the assigned-interview card next to "Open Interview"; removed from the interview detail page.
- **Interview availability timezone fix** — window bounds + `CalendarGrid` now operate in the configured interview timezone (new `zonedWallTimeUtc` / `getZonedParts` helpers), fixing availability that was being silently dropped on save.
- **Bid resolution** — a bid is gated only by the project's declared domains (never level/role-requests). It lands in the member's eligibility-overlap domains, falling back to the project's domains when there's no overlap so a bid never vanishes from the board. Level is display-only.

### Pre-existing in the tree (not authored this session, included per request)
- Review **rubric versioning**: `ApplicationReview.rubricVersionId` + migration `20260525210000_add_review_rubric_version`, `rubric-criteria.*`, `api.reviews.$id`, `CollaborativeEditor`, and delibs/full-context edits.

## ⚠️ CI expectations
- `api.reviews.$id.test.ts` currently **fails** (`Cannot read properties of undefined (reading 'domainId')` at `api.reviews.$id.ts:207`) — part of the WIP rubric work.
- A new Prisma migration is included, so `migration-check.yml` will run.
- The authored changes above pass their own unit tests and typecheck (the only pre-existing `tsc` errors are in `scripts/*.ts`).

## Test plan
- `npm test` — note the known rubric test failure above.
- Manually verify: applications filter/search, assigned-interview "Mark Unavailable", interview availability save round-trip, bid modal shows resolved preferences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/701"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782407863&installation_id=133523038&pr_number=701&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F701&signature=54009adbded460854c9ec5a3d0b1d88522902c13e2bee4ad9167925bb793060a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->