### PR TITLE
Fix S3 presigned URL signature mismatch on photo loads

### DIFF
--- a/dali-api/app/lib/s3.ts
+++ b/dali-api/app/lib/s3.ts
@@ -6,12 +6,19 @@ import { MAX_UPLOAD_BYTES } from './file-validation'
 const REGION = process.env.AWS_REGION
 const BUCKET = process.env.AWS_S3_BUCKET
 
+// `responseChecksumValidation: "WHEN_REQUIRED"` opts out of the SDK's default
+// behavior of adding `x-amz-checksum-mode=ENABLED` to presigned GetObject URLs.
+// That extra query param breaks SigV4 (signed headers don't account for it),
+// producing "signature does not match" on the browser-side fetch. We don't
+// rely on response checksum validation — S3 already integrity-checks via TLS.
 const s3 = new S3Client({
   region: REGION,
   credentials: {
     accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
     secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
   },
+  responseChecksumValidation: "WHEN_REQUIRED",
+  requestChecksumCalculation: "WHEN_REQUIRED",
 })
 
 // Generate a presigned POST policy for uploading a file directly from the


### PR DESCRIPTION
## Summary
- Disables the default `responseChecksumValidation`/`requestChecksumCalculation` on the shared `S3Client` in `app/lib/s3.ts`.
- @aws-sdk/client-s3 v3.730+ defaults to appending `x-amz-checksum-mode=ENABLED` to presigned GetObject URLs, which isn't reflected in `X-Amz-SignedHeaders=host` → every avatar/photo URL fails with *"The request signature we calculated does not match the signature you provided."*
- TLS already integrity-checks the response payload, so we lose nothing by opting out of checksum validation here.

## Test plan
- [ ] Pull the branch, run `npm run typecheck` to confirm the new `S3ClientConfig` keys are accepted by the installed SDK version.
- [ ] Deploy to staging (or set `AWS_REQUEST_CHECKSUM_CALCULATION=when_required` / `AWS_RESPONSE_CHECKSUM_VALIDATION=when_required` on a staging machine and restart) and load a member detail page — avatar should render instead of 403'ing.
- [ ] Upload a new avatar via `PhotoUploadField` — presigned POST flow should be unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/712"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782428925&installation_id=133523038&pr_number=712&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F712&signature=9d76c1972723acf67d32e3497e228f936d7adc51d3c66f9ce3bca7613bab2a65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->