### PR TITLE
Send reassignment emails on interviewer-decline auto-reassign

### DIFF
--- a/dali-api/app/hiring/lib/scheduling.ts
+++ b/dali-api/app/hiring/lib/scheduling.ts
@@ -1,6 +1,7 @@
 import type { Prisma } from "~/generated/prisma/client";
 import { prisma } from "~/lib/db";
 import { notifyInterviewAssigned } from "~/hiring/lib/interview-notifications";
+import { sendReassignmentEmails } from "~/hiring/lib/interview-emails";
 
 // New-assignee notifications fire outside transactions (best-effort), so
 // scheduling.ts hands callers the cycleInterviewerIds that need notifying
@@ -482,6 +483,8 @@ export async function reassignInterviewer(
       reassigned: true as const,
       newInterviewerId: created.cycleInterviewerId,
       newAssignmentId: created.id,
+      oldCycleInterviewerId: assignment.cycleInterviewerId,
+      domainApplicationId: interview.domainApplicationId,
     };
   });
 
@@ -489,6 +492,12 @@ export async function reassignInterviewer(
     notifyInterviewAssigned({
       assignmentIds: [result.newAssignmentId],
     }).catch(() => {});
+    sendReassignmentEmails(
+      interviewId,
+      result.domainApplicationId,
+      result.oldCycleInterviewerId,
+      result.newInterviewerId,
+    ).catch(() => {});
   }
 
   return result;


### PR DESCRIPTION
## Summary

- Fixes a silent gap: when an interviewer declined an interview, the auto-reassign succeeded but **no email went out** to any party (declining interviewer, replacement, applicant, co-interviewers).
- Root cause: `reassignInterviewer()` (called from the decline route) fired the in-app `notifyInterviewAssigned` notification but never called `sendReassignmentEmails()`. The admin reassign route (`POST /api/interviews/:id/reassign`) already calls both; the decline route went through `reassignInterviewer` and only got the in-app half.
- Fix: invoke `sendReassignmentEmails` from inside `reassignInterviewer` after the swap commits, so both code paths behave identically. Same best-effort `.catch(() => {})` pattern as the admin route — email failures don't roll back the reassign.

## Affected paths

- `app/hiring/lib/scheduling.ts` — `reassignInterviewer`: returns now include `oldCycleInterviewerId` and `domainApplicationId`; fires `sendReassignmentEmails` post-commit.
- Decline route (`app/hiring/routes/api.cycles.\$cycleId.my-interviews.\$interviewId.decline.ts`) — **unchanged**; gets the fix transitively.
- Admin reassign route — **unchanged**; still calls `sendReassignmentEmails` directly. No double-send since the admin route does its own inline transaction and does not call `reassignInterviewer`.

## Test plan

- [ ] Existing `reassignInterviewer` unit tests still pass (verified locally: 30/30 in `scheduling.test.ts`)
- [ ] Manual: interviewer declines a scheduled interview where a free replacement exists — confirm declining interviewer gets cancel email + ICS CANCEL, replacement gets invite + ICS REQUEST, applicant gets confirmation + ICS REQUEST(update), unchanged co-interviewers get ICS REQUEST(update)
- [ ] Manual: interviewer declines where no replacement is free — confirm 409 returned, original assignment stays Active, **no** emails sent (regression check)
- [ ] Manual: admin reassign still sends a single set of emails (no double-send)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/702"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782411981&installation_id=133523038&pr_number=702&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F702&signature=50443fc40b52dfdbe9a445f0e7f05341d1d7d0807105e486f9c0b175fbb62c2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->