### PR TITLE
Project-hub edits for project members + Level Up under Internal Processes

### DIFF
--- a/dali-api/app/calendar/routes/calendar.tsx
+++ b/dali-api/app/calendar/routes/calendar.tsx
@@ -3474,15 +3474,22 @@ function WeekGrid({
               const lo = Math.min(drag.anchor, drag.hover);
               const hi = Math.max(drag.anchor, drag.hover);
               const heightHours = Math.max(SNAP_HOURS, hi - lo);
+              const top = (lo - MIN_HOUR) * HOUR_PX;
+              // Caption sits above the rectangle's top edge so a short (e.g.
+              // 10-min) selection doesn't have the text spilling through the
+              // box into the slot below. Near the grid's top there's no room
+              // above (the column clips overflow), so drop it just inside.
+              const captionBelow = top < 16;
               return (
                 <div
                   className="absolute left-0 right-0 border-2 border-accent-coral bg-accent-coral/15 pointer-events-none rounded-sm z-30 shadow-md"
-                  style={{
-                    top: (lo - MIN_HOUR) * HOUR_PX,
-                    height: heightHours * HOUR_PX,
-                  }}
+                  style={{ top, height: heightHours * HOUR_PX }}
                 >
-                  <div className="px-1 py-0.5 text-[11px] font-semibold rounded-sm m-1 inline-block shadow-sm bg-accent-coral text-white">
+                  <div
+                    className={`absolute left-0 px-1 py-0.5 rounded bg-white/75 text-[11px] font-semibold leading-none whitespace-nowrap text-accent-coral ${
+                      captionBelow ? "top-1" : "bottom-full mb-1"
+                    }`}
+                  >
                     {formatHourMinute(lo)} – {formatHourMinute(hi)}
                   </div>
                 </div>
@@ -3505,7 +3512,12 @@ function WeekGrid({
                   }`}
                   style={{ top, height }}
                 >
-                  <div className="px-1 py-0.5 text-[11px] font-semibold rounded-sm m-1 inline-block bg-accent-coral text-white pointer-events-none">
+                  {/* Caption above the top edge — see drag-preview note. */}
+                  <div
+                    className={`absolute left-0 px-1 py-0.5 rounded bg-white/75 text-[11px] font-semibold leading-none whitespace-nowrap text-accent-coral pointer-events-none ${
+                      top < 16 ? "top-1" : "bottom-full mb-1"
+                    }`}
+                  >
                     {formatHourMinute(lo)} – {formatHourMinute(hi)}
                   </div>
                   {resizable && (

--- a/dali-api/app/components/Layout.tsx
+++ b/dali-api/app/components/Layout.tsx
@@ -146,6 +146,9 @@ export function Layout({ user, photoUrl, isCore = false, isAdmin = false, isDoma
     const areaKey: AreaKey | null =
       path.startsWith('/admin-console') ? 'admin-console'
       : path.startsWith('/hiring') ? 'hiring'
+      // Level Up lives at /projects/level-up but is surfaced under Internal
+      // Processes — resolve it there before the generic /projects branch.
+      : path.startsWith('/projects/level-up') ? 'internal-processes'
       : path.startsWith('/projects') ? 'projects'
       : path.startsWith('/members') ? 'members'
       : path.startsWith('/partners') ? 'partners'
@@ -234,6 +237,9 @@ export function Layout({ user, photoUrl, isCore = false, isAdmin = false, isDoma
   const activeAreaKey: AreaKey | null =
     path.startsWith('/admin-console') ? 'admin-console'
     : path.startsWith('/hiring') ? 'hiring'
+    // Level Up lives at /projects/level-up but is surfaced under Internal
+    // Processes — resolve it there before the generic /projects branch.
+    : path.startsWith('/projects/level-up') ? 'internal-processes'
     : path.startsWith('/projects') ? 'projects'
     : path.startsWith('/members') ? 'members'
     : path.startsWith('/partners') ? 'partners'
@@ -388,14 +394,6 @@ export function Layout({ user, photoUrl, isCore = false, isAdmin = false, isDoma
       active: path.startsWith('/projects/project-bids'),
       sub: null,
     },
-    {
-      label: 'Level Up',
-      to: '/projects/level-up',
-      icon: TrendingUp,
-      show: canViewStaffing,
-      active: path.startsWith('/projects/level-up'),
-      sub: null,
-    },
   ].filter((s) => s.show)
 
   const membersSections = [
@@ -455,6 +453,18 @@ export function Layout({ user, photoUrl, isCore = false, isAdmin = false, isDoma
       show: true,
       active: path.startsWith('/internal-processes/transfer'),
       sub: null as { label: string; to: string; active: boolean }[] | null,
+    },
+    {
+      label: 'Level Up',
+      // Page lives under /projects/level-up; surfaced here under Internal
+      // Processes. Match both so the entry highlights on either path.
+      to: '/projects/level-up',
+      icon: TrendingUp,
+      show: canViewStaffing,
+      active:
+        path.startsWith('/projects/level-up') ||
+        path.startsWith('/internal-processes/level-up'),
+      sub: null,
     },
     {
       label: 'JobX',

--- a/dali-api/app/lib/roles.ts
+++ b/dali-api/app/lib/roles.ts
@@ -148,6 +148,22 @@ export async function isDomainLead(userId: string): Promise<boolean> {
 }
 
 /**
+ * Whether the user is staffed on a project — a ProjectAssignment row for that
+ * project in any term (past contributors keep access). Used to grant
+ * content-edit access to the project hub; scope/domain settings stay Core/Admin.
+ */
+export async function isProjectMember(
+  userId: string,
+  projectId: string,
+): Promise<boolean> {
+  const row = await prisma.projectAssignment.findFirst({
+    where: { userId, projectId },
+    select: { id: true },
+  });
+  return row !== null;
+}
+
+/**
  * Lab-membership gate. Returns the DALIMember row (thin marker — just
  * `{ id, userId, createdAt, updatedAt }`) if the user is a member, null
  * otherwise. The row is now a presence-only marker; callers should not

--- a/dali-api/app/projects/routes/projects.$id.tsx
+++ b/dali-api/app/projects/routes/projects.$id.tsx
@@ -735,10 +735,10 @@ export default function ProjectDetail() {
             type="button"
             onClick={() => setScopeSettingsOpen(true)}
             className="ml-auto -mb-px inline-flex items-center gap-1.5 px-3 py-2 text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
-            title="Project scope & challenges"
+            title="Domain settings & challenges"
           >
             <Settings className="w-4 h-4" />
-            <span className="hidden sm:inline">Scope settings</span>
+            <span className="hidden sm:inline">Domain settings</span>
           </button>
         )}
       </div>
@@ -768,7 +768,7 @@ export default function ProjectDetail() {
           <div className="flex items-start justify-between gap-3 mb-4">
             <div>
               <h2 id="scope-settings-title" className="font-heading text-lg font-bold text-foreground">
-                Scope &amp; challenges
+                Domain settings
               </h2>
               <p className="text-xs text-muted-foreground mt-0.5">
                 Declared domains, planned terms, and the per-domain challenge

--- a/dali-api/app/projects/routes/projects.$id.tsx
+++ b/dali-api/app/projects/routes/projects.$id.tsx
@@ -9,7 +9,8 @@ import {
   useSearchParams,
   useSubmit,
 } from "react-router";
-import { Check, Pencil, X } from "lucide-react";
+import { Check, Pencil, X, Settings } from "lucide-react";
+import { Modal } from "~/components/Modal";
 import { EditableSection } from "~/components/EditableSection";
 import { TagPicker } from "~/components/TagPicker";
 import { uploadFileToS3, formatBytes } from "~/lib/upload-client";
@@ -18,7 +19,7 @@ import { prisma } from "~/lib/db";
 import { ensureProjectGroup } from "~/lib/groups";
 import { requireAuth } from "~/lib/auth";
 import { parseSessionCookie } from "~/lib/cookies";
-import { isCore, currentTerm } from "~/lib/roles";
+import { isCore, canManageStaffing, currentTerm } from "~/lib/roles";
 import { TaskBoard } from "../components/TaskBoard";
 import { type TimelineEpic, type EpicStatus } from "../components/EpicsTimeline";
 import {
@@ -57,15 +58,17 @@ function openDocumentTab(pageId: string, label: string) {
 const STATUSES = ["Active", "Paused", "Archived"] as const;
 type ProjectStatus = (typeof STATUSES)[number];
 
-const TABS = ["overview", "scope", "work"] as const;
+// "Scope" is no longer a public tab — its domain/term/challenge config moved
+// into a settings popup (gated to Core/Admin/Staff). Public tabs are just the
+// content views.
+const TABS = ["overview", "work"] as const;
 type Tab = (typeof TABS)[number];
 function isTab(x: string | null): x is Tab {
-  return x === "overview" || x === "scope" || x === "work";
+  return x === "overview" || x === "work";
 }
 
 const TAB_LABELS: Record<Tab, string> = {
   overview: "Overview",
-  scope: "Scope",
   work: "Work",
 };
 
@@ -218,6 +221,9 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 
   // Admin or Core members may edit projects (isCore === Admin || Core).
   const canEdit = await isCore(auth.user.sub);
+  // The Scope/challenge settings popup is visible to Core, Admin, or staffing
+  // leads. Editing still requires canEdit (isCore) — the action enforces that.
+  const canViewScope = canEdit || (await canManageStaffing(auth.user.sub));
 
   // Collab editor wiring (same as the hiring routes): session cookie is the
   // WebSocket auth token; userName labels the presence cursor.
@@ -462,6 +468,8 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     tasks,
     boardOptions,
     canEdit,
+    canViewScope,
+    currentTerm: current ? { id: current.id, code: current.code } : null,
     collabToken,
     userName,
     currentUserId: auth.user.sub,
@@ -665,10 +673,13 @@ export default function ProjectDetail() {
     allTermOptions,
     domainScopeGrid,
     canEdit,
+    canViewScope,
+    currentTerm,
     collabToken,
     userName,
   } = useLoaderData() as LoaderData;
   const actionData = useActionData<typeof action>();
+  const [scopeSettingsOpen, setScopeSettingsOpen] = useState(false);
   const [searchParams, setSearchParams] = useSearchParams();
   const partnerNames = project.partners.map((p) => p.partnerOrg.name);
 
@@ -717,6 +728,19 @@ export default function ProjectDetail() {
             {TAB_LABELS[t]}
           </button>
         ))}
+        {/* Scope/challenge config lives behind this gear, visible only to
+            Core/Admin/Staff. */}
+        {canViewScope && (
+          <button
+            type="button"
+            onClick={() => setScopeSettingsOpen(true)}
+            className="ml-auto -mb-px inline-flex items-center gap-1.5 px-3 py-2 text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
+            title="Project scope & challenges"
+          >
+            <Settings className="w-4 h-4" />
+            <span className="hidden sm:inline">Scope settings</span>
+          </button>
+        )}
       </div>
 
       {tab === "overview" && (
@@ -727,20 +751,49 @@ export default function ProjectDetail() {
           files={files}
           allTags={allTags}
           canEdit={canEdit}
+          domainScopeGrid={domainScopeGrid}
+          currentTerm={currentTerm}
           actionError={actionData?.error}
         />
       )}
 
-      {tab === "scope" && (
-        <ScopeTab
-          project={project}
-          allDomainOptions={allDomainOptions}
-          plannedTerms={plannedTerms}
-          allTermOptions={allTermOptions}
-          domainScopeGrid={domainScopeGrid}
-          canEdit={canEdit}
-          actionError={actionData?.error}
-        />
+      {/* Scope & challenges, now a settings popup gated to Core/Admin/Staff. */}
+      {canViewScope && (
+        <Modal
+          open={scopeSettingsOpen}
+          onClose={() => setScopeSettingsOpen(false)}
+          labelledBy="scope-settings-title"
+          containerClassName="bg-card rounded-2xl shadow-xl w-full max-w-4xl p-5 sm:p-6 my-auto max-h-[85vh] overflow-y-auto"
+        >
+          <div className="flex items-start justify-between gap-3 mb-4">
+            <div>
+              <h2 id="scope-settings-title" className="font-heading text-lg font-bold text-foreground">
+                Scope &amp; challenges
+              </h2>
+              <p className="text-xs text-muted-foreground mt-0.5">
+                Declared domains, planned terms, and the per-domain challenge
+                for each term.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={() => setScopeSettingsOpen(false)}
+              aria-label="Close scope settings"
+              className="text-muted-foreground hover:text-foreground text-xl leading-none px-1"
+            >
+              ×
+            </button>
+          </div>
+          <ScopeTab
+            project={project}
+            allDomainOptions={allDomainOptions}
+            plannedTerms={plannedTerms}
+            allTermOptions={allTermOptions}
+            domainScopeGrid={domainScopeGrid}
+            canEdit={canEdit}
+            actionError={actionData?.error}
+          />
+        </Modal>
       )}
 
       {tab === "work" && (
@@ -1505,6 +1558,8 @@ function OverviewTab({
   files,
   allTags,
   canEdit,
+  domainScopeGrid,
+  currentTerm,
   actionError,
 }: {
   project: LoaderData["project"];
@@ -1513,8 +1568,18 @@ function OverviewTab({
   files: LoaderData["files"];
   allTags: LoaderData["allTags"];
   canEdit: boolean;
+  domainScopeGrid: LoaderData["domainScopeGrid"];
+  currentTerm: LoaderData["currentTerm"];
   actionError?: string;
 }) {
+  // The current term's per-domain challenge, read-only on Overview. Edited in
+  // the Scope settings popup. Only non-empty cells for the current term show.
+  const currentChallenges = currentTerm
+    ? domainScopeGrid.filter(
+        (c) => c.termId === currentTerm.id && c.scope.trim() !== "",
+      )
+    : [];
+
   return (
     <div className="flex flex-col gap-4">
       {actionError && (
@@ -1525,6 +1590,30 @@ function OverviewTab({
 
       {/* Description — its own segment on top, separate from Project details */}
       <DescriptionSegment description={project.description} canEdit={canEdit} />
+
+      {/* Challenge for the current term, per declared domain (read-only). */}
+      {currentTerm && currentChallenges.length > 0 && (
+        <section className="bg-card border border-border rounded-lg p-4">
+          <h3 className="text-sm font-semibold text-foreground mb-3">
+            Challenge{" "}
+            <span className="text-xs font-normal text-muted-foreground">
+              · {currentTerm.code}
+            </span>
+          </h3>
+          <div className="space-y-3">
+            {currentChallenges.map((c) => (
+              <div key={c.domainId}>
+                <div className="text-xs font-medium text-muted-foreground">
+                  {c.domainName}
+                </div>
+                <p className="text-sm text-foreground whitespace-pre-wrap mt-0.5">
+                  {c.scope}
+                </p>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
 
       {/* Project details. Editable as one section; commits via intent=details
           which expects the full field set. Section-level Save submits and

--- a/dali-api/app/projects/routes/projects.$id.tsx
+++ b/dali-api/app/projects/routes/projects.$id.tsx
@@ -19,7 +19,7 @@ import { prisma } from "~/lib/db";
 import { ensureProjectGroup } from "~/lib/groups";
 import { requireAuth } from "~/lib/auth";
 import { parseSessionCookie } from "~/lib/cookies";
-import { isCore, canManageStaffing, currentTerm } from "~/lib/roles";
+import { isCore, isProjectMember, canManageStaffing, currentTerm } from "~/lib/roles";
 import { TaskBoard } from "../components/TaskBoard";
 import { type TimelineEpic, type EpicStatus } from "../components/EpicsTimeline";
 import {
@@ -219,11 +219,15 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     select: { id: true, label: true, slug: true, color: true },
   });
 
-  // Admin or Core members may edit projects (isCore === Admin || Core).
-  const canEdit = await isCore(auth.user.sub);
+  // Content edits (name/status, description, details, docs/files, epics/
+  // sprints/tasks) are open to Core/Admin *and* anyone staffed on this project
+  // in any term. Scope/domain settings stay Core/Admin only (canEditScope).
+  const core = await isCore(auth.user.sub);
+  const canEditScope = core;
+  const canEdit = core || (await isProjectMember(auth.user.sub, params.id));
   // The Scope/challenge settings popup is visible to Core, Admin, or staffing
-  // leads. Editing still requires canEdit (isCore) — the action enforces that.
-  const canViewScope = canEdit || (await canManageStaffing(auth.user.sub));
+  // leads. Editing still requires canEditScope (isCore) — the action enforces that.
+  const canViewScope = canEditScope || (await canManageStaffing(auth.user.sub));
 
   // Collab editor wiring (same as the hiring routes): session cookie is the
   // WebSocket auth token; userName labels the presence cursor.
@@ -468,6 +472,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     tasks,
     boardOptions,
     canEdit,
+    canEditScope,
     canViewScope,
     currentTerm: current ? { id: current.id, code: current.code } : null,
     collabToken,
@@ -481,12 +486,20 @@ export async function action({ request, params }: Route.ActionArgs) {
   if (!auth.ok) return redirect("/login");
   if (auth.user.type === "applicant") return redirect("/portal");
 
-  if (!(await isCore(auth.user.sub))) {
+  // Content edits are open to Core/Admin or anyone staffed on the project;
+  // scope/domain settings (scopesBulk, domains, terms) stay Core/Admin only.
+  const core = await isCore(auth.user.sub);
+  if (!core && !(await isProjectMember(auth.user.sub, params.id))) {
     return { error: "You don't have permission to edit this project." };
   }
 
   const form = await request.formData();
   const intent = (form.get("intent") as string | null) ?? "details";
+
+  const SCOPE_INTENTS = ["scopesBulk", "domains", "terms"];
+  if (SCOPE_INTENTS.includes(intent) && !core) {
+    return { error: "Only Core or Admin can change domain settings." };
+  }
 
   // Header form: name + status only.
   if (intent === "header") {
@@ -673,6 +686,7 @@ export default function ProjectDetail() {
     allTermOptions,
     domainScopeGrid,
     canEdit,
+    canEditScope,
     canViewScope,
     currentTerm,
     collabToken,
@@ -790,7 +804,7 @@ export default function ProjectDetail() {
             plannedTerms={plannedTerms}
             allTermOptions={allTermOptions}
             domainScopeGrid={domainScopeGrid}
-            canEdit={canEdit}
+            canEdit={canEditScope}
             actionError={actionData?.error}
           />
         </Modal>

--- a/dali-api/app/routes/layout.tsx
+++ b/dali-api/app/routes/layout.tsx
@@ -123,6 +123,48 @@ export default function AppLayoutRoute() {
     return () => window.clearTimeout(id)
   }, [embedded, location.pathname, location.search])
 
+  // Scroll restoration WITHIN an embedded tab. React Router's <ScrollRestoration>
+  // doesn't reliably restore the iframe window's scroll on in-tab back/forward
+  // (the iframe is its own document and RR's key tracking gets lost across the
+  // shell↔iframe boundary), so we persist scrollY per history entry ourselves.
+  // Keyed by location.key (stable per history entry) in sessionStorage, scoped
+  // to this document, so navigating into a nested page and back restores where
+  // you were. Runs in both embedded and standalone documents — harmless either
+  // way, and standalone deep links benefit too.
+  const SCROLL_KEY_PREFIX = "dali:scroll:";
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const key = SCROLL_KEY_PREFIX + location.key;
+
+    // Restore on entering this location. rAF waits for the new route's content
+    // to paint so the target offset exists; fall back to top when unseen.
+    let raf = 0;
+    try {
+      const saved = window.sessionStorage.getItem(key);
+      raf = window.requestAnimationFrame(() => {
+        window.scrollTo(0, saved ? parseInt(saved, 10) || 0 : 0);
+      });
+    } catch {
+      // sessionStorage disabled — nothing to restore.
+    }
+
+    // Continuously record this entry's scroll while it's the active location,
+    // so a later back-navigation lands where the user left off.
+    const onScroll = () => {
+      try {
+        window.sessionStorage.setItem(key, String(window.scrollY));
+      } catch {
+        // ignore quota / disabled storage
+      }
+    };
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => {
+      window.cancelAnimationFrame(raf);
+      onScroll(); // capture final position for this entry before it changes
+      window.removeEventListener("scroll", onScroll);
+    };
+  }, [location.key]);
+
   // Skip the sidebar shell when rendered inside a TabWorkspace iframe.
   if (embedded) {
     return (


### PR DESCRIPTION
## Summary

Two changes on top of the latest `dev` (merged in, including the new Level Up form from #710):

**1. Project members can edit the project hub (content only)**
Project hub content — name/status, description, details (calendar/image/repos/GitHub team), project docs/files/tags, and epics/sprints/tasks — is now editable by anyone staffed on the project in any term, not just Core/Admin.

The **Domain settings** popup (declared domains, planned terms, per-domain scope cells) stays **Core/Admin-only**, since those drive staffing biddability. Staffing leads can still *view* the popup but not save.

- `roles.ts`: new `isProjectMember(userId, projectId)` — any-term `ProjectAssignment`.
- `projects.$id` loader: `canEdit` = Core **or** project member; `canEditScope` = Core only (gates the Domain settings popup); `canViewScope` unchanged.
- `projects.$id` action: admits members for content edits; rejects the scope intents (`scopesBulk`, `domains`, `terms`) for non-Core with a clear error.

**2. Level Up nav moved under Internal Processes**
PR #710 placed the new Level Up form's nav link under the **Projects** area. This surfaces it under **Internal Processes** instead, keeping the page route at `/projects/level-up`. Area resolution special-cases `/projects/level-up → internal-processes` (before the generic `/projects` branch) so the correct area highlights and expands.

## Testing
- `npm run typecheck` passes (the only remaining errors are pre-existing in `scripts/`, untouched here).
- No schema/migration changes; nav + permission-gate change only.

## Notes
- The edit-access change is a UI-gate + action-gate change, scoped to the project hub. Other surfaces (e.g. the project list) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/714"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782438056&installation_id=133523038&pr_number=714&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F714&signature=1aa3800985ad47114ade74920cc35fd9c5535150737ea5951fea015b1379e62f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->