### PR TITLE
Domain page + staffing board UX: Reviews/Interviews, delibs recs, full bid detail

### DIFF
--- a/dali-api/app/calendar/routes/calendar.tsx
+++ b/dali-api/app/calendar/routes/calendar.tsx
@@ -2680,6 +2680,10 @@ function ScheduleWeekGrid({
     let cancelled = false;
     setLoading(true);
     setError(null);
+    // durationMinutes is intentionally omitted: it only affects the server's
+    // ≥-duration match windows (data.days), which this grid never reads — the
+    // gradient and slot breakdown are built from per-user free intervals. Re-
+    // fetching on every drag would just flash "Loading availability…".
     fetch("/api/calendar/group-availability", {
       method: "POST",
       credentials: "include",
@@ -2712,7 +2716,8 @@ function ScheduleWeekGrid({
     return () => {
       cancelled = true;
     };
-  }, [participantKey, durationMinutes, weekStartIso, weekEndIso, timezone, refreshKey]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [participantKey, weekStartIso, weekEndIso, timezone, refreshKey]);
 
   // Build the 7-day axis from the week window so empty days still render.
   const weekStart = new Date(weekStartIso);
@@ -2955,9 +2960,6 @@ function ScheduleWeekGrid({
                   duration={selectedSlot.duration}
                   available={selectedSlot.available}
                   unavailable={selectedSlot.unavailable}
-                  // Flip the popover to the left edge for the rightmost columns
-                  // (Fri/Sat) so the attendee list isn't clipped off-screen.
-                  flipLeft={dayIdx >= 5}
                 />
               );
             }}
@@ -3031,22 +3033,22 @@ function SelectedSlotBlock({
   duration,
   available,
   unavailable,
-  flipLeft = false,
 }: {
   startHour: number;
   duration: number;
   available: UserOption[];
   unavailable: UserOption[];
-  // Open the attendee popover toward the left for rightmost columns so it
-  // doesn't get clipped off the right edge of the screen.
-  flipLeft?: boolean;
 }) {
   const [open, setOpen] = useState(false);
+  // Anchor the popover to the block's real on-screen rect (state, not a plain
+  // ref, so the portal re-renders the moment the node attaches).
+  const [anchorEl, setAnchorEl] = useState<HTMLDivElement | null>(null);
   const total = available.length + unavailable.length;
   const top = (startHour - HOURS[0]) * HOUR_PX;
   const height = duration * HOUR_PX;
   return (
     <div
+      ref={setAnchorEl}
       className="absolute left-0 right-0 z-30 cursor-help border-2 border-accent-coral bg-accent-coral/10 rounded-sm"
       style={{ top, height }}
       onMouseEnter={() => setOpen(true)}
@@ -3056,50 +3058,140 @@ function SelectedSlotBlock({
         {available.length}/{total}
       </div>
       {open && (
-        <div
-          className={`absolute top-0 z-40 w-56 rounded-md shadow-lg p-2 text-xs ${
-            flipLeft ? "right-full mr-2" : "left-full ml-2"
-          }`}
-          style={{
-            backgroundColor: "var(--color-card)",
-            color: "var(--color-foreground)",
-            border: "1px solid var(--color-border)",
-          }}
-        >
-          <div className="font-semibold mb-1 text-foreground">
-            {available.length} of {total} can attend
-          </div>
-          {available.length > 0 && (
-            <div className="mb-1.5">
-              <div className="uppercase tracking-wide text-[10px] text-muted-foreground mb-0.5">
-                Available
-              </div>
-              <ul className="space-y-0.5">
-                {available.map((u) => (
-                  <li key={u.id} className="text-green-700 dark:text-green-400">
-                    {userLabel(u)}
-                  </li>
-                ))}
-              </ul>
-            </div>
-          )}
-          {unavailable.length > 0 && (
-            <div>
-              <div className="uppercase tracking-wide text-[10px] text-muted-foreground mb-0.5">
-                Busy
-              </div>
-              <ul className="space-y-0.5">
-                {unavailable.map((u) => (
-                  <li key={u.id} className="text-red-700 dark:text-red-400">
-                    {userLabel(u)}
-                  </li>
-                ))}
-              </ul>
-            </div>
-          )}
-        </div>
+        <SlotAttendeePopover
+          anchorEl={anchorEl}
+          available={available}
+          unavailable={unavailable}
+        />
       )}
     </div>
+  );
+}
+
+// The attendee breakdown for a selected slot. Rendered in a <body> portal so
+// the grid's overflow-hidden / column edges can't clip it, and positioned
+// `fixed` against the slot block's screen rect — preferring the right side but
+// flipping left and clamping vertically to stay fully on-screen. Anchoring off
+// the measured rect (in a layout effect) keeps it from jumping when the
+// availability data refetches under it.
+function SlotAttendeePopover({
+  anchorEl,
+  available,
+  unavailable,
+}: {
+  anchorEl: HTMLElement | null;
+  available: UserOption[];
+  unavailable: UserOption[];
+}) {
+  const cardRef = useRef<HTMLDivElement | null>(null);
+  const [pos, setPos] = useState<{ left: number; top: number } | null>(null);
+  const total = available.length + unavailable.length;
+
+  useLayoutEffect(() => {
+    if (!anchorEl) return;
+    const place = () => {
+      const card = cardRef.current;
+      if (!card) return;
+      const a = anchorEl.getBoundingClientRect();
+      const cw = card.offsetWidth;
+      const ch = card.offsetHeight;
+      const gap = 8;
+      const margin = 8;
+      const vw = window.innerWidth;
+      const vh = window.innerHeight;
+      // Prefer the right of the block; flip left if it would overflow.
+      let left = a.right + gap;
+      if (left + cw + margin > vw) left = a.left - gap - cw;
+      left = Math.max(margin, Math.min(left, vw - cw - margin));
+      // Top-align with the block when the card fits below, else lift it so the
+      // bottom stays on-screen.
+      let top = a.top + ch + margin <= vh ? a.top : vh - ch - margin;
+      top = Math.max(margin, top);
+      setPos((prev) =>
+        prev && prev.left === left && prev.top === top ? prev : { left, top },
+      );
+    };
+    place();
+    const ro = new ResizeObserver(place);
+    if (cardRef.current) ro.observe(cardRef.current);
+    window.addEventListener("resize", place);
+    window.addEventListener("scroll", place, true);
+    return () => {
+      ro.disconnect();
+      window.removeEventListener("resize", place);
+      window.removeEventListener("scroll", place, true);
+    };
+  }, [anchorEl]);
+
+  if (typeof document === "undefined") return null;
+
+  // First paint (before the layout effect measures): estimate a spot beside the
+  // anchor so it renders next to the block, not at (0,0). Hidden via opacity
+  // until measured to avoid a one-frame flash at the estimate, then clamped.
+  const measured = pos != null;
+  let left = pos?.left ?? 0;
+  let top = pos?.top ?? 0;
+  if (!measured) {
+    const a = anchorEl?.getBoundingClientRect();
+    if (a) {
+      const CARD_W = 224; // matches w-56
+      const gap = 8;
+      const margin = 8;
+      left =
+        a.right + gap + CARD_W + margin > window.innerWidth
+          ? a.left - gap - CARD_W
+          : a.right + gap;
+      left = Math.max(margin, left);
+      top = Math.max(margin, a.top);
+    }
+  }
+
+  return createPortal(
+    <div
+      ref={cardRef}
+      className="fixed z-50 w-56 rounded-md shadow-lg p-2 text-xs"
+      style={{
+        left,
+        top,
+        visibility: measured ? "visible" : "hidden",
+        backgroundColor: "var(--color-card)",
+        color: "var(--color-foreground)",
+        border: "1px solid var(--color-border)",
+      }}
+    >
+      <div className="font-semibold mb-1 text-foreground">
+        {available.length} of {total} can attend
+      </div>
+      {available.length > 0 && (
+        <div className="mb-1.5">
+          <div className="uppercase tracking-wide text-[10px] text-muted-foreground mb-0.5">
+            Available
+          </div>
+          <ul className="space-y-0.5">
+            {available.map((u) => (
+              <li key={u.id} className="text-green-700 dark:text-green-400">
+                {userLabel(u)}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {unavailable.length > 0 && (
+        <div>
+          <div className="uppercase tracking-wide text-[10px] text-muted-foreground mb-0.5">
+            Busy
+          </div>
+          <ul className="space-y-0.5">
+            {unavailable.map((u) => (
+              <li key={u.id} className="text-red-700 dark:text-red-400">
+                {userLabel(u)}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>,
+    document.body,
   );
 }
 

--- a/dali-api/app/hiring/components/delibs/ApplicantContextModal.tsx
+++ b/dali-api/app/hiring/components/delibs/ApplicantContextModal.tsx
@@ -65,14 +65,14 @@ export function ApplicantContextModal({
 
   return (
     <div
-      className="fixed inset-0 z-50 bg-black/40 flex items-start justify-center p-4 overflow-y-auto"
+      className="fixed inset-0 z-50 bg-black/40 flex items-start justify-center p-4"
       onClick={onClose}
     >
       <div
-        className="bg-card rounded-xl shadow-xl w-full max-w-3xl my-8"
+        className="bg-card rounded-xl shadow-xl w-full max-w-5xl my-8 max-h-[90vh] flex flex-col"
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="px-6 py-4 border-b border-border flex items-center justify-between sticky top-0 bg-card rounded-t-xl">
+        <div className="px-6 py-4 border-b border-border flex items-center justify-between bg-card rounded-t-xl flex-shrink-0">
           <div>
             {isLoading || isError || !data ? (
               <h2 className="text-lg font-semibold text-foreground">Applicant Context</h2>
@@ -108,7 +108,7 @@ export function ApplicantContextModal({
           </button>
         </div>
 
-        <div className="p-6 space-y-6">
+        <div className="flex-1 min-h-0 overflow-y-auto lg:overflow-hidden flex flex-col p-6 gap-6">
           <InterviewPrepNoteSection
             domainApplicationId={domainApplicationId}
             editable={editable}
@@ -127,24 +127,34 @@ export function ApplicantContextModal({
           )}
 
           {!isLoading && !isError && data && (
-            <>
-              <AnswerSection
-                title="General Application"
-                questions={data.application.generalQuestions}
-                answers={data.application.answers}
-              />
-              <AnswerSection
-                title={`${data.domainApplication.domain?.name ?? "Domain"} Challenge`}
-                questions={data.domainApplication.challengeQuestions}
-                answers={data.domainApplication.answers}
-              />
-              <ReviewsSection
-                reviews={data.reviews ?? []}
-                criteriaByKey={data.criteriaByKey ?? {}}
-                fieldContext={buildFieldContext(data)}
-              />
-              <DecisionsSection decisions={data.decisions ?? []} />
-            </>
+            // Each column scrolls independently so scrolling is predictable:
+            // whichever side the cursor is over moves, the other stays put.
+            <div className="flex-1 min-h-0 grid grid-cols-1 lg:grid-cols-3 gap-6">
+              {/* Left: application answers */}
+              <div className="lg:col-span-2 min-h-0 lg:overflow-y-auto space-y-6 pr-1">
+                <AnswerSection
+                  title="General Application"
+                  questions={data.application.generalQuestions}
+                  answers={data.application.answers}
+                />
+                <AnswerSection
+                  title={`${data.domainApplication.domain?.name ?? "Domain"} Challenge`}
+                  questions={data.domainApplication.challengeQuestions}
+                  answers={data.domainApplication.answers}
+                />
+              </div>
+
+              {/* Right: review + interview + decision data */}
+              <div className="min-h-0 lg:overflow-y-auto space-y-6 pr-1">
+                <ReviewsSection
+                  reviews={data.reviews ?? []}
+                  criteriaByKey={data.criteriaByKey ?? {}}
+                  fieldContext={buildFieldContext(data)}
+                />
+                <InterviewSection interview={data.interviews?.[0] ?? null} />
+                <DecisionsSection decisions={data.decisions ?? []} />
+              </div>
+            </div>
           )}
         </div>
       </div>
@@ -461,6 +471,91 @@ export function ReviewsSection({
           })}
         </div>
       )}
+    </section>
+  );
+}
+
+function InterviewSection({ interview }: { interview: any | null }) {
+  if (!interview) return null;
+  const assignments: any[] = Array.isArray(interview.assignments) ? interview.assignments : [];
+  return (
+    <section className="bg-card border border-border rounded-lg overflow-hidden">
+      <div className="px-4 py-2 bg-muted/50 border-b border-border">
+        <h3 className="text-sm font-semibold text-foreground">Interview</h3>
+      </div>
+      <div className="px-4 py-3 space-y-2">
+        <div className="flex items-center justify-between">
+          <span className="text-sm text-muted-foreground">
+            {new Date(interview.startTime).toLocaleDateString(undefined, { month: "short", day: "numeric" })}{" "}
+            {new Date(interview.startTime).toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" })}
+          </span>
+          <span
+            className={`text-xs px-2 py-0.5 rounded-full font-medium ${
+              interview.status === "Completed"
+                ? "bg-green-100 text-green-700"
+                : "bg-blue-100 text-blue-700"
+            }`}
+          >
+            {interview.status}
+          </span>
+        </div>
+        {interview.recommendation && (
+          <div className="text-sm">
+            <span className="text-muted-foreground">Recommendation:</span>{" "}
+            <span className="font-medium text-foreground">{interview.recommendation}</span>
+          </div>
+        )}
+        {interview.recommendationNotes && (
+          <p className="text-xs text-muted-foreground bg-muted/50 rounded p-2 whitespace-pre-wrap">
+            {interview.recommendationNotes}
+          </p>
+        )}
+        {assignments.length > 0 && (
+          <div className="text-xs text-muted-foreground pt-1">
+            Interviewers:{" "}
+            {assignments
+              .map((a) => {
+                const m = a.cycleInterviewer?.user;
+                return m ? `${m.firstName} ${m.lastName}` : "?";
+              })
+              .join(", ")}
+          </div>
+        )}
+
+        {/* Joint interview notes (shared by interviewers). */}
+        <div className="pt-2 border-t border-border">
+          <div className="text-[10px] uppercase tracking-wide font-semibold text-muted-foreground/70 mb-1">
+            Interview notes
+          </div>
+          {interview.jointNotes ? (
+            <p className="text-sm text-foreground whitespace-pre-wrap">{interview.jointNotes}</p>
+          ) : (
+            <p className="text-xs text-muted-foreground/70 italic">No interview notes.</p>
+          )}
+        </div>
+
+        {/* Per-interviewer recommendation notes, when present. */}
+        {assignments.some((a) => a.recNotes) && (
+          <div className="pt-2 space-y-2">
+            {assignments
+              .filter((a) => a.recNotes)
+              .map((a) => {
+                const m = a.cycleInterviewer?.user;
+                const who = m ? `${m.firstName} ${m.lastName}` : "Interviewer";
+                return (
+                  <div key={a.id}>
+                    <div className="text-xs font-medium text-muted-foreground">
+                      {who}&rsquo;s notes
+                    </div>
+                    <p className="mt-0.5 text-sm text-foreground whitespace-pre-wrap">
+                      {a.recNotes}
+                    </p>
+                  </div>
+                );
+              })}
+          </div>
+        )}
+      </div>
     </section>
   );
 }

--- a/dali-api/app/hiring/routes/__tests__/api.domain-applications.full-context.test.ts
+++ b/dali-api/app/hiring/routes/__tests__/api.domain-applications.full-context.test.ts
@@ -18,6 +18,7 @@ const mockPrisma = prisma as unknown as {
     findUnique: ReturnType<typeof vi.fn>;
     findMany: ReturnType<typeof vi.fn>;
   };
+  collabDocumentVersion: { findMany: ReturnType<typeof vi.fn> };
 };
 
 const USER_ID = "user-1";
@@ -29,6 +30,7 @@ beforeEach(() => {
   (mockPrisma as any).domainApplication = { findUnique: vi.fn() };
   (mockPrisma as any).domainApplicationCycle = { findUnique: vi.fn() };
   (mockPrisma as any).rubricVersion = { findUnique: vi.fn(), findMany: vi.fn() };
+  (mockPrisma as any).collabDocumentVersion = { findMany: vi.fn() };
   vi.mocked(requireAuth).mockResolvedValue({
     ok: true,
     user: { sub: USER_ID },
@@ -81,7 +83,26 @@ function setupHappyPathDomainApp() {
         madeBy: { firstName: "Lead", lastName: "User" },
       },
     ],
+    interviews: [
+      {
+        id: "iv-1",
+        status: "Completed",
+        startTime: new Date("2026-04-20T15:00:00Z"),
+        recommendation: "Hire",
+        assignments: [
+          {
+            id: "asg-1",
+            cycleInterviewer: { user: { firstName: "Int", lastName: "Erviewer" } },
+          },
+        ],
+      },
+    ],
   });
+  // Latest collab snapshots for the interview's notes docs.
+  mockPrisma.collabDocumentVersion.findMany.mockResolvedValue([
+    { name: "interview:iv-1:notes", plainText: "Discussed the rollback plan." },
+    { name: "interview:iv-1:rec-notes-asg-1", plainText: "Would hire again." },
+  ]);
   // Current domain rubric version for the cycle.
   mockPrisma.domainApplicationCycle.findUnique.mockResolvedValue({
     rubricVersionId: "drv-1",
@@ -134,6 +155,11 @@ describe("GET /api/hiring/domain-applications/:id/full-context", () => {
     expect(json.reviews[0].rejectionRationale).toBe("");
     expect(json.decisions).toHaveLength(1);
     expect(json.decisions[0].notes).toBe("moved from Initial delibs");
+    // The bundle carries the latest interview with resolved collab notes.
+    expect(json.interviews).toHaveLength(1);
+    expect(json.interviews[0].recommendation).toBe("Hire");
+    expect(json.interviews[0].jointNotes).toBe("Discussed the rollback plan.");
+    expect(json.interviews[0].assignments[0].recNotes).toBe("Would hire again.");
     // Criteria are now returned as a resolved key -> meta map (resilient to
     // rubric edits) rather than separate general/domain arrays.
     expect(json.criteriaByKey.g1c).toEqual({ label: "General", maxScore: 5, description: undefined });

--- a/dali-api/app/hiring/routes/api.domain-applications.$id.full-context.ts
+++ b/dali-api/app/hiring/routes/api.domain-applications.$id.full-context.ts
@@ -41,6 +41,21 @@ export async function loader({ request, params }: Route.LoaderArgs) {
         orderBy: { createdAt: "desc" },
         include: { madeBy: { select: { firstName: true, lastName: true } } },
       },
+      interviews: {
+        where: { status: { in: ["Scheduled", "Completed"] } },
+        orderBy: { createdAt: "desc" },
+        take: 1,
+        include: {
+          assignments: {
+            where: { status: "Active" },
+            include: {
+              cycleInterviewer: {
+                include: { user: { select: { firstName: true, lastName: true } } },
+              },
+            },
+          },
+        },
+      },
     },
   });
 
@@ -84,6 +99,40 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     pinnedVersionIds: da.reviews.map((r) => r.rubricVersionId),
   });
 
+  // Interview notes live in CollabDocumentVersion (Yjs/Tiptap), keyed by doc
+  // name — mirror the domain-lead applicant-detail view:
+  //   interview:{id}:notes                     — joint, shared by interviewers
+  //   interview:{id}:rec-notes-{assignmentId}  — per-interviewer rec notes
+  const collabDocNames: string[] = [];
+  for (const iv of da.interviews) {
+    collabDocNames.push(`interview:${iv.id}:notes`);
+    for (const a of iv.assignments) {
+      collabDocNames.push(`interview:${iv.id}:rec-notes-${a.id}`);
+    }
+  }
+  const collabVersionRows = collabDocNames.length > 0
+    ? await prisma.collabDocumentVersion.findMany({
+        where: { name: { in: collabDocNames } },
+        orderBy: { createdAt: "desc" },
+        select: { name: true, plainText: true },
+      })
+    : [];
+  const latestCollabByName = new Map<string, string>();
+  for (const row of collabVersionRows) {
+    if (!latestCollabByName.has(row.name)) {
+      latestCollabByName.set(row.name, row.plainText);
+    }
+  }
+  const interviews = da.interviews.map((iv) => ({
+    ...iv,
+    jointNotes: latestCollabByName.get(`interview:${iv.id}:notes`)?.trim() || null,
+    assignments: iv.assignments.map((a) => ({
+      ...a,
+      recNotes:
+        latestCollabByName.get(`interview:${iv.id}:rec-notes-${a.id}`)?.trim() || null,
+    })),
+  }));
+
   return Response.json({
       domainApplication: {
         id: da.id,
@@ -103,6 +152,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
       },
       reviews: da.reviews,
       decisions: da.decisions,
+      interviews,
       criteriaByKey,
     });
 }

--- a/dali-api/app/hiring/routes/domain-lead.application.$id.tsx
+++ b/dali-api/app/hiring/routes/domain-lead.application.$id.tsx
@@ -24,22 +24,26 @@ const RECOMMENDATION_COLORS: Record<string, string> = {
   "No Hire": "bg-red-100 text-red-700",
 };
 
+// bg + text + an explicit same-hue border (e.g. red pill → red border), so the
+// outline always matches the pill and never falls back to the neutral gray
+// border from the global `*` rule. Mirrors the dashboard's DECISION_COLORS:
+// `-300` light borders read clearly (not the faint `-200`), with dark variants.
 const STATUS_BADGE: Record<string, { bg: string; label: string }> = {
-  ApplicationOpen: { bg: "bg-muted text-foreground/80", label: "Draft" },
-  Pending: { bg: "bg-yellow-100 text-yellow-800", label: "Pending Review" },
-  Rejected: { bg: "bg-red-100 text-red-700", label: "Rejected" },
-  InvitedToInterview: { bg: "bg-blue-100 text-blue-700", label: "Invited to Interview" },
-  InterviewScheduled: { bg: "bg-blue-100 text-blue-700", label: "Interview Scheduled" },
-  PostInterviewPending: { bg: "bg-purple-100 text-purple-700", label: "Post-Interview" },
-  Accepted: { bg: "bg-green-100 text-green-700", label: "Accepted" },
-  Waitlisted: { bg: "bg-yellow-100 text-yellow-700", label: "Waitlisted" },
+  ApplicationOpen: { bg: "bg-muted text-foreground/80 border-current/30", label: "Draft" },
+  Pending: { bg: "bg-yellow-100 text-yellow-800 border-yellow-300 dark:border-yellow-700", label: "Pending Review" },
+  Rejected: { bg: "bg-red-100 text-red-700 border-red-300 dark:bg-red-900/30 dark:text-red-400 dark:border-red-700", label: "Rejected" },
+  InvitedToInterview: { bg: "bg-blue-100 text-blue-700 border-blue-300 dark:bg-blue-900/30 dark:text-blue-400 dark:border-blue-700", label: "Invited to Interview" },
+  InterviewScheduled: { bg: "bg-blue-100 text-blue-700 border-blue-300 dark:bg-blue-900/30 dark:text-blue-400 dark:border-blue-700", label: "Interview Scheduled" },
+  PostInterviewPending: { bg: "bg-purple-100 text-purple-700 border-purple-300 dark:bg-purple-900/30 dark:text-purple-400 dark:border-purple-700", label: "Post-Interview" },
+  Accepted: { bg: "bg-green-100 text-green-700 border-green-300 dark:bg-green-900/30 dark:text-green-400 dark:border-green-700", label: "Accepted" },
+  Waitlisted: { bg: "bg-yellow-100 text-yellow-700 border-yellow-300 dark:bg-yellow-900/30 dark:text-yellow-400 dark:border-yellow-700", label: "Waitlisted" },
 };
 
 const DECISION_COLORS: Record<string, string> = {
-  Rejected: "bg-red-100 text-red-700",
-  InvitedToInterview: "bg-blue-100 text-blue-700",
-  Accepted: "bg-green-100 text-green-700",
-  Waitlisted: "bg-yellow-100 text-yellow-700",
+  Rejected: "bg-red-100 text-red-700 border-red-300 dark:bg-red-900/30 dark:text-red-400 dark:border-red-700",
+  InvitedToInterview: "bg-purple-100 text-purple-700 border-purple-300 dark:bg-purple-900/30 dark:text-purple-400 dark:border-purple-700",
+  Accepted: "bg-green-100 text-green-700 border-green-300 dark:bg-green-900/30 dark:text-green-400 dark:border-green-700",
+  Waitlisted: "bg-yellow-100 text-yellow-700 border-yellow-300 dark:bg-yellow-900/30 dark:text-yellow-400 dark:border-yellow-700",
 };
 
 const STAGE_LABELS: Record<string, string> = {
@@ -155,6 +159,45 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     pinnedVersionIds: (da.reviews ?? []).map((r: any) => r.rubricVersionId),
   });
 
+  // Interview notes live in CollabDocumentVersion (Yjs/Tiptap), keyed by doc
+  // name — mirror the unified applicant-detail view. Two kinds per interview:
+  //   interview:{id}:notes                     — joint, shared by interviewers
+  //   interview:{id}:rec-notes-{assignmentId}  — per-interviewer rec notes
+  // A domain lead is a pre-release-decision viewer (access is already gated to
+  // their domains above), so both kinds are surfaced here.
+  const interviewRows = da.interviews ?? [];
+  const collabDocNames: string[] = [];
+  for (const iv of interviewRows) {
+    collabDocNames.push(`interview:${iv.id}:notes`);
+    for (const a of iv.assignments) {
+      collabDocNames.push(`interview:${iv.id}:rec-notes-${a.id}`);
+    }
+  }
+  const collabVersionRows = collabDocNames.length > 0
+    ? await prisma.collabDocumentVersion.findMany({
+        where: { name: { in: collabDocNames } },
+        orderBy: { createdAt: "desc" },
+        select: { name: true, plainText: true, createdAt: true },
+      })
+    : [];
+  // Keep only the latest snapshot per doc name.
+  const latestCollabByName = new Map<string, string>();
+  for (const row of collabVersionRows) {
+    if (!latestCollabByName.has(row.name)) {
+      latestCollabByName.set(row.name, row.plainText);
+    }
+  }
+  // Attach resolved notes onto the interview object the component reads.
+  const interviewsWithNotes = interviewRows.map((iv: any) => ({
+    ...iv,
+    jointNotes: latestCollabByName.get(`interview:${iv.id}:notes`)?.trim() || null,
+    assignments: iv.assignments.map((a: any) => ({
+      ...a,
+      recNotes:
+        latestCollabByName.get(`interview:${iv.id}:rec-notes-${a.id}`)?.trim() || null,
+    })),
+  }));
+
   const cycleStatus = (da.application.applicationCycle.statusUpdates[0]?.newStatus ?? "Draft") as ApplicationCycleStatus;
   const inferredStatus = inferDomainApplicationStatus(
     { ...da, application: { statusUpdates: da.application.statusUpdates } } as any,
@@ -177,7 +220,11 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   );
 
   return {
-      domainApplication: { ...da, answers: presignedChallengeAnswers },
+      domainApplication: {
+        ...da,
+        answers: presignedChallengeAnswers,
+        interviews: interviewsWithNotes,
+      },
       application: { ...da.application, answers: presignedGeneralAnswers },
       inferredStatus,
       criteriaByKey,
@@ -242,7 +289,7 @@ export default function DomainLeadApplicationView() {
             {da.challengeVersion.domain?.name} · {application.applicationCycle.name}
           </p>
         </div>
-        <span className={`inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold flex-shrink-0 ${statusInfo.bg}`}>
+        <span className={`inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold border flex-shrink-0 ${statusInfo.bg}`}>
           {statusInfo.label}
         </span>
       </div>
@@ -314,6 +361,44 @@ export default function DomainLeadApplicationView() {
                     }).join(", ")}
                   </div>
                 )}
+
+                {/* Joint interview notes (shared by both interviewers). */}
+                <div className="pt-2 border-t border-border">
+                  <div className="text-xs font-bold text-muted-foreground uppercase tracking-wider">
+                    Interview notes
+                  </div>
+                  {interview.jointNotes ? (
+                    <p className="mt-1 text-sm text-foreground whitespace-pre-wrap">
+                      {interview.jointNotes}
+                    </p>
+                  ) : (
+                    <p className="mt-1 text-xs text-muted-foreground/70 italic">
+                      No interview notes.
+                    </p>
+                  )}
+                </div>
+
+                {/* Per-interviewer recommendation notes, when present. */}
+                {interview.assignments?.some((a: any) => a.recNotes) && (
+                  <div className="pt-2 space-y-2">
+                    {interview.assignments
+                      .filter((a: any) => a.recNotes)
+                      .map((a: any) => {
+                        const m = a.cycleInterviewer?.user;
+                        const who = m ? `${m.firstName} ${m.lastName}` : "Interviewer";
+                        return (
+                          <div key={a.id}>
+                            <div className="text-xs font-medium text-muted-foreground">
+                              {who}&rsquo;s notes
+                            </div>
+                            <p className="mt-0.5 text-sm text-foreground whitespace-pre-wrap">
+                              {a.recNotes}
+                            </p>
+                          </div>
+                        );
+                      })}
+                  </div>
+                )}
               </div>
             </div>
           )}
@@ -328,7 +413,7 @@ export default function DomainLeadApplicationView() {
                 {decisions.map((d: any) => (
                   <div key={d.id} className="flex items-center justify-between text-sm">
                     <div className="flex items-center gap-2">
-                      <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${DECISION_COLORS[d.type] ?? "bg-muted text-foreground/80"}`}>
+                      <span className={`text-xs px-2 py-0.5 rounded-full font-medium border ${DECISION_COLORS[d.type] ?? "bg-muted text-foreground/80 border-current/30"}`}>
                         {d.type}
                       </span>
                       <span className="text-xs text-muted-foreground">{STAGE_LABELS[d.stage] ?? d.stage}</span>
@@ -354,7 +439,9 @@ function ReviewCard({
   review: any;
   criteriaByKey: Record<string, { label: string; maxScore?: number }>;
 }) {
-  const [expanded, setExpanded] = useState(false);
+  // Reviewer feedback is shown open by default — domain leads want to read it
+  // at a glance, not click into each review.
+  const [expanded, setExpanded] = useState(true);
   const reviewer = review.cycleReviewer?.user;
   const name = reviewer ? `${reviewer.firstName} ${reviewer.lastName}` : "Unknown";
   const isSubmitted = !!review.submittedAt;

--- a/dali-api/app/hiring/routes/domain-lead.delibs.$id.tsx
+++ b/dali-api/app/hiring/routes/domain-lead.delibs.$id.tsx
@@ -11,6 +11,16 @@ import { INITIAL_COLUMNS, FINAL_COLUMNS, buildColumnOrder } from "~/hiring/lib/d
 import { inReviewPipelineFilter } from "~/hiring/lib/application-pipeline-filter";
 import { ApplicantContextModal } from "~/hiring/components/delibs/ApplicantContextModal";
 
+// Same recommendation scale + tones used by the ApplicantContextModal, so the
+// card's reviewer/interviewer recommendation pills read consistently.
+const RECOMMENDATION_COLORS: Record<string, string> = {
+  "Strong Hire": "bg-green-100 text-green-800 border-green-300",
+  Hire: "bg-green-50 text-green-700 border-green-200",
+  "Lean Hire": "bg-yellow-50 text-yellow-700 border-yellow-300",
+  "Lean No Hire": "bg-orange-50 text-orange-700 border-orange-300",
+  "No Hire": "bg-red-100 text-red-700 border-red-300",
+};
+
 export const meta: Route.MetaFunction = ({ data }) => {
   const domain = (data as any)?.session?.domain?.name;
   return [{ title: `${domain ? `${domain} ` : ""}delibs · DALI OS` }];
@@ -107,7 +117,19 @@ export async function loader({ request, params }: Route.LoaderArgs) {
         orderBy: { createdAt: "desc" },
         take: 1,
       },
-      interviews: { where: { status: { in: ["Scheduled", "Completed"] } } },
+      interviews: {
+        where: { status: { in: ["Scheduled", "Completed"] } },
+        include: {
+          assignments: {
+            where: { status: "Active" },
+            include: {
+              cycleInterviewer: {
+                include: { user: { select: { firstName: true, lastName: true } } },
+              },
+            },
+          },
+        },
+      },
     },
   });
 
@@ -433,16 +455,90 @@ export default function DelibsKanban() {
                               </span>
                             )}
                           </div>
-                          {da.reviews
-                            .filter((r: any) => r.overallRecommendation)
-                            .map((r: any) => (
+                          {(() => {
+                            const fmt = (u: any) =>
+                              u ? `${u.firstName ?? ""} ${u.lastName ?? ""}`.trim() : "";
+                            const recPill = (rec: string, key: string) => (
                               <span
-                                key={r.id}
-                                className="inline-block mt-1 mr-1 text-[10px] font-medium px-1.5 py-0.5 rounded border border-border bg-muted/50 text-muted-foreground"
+                                key={key}
+                                className={`inline-block text-[10px] font-medium px-1.5 py-0.5 rounded border ${
+                                  RECOMMENDATION_COLORS[rec] ?? "border-border bg-muted/50 text-muted-foreground"
+                                }`}
                               >
-                                {r.overallRecommendation}
+                                {rec}
                               </span>
-                            ))}
+                            );
+                            // Reviewer recommendations: one per submitted review.
+                            const reviewerNames = Array.from(
+                              new Set(
+                                (da.reviews ?? [])
+                                  .map((r: any) => fmt(r.cycleReviewer?.user))
+                                  .filter(Boolean),
+                              ),
+                            );
+                            const reviewerRecs = (da.reviews ?? [])
+                              .filter((r: any) => r.overallRecommendation)
+                              .map((r: any) => ({ id: r.id, rec: r.overallRecommendation as string }));
+                            // Interviewer recommendation: the joint interview rec.
+                            const interviewerNames = Array.from(
+                              new Set(
+                                (da.interviews ?? [])
+                                  .flatMap((iv: any) => iv.assignments ?? [])
+                                  .map((a: any) => fmt(a.cycleInterviewer?.user))
+                                  .filter(Boolean),
+                              ),
+                            );
+                            const interviewRecs = (da.interviews ?? [])
+                              .filter((iv: any) => iv.recommendation)
+                              .map((iv: any) => ({ id: iv.id, rec: iv.recommendation as string }));
+
+                            const hasReviewers = reviewerNames.length > 0 || reviewerRecs.length > 0;
+                            const hasInterviewers = interviewerNames.length > 0 || interviewRecs.length > 0;
+                            if (!hasReviewers && !hasInterviewers) return null;
+
+                            return (
+                              <div className="mt-2 pt-2 border-t border-border space-y-2">
+                                {hasReviewers && (
+                                  <div>
+                                    <p className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider">
+                                      Reviewers
+                                    </p>
+                                    {reviewerNames.length > 0 && (
+                                      <p className="text-[10px] text-muted-foreground">
+                                        {reviewerNames.join(", ")}
+                                      </p>
+                                    )}
+                                    {reviewerRecs.length > 0 && (
+                                      <div className="flex flex-wrap gap-1 mt-1">
+                                        {reviewerRecs.map((r: { id: string; rec: string }) => recPill(r.rec, r.id))}
+                                      </div>
+                                    )}
+                                  </div>
+                                )}
+                                {hasInterviewers && (
+                                  <div>
+                                    <p className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider">
+                                      Interviewers
+                                    </p>
+                                    {interviewerNames.length > 0 && (
+                                      <p className="text-[10px] text-muted-foreground">
+                                        {interviewerNames.join(", ")}
+                                      </p>
+                                    )}
+                                    {interviewRecs.length > 0 ? (
+                                      <div className="flex flex-wrap gap-1 mt-1">
+                                        {interviewRecs.map((r: { id: string; rec: string }) => recPill(r.rec, r.id))}
+                                      </div>
+                                    ) : (
+                                      <p className="text-[10px] text-muted-foreground/60 italic mt-0.5">
+                                        No interview recommendation yet.
+                                      </p>
+                                    )}
+                                  </div>
+                                )}
+                              </div>
+                            );
+                          })()}
                         </div>
                       </div>
                     </div>

--- a/dali-api/app/hiring/routes/domain-lead.tsx
+++ b/dali-api/app/hiring/routes/domain-lead.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { Form, Link, useLoaderData, useSearchParams, useRevalidator, useSubmit } from "react-router";
+import { Form, Link, useLoaderData, useNavigate, useSearchParams, useRevalidator, useSubmit } from "react-router";
 import { requestOpenTabIfEmbedded } from "~/components/workspace-link";
 import { redirect } from "react-router";
 import type { Route } from "./+types/domain-lead";
@@ -35,11 +35,13 @@ const STATUS_LABELS: Record<string, string> = {
   Completed: "Completed",
 };
 
+// Every status/decision pill carries a border in its OWN hue (never a neutral
+// black/gray line on a colored pill) so the whole page reads consistently.
 const STATUS_COLORS: Record<string, string> = {
-  Draft: "bg-muted text-foreground/80",
-  Open: "bg-green-100 text-green-700",
-  UnderReview: "bg-yellow-100 text-yellow-700",
-  Completed: "bg-blue-100 text-blue-700",
+  Draft: "bg-muted text-foreground/80 border border-current/30",
+  Open: "bg-green-100 text-green-700 border border-green-200",
+  UnderReview: "bg-yellow-100 text-yellow-700 border border-yellow-200",
+  Completed: "bg-blue-100 text-blue-700 border border-blue-200",
 };
 
 const STATUS_MESSAGES: Record<string, string> = {
@@ -187,14 +189,15 @@ export async function loader({ request }: Route.LoaderArgs) {
         return latestStatus === "Submitted" && app.domainApplications.length > 0;
       });
 
-      // Interviews for this domain in this cycle. Only Scheduled rows appear
-      // in the dashboard table — cancelled rows are audit-only.
+      // Interviews for this domain in this cycle. Both Scheduled and Completed
+      // rows appear in the dashboard table — only cancelled rows are excluded
+      // (audit-only).
       const currentStatus = cycle?.statusUpdates[0]?.newStatus ?? "Draft";
       const interviews = (currentStatus === "UnderReview" || currentStatus === "Completed") && cycle
         ? await prisma.interview.findMany({
             where: {
               applicationCycleId: cycle.id,
-              status: "Scheduled",
+              status: { in: ["Scheduled", "Completed"] },
               domainApplication: {
                 OR: [
                   { challengeVersion: { domainId: assignment.domainId } },
@@ -643,6 +646,7 @@ function StatPill({ label, value, color = "text-foreground" }: { label: string; 
 
 export default function DomainLeadDashboard() {
   const data = useLoaderData<typeof loader>() as any;
+  const navigate = useNavigate();
   const domainData = data?.domainData ?? [];
 
   if (domainData.length === 0) {
@@ -725,8 +729,8 @@ export default function DomainLeadDashboard() {
                       subtitle="Pick which challenge versions applicants answer."
                       badge={
                         isChallengeReady
-                          ? <span className="text-xs text-green-700 bg-green-100 px-2 py-0.5 rounded-full font-medium">Ready</span>
-                          : <span className="text-xs text-yellow-700 bg-yellow-100 px-2 py-0.5 rounded-full font-medium">Action needed</span>
+                          ? <span className="text-xs text-green-700 bg-green-100 border border-green-200 px-2 py-0.5 rounded-full font-medium">Ready</span>
+                          : <span className="text-xs text-yellow-700 bg-yellow-100 border border-yellow-200 px-2 py-0.5 rounded-full font-medium">Action needed</span>
                       }
                       defaultOpen={!isChallengeReady}
                     >
@@ -762,8 +766,8 @@ export default function DomainLeadDashboard() {
                       }
                       badge={
                         hasLinkedChallenge
-                          ? <span className="text-xs text-green-700 bg-green-100 px-2 py-0.5 rounded-full font-medium">Configured</span>
-                          : <span className="text-xs text-yellow-700 bg-yellow-100 px-2 py-0.5 rounded-full font-medium">Needs attention</span>
+                          ? <span className="text-xs text-green-700 bg-green-100 border border-green-200 px-2 py-0.5 rounded-full font-medium">Configured</span>
+                          : <span className="text-xs text-yellow-700 bg-yellow-100 border border-yellow-200 px-2 py-0.5 rounded-full font-medium">Needs attention</span>
                       }
                       defaultOpen={!hasLinkedChallenge}
                     >
@@ -817,8 +821,8 @@ export default function DomainLeadDashboard() {
                     subtitle="Scoring criteria reviewers use for this domain."
                     badge={
                       currentRubricVersionId
-                        ? <span className="text-xs text-green-700 bg-green-100 px-2 py-0.5 rounded-full font-medium">Set</span>
-                        : <span className="text-xs text-yellow-700 bg-yellow-100 px-2 py-0.5 rounded-full font-medium">Not set</span>
+                        ? <span className="text-xs text-green-700 bg-green-100 border border-green-200 px-2 py-0.5 rounded-full font-medium">Set</span>
+                        : <span className="text-xs text-yellow-700 bg-yellow-100 border border-yellow-200 px-2 py-0.5 rounded-full font-medium">Not set</span>
                     }
                     defaultOpen={!currentRubricVersionId}
                   >
@@ -870,10 +874,21 @@ export default function DomainLeadDashboard() {
                     </div>
                   </Section>
 
-                  {/* Applications */}
-                  {currentStatus !== "Draft" && (
+                  {/* Reviews — applicants still under review plus those rejected
+                      at the review stage. Anyone invited to interview moves to
+                      the Interviews section below, so the two never duplicate. */}
+                  {currentStatus !== "Draft" && (() => {
+                    const reviewApps = apps.filter((a: any) => {
+                      const status = a.domainApplications?.[0]?.inferredStatus;
+                      return (
+                        status !== "InvitedToInterview" &&
+                        status !== "InterviewScheduled" &&
+                        status !== "PostInterviewPending"
+                      );
+                    });
+                    return (
                     <Section
-                      title="Applications"
+                      title="Reviews"
                       badge={
                         confidentialityRequired ? (
                           <span className="text-xs text-muted-foreground">hidden</span>
@@ -894,9 +909,9 @@ export default function DomainLeadDashboard() {
                           reason={confidentialityRequired}
                           next="/hiring/domain-lead"
                         />
-                      ) : apps.length > 0 ? (
+                      ) : reviewApps.length > 0 ? (
                         <ApplicationsTable
-                          apps={apps}
+                          apps={reviewApps}
                           draftDecisions={draftDecisions ?? []}
                           cycleReviewersForDomain={cycleReviewersForDomain}
                           cycleId={cycle.id}
@@ -907,11 +922,12 @@ export default function DomainLeadDashboard() {
                         />
                       ) : (
                         <div className="text-center text-muted-foreground text-sm py-6">
-                          No submitted applications yet.
+                          No applicants in review. Anyone invited to interview appears under Interviews.
                         </div>
                       )}
                     </Section>
-                  )}
+                    );
+                  })()}
 
                   {/* Deliberations — UnderReview only */}
                   {currentStatus === "UnderReview" && (
@@ -992,143 +1008,151 @@ export default function DomainLeadDashboard() {
                             </div>
                           )}
 
-                          {/* Awaiting booking */}
-                          {awaitingBooking.length > 0 && (
-                            <div>
-                              <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-wider mb-2">Awaiting Booking</h4>
-                              <div className="divide-y divide-gray-100 border border-border rounded-lg">
-                                {awaitingBooking.map((app: any) => (
-                                  <div key={app.id} className="flex items-center justify-between px-4 py-3">
-                                    <span className="text-sm font-medium text-foreground">
-                                      {app.user.firstName} {app.user.lastName}
-                                    </span>
-                                    <span className="text-xs text-yellow-700 bg-yellow-100 px-2 py-0.5 rounded-full font-medium">
-                                      Invited — not booked
-                                    </span>
-                                  </div>
-                                ))}
-                              </div>
-                            </div>
-                          )}
-
-                          {/* Scheduled / Completed interviews */}
-                          {interviews.length > 0 && (
-                            <div>
-                              <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-wider mb-2">Booked Interviews</h4>
-                              <div className="hidden sm:block overflow-x-auto -mx-4 px-4 sm:mx-0 sm:px-0">
-                              <table className="w-full text-sm border border-border rounded-lg overflow-hidden min-w-[640px]">
-                                <thead className="bg-muted/50 text-xs font-medium text-muted-foreground uppercase tracking-wide">
-                                  <tr>
-                                    <th className="px-4 py-2 text-left">Applicant</th>
-                                    <th className="px-4 py-2 text-left">Time</th>
-                                    <th className="px-4 py-2 text-left">Location</th>
-                                    <th className="px-4 py-2 text-left">Status</th>
-                                    <th className="px-4 py-2 text-left">In-Domain</th>
-                                    <th className="px-4 py-2 text-left">Cross-Domain</th>
-                                  </tr>
-                                </thead>
-                                <tbody className="divide-y divide-gray-100">
-                                  {interviews.map((interview: any) => {
-                                    const start = new Date(interview.startTime);
-                                    const end = new Date(interview.endTime);
-                                    const formatAssignment = (a: any) => {
-                                      const m = a.cycleInterviewer.user;
-                                      return m.firstName && m.lastName
-                                        ? `${m.firstName} ${m.lastName}`
-                                        : m.daliEmail ?? '?';
-                                    };
-                                    const inDomain = interview.assignments
-                                      .filter((a: any) => a.role === 'InDomain' && a.status === 'Active')
-                                      .map(formatAssignment)
-                                      .join(', ') || '—';
-                                    const crossDomain = interview.assignments
-                                      .filter((a: any) => a.role === 'CrossDomain' && a.status === 'Active')
-                                      .map((a: any) => `${formatAssignment(a)} (${a.cycleInterviewer.domain.name})`)
-                                      .join(', ') || '—';
-                                    return (
-                                      <tr key={interview.id} className="hover:bg-muted/50">
-                                        <td className="px-4 py-3 font-medium text-foreground">
-                                          {interview.domainApplication.application.user.firstName} {interview.domainApplication.application.user.lastName}
-                                        </td>
-                                        <td className="px-4 py-3 text-muted-foreground">
-                                          {start.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })}{' '}
-                                          {start.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })} –{' '}
-                                          {end.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })}
-                                        </td>
-                                        <td className="px-4 py-3 text-muted-foreground text-xs">
-                                          {interview.location === 'PodAppa' ? 'Pod Appa' :
-                                           interview.location === 'PodMomo' ? 'Pod Momo' : 'Online'}
-                                          {interview.location === 'Online' && interview.zoomJoinUrl && (
-                                            <a href={interview.zoomJoinUrl} target="_blank" rel="noopener noreferrer"
-                                               className="block text-xs text-blue-600 hover:underline mt-0.5">Zoom</a>
-                                          )}
-                                        </td>
-                                        <td className="px-4 py-3">
-                                          <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-bold ${
-                                            interview.status === "Completed" ? "bg-green-100 text-green-700" : "bg-blue-100 text-blue-700"
-                                          }`}>
-                                            {interview.status}
-                                          </span>
-                                        </td>
-                                        <td className="px-4 py-3 text-muted-foreground text-xs">{inDomain}</td>
-                                        <td className="px-4 py-3 text-muted-foreground text-xs">{crossDomain}</td>
+                          {/* One Interviews table: booked interviews AND
+                              invited-but-not-yet-booked applicants share the same
+                              table, with booking surfaced in the Status column.
+                              Styling mirrors the Reviews table (px-6 padding,
+                              bg-muted/50 head, divide-y rows). */}
+                          {(() => {
+                            const fmtAssignment = (a: any) => {
+                              const m = a.cycleInterviewer.user;
+                              return m.firstName && m.lastName
+                                ? `${m.firstName} ${m.lastName}`
+                                : m.daliEmail ?? '?';
+                            };
+                            // Booked rows from interview records.
+                            const bookedRows = interviews.map((interview: any) => {
+                              const start = new Date(interview.startTime);
+                              const end = new Date(interview.endTime);
+                              return {
+                                key: interview.id,
+                                daId: interview.domainApplication?.id as string | undefined,
+                                name: `${interview.domainApplication.application.user.firstName} ${interview.domainApplication.application.user.lastName}`,
+                                booked: true,
+                                status: interview.status as string,
+                                time: `${start.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })} ${start.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })} – ${end.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })}`,
+                                location:
+                                  interview.location === 'PodAppa' ? 'Pod Appa'
+                                  : interview.location === 'PodMomo' ? 'Pod Momo'
+                                  : 'Online',
+                                zoomJoinUrl: interview.location === 'Online' ? interview.zoomJoinUrl : null,
+                                inDomain: interview.assignments
+                                  .filter((a: any) => a.role === 'InDomain' && a.status === 'Active')
+                                  .map(fmtAssignment)
+                                  .join(', ') || '—',
+                                crossDomain: interview.assignments
+                                  .filter((a: any) => a.role === 'CrossDomain' && a.status === 'Active')
+                                  .map((a: any) => `${fmtAssignment(a)} (${a.cycleInterviewer.domain.name})`)
+                                  .join(', ') || '—',
+                              };
+                            });
+                            // Invited-but-not-booked applicants become rows too.
+                            const pendingRows = awaitingBooking.map((app: any) => ({
+                              key: `pending-${app.id}`,
+                              daId: app.domainApplications?.[0]?.id as string | undefined,
+                              name: `${app.user.firstName} ${app.user.lastName}`,
+                              booked: false,
+                              status: 'Invited — not booked',
+                              time: '—',
+                              location: '—',
+                              zoomJoinUrl: null,
+                              inDomain: '—',
+                              crossDomain: '—',
+                            }));
+                            // Awaiting booking first (needs action), then booked.
+                            const rows = [...pendingRows, ...bookedRows];
+                            const statusPill = (row: any) =>
+                              !row.booked
+                                ? 'bg-yellow-100 text-yellow-700 border border-yellow-200'
+                                : row.status === 'Completed'
+                                  ? 'bg-green-100 text-green-700 border border-green-200'
+                                  : 'bg-blue-100 text-blue-700 border border-blue-200';
+                            // Clicking a row opens that applicant's review/detail
+                            // page — same target as the Reviews table.
+                            const openReview = (row: any) => {
+                              if (!row.daId) return;
+                              const url = `/hiring/domain-lead/application/${row.daId}`;
+                              const label = row.name || 'Applicant';
+                              if (!requestOpenTabIfEmbedded(url, label)) navigate(url);
+                            };
+                            if (rows.length === 0) return null;
+                            return (
+                              <div>
+                                <div className="hidden sm:block overflow-x-auto border border-border rounded-lg">
+                                  <table className="w-full text-sm min-w-[640px]">
+                                    <thead className="bg-muted/50 text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                                      <tr>
+                                        <th className="px-6 py-3 text-left">Applicant</th>
+                                        <th className="px-6 py-3 text-left">Time</th>
+                                        <th className="px-6 py-3 text-left">Location</th>
+                                        <th className="px-6 py-3 text-left">Status</th>
+                                        <th className="px-6 py-3 text-left">In-Domain</th>
+                                        <th className="px-6 py-3 text-left">Cross-Domain</th>
                                       </tr>
-                                    );
-                                  })}
-                                </tbody>
-                              </table>
-                              </div>
-                              <ul className="sm:hidden space-y-2">
-                                {interviews.map((interview: any) => {
-                                  const start = new Date(interview.startTime);
-                                  const end = new Date(interview.endTime);
-                                  const formatAssignment = (a: any) => {
-                                    const m = a.cycleInterviewer.user;
-                                    return m.firstName && m.lastName
-                                      ? `${m.firstName} ${m.lastName}`
-                                      : m.daliEmail ?? '?';
-                                  };
-                                  const inDomain = interview.assignments
-                                    .filter((a: any) => a.role === 'InDomain' && a.status === 'Active')
-                                    .map(formatAssignment)
-                                    .join(', ') || '—';
-                                  const crossDomain = interview.assignments
-                                    .filter((a: any) => a.role === 'CrossDomain' && a.status === 'Active')
-                                    .map((a: any) => `${formatAssignment(a)} (${a.cycleInterviewer.domain.name})`)
-                                    .join(', ') || '—';
-                                  return (
-                                    <li key={interview.id} className="border border-border rounded-lg p-3 space-y-1.5">
+                                    </thead>
+                                    <tbody className="divide-y divide-gray-100">
+                                      {rows.map((row) => (
+                                        <tr
+                                          key={row.key}
+                                          onClick={() => openReview(row)}
+                                          className={`hover:bg-muted/50 ${row.daId ? "cursor-pointer" : ""}`}
+                                        >
+                                          <td className="px-6 py-4 font-medium text-foreground">{row.name}</td>
+                                          <td className="px-6 py-4 text-muted-foreground">{row.time}</td>
+                                          <td className="px-6 py-4 text-muted-foreground text-xs">
+                                            {row.location}
+                                            {row.zoomJoinUrl && (
+                                              <a href={row.zoomJoinUrl} target="_blank" rel="noopener noreferrer"
+                                                 onClick={(e) => e.stopPropagation()}
+                                                 className="block text-xs text-blue-600 hover:underline mt-0.5">Zoom</a>
+                                            )}
+                                          </td>
+                                          <td className="px-6 py-4">
+                                            <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-bold ${statusPill(row)}`}>
+                                              {row.status}
+                                            </span>
+                                          </td>
+                                          <td className="px-6 py-4 text-muted-foreground text-xs">{row.inDomain}</td>
+                                          <td className="px-6 py-4 text-muted-foreground text-xs">{row.crossDomain}</td>
+                                        </tr>
+                                      ))}
+                                    </tbody>
+                                  </table>
+                                </div>
+                                <ul className="sm:hidden space-y-2">
+                                  {rows.map((row) => (
+                                    <li
+                                      key={row.key}
+                                      onClick={() => openReview(row)}
+                                      className={`border border-border rounded-lg p-3 space-y-1.5 ${row.daId ? "cursor-pointer hover:bg-muted/50" : ""}`}
+                                    >
                                       <div className="flex items-start justify-between gap-2">
-                                        <div className="font-medium text-foreground min-w-0 truncate">
-                                          {interview.domainApplication.application.user.firstName} {interview.domainApplication.application.user.lastName}
-                                        </div>
-                                        <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-bold flex-shrink-0 ${
-                                          interview.status === "Completed" ? "bg-green-100 text-green-700" : "bg-blue-100 text-blue-700"
-                                        }`}>
-                                          {interview.status}
+                                        <div className="font-medium text-foreground min-w-0 truncate">{row.name}</div>
+                                        <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-bold flex-shrink-0 ${statusPill(row)}`}>
+                                          {row.status}
                                         </span>
                                       </div>
-                                      <div className="text-xs text-muted-foreground">
-                                        {start.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })}{' '}
-                                        {start.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })} –{' '}
-                                        {end.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })}
-                                      </div>
-                                      <div className="text-xs text-muted-foreground">
-                                        {interview.location === 'PodAppa' ? 'Pod Appa' :
-                                         interview.location === 'PodMomo' ? 'Pod Momo' : 'Online'}
-                                        {interview.location === 'Online' && interview.zoomJoinUrl && (
-                                          <a href={interview.zoomJoinUrl} target="_blank" rel="noopener noreferrer"
-                                             className="ml-2 text-blue-600 hover:underline">Zoom</a>
-                                        )}
-                                      </div>
-                                      <div className="text-xs text-muted-foreground"><span className="font-medium">In-Domain:</span> {inDomain}</div>
-                                      <div className="text-xs text-muted-foreground"><span className="font-medium">Cross-Domain:</span> {crossDomain}</div>
+                                      {row.booked && (
+                                        <>
+                                          <div className="text-xs text-muted-foreground">{row.time}</div>
+                                          <div className="text-xs text-muted-foreground">
+                                            {row.location}
+                                            {row.zoomJoinUrl && (
+                                              <a href={row.zoomJoinUrl} target="_blank" rel="noopener noreferrer"
+                                                 onClick={(e) => e.stopPropagation()}
+                                                 className="ml-2 text-blue-600 hover:underline">Zoom</a>
+                                            )}
+                                          </div>
+                                          <div className="text-xs text-muted-foreground"><span className="font-medium">In-Domain:</span> {row.inDomain}</div>
+                                          <div className="text-xs text-muted-foreground"><span className="font-medium">Cross-Domain:</span> {row.crossDomain}</div>
+                                        </>
+                                      )}
                                     </li>
-                                  );
-                                })}
-                              </ul>
-                            </div>
-                          )}
+                                  ))}
+                                </ul>
+                              </div>
+                            );
+                          })()}
                         </div>
                       </Section>
                     ) : null;
@@ -1370,7 +1394,7 @@ function ChallengeSelector({ cycleId, domainId, options, linkedChallengeVersions
           <button
             type="submit"
             disabled={!pickerId}
-            className="px-3 py-2 text-sm font-medium text-white bg-accent-coral rounded-md hover:bg-accent-coral/90 disabled:opacity-40 disabled:cursor-not-allowed"
+            className="px-3 py-2 text-sm font-medium text-white bg-accent-teal rounded-md hover:bg-accent-teal/90 disabled:opacity-40 disabled:cursor-not-allowed"
           >
             Add
           </button>
@@ -1508,7 +1532,7 @@ function ReviewerSection({ cycleId, domainId, initialReviewers }: {
           <button
             onClick={addReviewer}
             disabled={!selectedMemberId}
-            className="flex items-center gap-1 px-3 py-2 text-sm font-medium rounded-lg bg-accent-coral hover:bg-accent-coral/90 text-white transition disabled:opacity-50"
+            className="flex items-center gap-1 px-3 py-2 text-sm font-medium rounded-lg bg-accent-teal hover:bg-accent-teal/90 text-white transition disabled:opacity-50"
           >
             <Plus className="w-4 h-4" /> Add
           </button>
@@ -1604,7 +1628,7 @@ function RubricPicker({ cycleId, domainId, options, selectedId, locked }: {
             </div>
             <button
               type="submit"
-              className="px-4 py-2 text-sm font-medium rounded-lg bg-accent-coral hover:bg-accent-coral/90 text-white transition"
+              className="px-4 py-2 text-sm font-medium rounded-lg bg-accent-teal hover:bg-accent-teal/90 text-white transition"
             >
               Save
             </button>
@@ -1699,7 +1723,7 @@ function InterviewerSection({ cycleId, domainId, initialInterviewers }: {
           <button
             onClick={addInterviewer}
             disabled={!selectedMemberId}
-            className="flex items-center gap-1 px-3 py-2 text-sm font-medium rounded-lg bg-accent-coral hover:bg-accent-coral/90 text-white transition disabled:opacity-50"
+            className="flex items-center gap-1 px-3 py-2 text-sm font-medium rounded-lg bg-accent-teal hover:bg-accent-teal/90 text-white transition disabled:opacity-50"
           >
             <Plus className="w-4 h-4" /> Add
           </button>
@@ -1725,7 +1749,7 @@ function InterviewerSection({ cycleId, domainId, initialInterviewers }: {
                         {hoursLabel} available
                       </span>
                     ) : (
-                      <span className="flex items-center gap-1 text-xs font-medium text-muted-foreground bg-muted/50 border border-border px-2 py-0.5 rounded-full">
+                      <span className="flex items-center gap-1 text-xs font-medium text-muted-foreground bg-muted/50 border border-current/40 px-2 py-0.5 rounded-full">
                         <Clock className="w-3 h-3" />
                         No availability
                       </span>
@@ -1821,7 +1845,7 @@ function DelibsSection({ cycleId, domainId, sessions, initialCount, finalCount }
       <button
         onClick={() => openDelibs(type)}
         disabled={loading === type || count === 0}
-        className="px-4 py-2 text-sm font-medium rounded-lg bg-green-600 hover:bg-green-700 text-white transition disabled:opacity-50"
+        className="px-4 py-2 text-sm font-medium rounded-lg bg-muted hover:bg-muted/70 text-foreground border border-border transition disabled:opacity-50"
       >
         {loading === type ? "Starting..." : `Start ${type} Delibs${countBadge}`}
       </button>
@@ -1848,11 +1872,14 @@ function DelibsSection({ cycleId, domainId, sessions, initialCount, finalCount }
   );
 }
 
+// bg + text + an explicit same-hue border (e.g. red pill → red border), so the
+// outline always matches the pill and never falls back to the neutral gray
+// border from the global `*` rule.
 const DECISION_COLORS: Record<string, string> = {
-  Rejected: "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400",
-  InvitedToInterview: "bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400",
-  Accepted: "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400",
-  Waitlisted: "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400",
+  Rejected: "bg-red-100 text-red-700 border-red-300 dark:bg-red-900/30 dark:text-red-400 dark:border-red-700",
+  InvitedToInterview: "bg-purple-100 text-purple-700 border-purple-300 dark:bg-purple-900/30 dark:text-purple-400 dark:border-purple-700",
+  Accepted: "bg-green-100 text-green-700 border-green-300 dark:bg-green-900/30 dark:text-green-400 dark:border-green-700",
+  Waitlisted: "bg-yellow-100 text-yellow-700 border-yellow-300 dark:bg-yellow-900/30 dark:text-yellow-400 dark:border-yellow-700",
 };
 
 const DECISION_LABELS: Record<string, string> = {
@@ -1862,11 +1889,12 @@ const DECISION_LABELS: Record<string, string> = {
   Waitlisted: "Waitlist",
 };
 
-// Draft pills are rendered with reduced opacity + dashed border to read as
-// "tentative", Final pills get a solid border, Released pills are full strength.
+// Stage treatment composes on top of the `border border-current/40` the badge
+// always applies. Draft reads as "tentative" (faded + dashed, same hue);
+// Final/Released keep the solid same-hue border.
 const STAGE_TREATMENT: Record<DecisionPill["stage"], string> = {
-  Draft: "opacity-60 border border-dashed border-current/40",
-  Final: "border border-current/30",
+  Draft: "opacity-60 border-dashed",
+  Final: "",
   Released: "",
 };
 
@@ -1892,12 +1920,15 @@ function DecisionPillBadge({ pill, isCurrent = false }: { pill: DecisionPill; is
   const stageSuffix = ` (${pill.stage.toLowerCase()})`;
   const Icon = DECISION_ICONS[pill.type];
   const tooltip = DECISION_TOOLTIPS[pill.stage](`${baseLabel}${rankSuffix}`);
-  const accent = isCurrent ? "ring-2 ring-offset-1 ring-foreground/30" : "";
+  // "Current" emphasis ring uses the pill's OWN hue (ring-current = its text
+  // color) so it reads as the same color as the border, not a competing gray
+  // ring sitting just outside a red/green/etc. border.
+  const accent = isCurrent ? "ring-2 ring-offset-1 ring-current/60" : "";
   return (
     <span
       title={tooltip}
       aria-label={tooltip}
-      className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-bold ${DECISION_COLORS[pill.type] ?? "bg-muted text-muted-foreground"} ${STAGE_TREATMENT[pill.stage]} ${accent}`}
+      className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-bold border ${DECISION_COLORS[pill.type] ?? "bg-muted text-muted-foreground border-current/40"} ${STAGE_TREATMENT[pill.stage]} ${accent}`}
     >
       {Icon && <Icon className="w-3 h-3" />}
       {baseLabel}{rankSuffix}{stageSuffix}
@@ -1929,7 +1960,7 @@ function PrePipelinePillBadge({ pill }: { pill: PrePipelinePill }) {
     <span
       title={PRE_PIPELINE_TOOLTIPS[pill]}
       aria-label={PRE_PIPELINE_TOOLTIPS[pill]}
-      className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-muted text-muted-foreground"
+      className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-muted text-muted-foreground border border-current/40"
     >
       <Icon className="w-3 h-3" />
       {PRE_PIPELINE_LABELS[pill]}
@@ -2020,12 +2051,6 @@ function ApplicationsTable({ apps, draftDecisions, cycleReviewersForDomain, cycl
     });
   });
 
-  // Bulk-selection state — set of DomainApplication ids the lead has ticked.
-  // Local React state (not URL) so a refresh resets it; pairs with revalidator.
-  const [selectedDaIds, setSelectedDaIds] = useState<Set<string>>(new Set());
-  const [bulkReviewerId, setBulkReviewerId] = useState("");
-  const [bulkBusy, setBulkBusy] = useState<"assign" | "auto" | null>(null);
-
   const baseApps = filter === "finalize" ? finalizableApps : apps;
   const lowerQuery = query.trim().toLowerCase();
   const filteredApps = lowerQuery === ""
@@ -2053,75 +2078,6 @@ function ApplicationsTable({ apps, draftDecisions, cycleReviewersForDomain, cycl
         return sortDir === "asc" ? cmp : -cmp;
       });
   const displayedApps = sortedApps;
-  const displayedDaIds: string[] = displayedApps
-    .map((a: any) => a.domainApplications?.[0]?.id)
-    .filter((v: any): v is string => typeof v === "string");
-  const allVisibleSelected = displayedDaIds.length > 0 && displayedDaIds.every((id) => selectedDaIds.has(id));
-  const someVisibleSelected = displayedDaIds.some((id) => selectedDaIds.has(id));
-  const toggleSelected = (daId: string) => {
-    setSelectedDaIds(prev => {
-      const next = new Set(prev);
-      if (next.has(daId)) next.delete(daId);
-      else next.add(daId);
-      return next;
-    });
-  };
-  const toggleSelectAllVisible = () => {
-    setSelectedDaIds(prev => {
-      const next = new Set(prev);
-      if (allVisibleSelected) {
-        for (const id of displayedDaIds) next.delete(id);
-      } else {
-        for (const id of displayedDaIds) next.add(id);
-      }
-      return next;
-    });
-  };
-  const clearSelection = () => setSelectedDaIds(new Set());
-
-  async function bulkAssignReviewer() {
-    if (!bulkReviewerId || selectedDaIds.size === 0) return;
-    setBulkBusy("assign");
-    const ids = Array.from(selectedDaIds);
-    let okCount = 0;
-    let skipCount = 0;
-    for (const daId of ids) {
-      const res = await fetch(`/api/hiring/domain-applications/${daId}/reviews`, {
-        method: "POST",
-        credentials: "include",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ cycleReviewerId: bulkReviewerId }),
-      });
-      if (res.ok) okCount++;
-      else skipCount++;
-    }
-    setBulkBusy(null);
-    setBulkReviewerId("");
-    clearSelection();
-    revalidator.revalidate();
-    if (skipCount > 0) {
-      alert(`Assigned ${okCount} of ${ids.length} applicants. ${skipCount} skipped (likely already assigned).`);
-    }
-  }
-
-  async function bulkAutoAssign() {
-    if (selectedDaIds.size === 0) return;
-    setBulkBusy("auto");
-    const res = await fetch(`/api/hiring/cycles/${cycleId}/domains/${domainId}/auto-assign`, {
-      method: "POST",
-      credentials: "include",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ applicationIds: Array.from(selectedDaIds) }),
-    });
-    setBulkBusy(null);
-    if (res.ok) {
-      clearSelection();
-      revalidator.revalidate();
-    } else {
-      const body = await res.json().catch(() => ({}));
-      alert(body.error ?? "Auto-assign failed. Check that rubrics are set and reviewers are added.");
-    }
-  }
 
   return (
     <div className="border border-border rounded-lg overflow-hidden">
@@ -2196,7 +2152,7 @@ function ApplicationsTable({ apps, draftDecisions, cycleReviewersForDomain, cycl
                 }
                 revalidator.revalidate();
               }}
-              className="px-3 py-1.5 text-xs font-medium rounded-lg bg-green-600 hover:bg-green-700 text-white transition"
+              className="px-3 py-1.5 text-xs font-medium rounded-lg bg-accent-coral hover:bg-accent-coral/90 text-white transition"
             >
               Finalize All ({finalizableApps.length})
             </button>
@@ -2222,78 +2178,17 @@ function ApplicationsTable({ apps, draftDecisions, cycleReviewersForDomain, cycl
                     ? "Add reviewers to this domain first"
                     : undefined
               }
-              className="px-3 py-1.5 text-xs font-medium rounded-lg bg-accent-coral hover:bg-accent-coral/90 text-white transition disabled:opacity-50"
+              className="px-3 py-1.5 text-xs font-medium rounded-lg bg-muted hover:bg-muted/70 text-foreground border border-border transition disabled:opacity-50"
             >
               Auto-Assign Reviewers
             </button>
           )}
         </div>
       </div>
-      {isUnderReview && selectedDaIds.size > 0 && canAssignReviewers && (
-        <div className="sticky top-0 z-10 px-4 sm:px-6 py-2 border-b border-border bg-blue-50 dark:bg-blue-900/20 flex flex-wrap items-center gap-2">
-          <span className="text-sm font-medium text-foreground">
-            {selectedDaIds.size} selected
-          </span>
-          <button
-            type="button"
-            onClick={clearSelection}
-            className="text-xs text-muted-foreground hover:text-foreground/80 underline"
-          >
-            Clear
-          </button>
-          <div className="ml-auto flex flex-wrap items-center gap-2">
-            <select
-              value={bulkReviewerId}
-              onChange={e => setBulkReviewerId(e.target.value)}
-              className="rounded-md border border-border bg-card px-2 py-1 text-xs"
-              aria-label="Reviewer to assign to selected applicants"
-              disabled={bulkBusy !== null}
-            >
-              <option value="">Assign reviewer…</option>
-              {cycleReviewersForDomain.map((cr: any) => {
-                const m = cr.user;
-                const label = m?.firstName && m?.lastName
-                  ? `${m.firstName} ${m.lastName}`
-                  : m?.daliEmail ?? cr.id;
-                return <option key={cr.id} value={cr.id}>{label}</option>;
-              })}
-            </select>
-            <button
-              type="button"
-              onClick={bulkAssignReviewer}
-              disabled={!bulkReviewerId || bulkBusy !== null}
-              className="px-3 py-1 text-xs font-medium rounded-md bg-accent-coral hover:bg-accent-coral/90 text-white transition disabled:opacity-50"
-            >
-              {bulkBusy === "assign" ? "Assigning..." : "Assign"}
-            </button>
-            <button
-              type="button"
-              onClick={bulkAutoAssign}
-              disabled={bulkBusy !== null || cycleReviewersForDomain.length === 0}
-              title={cycleReviewersForDomain.length === 0 ? "Add reviewers to this domain first" : "Auto-fill reviewer slots on selected applicants"}
-              className="px-3 py-1 text-xs font-medium rounded-md bg-accent-coral hover:bg-accent-coral/90 text-white transition disabled:opacity-50"
-            >
-              {bulkBusy === "auto" ? "Assigning..." : "Auto-assign to selected"}
-            </button>
-          </div>
-        </div>
-      )}
       <div className="hidden sm:block overflow-x-auto">
       <table className="w-full text-sm min-w-[640px]">
         <thead className="bg-muted/50 text-xs font-medium text-muted-foreground uppercase tracking-wide">
           <tr>
-            {isUnderReview && canAssignReviewers && (
-              <th className="pl-6 pr-2 py-3 w-8">
-                <input
-                  type="checkbox"
-                  aria-label="Select all visible applicants"
-                  checked={allVisibleSelected}
-                  ref={el => { if (el) el.indeterminate = !allVisibleSelected && someVisibleSelected; }}
-                  onChange={toggleSelectAllVisible}
-                  className="h-4 w-4 rounded border-border"
-                />
-              </th>
-            )}
             <th className="px-6 py-3 text-left">
               <button
                 type="button"
@@ -2347,23 +2242,24 @@ function ApplicationsTable({ apps, draftDecisions, cycleReviewersForDomain, cycl
                 })
               : null;
             const daId = da?.id as string | undefined;
-            const isSelected = daId ? selectedDaIds.has(daId) : false;
             return (
-              <tr key={app.id} className={`hover:bg-muted/50 ${isSelected ? "bg-blue-50/50 dark:bg-blue-900/10" : ""}`}>
-                {isUnderReview && canAssignReviewers && (
-                  <td className="pl-6 pr-2 py-4 w-8">
-                    <input
-                      type="checkbox"
-                      aria-label={`Select ${app.user.firstName} ${app.user.lastName}`}
-                      checked={isSelected}
-                      disabled={!daId}
-                      onChange={() => daId && toggleSelected(daId)}
-                      className="h-4 w-4 rounded border-border"
-                    />
-                  </td>
-                )}
-                <td className="px-6 py-4 font-medium text-foreground">
-                  {app.user.firstName} {app.user.lastName}
+              <tr key={app.id} className="hover:bg-muted/50">
+                <td className="px-6 py-4 font-medium">
+                  {daId ? (
+                    <Link
+                      to={`/hiring/domain-lead/application/${daId}`}
+                      onClick={(e) => {
+                        const url = `/hiring/domain-lead/application/${daId}`
+                        const label = `${app.user.firstName ?? ''} ${app.user.lastName ?? ''}`.trim() || 'Applicant'
+                        if (requestOpenTabIfEmbedded(url, label)) e.preventDefault()
+                      }}
+                      className="text-foreground hover:text-accent-coral hover:underline"
+                    >
+                      {app.user.firstName} {app.user.lastName}
+                    </Link>
+                  ) : (
+                    <span className="text-foreground">{app.user.firstName} {app.user.lastName}</span>
+                  )}
                 </td>
                 <td className="px-6 py-4">
                   <ReviewerAssignmentCell
@@ -2389,29 +2285,19 @@ function ApplicationsTable({ apps, draftDecisions, cycleReviewersForDomain, cycl
                 </td>
                 <td className="px-6 py-4 text-right">
                   <div className="flex flex-wrap items-center justify-end gap-2">
-                  {isUnderReview && draftToFinalize && (
+                  {isUnderReview && draftToFinalize ? (
                     <button
                       onClick={async () => {
                         await fetch(`/api/hiring/decisions/${draftToFinalize.id}/finalize`, { method: "POST", credentials: "include" });
                         revalidator.revalidate();
                       }}
-                      className="px-2 py-1 text-xs font-medium rounded bg-green-600 hover:bg-green-700 text-white transition"
+                      className="px-2 py-1 text-xs font-medium rounded bg-accent-coral hover:bg-accent-coral/90 text-white transition"
                     >
                       Finalize
                     </button>
+                  ) : (
+                    <span className="text-xs text-muted-foreground/60">—</span>
                   )}
-                  <Link
-                    to={`/hiring/domain-lead/application/${da?.id}`}
-                    onClick={(e) => {
-                      if (!da?.id) return
-                      const url = `/hiring/domain-lead/application/${da.id}`
-                      const label = `${app.user.firstName ?? ''} ${app.user.lastName ?? ''}`.trim() || 'Applicant'
-                      if (requestOpenTabIfEmbedded(url, label)) e.preventDefault()
-                    }}
-                    className="text-blue-600 hover:text-blue-800 font-medium"
-                  >
-                    Review →
-                  </Link>
                   </div>
                 </td>
               </tr>
@@ -2448,23 +2334,26 @@ function ApplicationsTable({ apps, draftDecisions, cycleReviewersForDomain, cycl
               })
             : null;
           const daId = da?.id as string | undefined;
-          const isSelected = daId ? selectedDaIds.has(daId) : false;
           return (
-            <li key={app.id} className={`px-4 py-3 space-y-2 ${isSelected ? "bg-blue-50/50 dark:bg-blue-900/10" : ""}`}>
+            <li key={app.id} className="px-4 py-3 space-y-2">
               <div className="flex items-center gap-2">
-                {isUnderReview && canAssignReviewers && (
-                  <input
-                    type="checkbox"
-                    aria-label={`Select ${app.user.firstName} ${app.user.lastName}`}
-                    checked={isSelected}
-                    disabled={!daId}
-                    onChange={() => daId && toggleSelected(daId)}
-                    className="h-4 w-4 rounded border-border flex-shrink-0"
-                  />
+                {daId ? (
+                  <Link
+                    to={`/hiring/domain-lead/application/${daId}`}
+                    onClick={(e) => {
+                      const url = `/hiring/domain-lead/application/${daId}`
+                      const label = `${app.user.firstName ?? ''} ${app.user.lastName ?? ''}`.trim() || 'Applicant'
+                      if (requestOpenTabIfEmbedded(url, label)) e.preventDefault()
+                    }}
+                    className="font-medium text-foreground hover:text-accent-coral hover:underline"
+                  >
+                    {app.user.firstName} {app.user.lastName}
+                  </Link>
+                ) : (
+                  <div className="font-medium text-foreground">
+                    {app.user.firstName} {app.user.lastName}
+                  </div>
                 )}
-                <div className="font-medium text-foreground">
-                  {app.user.firstName} {app.user.lastName}
-                </div>
               </div>
               <div>
                 <div className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider mb-1">Reviewers</div>
@@ -2490,31 +2379,19 @@ function ApplicationsTable({ apps, draftDecisions, cycleReviewersForDomain, cycl
                   <span className="text-xs text-muted-foreground">—</span>
                 )}
               </div>
-              <div className="flex flex-wrap items-center gap-2">
-                {isUnderReview && draftToFinalize && (
+              {isUnderReview && draftToFinalize && (
+                <div className="flex flex-wrap items-center gap-2">
                   <button
                     onClick={async () => {
                       await fetch(`/api/hiring/decisions/${draftToFinalize.id}/finalize`, { method: "POST", credentials: "include" });
                       revalidator.revalidate();
                     }}
-                    className="px-2 py-1 text-xs font-medium rounded bg-green-600 hover:bg-green-700 text-white transition"
+                    className="px-2 py-1 text-xs font-medium rounded bg-accent-coral hover:bg-accent-coral/90 text-white transition"
                   >
                     Finalize
                   </button>
-                )}
-                <Link
-                  to={`/hiring/domain-lead/application/${da?.id}`}
-                  onClick={(e) => {
-                    if (!da?.id) return
-                    const url = `/hiring/domain-lead/application/${da.id}`
-                    const label = `${app.user.firstName ?? ''} ${app.user.lastName ?? ''}`.trim() || 'Applicant'
-                    if (requestOpenTabIfEmbedded(url, label)) e.preventDefault()
-                  }}
-                  className="text-blue-600 hover:text-blue-800 text-sm font-medium"
-                >
-                  Review →
-                </Link>
-              </div>
+                </div>
+              )}
             </li>
           );
         })}
@@ -2697,7 +2574,7 @@ function ReviewerAssignmentCell({ domainApplicationId, reviews, cycleReviewers, 
           <button
             onClick={addReviewer}
             disabled={!selectedReviewerId}
-            className="px-1.5 py-0.5 text-xs font-medium rounded bg-accent-coral text-white hover:bg-accent-coral/90 disabled:opacity-50"
+            className="px-1.5 py-0.5 text-xs font-medium rounded bg-accent-teal text-white hover:bg-accent-teal/90 disabled:opacity-50"
           >
             Add
           </button>

--- a/dali-api/app/hiring/routes/domain-lead.tsx
+++ b/dali-api/app/hiring/routes/domain-lead.tsx
@@ -191,9 +191,12 @@ export async function loader({ request }: Route.LoaderArgs) {
 
       // Interviews for this domain in this cycle. Both Scheduled and Completed
       // rows appear in the dashboard table — only cancelled rows are excluded
-      // (audit-only).
+      // (audit-only). Load for any non-Draft cycle: an interview can be booked
+      // while the cycle is still Open (a Released invite + scheduled slot), and
+      // those applicants must surface in the Interviews section rather than
+      // vanishing (they're excluded from Reviews).
       const currentStatus = cycle?.statusUpdates[0]?.newStatus ?? "Draft";
-      const interviews = (currentStatus === "UnderReview" || currentStatus === "Completed") && cycle
+      const interviews = currentStatus !== "Draft" && cycle
         ? await prisma.interview.findMany({
             where: {
               applicationCycleId: cycle.id,

--- a/dali-api/app/projects/components/BidModal.tsx
+++ b/dali-api/app/projects/components/BidModal.tsx
@@ -1,11 +1,14 @@
 import { Modal } from "~/components/Modal";
-import type { Level, Preference } from "../lib/staffing-board";
+import type { BidField, Level, Preference } from "../lib/staffing-board";
 
 type BidModalProps = {
   open: boolean;
   onClose: () => void;
   memberName: string;
   preferences: Preference[];
+  // The member's full Project Bids form answers (label/value) — the complete
+  // bid content, beyond just the resolved rankings.
+  bidFields: BidField[];
   // Project id → display name, for rendering rank rows.
   projectNames: Record<string, string>;
   // Domain id → display name, for the per-bid domain chip.
@@ -25,6 +28,7 @@ export function BidModal({
   onClose,
   memberName,
   preferences,
+  bidFields,
   projectNames,
   domainNames,
   currentProjectId,
@@ -35,7 +39,7 @@ export function BidModal({
       open={open}
       onClose={onClose}
       labelledBy="bid-modal-title"
-      containerClassName="bg-card rounded-2xl shadow-xl max-w-lg w-full p-5 sm:p-6 my-auto"
+      containerClassName="bg-card rounded-2xl shadow-xl max-w-lg w-full p-5 sm:p-6 my-auto max-h-[85vh] overflow-y-auto"
     >
       <div className="flex items-start justify-between gap-4 mb-4">
         <div>
@@ -43,7 +47,7 @@ export function BidModal({
             {memberName}'s bid
           </h2>
           <p className="text-xs text-muted-foreground mt-0.5">
-            Project rankings for this staffing cycle.
+            Full bid submission for this staffing cycle.
           </p>
         </div>
         <button
@@ -55,45 +59,74 @@ export function BidModal({
         </button>
       </div>
 
-      {sorted.length === 0 ? (
+      {sorted.length === 0 && bidFields.length === 0 ? (
         <p className="text-sm text-muted-foreground italic">
-          This member didn't submit any project preferences for this cycle.
+          This member didn't submit a bid for this cycle.
         </p>
       ) : (
-        <ol className="flex flex-col gap-3">
-          {sorted.map((p) => {
-            const isCurrent = p.projectId === currentProjectId;
-            return (
-              <li
-                key={p.projectId}
-                className={`border rounded-md p-3 ${
-                  isCurrent
-                    ? "border-accent-coral bg-accent-coral/5"
-                    : "border-border bg-background"
-                }`}
-              >
-                <div className="flex items-baseline justify-between gap-2 flex-wrap">
-                  <span className="font-semibold text-foreground">
-                    #{p.preferenceRank} · {projectNames[p.projectId] ?? p.projectId}
-                  </span>
-                  <span className="text-xs text-muted-foreground">
-                    {domainNames[p.domainId] ?? p.domainId} · {LEVEL_LABEL[p.level]}
-                  </span>
-                </div>
-                {p.notes && (
-                  <p className="text-sm text-muted-foreground mt-2 whitespace-pre-wrap">
-                    {p.notes}
-                  </p>
-                )}
-                {isCurrent && (
-                  <p className="text-xs text-accent-coral font-medium mt-2">
-                    Currently assigned here.
-                  </p>
-                )}
-              </li>
-            );
-          })}
-        </ol>
+        <div className="space-y-5">
+          {/* Resolved project rankings (when the bid produced preferences). */}
+          {sorted.length > 0 && (
+            <section>
+              <h3 className="text-xs font-bold text-muted-foreground uppercase tracking-wider mb-2">
+                Project rankings
+              </h3>
+              <ol className="flex flex-col gap-3">
+                {sorted.map((p) => {
+                  const isCurrent = p.projectId === currentProjectId;
+                  return (
+                    <li
+                      key={`${p.projectId}:${p.domainId}`}
+                      className={`border rounded-md p-3 ${
+                        isCurrent
+                          ? "border-accent-coral bg-accent-coral/5"
+                          : "border-border bg-background"
+                      }`}
+                    >
+                      <div className="flex items-baseline justify-between gap-2 flex-wrap">
+                        <span className="font-semibold text-foreground">
+                          #{p.preferenceRank} · {projectNames[p.projectId] ?? p.projectId}
+                        </span>
+                        <span className="text-xs text-muted-foreground">
+                          {domainNames[p.domainId] ?? p.domainId} · {LEVEL_LABEL[p.level]}
+                        </span>
+                      </div>
+                      {p.notes && (
+                        <p className="text-sm text-muted-foreground mt-2 whitespace-pre-wrap">
+                          {p.notes}
+                        </p>
+                      )}
+                      {isCurrent && (
+                        <p className="text-xs text-accent-coral font-medium mt-2">
+                          Currently assigned here.
+                        </p>
+                      )}
+                    </li>
+                  );
+                })}
+              </ol>
+            </section>
+          )}
+
+          {/* Full bid form answers — the complete submission. */}
+          {bidFields.length > 0 && (
+            <section>
+              <h3 className="text-xs font-bold text-muted-foreground uppercase tracking-wider mb-2">
+                Bid responses
+              </h3>
+              <dl className="space-y-3">
+                {bidFields.map((f, i) => (
+                  <div key={i}>
+                    <dt className="text-xs font-medium text-muted-foreground">{f.label}</dt>
+                    <dd className="text-sm text-foreground whitespace-pre-wrap mt-0.5">
+                      {f.value}
+                    </dd>
+                  </div>
+                ))}
+              </dl>
+            </section>
+          )}
+        </div>
       )}
     </Modal>
   );

--- a/dali-api/app/projects/components/StaffingBoard.tsx
+++ b/dali-api/app/projects/components/StaffingBoard.tsx
@@ -141,11 +141,8 @@ export function StaffingBoard({
 
   return (
     <div className="flex flex-col gap-3">
-      <div className="flex items-center justify-between gap-3 flex-wrap">
+      <div className="flex items-center justify-end gap-3 flex-wrap">
         <div className="flex items-center gap-2">
-          <h2 className="font-heading text-lg font-bold text-foreground">
-            Staffing
-          </h2>
           <label className="sr-only" htmlFor="staffing-term">
             Term
           </label>
@@ -170,11 +167,6 @@ export function StaffingBoard({
             ))}
           </select>
         </div>
-        <p className="text-xs text-muted-foreground hidden sm:block">
-          {canManage
-            ? "Drag a member onto a project. Click a card to view their bid."
-            : "Click a card to view their bid."}
-        </p>
       </div>
 
       {error && (
@@ -226,6 +218,7 @@ export function StaffingBoard({
           onClose={() => setOpenBidUserId(null)}
           memberName={`${openBidMember.firstName} ${openBidMember.lastName}`}
           preferences={openBidMember.preferences}
+          bidFields={openBidMember.bidFields ?? []}
           projectNames={projectNames}
           domainNames={domainNames}
           currentProjectId={openBidColumnId}

--- a/dali-api/app/projects/lib/__tests__/staffing-board.test.ts
+++ b/dali-api/app/projects/lib/__tests__/staffing-board.test.ts
@@ -16,6 +16,7 @@ function member(overrides: Partial<MemberInput> = {}): MemberInput {
     isAdmin: false,
     coreTitles: [],
     preferences: [],
+    bidFields: [],
     domainLevels: [],
     ...overrides,
   };

--- a/dali-api/app/projects/lib/staffing-board.ts
+++ b/dali-api/app/projects/lib/staffing-board.ts
@@ -19,6 +19,13 @@ export type DomainLevel = {
   level: Level;
 };
 
+// One labeled answer from the member's Project Bids form submission — the full
+// bid content shown in the BidModal (question label + resolved string value).
+export type BidField = {
+  label: string;
+  value: string;
+};
+
 export type MemberInput = {
   userId: string;
   firstName: string;
@@ -28,6 +35,9 @@ export type MemberInput = {
   isAdmin: boolean;
   coreTitles: string[];
   preferences: Preference[];
+  // The member's full Project Bids form answers (label/value), shown in the
+  // BidModal alongside the resolved rankings. Empty when there's no submission.
+  bidFields: BidField[];
   domainLevels: DomainLevel[];
   // True when the member submitted a project-bids form for this cycle but it
   // produced no usable preference (e.g. the bid projects have no open role in

--- a/dali-api/app/projects/routes/projects.staffing.tsx
+++ b/dali-api/app/projects/routes/projects.staffing.tsx
@@ -6,9 +6,11 @@ import { prisma } from "~/lib/db";
 import { resolvePhotoUrl } from "~/lib/photo";
 import { ensureStaffingCycle } from "../lib/staffing-cycle";
 import { getSlotBinding } from "../lib/form-slots";
+import { buildSubmissionView } from "../lib/submission-view.server";
 import { StaffingBoard } from "../components/StaffingBoard";
 import type {
   Assignment,
+  BidField,
   Level,
   MemberInput,
   Preference,
@@ -146,6 +148,30 @@ export async function loader({ request }: Route.LoaderArgs) {
   // Same shape for both pools (members with preferences, and bid-submitters
   // whose bids resolved to none). preferences/unresolvedBid are passed in
   // because they differ between the two.
+  // Full Project Bids answers per member, so clicking a card shows the whole
+  // bid (all form answers), not just the resolved rankings. One call resolves
+  // every member's submission for the cycle (reference answers → project/domain
+  // names) in a few batched queries — cheaper than a fetch per opened card.
+  const bidsBinding = await getSlotBinding(cycle.id, "project-bids");
+  const bidFieldsByUser = new Map<string, BidField[]>();
+  if (bidsBinding) {
+    const view = await buildSubmissionView({
+      cycleIds: [cycle.id],
+      slot: "project-bids",
+      formId: bidsBinding.formId,
+    });
+    for (const row of view.rows) {
+      // Show the member's own form answers (question fields) that have a value.
+      // Builtins like "Submitter" are redundant in a per-member modal.
+      bidFieldsByUser.set(
+        row.userId,
+        row.detailFields
+          .filter((f) => f.source === "question" && f.value.trim() !== "")
+          .map((f) => ({ label: f.label, value: f.value })),
+      );
+    }
+  }
+
   const toMemberInput = async (
     u: (typeof users)[number],
     preferences: Preference[],
@@ -164,6 +190,7 @@ export async function loader({ request }: Route.LoaderArgs) {
       .map((e) => ({ domainName: e.domain.displayName, level: e.level as Level }))
       .sort((a, b) => a.domainName.localeCompare(b.domainName)),
     preferences,
+    bidFields: bidFieldsByUser.get(u.id) ?? [],
     unresolvedBid,
   });
 
@@ -247,7 +274,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   // board legitimately has no new bids to staff — surface that so a lead
   // doesn't read an empty board as a bug. (Legacy StaffingPreference rows
   // may still appear; that's the documented exception.)
-  const bidsFormBound = !!(await getSlotBinding(cycle.id, "project-bids"));
+  const bidsFormBound = !!bidsBinding;
 
   return {
     cycle: {

--- a/dali-api/e2e/domain-lead.spec.ts
+++ b/dali-api/e2e/domain-lead.spec.ts
@@ -18,10 +18,13 @@ test.describe('domain lead workflow', () => {
     await expect(frame.getByText('Open').first()).toBeVisible();
   });
 
-  test('shows applicants table with known applicants', async ({ page }) => {
+  test('shows known applicants on the dashboard', async ({ page }) => {
     await page.goto('/hiring/domain-lead');
     const frame = domainFrame(page);
-    await expect(frame.getByRole('columnheader', { name: 'Applicant' }).first()).toBeVisible();
+    // Alice and Diego are seeded as invited-to-interview, so they now appear in
+    // the Interviews section (the Reviews section is scoped to under-review /
+    // rejected applicants — invited applicants live only under Interviews).
+    await expect(frame.getByRole('heading', { name: 'Interviews' }).first()).toBeVisible();
     await expect(frame.getByText('Alice Johnson').first()).toBeVisible();
     await expect(frame.getByText('Diego Rivera').first()).toBeVisible();
   });
@@ -34,7 +37,8 @@ test.describe('domain lead workflow', () => {
     await expect(frame.getByText(/Challenges \((setup|locked)\)/).first()).toBeVisible();
     await expect(frame.getByText('Rubric').first()).toBeVisible();
     await expect(frame.getByText('Team').first()).toBeVisible();
-    await expect(frame.getByText('Applications').first()).toBeVisible();
+    // "Applications" was renamed to "Reviews".
+    await expect(frame.getByText('Reviews').first()).toBeVisible();
   });
 
   test('application detail page shows challenge responses', async ({ page }) => {

--- a/dali-api/e2e/domain-lead.spec.ts
+++ b/dali-api/e2e/domain-lead.spec.ts
@@ -21,10 +21,10 @@ test.describe('domain lead workflow', () => {
   test('shows known applicants on the dashboard', async ({ page }) => {
     await page.goto('/hiring/domain-lead');
     const frame = domainFrame(page);
-    // Alice and Diego are seeded as invited-to-interview, so they now appear in
-    // the Interviews section (the Reviews section is scoped to under-review /
-    // rejected applicants — invited applicants live only under Interviews).
-    await expect(frame.getByRole('heading', { name: 'Interviews' }).first()).toBeVisible();
+    // Alice and Diego are seeded as invited-to-interview. After the redesign
+    // they appear in the Interviews section rather than the (renamed) Reviews
+    // table, but either way their names are visible on the domain dashboard.
+    await expect(frame.getByText('Interviews').first()).toBeVisible();
     await expect(frame.getByText('Alice Johnson').first()).toBeVisible();
     await expect(frame.getByText('Diego Rivera').first()).toBeVisible();
   });


### PR DESCRIPTION
Builds on #701 (now merged into dev). UI/UX pass over the hiring **domain-lead dashboard**, **deliberations** cards, and the **staffing board**.

## Domain lead dashboard (`domain-lead.tsx`)
- Renamed **Applications → Reviews**. Scoped it to applicants still under review or rejected; anyone invited to interview now appears **only** in the Interviews section (fixes the duplicate-across-sections issue).
- Merged the separate "Awaiting Booking" list + "Booked Interviews" table into **one Interviews table**, with booking surfaced in the Status column. The loader now fetches **Completed** interviews too, so the section shows all interviews (scheduled + finished).
- Clicking an **interview row** opens the applicant's review page (same as the Reviews table); clicking an **applicant name** opens their detail page.
- Removed the **bulk-select checkbox** + bar. Actions column is finalize-only.
- **Consistent pill borders** — every status/decision pill has a same-hue border (no neutral/black borders on colored pills).
- Recolored Finalize/Delibs buttons off green; **Auto-Assign Reviewers** and **Start Delibs** use a subtle off-white surface.

## Deliberations (`domain-lead.delibs.$id.tsx`)
- Member card now lists **reviewers and interviewers**, with their **recommendations split by source** (reviewer recs vs. the interviewer recommendation), color-coded by recommendation level.

## Staffing board (`projects.staffing.tsx`, `StaffingBoard`, `BidModal`)
- Clicking a member shows the **full bid submission** (all form answers, reference picks resolved to names), not just the resolved project rankings — reuses `buildSubmissionView`.
- Removed the redundant "Staffing" subheading + helper text; term selector moved to the right.

## Domain-lead detail + delibs context modal
- Interview notes + reviewer notes surfaced; same-hue status-pill borders.

Also includes a calendar group-availability fetch fix and the `ApplicantContextModal` / full-context reviewer+interviewer additions that were in the working tree.

## Test plan
- `npm run typecheck` — clean (only pre-existing `scripts/*.ts` errors).
- `npm test` — 1020/1020 pass.
- Worth an eyeball on the preview deploy: the Reviews/Interviews tables, delibs card recs, and the bid modal's full content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/706"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782422282&installation_id=133523038&pr_number=706&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F706&signature=96972fb0f8e16beacdc906fee417f760cd02a6afc1ffe8851d4cbbed5ac4e54b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->