### PR TITLE
Backfill script: resend decline-reassign invites (skips past interviews)

### DIFF
--- a/dali-api/app/hiring/lib/interview-emails.ts
+++ b/dali-api/app/hiring/lib/interview-emails.ts
@@ -448,6 +448,87 @@ export async function sendReassignmentEmails(
   }
 }
 
+// Targeted backfill: send the "you're now the interviewer" invite to a
+// single CycleInterviewer for an existing interview. Used by the
+// resend-decline-invites script to repair decline-auto-reassigns that
+// completed before PR #702 wired up sendReassignmentEmails. Refuses to send
+// for past interviews or interviews that aren't Scheduled (Completed,
+// Cancelled*) — there's nothing to add to the recipient's calendar.
+// Does NOT email the applicant, co-interviewers, or the original decliner.
+export async function sendInviteEmailToNewInterviewer(
+  interviewId: string,
+  cycleInterviewerId: string,
+): Promise<{ sent: boolean; reason?: string }> {
+  const refreshToken = await getGmailRefreshToken();
+  if (!refreshToken) return { sent: false, reason: "no_refresh_token" };
+
+  const interview = await prisma.interview.findUnique({
+    where: { id: interviewId },
+    include: {
+      domainApplication: {
+        include: {
+          challengeVersion: { include: { domain: { select: { name: true } } } },
+        },
+      },
+    },
+  });
+  if (!interview) return { sent: false, reason: "interview_not_found" };
+  if (interview.status !== "Scheduled") {
+    return { sent: false, reason: `interview_status_${interview.status}` };
+  }
+  if (interview.endTime.getTime() < Date.now()) {
+    return { sent: false, reason: "interview_in_past" };
+  }
+
+  const newCI = await prisma.cycleInterviewer.findUnique({
+    where: { id: cycleInterviewerId },
+    include: { user: { select: { firstName: true, daliEmail: true } } },
+  });
+  if (!newCI?.user.daliEmail) return { sent: false, reason: "no_dali_email" };
+
+  const applicant = await getApplicantRecipient(interview.domainApplicationId);
+  const sequence = await bumpIcsSequence(interview.id);
+  const domainName = interview.domainApplication.challengeVersion?.domain?.name ?? "DALI Lab";
+  const firstName = newCI.user.firstName ?? "Interviewer";
+
+  const ics = buildInviteIcs({
+    interviewId: interview.id,
+    summary: `DALI Interview — ${domainName}`,
+    startTime: interview.startTime,
+    endTime: interview.endTime,
+    location: formatLocation(interview.location, interview.zoomJoinUrl),
+    meetingUrl: interview.zoomJoinUrl,
+    organizer: ORGANIZER,
+    attendees: [
+      ...(applicant ? [{ email: applicant.email, name: applicant.firstName }] : []),
+      { email: newCI.user.daliEmail, name: firstName },
+    ],
+    sequence,
+  });
+
+  const rendered = await renderFromBinding(
+    interview.applicationCycleId,
+    "InterviewInviteMentor",
+    {
+      firstName,
+      domain: domainName,
+      time: formatTime(interview.startTime),
+      location: formatLocation(interview.location, interview.zoomJoinUrl),
+      meetingUrl: interview.zoomJoinUrl ?? undefined,
+    },
+  );
+  if (!rendered) return { sent: false, reason: "no_template_binding" };
+
+  await sendEmail({
+    refreshToken,
+    to: newCI.user.daliEmail,
+    subject: rendered.subject,
+    html: rendered.html,
+    ics,
+  });
+  return { sent: true };
+}
+
 export async function sendLocationChangeEmails(
   interviewId: string,
   domainApplicationId: string,

--- a/dali-api/scripts/resend-decline-invites.ts
+++ b/dali-api/scripts/resend-decline-invites.ts
@@ -1,0 +1,99 @@
+// Backfill the "you're the new interviewer" invite for interviews where an
+// interviewer declined and the auto-reassign succeeded but no email was
+// sent. The decline path was missing the call to sendReassignmentEmails
+// before PR #702 — this script repairs the affected cases.
+//
+// For each interview ID, finds the post-decline Active assignment (the
+// replacement) and emails just that one interviewer (invite + ICS REQUEST).
+// Does NOT email the applicant, co-interviewers, or the original decliner.
+//
+// Safety: skips interviews that have already happened (endTime in the past)
+// or whose status is not Scheduled (Completed / Cancelled*). The guard
+// lives in sendInviteEmailToNewInterviewer too, but the script pre-checks
+// so the dry-run preview is honest.
+//
+// Usage:
+//   DATABASE_URL=... npx tsx scripts/resend-decline-invites.ts [--dry-run] <interviewId> [<interviewId> ...]
+//
+// Tip: run with --dry-run first to see who would receive each email.
+
+import { PrismaClient } from "../app/generated/prisma/client.js";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { sendInviteEmailToNewInterviewer } from "../app/hiring/lib/interview-emails.js";
+
+const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL! });
+const prisma = new PrismaClient({ adapter });
+
+const args = process.argv.slice(2);
+const dryRun = args.includes("--dry-run");
+const interviewIds = args.filter((a) => !a.startsWith("--"));
+
+if (interviewIds.length === 0) {
+  console.error(
+    "Usage: DATABASE_URL=... npx tsx scripts/resend-decline-invites.ts [--dry-run] <interviewId> [...]",
+  );
+  process.exit(1);
+}
+
+const now = new Date();
+
+for (const interviewId of interviewIds) {
+  const interview = await prisma.interview.findUnique({
+    where: { id: interviewId },
+    select: { id: true, status: true, startTime: true, endTime: true },
+  });
+  if (!interview) {
+    console.log(`[${interviewId}] interview not found — skip`);
+    continue;
+  }
+  if (interview.status !== "Scheduled") {
+    console.log(`[${interviewId}] status=${interview.status} — skip`);
+    continue;
+  }
+  if (interview.endTime < now) {
+    console.log(`[${interviewId}] already happened (ended ${interview.endTime.toISOString()}) — skip`);
+    continue;
+  }
+
+  const declined = await prisma.interviewAssignment.findFirst({
+    where: { interviewId, status: "Declined" },
+    orderBy: { createdAt: "desc" },
+  });
+  if (!declined) {
+    console.log(`[${interviewId}] no Declined assignment — skip`);
+    continue;
+  }
+
+  const active = await prisma.interviewAssignment.findFirst({
+    where: {
+      interviewId,
+      status: "Active",
+      role: declined.role,
+      createdAt: { gt: declined.createdAt },
+    },
+    include: {
+      cycleInterviewer: {
+        include: { user: { select: { firstName: true, daliEmail: true } } },
+      },
+    },
+    orderBy: { createdAt: "asc" },
+  });
+  if (!active) {
+    console.log(`[${interviewId}] no replacement Active assignment for role=${declined.role} — skip`);
+    continue;
+  }
+
+  const user = active.cycleInterviewer.user;
+  const name = user?.firstName ?? "?";
+  const email = user?.daliEmail ?? "?";
+  console.log(
+    `[${interviewId}] ${dryRun ? "WOULD send" : "sending"} invite to ${name} <${email}> (cycleInterviewerId=${active.cycleInterviewerId}, role=${active.role}, startTime=${interview.startTime.toISOString()})`,
+  );
+
+  if (!dryRun) {
+    const result = await sendInviteEmailToNewInterviewer(interviewId, active.cycleInterviewerId);
+    console.log(`[${interviewId}] result: ${JSON.stringify(result)}`);
+  }
+}
+
+await prisma.$disconnect();


