### PR TITLE
Tab-workspace scroll restoration + project-hub scope settings popup

### DIFF
--- a/dali-api/app/projects/routes/projects.$id.tsx
+++ b/dali-api/app/projects/routes/projects.$id.tsx
@@ -735,10 +735,10 @@ export default function ProjectDetail() {
             type="button"
             onClick={() => setScopeSettingsOpen(true)}
             className="ml-auto -mb-px inline-flex items-center gap-1.5 px-3 py-2 text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
-            title="Project scope & challenges"
+            title="Domain settings & challenges"
           >
             <Settings className="w-4 h-4" />
-            <span className="hidden sm:inline">Scope settings</span>
+            <span className="hidden sm:inline">Domain settings</span>
           </button>
         )}
       </div>
@@ -768,7 +768,7 @@ export default function ProjectDetail() {
           <div className="flex items-start justify-between gap-3 mb-4">
             <div>
               <h2 id="scope-settings-title" className="font-heading text-lg font-bold text-foreground">
-                Scope &amp; challenges
+                Domain settings
               </h2>
               <p className="text-xs text-muted-foreground mt-0.5">
                 Declared domains, planned terms, and the per-domain challenge

--- a/dali-api/app/projects/routes/projects.$id.tsx
+++ b/dali-api/app/projects/routes/projects.$id.tsx
@@ -9,7 +9,8 @@ import {
   useSearchParams,
   useSubmit,
 } from "react-router";
-import { Check, Pencil, X } from "lucide-react";
+import { Check, Pencil, X, Settings } from "lucide-react";
+import { Modal } from "~/components/Modal";
 import { EditableSection } from "~/components/EditableSection";
 import { TagPicker } from "~/components/TagPicker";
 import { uploadFileToS3, formatBytes } from "~/lib/upload-client";
@@ -18,7 +19,7 @@ import { prisma } from "~/lib/db";
 import { ensureProjectGroup } from "~/lib/groups";
 import { requireAuth } from "~/lib/auth";
 import { parseSessionCookie } from "~/lib/cookies";
-import { isCore, currentTerm } from "~/lib/roles";
+import { isCore, canManageStaffing, currentTerm } from "~/lib/roles";
 import { TaskBoard } from "../components/TaskBoard";
 import { type TimelineEpic, type EpicStatus } from "../components/EpicsTimeline";
 import {
@@ -57,15 +58,17 @@ function openDocumentTab(pageId: string, label: string) {
 const STATUSES = ["Active", "Paused", "Archived"] as const;
 type ProjectStatus = (typeof STATUSES)[number];
 
-const TABS = ["overview", "scope", "work"] as const;
+// "Scope" is no longer a public tab — its domain/term/challenge config moved
+// into a settings popup (gated to Core/Admin/Staff). Public tabs are just the
+// content views.
+const TABS = ["overview", "work"] as const;
 type Tab = (typeof TABS)[number];
 function isTab(x: string | null): x is Tab {
-  return x === "overview" || x === "scope" || x === "work";
+  return x === "overview" || x === "work";
 }
 
 const TAB_LABELS: Record<Tab, string> = {
   overview: "Overview",
-  scope: "Scope",
   work: "Work",
 };
 
@@ -218,6 +221,9 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 
   // Admin or Core members may edit projects (isCore === Admin || Core).
   const canEdit = await isCore(auth.user.sub);
+  // The Scope/challenge settings popup is visible to Core, Admin, or staffing
+  // leads. Editing still requires canEdit (isCore) — the action enforces that.
+  const canViewScope = canEdit || (await canManageStaffing(auth.user.sub));
 
   // Collab editor wiring (same as the hiring routes): session cookie is the
   // WebSocket auth token; userName labels the presence cursor.
@@ -462,6 +468,8 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     tasks,
     boardOptions,
     canEdit,
+    canViewScope,
+    currentTerm: current ? { id: current.id, code: current.code } : null,
     collabToken,
     userName,
     currentUserId: auth.user.sub,
@@ -665,10 +673,13 @@ export default function ProjectDetail() {
     allTermOptions,
     domainScopeGrid,
     canEdit,
+    canViewScope,
+    currentTerm,
     collabToken,
     userName,
   } = useLoaderData() as LoaderData;
   const actionData = useActionData<typeof action>();
+  const [scopeSettingsOpen, setScopeSettingsOpen] = useState(false);
   const [searchParams, setSearchParams] = useSearchParams();
   const partnerNames = project.partners.map((p) => p.partnerOrg.name);
 
@@ -717,6 +728,19 @@ export default function ProjectDetail() {
             {TAB_LABELS[t]}
           </button>
         ))}
+        {/* Scope/challenge config lives behind this gear, visible only to
+            Core/Admin/Staff. */}
+        {canViewScope && (
+          <button
+            type="button"
+            onClick={() => setScopeSettingsOpen(true)}
+            className="ml-auto -mb-px inline-flex items-center gap-1.5 px-3 py-2 text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
+            title="Project scope & challenges"
+          >
+            <Settings className="w-4 h-4" />
+            <span className="hidden sm:inline">Scope settings</span>
+          </button>
+        )}
       </div>
 
       {tab === "overview" && (
@@ -727,20 +751,49 @@ export default function ProjectDetail() {
           files={files}
           allTags={allTags}
           canEdit={canEdit}
+          domainScopeGrid={domainScopeGrid}
+          currentTerm={currentTerm}
           actionError={actionData?.error}
         />
       )}
 
-      {tab === "scope" && (
-        <ScopeTab
-          project={project}
-          allDomainOptions={allDomainOptions}
-          plannedTerms={plannedTerms}
-          allTermOptions={allTermOptions}
-          domainScopeGrid={domainScopeGrid}
-          canEdit={canEdit}
-          actionError={actionData?.error}
-        />
+      {/* Scope & challenges, now a settings popup gated to Core/Admin/Staff. */}
+      {canViewScope && (
+        <Modal
+          open={scopeSettingsOpen}
+          onClose={() => setScopeSettingsOpen(false)}
+          labelledBy="scope-settings-title"
+          containerClassName="bg-card rounded-2xl shadow-xl w-full max-w-4xl p-5 sm:p-6 my-auto max-h-[85vh] overflow-y-auto"
+        >
+          <div className="flex items-start justify-between gap-3 mb-4">
+            <div>
+              <h2 id="scope-settings-title" className="font-heading text-lg font-bold text-foreground">
+                Scope &amp; challenges
+              </h2>
+              <p className="text-xs text-muted-foreground mt-0.5">
+                Declared domains, planned terms, and the per-domain challenge
+                for each term.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={() => setScopeSettingsOpen(false)}
+              aria-label="Close scope settings"
+              className="text-muted-foreground hover:text-foreground text-xl leading-none px-1"
+            >
+              ×
+            </button>
+          </div>
+          <ScopeTab
+            project={project}
+            allDomainOptions={allDomainOptions}
+            plannedTerms={plannedTerms}
+            allTermOptions={allTermOptions}
+            domainScopeGrid={domainScopeGrid}
+            canEdit={canEdit}
+            actionError={actionData?.error}
+          />
+        </Modal>
       )}
 
       {tab === "work" && (
@@ -1505,6 +1558,8 @@ function OverviewTab({
   files,
   allTags,
   canEdit,
+  domainScopeGrid,
+  currentTerm,
   actionError,
 }: {
   project: LoaderData["project"];
@@ -1513,8 +1568,18 @@ function OverviewTab({
   files: LoaderData["files"];
   allTags: LoaderData["allTags"];
   canEdit: boolean;
+  domainScopeGrid: LoaderData["domainScopeGrid"];
+  currentTerm: LoaderData["currentTerm"];
   actionError?: string;
 }) {
+  // The current term's per-domain challenge, read-only on Overview. Edited in
+  // the Scope settings popup. Only non-empty cells for the current term show.
+  const currentChallenges = currentTerm
+    ? domainScopeGrid.filter(
+        (c) => c.termId === currentTerm.id && c.scope.trim() !== "",
+      )
+    : [];
+
   return (
     <div className="flex flex-col gap-4">
       {actionError && (
@@ -1525,6 +1590,30 @@ function OverviewTab({
 
       {/* Description — its own segment on top, separate from Project details */}
       <DescriptionSegment description={project.description} canEdit={canEdit} />
+
+      {/* Challenge for the current term, per declared domain (read-only). */}
+      {currentTerm && currentChallenges.length > 0 && (
+        <section className="bg-card border border-border rounded-lg p-4">
+          <h3 className="text-sm font-semibold text-foreground mb-3">
+            Challenge{" "}
+            <span className="text-xs font-normal text-muted-foreground">
+              · {currentTerm.code}
+            </span>
+          </h3>
+          <div className="space-y-3">
+            {currentChallenges.map((c) => (
+              <div key={c.domainId}>
+                <div className="text-xs font-medium text-muted-foreground">
+                  {c.domainName}
+                </div>
+                <p className="text-sm text-foreground whitespace-pre-wrap mt-0.5">
+                  {c.scope}
+                </p>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
 
       {/* Project details. Editable as one section; commits via intent=details
           which expects the full field set. Section-level Save submits and

--- a/dali-api/app/routes/layout.tsx
+++ b/dali-api/app/routes/layout.tsx
@@ -123,6 +123,48 @@ export default function AppLayoutRoute() {
     return () => window.clearTimeout(id)
   }, [embedded, location.pathname, location.search])
 
+  // Scroll restoration WITHIN an embedded tab. React Router's <ScrollRestoration>
+  // doesn't reliably restore the iframe window's scroll on in-tab back/forward
+  // (the iframe is its own document and RR's key tracking gets lost across the
+  // shell↔iframe boundary), so we persist scrollY per history entry ourselves.
+  // Keyed by location.key (stable per history entry) in sessionStorage, scoped
+  // to this document, so navigating into a nested page and back restores where
+  // you were. Runs in both embedded and standalone documents — harmless either
+  // way, and standalone deep links benefit too.
+  const SCROLL_KEY_PREFIX = "dali:scroll:";
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const key = SCROLL_KEY_PREFIX + location.key;
+
+    // Restore on entering this location. rAF waits for the new route's content
+    // to paint so the target offset exists; fall back to top when unseen.
+    let raf = 0;
+    try {
+      const saved = window.sessionStorage.getItem(key);
+      raf = window.requestAnimationFrame(() => {
+        window.scrollTo(0, saved ? parseInt(saved, 10) || 0 : 0);
+      });
+    } catch {
+      // sessionStorage disabled — nothing to restore.
+    }
+
+    // Continuously record this entry's scroll while it's the active location,
+    // so a later back-navigation lands where the user left off.
+    const onScroll = () => {
+      try {
+        window.sessionStorage.setItem(key, String(window.scrollY));
+      } catch {
+        // ignore quota / disabled storage
+      }
+    };
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => {
+      window.cancelAnimationFrame(raf);
+      onScroll(); // capture final position for this entry before it changes
+      window.removeEventListener("scroll", onScroll);
+    };
+  }, [location.key]);
+
   // Skip the sidebar shell when rendered inside a TabWorkspace iframe.
   if (embedded) {
     return (


### PR DESCRIPTION
Three requested features (separate branch off dev).

## 1. In-tab scroll restoration (`app/routes/layout.tsx`)
When you navigate into a nested page within a workspace tab and then go back, the original page's scroll position is restored. We persist the embedded iframe window's `scrollY` per history entry (`location.key`) in `sessionStorage` and restore it on back/forward with a rAF-timed `scrollTo` (so it lands correctly after async content paints). React Router's `<ScrollRestoration>` doesn't reliably restore the iframe's scroll across the shell↔iframe boundary, so this owns it explicitly.

## 2. Real-time note sync across split panes — no change needed
Investigated thoroughly. Live collaborative editors (project documents `doc:{pageId}:body`, epic descriptions, interview joint notes) **already sync across split panes** — two iframes open two Hocuspocus WS connections that the server relays. Per request, **interview notes were excluded** (and per-interviewer rec-notes are owner-only, so they can't safely go live for non-owners). The remaining note-like surfaces in the project hub (description, challenge/scope) are **plain DB form fields, not collab docs**, so there's no real-time channel to add. No code change was required to satisfy the scenario.

## 3. Project-hub scope → settings popup (`app/projects/routes/projects.$id.tsx`)
- **Scope is no longer a public tab.** Its domain / planned-term / per-domain **challenge** config moved behind a **"Scope settings"** gear in the tab bar, visible only to **Core / Admin / staffing leads** (`canViewScope`). Editing still requires `isCore` (the action enforces it).
- **Overview** now displays the **current term's** per-domain challenge (read-only), resolved from `ProjectDomainScope` for `currentTerm()`.

## Test plan
- `npm run typecheck` — clean (only pre-existing `scripts/*.ts` errors).
- `npm test` — 1020/1020 pass.
- Worth an eyeball on the preview deploy: in-tab back-navigation scroll; the project page's Scope-settings gear (and that non-staff users don't see it); Overview's current-term challenge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/708"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782424913&installation_id=133523038&pr_number=708&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F708&signature=66605d94887cef6cf2f8bb62322a71a92d5d32b5b05c903d1f3b34e885684170"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->