### PR TITLE
Project-hub edits for project members + Level Up under Internal Proce…

### DIFF
--- a/dali-api/app/calendar/routes/calendar.tsx
+++ b/dali-api/app/calendar/routes/calendar.tsx
@@ -3474,15 +3474,22 @@ function WeekGrid({
               const lo = Math.min(drag.anchor, drag.hover);
               const hi = Math.max(drag.anchor, drag.hover);
               const heightHours = Math.max(SNAP_HOURS, hi - lo);
+              const top = (lo - MIN_HOUR) * HOUR_PX;
+              // Caption sits above the rectangle's top edge so a short (e.g.
+              // 10-min) selection doesn't have the text spilling through the
+              // box into the slot below. Near the grid's top there's no room
+              // above (the column clips overflow), so drop it just inside.
+              const captionBelow = top < 16;
               return (
                 <div
                   className="absolute left-0 right-0 border-2 border-accent-coral bg-accent-coral/15 pointer-events-none rounded-sm z-30 shadow-md"
-                  style={{
-                    top: (lo - MIN_HOUR) * HOUR_PX,
-                    height: heightHours * HOUR_PX,
-                  }}
+                  style={{ top, height: heightHours * HOUR_PX }}
                 >
-                  <div className="px-1 py-0.5 text-[11px] font-semibold rounded-sm m-1 inline-block shadow-sm bg-accent-coral text-white">
+                  <div
+                    className={`absolute left-0 px-1 py-0.5 rounded bg-white/75 text-[11px] font-semibold leading-none whitespace-nowrap text-accent-coral ${
+                      captionBelow ? "top-1" : "bottom-full mb-1"
+                    }`}
+                  >
                     {formatHourMinute(lo)} – {formatHourMinute(hi)}
                   </div>
                 </div>
@@ -3505,7 +3512,12 @@ function WeekGrid({
                   }`}
                   style={{ top, height }}
                 >
-                  <div className="px-1 py-0.5 text-[11px] font-semibold rounded-sm m-1 inline-block bg-accent-coral text-white pointer-events-none">
+                  {/* Caption above the top edge — see drag-preview note. */}
+                  <div
+                    className={`absolute left-0 px-1 py-0.5 rounded bg-white/75 text-[11px] font-semibold leading-none whitespace-nowrap text-accent-coral pointer-events-none ${
+                      top < 16 ? "top-1" : "bottom-full mb-1"
+                    }`}
+                  >
                     {formatHourMinute(lo)} – {formatHourMinute(hi)}
                   </div>
                   {resizable && (

--- a/dali-api/app/components/Layout.tsx
+++ b/dali-api/app/components/Layout.tsx
@@ -146,6 +146,9 @@ export function Layout({ user, photoUrl, isCore = false, isAdmin = false, isDoma
     const areaKey: AreaKey | null =
       path.startsWith('/admin-console') ? 'admin-console'
       : path.startsWith('/hiring') ? 'hiring'
+      // Level Up lives at /projects/level-up but is surfaced under Internal
+      // Processes — resolve it there before the generic /projects branch.
+      : path.startsWith('/projects/level-up') ? 'internal-processes'
       : path.startsWith('/projects') ? 'projects'
       : path.startsWith('/members') ? 'members'
       : path.startsWith('/partners') ? 'partners'
@@ -234,6 +237,9 @@ export function Layout({ user, photoUrl, isCore = false, isAdmin = false, isDoma
   const activeAreaKey: AreaKey | null =
     path.startsWith('/admin-console') ? 'admin-console'
     : path.startsWith('/hiring') ? 'hiring'
+    // Level Up lives at /projects/level-up but is surfaced under Internal
+    // Processes — resolve it there before the generic /projects branch.
+    : path.startsWith('/projects/level-up') ? 'internal-processes'
     : path.startsWith('/projects') ? 'projects'
     : path.startsWith('/members') ? 'members'
     : path.startsWith('/partners') ? 'partners'
@@ -388,14 +394,6 @@ export function Layout({ user, photoUrl, isCore = false, isAdmin = false, isDoma
       active: path.startsWith('/projects/project-bids'),
       sub: null,
     },
-    {
-      label: 'Level Up',
-      to: '/projects/level-up',
-      icon: TrendingUp,
-      show: canViewStaffing,
-      active: path.startsWith('/projects/level-up'),
-      sub: null,
-    },
   ].filter((s) => s.show)
 
   const membersSections = [
@@ -455,6 +453,18 @@ export function Layout({ user, photoUrl, isCore = false, isAdmin = false, isDoma
       show: true,
       active: path.startsWith('/internal-processes/transfer'),
       sub: null as { label: string; to: string; active: boolean }[] | null,
+    },
+    {
+      label: 'Level Up',
+      // Page lives under /projects/level-up; surfaced here under Internal
+      // Processes. Match both so the entry highlights on either path.
+      to: '/projects/level-up',
+      icon: TrendingUp,
+      show: canViewStaffing,
+      active:
+        path.startsWith('/projects/level-up') ||
+        path.startsWith('/internal-processes/level-up'),
+      sub: null,
     },
     {
       label: 'JobX',

--- a/dali-api/app/lib/roles.ts
+++ b/dali-api/app/lib/roles.ts
@@ -148,6 +148,22 @@ export async function isDomainLead(userId: string): Promise<boolean> {
 }
 
 /**
+ * Whether the user is staffed on a project — a ProjectAssignment row for that
+ * project in any term (past contributors keep access). Used to grant
+ * content-edit access to the project hub; scope/domain settings stay Core/Admin.
+ */
+export async function isProjectMember(
+  userId: string,
+  projectId: string,
+): Promise<boolean> {
+  const row = await prisma.projectAssignment.findFirst({
+    where: { userId, projectId },
+    select: { id: true },
+  });
+  return row !== null;
+}
+
+/**
  * Lab-membership gate. Returns the DALIMember row (thin marker — just
  * `{ id, userId, createdAt, updatedAt }`) if the user is a member, null
  * otherwise. The row is now a presence-only marker; callers should not

--- a/dali-api/app/projects/routes/projects.$id.tsx
+++ b/dali-api/app/projects/routes/projects.$id.tsx
@@ -19,7 +19,7 @@ import { prisma } from "~/lib/db";
 import { ensureProjectGroup } from "~/lib/groups";
 import { requireAuth } from "~/lib/auth";
 import { parseSessionCookie } from "~/lib/cookies";
-import { isCore, canManageStaffing, currentTerm } from "~/lib/roles";
+import { isCore, isProjectMember, canManageStaffing, currentTerm } from "~/lib/roles";
 import { TaskBoard } from "../components/TaskBoard";
 import { type TimelineEpic, type EpicStatus } from "../components/EpicsTimeline";
 import {
@@ -219,11 +219,15 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     select: { id: true, label: true, slug: true, color: true },
   });
 
-  // Admin or Core members may edit projects (isCore === Admin || Core).
-  const canEdit = await isCore(auth.user.sub);
+  // Content edits (name/status, description, details, docs/files, epics/
+  // sprints/tasks) are open to Core/Admin *and* anyone staffed on this project
+  // in any term. Scope/domain settings stay Core/Admin only (canEditScope).
+  const core = await isCore(auth.user.sub);
+  const canEditScope = core;
+  const canEdit = core || (await isProjectMember(auth.user.sub, params.id));
   // The Scope/challenge settings popup is visible to Core, Admin, or staffing
-  // leads. Editing still requires canEdit (isCore) — the action enforces that.
-  const canViewScope = canEdit || (await canManageStaffing(auth.user.sub));
+  // leads. Editing still requires canEditScope (isCore) — the action enforces that.
+  const canViewScope = canEditScope || (await canManageStaffing(auth.user.sub));
 
   // Collab editor wiring (same as the hiring routes): session cookie is the
   // WebSocket auth token; userName labels the presence cursor.
@@ -468,6 +472,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     tasks,
     boardOptions,
     canEdit,
+    canEditScope,
     canViewScope,
     currentTerm: current ? { id: current.id, code: current.code } : null,
     collabToken,
@@ -481,12 +486,20 @@ export async function action({ request, params }: Route.ActionArgs) {
   if (!auth.ok) return redirect("/login");
   if (auth.user.type === "applicant") return redirect("/portal");
 
-  if (!(await isCore(auth.user.sub))) {
+  // Content edits are open to Core/Admin or anyone staffed on the project;
+  // scope/domain settings (scopesBulk, domains, terms) stay Core/Admin only.
+  const core = await isCore(auth.user.sub);
+  if (!core && !(await isProjectMember(auth.user.sub, params.id))) {
     return { error: "You don't have permission to edit this project." };
   }
 
   const form = await request.formData();
   const intent = (form.get("intent") as string | null) ?? "details";
+
+  const SCOPE_INTENTS = ["scopesBulk", "domains", "terms"];
+  if (SCOPE_INTENTS.includes(intent) && !core) {
+    return { error: "Only Core or Admin can change domain settings." };
+  }
 
   // Header form: name + status only.
   if (intent === "header") {
@@ -673,6 +686,7 @@ export default function ProjectDetail() {
     allTermOptions,
     domainScopeGrid,
     canEdit,
+    canEditScope,
     canViewScope,
     currentTerm,
     collabToken,
@@ -790,7 +804,7 @@ export default function ProjectDetail() {
             plannedTerms={plannedTerms}
             allTermOptions={allTermOptions}
             domainScopeGrid={domainScopeGrid}
-            canEdit={canEdit}
+            canEdit={canEditScope}
             actionError={actionData?.error}
           />
         </Modal>


### PR DESCRIPTION
…sses (#714)

* Tab-workspace scroll restoration + project-hub scope settings popup

Feature 1 — in-tab scroll restoration (app/routes/layout.tsx): Persist the embedded iframe window's scrollY per history entry (location.key) in sessionStorage and restore it on back/forward, so navigating into a nested page and back returns you to where you were. React Router's <ScrollRestoration> doesn't reliably cover the iframe across the shell↔iframe boundary; this owns it with a rAF-timed restore so it works after async content paints.

Feature 3 — project hub Scope → settings popup (app/projects/routes/projects.$id.tsx):
- Remove "Scope" as a public tab. Its domain/term/per-domain-challenge config now lives behind a "Scope settings" gear in the tab bar, shown only to Core/Admin/staffing leads (canViewScope); editing still requires isCore.
- Overview now displays the current term's per-domain challenge (read-only), resolved from ProjectDomainScope for currentTerm().

(Feature 2 — real-time note sync across split panes — needed no change: live collab editors already sync across panes via Hocuspocus; interview notes were explicitly excluded, and the remaining note-like surfaces are plain DB fields, not collab docs.)



* Rename 'Scope settings' to 'Domain settings' on the project hub



* Move Level Up nav entry under Internal Processes

PR #710 placed the new Level Up form's nav link under the Projects area. Surface it under Internal Processes instead, keeping the page route at /projects/level-up. Area resolution special-cases /projects/level-up → internal-processes (before the generic /projects branch) so the correct area highlights and expands.



* Let project members edit the project hub (content only)

Project hub content (name/status, description, details, docs/files/tags, epics/sprints/tasks) is now editable by anyone staffed on the project in any term, not just Core/Admin. Domain settings (declared domains, planned terms, per-domain scope cells) stay Core/Admin-only since they drive staffing biddability.

- roles.ts: add isProjectMember(userId, projectId) — any-term ProjectAssignment.
- projects.$id loader: canEdit = Core || project member; canEditScope = Core only (gates the Domain settings popup); canViewScope unchanged.
- projects.$id action: admit members for content edits; reject the scope intents (scopesBulk, domains, terms) for non-Core.



* Availability calendar: make drag time label a caption, not a chip

The start–end time shown while dragging (and on the committed selection) in the My Availability grid was a solid coral chip that read like a second block over the selection rectangle. Restyle it as a lightweight caption: plain coral text on a translucent white backing (bg-white/75), positioned just above the rectangle's top edge with a small gap.

A short selection (e.g. a 10-min slot) is only ~9px tall, so text inside the box overflowed into the slot below; anchoring the label above fixes that. Near the grid's top there's no room above (the column clips overflow), so the caption flips just inside the top edge instead.



---------

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/715"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782439824&installation_id=133523038&pr_number=715&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F715&signature=455f3cbb40cfcc40dfebd3d72f65859181d32c17ed53f5a4220196d49bb7540a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->