### PR DESCRIPTION
## Summary

- Adds `sendInviteEmailToNewInterviewer(interviewId, cycleInterviewerId)` to `app/hiring/lib/interview-emails.ts` — a single-recipient invite send used only by the backfill script. **Refuses to send if the interview is not `Scheduled` or its `endTime` is in the past**, so we never email anyone about an interview that already happened or was cancelled.
- Adds `scripts/resend-decline-invites.ts` — for each interview ID passed on the CLI, finds the post-decline `Active` `InterviewAssignment` (the replacement) and emails only that person. Same past/cancelled guard applied in the script itself so the `--dry-run` preview honestly reports what would be sent.

Backfills cases that hit the bug fixed in #702 before that fix shipped: interviewer declined, auto-reassign succeeded, but the replacement never got an invite.

## Usage

```bash
cd dali-api

# Preview (no sends)
DATABASE_URL='<prod neon pooled url>' \\
  npx tsx scripts/resend-decline-invites.ts --dry-run <id1> <id2> ...

# Actually send
DATABASE_URL='<prod neon pooled url>' \\
  npx tsx scripts/resend-decline-invites.ts <id1> <id2> ...
```

Interview IDs come from \`AuditLog\` rows where \`action='interview.decline'\` (the \`targetId\` column is the interview ID).

## Per-interview output reasons

- \`sent: true\` — email + ICS REQUEST delivered
- \`interview_in_past\` / \`interview_status_<X>\` — guard tripped, nothing sent
- \`no_refresh_token\` — Gmail integration not configured for this DB
- \`no_dali_email\` — replacement interviewer has no \`daliEmail\` on file
- \`no_template_binding\` — cycle is missing the \`InterviewInviteMentor\` template
- \`no Declined assignment\` / \`no replacement Active assignment\` — interview state doesn't match the pattern this script repairs

## Test plan

- [ ] \`--dry-run\` against staging with a known affected interview ID — confirm correct replacement identified, no Gmail call made
- [ ] Real send against a single staging interview — confirm new interviewer receives invite + calendar event
- [ ] Run against an interview whose \`endTime\` is in the past — confirm skip with \`already happened\` log line, no Gmail call
- [ ] Run against an interview with no Declined assignment — confirm skip with informative log line

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/705"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782414053&installation_id=133523038&pr_number=705&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F705&signature=8e31abfed22c877935d4fef567daa52cb0646d3bbabc8e409a2ea6fb4c887ab3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->