### PR TITLE
Add one-time launch welcome modal on home

### DIFF
--- a/dali-api/app/components/LaunchWelcome.tsx
+++ b/dali-api/app/components/LaunchWelcome.tsx
@@ -111,7 +111,7 @@ function readStep(): number {
   }
 }
 
-function SpotlightRing({ target }: { target: HTMLElement }) {
+function Spotlight({ target }: { target: HTMLElement }) {
   const [rect, setRect] = useState<DOMRect | null>(() => target.getBoundingClientRect());
 
   useEffect(() => {
@@ -122,8 +122,8 @@ function SpotlightRing({ target }: { target: HTMLElement }) {
     }
     measure();
     // Sidebar can collapse, page can scroll, mobile drawer can open — poll
-    // cheaply so the ring stays glued to the element. Throwaway tour code,
-    // a 150ms tick is plenty smooth.
+    // cheaply so the spotlight stays glued to the element. Throwaway tour
+    // code, a 150ms tick is plenty smooth.
     const id = window.setInterval(measure, 150);
     window.addEventListener("resize", measure);
     window.addEventListener("scroll", measure, true);
@@ -136,17 +136,36 @@ function SpotlightRing({ target }: { target: HTMLElement }) {
   }, [target]);
 
   if (!rect) return null;
+
+  const PAD = 6;
+  const top = rect.top - PAD;
+  const left = rect.left - PAD;
+  const width = rect.width + PAD * 2;
+  const height = rect.height + PAD * 2;
+
   return (
-    <div
-      aria-hidden="true"
-      className="pointer-events-none fixed z-50 rounded-md launch-tour-pulse"
-      style={{
-        top: rect.top - 4,
-        left: rect.left - 4,
-        width: rect.width + 8,
-        height: rect.height + 8,
-      }}
-    />
+    <>
+      {/* Cut-out: a transparent rectangle sitting where the target is, with
+          a massive box-shadow extending outward to dim the rest of the page.
+          pointer-events: none so the user can still click the real element. */}
+      <div
+        aria-hidden="true"
+        className="pointer-events-none fixed z-40 rounded-md"
+        style={{
+          top,
+          left,
+          width,
+          height,
+          boxShadow: "0 0 0 9999px rgba(0, 0, 0, 0.55)",
+        }}
+      />
+      {/* Pulsing coral ring on top of the cut-out for emphasis. */}
+      <div
+        aria-hidden="true"
+        className="pointer-events-none fixed z-40 rounded-md launch-tour-pulse"
+        style={{ top, left, width, height }}
+      />
+    </>
   );
 }
 
@@ -323,7 +342,7 @@ export function LaunchWelcome({ firstName }: { firstName: string }) {
         }
       `}</style>
 
-      {target && !arrived && !isFinal && <SpotlightRing target={target} />}
+      {target && !arrived && !isFinal && <Spotlight target={target} />}
 
       <div className="fixed bottom-4 right-4 z-50 w-80 max-w-[calc(100vw-2rem)] pointer-events-auto">
         <div className="bg-card border border-border rounded-2xl shadow-brand-2 p-4 flex flex-col gap-3">

--- a/dali-api/app/components/LaunchWelcome.tsx
+++ b/dali-api/app/components/LaunchWelcome.tsx
@@ -1,9 +1,7 @@
-import { useEffect, useId, useState } from "react";
-import { useLocation } from "react-router";
+import { useCallback, useEffect, useId, useState } from "react";
 import {
   Sparkles,
   PartyPopper,
-  Home,
   FolderKanban,
   CalendarDays,
   UserCircle2,
@@ -20,73 +18,82 @@ type Phase = "modal" | "card" | "done";
 
 type TourStep = {
   icon: React.ReactNode;
-  /** What the user should do next — short, action-oriented. */
+  /** Short, action-oriented prompt. */
   cta: React.ReactNode;
-  /** Path that, when visited, advances the tour. */
-  match: (pathname: string) => boolean;
-  /** Confirmation message once they land on the matched page. */
+  /** Confirmation shown once the user lands on the matched page. */
   arrived: React.ReactNode;
+  /** True if the iframe-reported URL means this step is satisfied. */
+  matches: (pathname: string) => boolean;
+  /** Locates the sidebar element to highlight, or null if not currently in DOM. */
+  findTarget: () => HTMLElement | null;
 };
 
+function findInSidebar(predicate: (el: HTMLButtonElement) => boolean): HTMLElement | null {
+  // Look in both desktop sidebar (<aside>) and the mobile nav panel.
+  const containers = Array.from(
+    document.querySelectorAll<HTMLElement>("aside, #mobile-nav-panel"),
+  );
+  for (const c of containers) {
+    if (c.offsetParent === null) continue; // skip hidden (mobile panel closed)
+    const buttons = c.querySelectorAll<HTMLButtonElement>("button");
+    for (const btn of buttons) {
+      if (predicate(btn)) return btn;
+    }
+  }
+  return null;
+}
+
+function findByExactText(text: string) {
+  return findInSidebar((btn) => (btn.textContent || "").trim() === text);
+}
+
 const STEPS: TourStep[] = [
-  {
-    icon: <Home className="w-4 h-4" />,
-    cta: (
-      <>
-        Click <strong>Home</strong> in the sidebar to see your week at a glance.
-      </>
-    ),
-    match: (p) => p === "/",
-    arrived: (
-      <>
-        This is home — tasks, meeting invites, and the lab's week all live
-        here.
-      </>
-    ),
-  },
   {
     icon: <FolderKanban className="w-4 h-4" />,
     cta: (
       <>
-        Now click <strong>Hub</strong> under Projects to browse every active
+        Click <strong>Projects</strong> in the sidebar to see every active
         project.
       </>
     ),
-    match: (p) => p.startsWith("/projects"),
     arrived: <>Nice — every active project lives here.</>,
+    matches: (p) => p.startsWith("/projects"),
+    findTarget: () => findByExactText("Projects"),
   },
   {
     icon: <CalendarDays className="w-4 h-4" />,
     cta: (
       <>
-        Next, click <strong>Calendar</strong> to see lab meetings and events.
+        Now click <strong>Calendar</strong> to see lab meetings and events.
       </>
     ),
-    match: (p) => p.startsWith("/calendar"),
     arrived: <>Lab meetings, standups, and your own events — all in lab time.</>,
+    matches: (p) => p.startsWith("/calendar"),
+    findTarget: () => findByExactText("Calendar"),
   },
   {
     icon: <UserCircle2 className="w-4 h-4" />,
     cta: (
       <>
-        Almost done — click your <strong>profile</strong> (top of the sidebar)
+        Last one — click your <strong>profile</strong> (bottom of the sidebar)
         to make it yours.
       </>
     ),
-    match: (p) => p.startsWith("/profile"),
     arrived: (
       <>
         Add a photo and a few words — this is how the lab gets to know you.
       </>
     ),
+    matches: (p) => p.startsWith("/profile"),
+    findTarget: () =>
+      findInSidebar((btn) => btn.getAttribute("aria-label") === "Open profile"),
   },
 ];
 
 function readPhase(): Phase {
   try {
     if (window.localStorage.getItem(DONE_KEY)) return "done";
-    const raw = window.localStorage.getItem(STEP_KEY);
-    if (raw !== null) return "card";
+    if (window.localStorage.getItem(STEP_KEY) !== null) return "card";
   } catch {
     return "done";
   }
@@ -104,28 +111,105 @@ function readStep(): number {
   }
 }
 
+function SpotlightRing({ target }: { target: HTMLElement }) {
+  const [rect, setRect] = useState<DOMRect | null>(() => target.getBoundingClientRect());
+
+  useEffect(() => {
+    let alive = true;
+    function measure() {
+      if (!alive) return;
+      setRect(target.getBoundingClientRect());
+    }
+    measure();
+    // Sidebar can collapse, page can scroll, mobile drawer can open — poll
+    // cheaply so the ring stays glued to the element. Throwaway tour code,
+    // a 150ms tick is plenty smooth.
+    const id = window.setInterval(measure, 150);
+    window.addEventListener("resize", measure);
+    window.addEventListener("scroll", measure, true);
+    return () => {
+      alive = false;
+      window.clearInterval(id);
+      window.removeEventListener("resize", measure);
+      window.removeEventListener("scroll", measure, true);
+    };
+  }, [target]);
+
+  if (!rect) return null;
+  return (
+    <div
+      aria-hidden="true"
+      className="pointer-events-none fixed z-50 rounded-md launch-tour-pulse"
+      style={{
+        top: rect.top - 4,
+        left: rect.left - 4,
+        width: rect.width + 8,
+        height: rect.height + 8,
+      }}
+    />
+  );
+}
+
 export function LaunchWelcome({ firstName }: { firstName: string }) {
   const [phase, setPhase] = useState<Phase>("done");
   const [step, setStep] = useState(0);
   const [arrived, setArrived] = useState(false);
+  const [target, setTarget] = useState<HTMLElement | null>(null);
   const titleId = useId();
-  const location = useLocation();
 
   useEffect(() => {
     setPhase(readPhase());
     setStep(readStep());
   }, []);
 
-  // Advance the floating card when the user reaches the step's target page.
-  // Show a brief "arrived" confirmation before moving on to the next CTA.
+  // Re-resolve the highlight target whenever the active step changes or the
+  // sidebar DOM might have shifted (mobile drawer open/close). Cheap interval
+  // because the sidebar isn't always present at mount time.
   useEffect(() => {
     if (phase !== "card") return;
     if (step >= STEPS.length) return;
-    if (arrived) return;
-    if (STEPS[step].match(location.pathname)) {
-      setArrived(true);
+    if (arrived) {
+      setTarget(null);
+      return;
     }
-  }, [phase, step, arrived, location.pathname]);
+    const find = STEPS[step].findTarget;
+    function resolve() {
+      const el = find();
+      setTarget(el);
+    }
+    resolve();
+    const id = window.setInterval(resolve, 300);
+    return () => window.clearInterval(id);
+  }, [phase, step, arrived]);
+
+  // Listen for iframe-reported tab navigation — that's how the workspace
+  // signals "the user is now looking at X". Falls back to top-level pathname
+  // for routes that aren't tab-wrapped.
+  const handleUrl = useCallback(
+    (url: string) => {
+      if (phase !== "card") return;
+      if (arrived) return;
+      if (step >= STEPS.length) return;
+      try {
+        const path = new URL(url, window.location.origin).pathname;
+        if (STEPS[step].matches(path)) setArrived(true);
+      } catch {
+        // Bad URL — ignore.
+      }
+    },
+    [phase, step, arrived],
+  );
+
+  useEffect(() => {
+    function onMsg(e: MessageEvent) {
+      if (e.origin !== window.location.origin) return;
+      const d = e.data;
+      if (!d || d.type !== "dali:tabNavigated" || typeof d.url !== "string") return;
+      handleUrl(d.url);
+    }
+    window.addEventListener("message", onMsg);
+    return () => window.removeEventListener("message", onMsg);
+  }, [handleUrl]);
 
   function startTour() {
     try {
@@ -212,97 +296,129 @@ export function LaunchWelcome({ firstName }: { firstName: string }) {
     );
   }
 
-  // phase === "card" — floating coach card in bottom-right.
   const isFinal = step >= STEPS.length;
   const current = isFinal ? null : STEPS[step];
 
   return (
-    <div className="fixed bottom-4 right-4 z-40 w-80 max-w-[calc(100vw-2rem)] pointer-events-auto">
-      <div className="bg-card border border-border rounded-2xl shadow-brand-2 p-4 flex flex-col gap-3">
-        <div className="flex items-start justify-between gap-2">
-          <span className="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-accent-coral">
+    <>
+      {/* CSS keyframes for the spotlight pulse. Scoped to this component via
+          the .launch-tour-pulse class so removal = delete file. */}
+      <style>{`
+        @keyframes launch-tour-pulse {
+          0%, 100% {
+            box-shadow:
+              0 0 0 2px rgba(255, 139, 129, 0.95),
+              0 0 0 6px rgba(255, 139, 129, 0.35),
+              0 0 16px 4px rgba(255, 139, 129, 0.35);
+          }
+          50% {
+            box-shadow:
+              0 0 0 2px rgba(255, 139, 129, 0.95),
+              0 0 0 10px rgba(255, 139, 129, 0),
+              0 0 24px 8px rgba(255, 139, 129, 0);
+          }
+        }
+        .launch-tour-pulse {
+          animation: launch-tour-pulse 1.6s ease-in-out infinite;
+        }
+      `}</style>
+
+      {target && !arrived && !isFinal && <SpotlightRing target={target} />}
+
+      <div className="fixed bottom-4 right-4 z-50 w-80 max-w-[calc(100vw-2rem)] pointer-events-auto">
+        <div className="bg-card border border-border rounded-2xl shadow-brand-2 p-4 flex flex-col gap-3">
+          <div className="flex items-start justify-between gap-2">
+            <span className="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-accent-coral">
+              {isFinal ? (
+                <PartyPopper className="w-4 h-4" />
+              ) : arrived ? (
+                <Check className="w-4 h-4" />
+              ) : (
+                current!.icon
+              )}
+              {isFinal
+                ? "Launch party"
+                : arrived
+                  ? "You're here"
+                  : `Step ${step + 1} of ${STEPS.length}`}
+            </span>
+            <button
+              type="button"
+              onClick={finishTour}
+              className="text-muted-foreground hover:text-foreground -mt-1 -mr-1 p-1"
+              aria-label="Dismiss tour"
+            >
+              <XIcon className="w-4 h-4" />
+            </button>
+          </div>
+
+          <p className="text-sm text-foreground leading-relaxed">
             {isFinal ? (
-              <PartyPopper className="w-4 h-4" />
+              <>
+                That's the tour! 🎉 The site launch party is right around the
+                corner — keep an eye on the calendar for the invite.
+              </>
             ) : arrived ? (
-              <Check className="w-4 h-4" />
+              current!.arrived
             ) : (
-              current!.icon
+              current!.cta
             )}
-            {isFinal
-              ? "Launch party"
-              : arrived
-                ? "You're here"
-                : `Step ${step + 1} of ${STEPS.length}`}
-          </span>
-          <button
-            type="button"
-            onClick={finishTour}
-            className="text-muted-foreground hover:text-foreground -mt-1 -mr-1 p-1"
-            aria-label="Dismiss tour"
-          >
-            <XIcon className="w-4 h-4" />
-          </button>
-        </div>
+          </p>
 
-        <p className="text-sm text-foreground leading-relaxed">
-          {isFinal ? (
-            <>
-              That's the tour! 🎉 The site launch party is right around the
-              corner — keep an eye on the calendar for the invite.
-            </>
-          ) : arrived ? (
-            current!.arrived
-          ) : (
-            current!.cta
-          )}
-        </p>
+          <div className="flex items-center gap-1.5" aria-hidden="true">
+            {STEPS.map((_, i) => (
+              <span
+                key={i}
+                className={
+                  "h-1 rounded-full flex-1 " +
+                  (i < step || (i === step && arrived) || isFinal
+                    ? "bg-accent-coral"
+                    : "bg-muted-foreground/20")
+                }
+              />
+            ))}
+          </div>
 
-        <div
-          className="flex items-center gap-1.5"
-          aria-hidden="true"
-        >
-          {STEPS.map((_, i) => (
-            <span
-              key={i}
-              className={
-                "h-1 rounded-full flex-1 " +
-                (i < step || (i === step && arrived) || isFinal
-                  ? "bg-accent-coral"
-                  : "bg-muted-foreground/20")
-              }
-            />
-          ))}
-        </div>
-
-        <div className="flex items-center justify-end gap-2 pt-1">
-          {isFinal ? (
-            <button
-              type="button"
-              onClick={finishTour}
-              className="inline-flex items-center gap-1.5 rounded-lg bg-accent-coral px-3 py-1.5 text-sm font-semibold text-white hover:bg-accent-coral/90"
-            >
-              Let's go
-            </button>
-          ) : arrived ? (
-            <button
-              type="button"
-              onClick={advance}
-              className="inline-flex items-center gap-1.5 rounded-lg bg-accent-coral px-3 py-1.5 text-sm font-semibold text-white hover:bg-accent-coral/90"
-            >
-              Next
-              <ArrowRight className="w-4 h-4" />
-            </button>
-          ) : (
-            <button
-              type="button"
-              onClick={finishTour}
-              className="text-xs text-muted-foreground hover:text-foreground"
-            >
-              Skip tour
-            </button>
-          )}
+          <div className="flex items-center justify-end gap-2 pt-1">
+            {isFinal ? (
+              <button
+                type="button"
+                onClick={finishTour}
+                className="inline-flex items-center gap-1.5 rounded-lg bg-accent-coral px-3 py-1.5 text-sm font-semibold text-white hover:bg-accent-coral/90"
+              >
+                Let's go
+              </button>
+            ) : arrived ? (
+              <button
+                type="button"
+                onClick={advance}
+                className="inline-flex items-center gap-1.5 rounded-lg bg-accent-coral px-3 py-1.5 text-sm font-semibold text-white hover:bg-accent-coral/90"
+              >
+                Next
+                <ArrowRight className="w-4 h-4" />
+              </button>
+            ) : (
+              <>
+                <button
+                  type="button"
+                  onClick={finishTour}
+                  className="text-xs text-muted-foreground hover:text-foreground"
+                >
+                  Skip tour
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setArrived(true)}
+                  className="text-xs text-muted-foreground hover:text-foreground"
+                  title="Skip this step"
+                >
+                  I'm there →
+                </button>
+              </>
+            )}
+          </div>
         </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/dali-api/app/components/LaunchWelcome.tsx
+++ b/dali-api/app/components/LaunchWelcome.tsx
@@ -29,12 +29,17 @@ type TourStep = {
 };
 
 function findInSidebar(predicate: (el: HTMLButtonElement) => boolean): HTMLElement | null {
-  // Look in both desktop sidebar (<aside>) and the mobile nav panel.
+  // Look in both desktop sidebar (<aside>) and the mobile nav panel. We can't
+  // use offsetParent to detect hidden containers — the desktop sidebar is
+  // position:fixed, which reports offsetParent === null even when visible.
+  // getBoundingClientRect's size is the reliable signal: display:none → 0×0,
+  // anything actually laid out → non-zero.
   const containers = Array.from(
     document.querySelectorAll<HTMLElement>("aside, #mobile-nav-panel"),
   );
   for (const c of containers) {
-    if (c.offsetParent === null) continue; // skip hidden (mobile panel closed)
+    const r = c.getBoundingClientRect();
+    if (r.width === 0 || r.height === 0) continue;
     const buttons = c.querySelectorAll<HTMLButtonElement>("button");
     for (const btn of buttons) {
       if (predicate(btn)) return btn;

--- a/dali-api/app/components/LaunchWelcome.tsx
+++ b/dali-api/app/components/LaunchWelcome.tsx
@@ -1,5 +1,15 @@
 import { useEffect, useId, useState } from "react";
-import { Sparkles, ArrowRight, ArrowLeft, PartyPopper } from "lucide-react";
+import { useNavigate } from "react-router";
+import {
+  Sparkles,
+  ArrowRight,
+  ArrowLeft,
+  PartyPopper,
+  Home,
+  FolderKanban,
+  CalendarDays,
+  UserCircle2,
+} from "lucide-react";
 import { Modal } from "./Modal";
 
 const STORAGE_KEY = "dalios-launch-welcome-seen-v1";
@@ -9,6 +19,8 @@ type Step = {
   eyebrow: string;
   title: string;
   body: React.ReactNode;
+  /** Path to navigate to when this step becomes active. Omit to stay put. */
+  to?: string;
 };
 
 function buildSteps(firstName: string): Step[] {
@@ -20,34 +32,60 @@ function buildSteps(firstName: string): Step[] {
       body: (
         <>
           This is the new home for everything DALI: projects, staffing,
-          mentorship, the calendar, your profile, and more. Take a quick tour —
-          it&apos;s short, promise.
+          mentorship, the calendar, your profile, and more. We&apos;ll walk you
+          through the main spots — should take under a minute.
         </>
       ),
+      to: "/",
     },
     {
-      icon: <Sparkles className="w-6 h-6 text-accent-coral" />,
-      eyebrow: "Your home",
+      icon: <Home className="w-6 h-6 text-accent-coral" />,
+      eyebrow: "Home",
       title: "Start here every day",
       body: (
         <>
           The home tab surfaces what needs your attention: open tasks, meeting
-          invites, and the lab&apos;s week at a glance. If something is on fire,
-          it shows up here first.
+          invites, and the lab&apos;s week at a glance. If something is on
+          fire, it shows up here first.
         </>
       ),
+      to: "/",
     },
     {
-      icon: <Sparkles className="w-6 h-6 text-accent-coral" />,
-      eyebrow: "Explore",
-      title: "Projects, profiles, and more",
+      icon: <FolderKanban className="w-6 h-6 text-accent-coral" />,
+      eyebrow: "Projects",
+      title: "Find your work",
       body: (
         <>
-          Use the sidebar to jump between projects, the calendar, and your
-          profile. Hover any project to see its team — click in to see sprints,
-          tasks, and updates.
+          Browse every active project, see who&apos;s on each team, and click in
+          to find sprints, tasks, and project updates.
         </>
       ),
+      to: "/projects/list",
+    },
+    {
+      icon: <CalendarDays className="w-6 h-6 text-accent-coral" />,
+      eyebrow: "Calendar",
+      title: "Never miss a meeting",
+      body: (
+        <>
+          Lab meetings, project standups, and your own events — all in one
+          place, in lab time. RSVPs flow back to home so nothing slips.
+        </>
+      ),
+      to: "/calendar",
+    },
+    {
+      icon: <UserCircle2 className="w-6 h-6 text-accent-coral" />,
+      eyebrow: "Your profile",
+      title: "Make it yours",
+      body: (
+        <>
+          Add a photo, set your domains, and tell the lab a little about
+          yourself. Your profile is how the rest of DALI gets to know you.
+        </>
+      ),
+      to: "/profile",
     },
     {
       icon: <PartyPopper className="w-6 h-6 text-accent-coral" />,
@@ -60,6 +98,7 @@ function buildSteps(firstName: string): Step[] {
           invite — we&apos;d love to see you there.
         </>
       ),
+      to: "/",
     },
   ];
 }
@@ -68,6 +107,7 @@ export function LaunchWelcome({ firstName }: { firstName: string }) {
   const [open, setOpen] = useState(false);
   const [step, setStep] = useState(0);
   const titleId = useId();
+  const navigate = useNavigate();
 
   useEffect(() => {
     try {
@@ -91,6 +131,14 @@ export function LaunchWelcome({ firstName }: { firstName: string }) {
     }
     setOpen(false);
   }
+
+  function goTo(nextStep: number) {
+    const target = steps[nextStep];
+    setStep(nextStep);
+    if (target.to) navigate(target.to);
+  }
+
+  if (!open) return null;
 
   return (
     <Modal open={open} onClose={close} labelledBy={titleId}>
@@ -141,7 +189,7 @@ export function LaunchWelcome({ firstName }: { firstName: string }) {
         <div className="flex items-center justify-between gap-2 pt-2">
           <button
             type="button"
-            onClick={() => setStep((s) => Math.max(0, s - 1))}
+            onClick={() => goTo(Math.max(0, step - 1))}
             disabled={isFirst}
             className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground disabled:opacity-0 disabled:pointer-events-none"
           >
@@ -150,7 +198,7 @@ export function LaunchWelcome({ firstName }: { firstName: string }) {
           </button>
           <button
             type="button"
-            onClick={() => (isLast ? close() : setStep((s) => s + 1))}
+            onClick={() => (isLast ? close() : goTo(step + 1))}
             className="inline-flex items-center gap-1.5 rounded-lg bg-accent-coral px-4 py-2 text-sm font-semibold text-white hover:bg-accent-coral/90"
           >
             {isLast ? "Let's go" : "Next"}

--- a/dali-api/app/components/LaunchWelcome.tsx
+++ b/dali-api/app/components/LaunchWelcome.tsx
@@ -1,211 +1,308 @@
 import { useEffect, useId, useState } from "react";
-import { useNavigate } from "react-router";
+import { useLocation } from "react-router";
 import {
   Sparkles,
-  ArrowRight,
-  ArrowLeft,
   PartyPopper,
   Home,
   FolderKanban,
   CalendarDays,
   UserCircle2,
+  ArrowRight,
+  X as XIcon,
+  Check,
 } from "lucide-react";
 import { Modal } from "./Modal";
 
-const STORAGE_KEY = "dalios-launch-welcome-seen-v1";
+const DONE_KEY = "dalios-launch-welcome-seen-v1";
+const STEP_KEY = "dalios-launch-tour-step-v1";
 
-type Step = {
+type Phase = "modal" | "card" | "done";
+
+type TourStep = {
   icon: React.ReactNode;
-  eyebrow: string;
-  title: string;
-  body: React.ReactNode;
-  /** Path to navigate to when this step becomes active. Omit to stay put. */
-  to?: string;
+  /** What the user should do next — short, action-oriented. */
+  cta: React.ReactNode;
+  /** Path that, when visited, advances the tour. */
+  match: (pathname: string) => boolean;
+  /** Confirmation message once they land on the matched page. */
+  arrived: React.ReactNode;
 };
 
-function buildSteps(firstName: string): Step[] {
-  return [
-    {
-      icon: <Sparkles className="w-6 h-6 text-accent-coral" />,
-      eyebrow: "Welcome",
-      title: `Hey ${firstName} — welcome to DALIos`,
-      body: (
-        <>
-          This is the new home for everything DALI: projects, staffing,
-          mentorship, the calendar, your profile, and more. We&apos;ll walk you
-          through the main spots — should take under a minute.
-        </>
-      ),
-      to: "/",
-    },
-    {
-      icon: <Home className="w-6 h-6 text-accent-coral" />,
-      eyebrow: "Home",
-      title: "Start here every day",
-      body: (
-        <>
-          The home tab surfaces what needs your attention: open tasks, meeting
-          invites, and the lab&apos;s week at a glance. If something is on
-          fire, it shows up here first.
-        </>
-      ),
-      to: "/",
-    },
-    {
-      icon: <FolderKanban className="w-6 h-6 text-accent-coral" />,
-      eyebrow: "Projects",
-      title: "Find your work",
-      body: (
-        <>
-          Browse every active project, see who&apos;s on each team, and click in
-          to find sprints, tasks, and project updates.
-        </>
-      ),
-      to: "/projects/list",
-    },
-    {
-      icon: <CalendarDays className="w-6 h-6 text-accent-coral" />,
-      eyebrow: "Calendar",
-      title: "Never miss a meeting",
-      body: (
-        <>
-          Lab meetings, project standups, and your own events — all in one
-          place, in lab time. RSVPs flow back to home so nothing slips.
-        </>
-      ),
-      to: "/calendar",
-    },
-    {
-      icon: <UserCircle2 className="w-6 h-6 text-accent-coral" />,
-      eyebrow: "Your profile",
-      title: "Make it yours",
-      body: (
-        <>
-          Add a photo, set your domains, and tell the lab a little about
-          yourself. Your profile is how the rest of DALI gets to know you.
-        </>
-      ),
-      to: "/profile",
-    },
-    {
-      icon: <PartyPopper className="w-6 h-6 text-accent-coral" />,
-      eyebrow: "Launch party",
-      title: "Come celebrate with us",
-      body: (
-        <>
-          We&apos;re throwing a launch party to christen the new site. Food,
-          demos, and a few surprises. Keep an eye on the calendar for the
-          invite — we&apos;d love to see you there.
-        </>
-      ),
-      to: "/",
-    },
-  ];
+const STEPS: TourStep[] = [
+  {
+    icon: <Home className="w-4 h-4" />,
+    cta: (
+      <>
+        Click <strong>Home</strong> in the sidebar to see your week at a glance.
+      </>
+    ),
+    match: (p) => p === "/",
+    arrived: (
+      <>
+        This is home — tasks, meeting invites, and the lab's week all live
+        here.
+      </>
+    ),
+  },
+  {
+    icon: <FolderKanban className="w-4 h-4" />,
+    cta: (
+      <>
+        Now click <strong>Hub</strong> under Projects to browse every active
+        project.
+      </>
+    ),
+    match: (p) => p.startsWith("/projects"),
+    arrived: <>Nice — every active project lives here.</>,
+  },
+  {
+    icon: <CalendarDays className="w-4 h-4" />,
+    cta: (
+      <>
+        Next, click <strong>Calendar</strong> to see lab meetings and events.
+      </>
+    ),
+    match: (p) => p.startsWith("/calendar"),
+    arrived: <>Lab meetings, standups, and your own events — all in lab time.</>,
+  },
+  {
+    icon: <UserCircle2 className="w-4 h-4" />,
+    cta: (
+      <>
+        Almost done — click your <strong>profile</strong> (top of the sidebar)
+        to make it yours.
+      </>
+    ),
+    match: (p) => p.startsWith("/profile"),
+    arrived: (
+      <>
+        Add a photo and a few words — this is how the lab gets to know you.
+      </>
+    ),
+  },
+];
+
+function readPhase(): Phase {
+  try {
+    if (window.localStorage.getItem(DONE_KEY)) return "done";
+    const raw = window.localStorage.getItem(STEP_KEY);
+    if (raw !== null) return "card";
+  } catch {
+    return "done";
+  }
+  return "modal";
+}
+
+function readStep(): number {
+  try {
+    const raw = window.localStorage.getItem(STEP_KEY);
+    if (raw === null) return 0;
+    const n = parseInt(raw, 10);
+    return Number.isFinite(n) ? Math.max(0, Math.min(STEPS.length, n)) : 0;
+  } catch {
+    return 0;
+  }
 }
 
 export function LaunchWelcome({ firstName }: { firstName: string }) {
-  const [open, setOpen] = useState(false);
+  const [phase, setPhase] = useState<Phase>("done");
   const [step, setStep] = useState(0);
+  const [arrived, setArrived] = useState(false);
   const titleId = useId();
-  const navigate = useNavigate();
+  const location = useLocation();
 
   useEffect(() => {
-    try {
-      if (window.localStorage.getItem(STORAGE_KEY)) return;
-    } catch {
-      return;
-    }
-    setOpen(true);
+    setPhase(readPhase());
+    setStep(readStep());
   }, []);
 
-  const steps = buildSteps(firstName);
-  const current = steps[step];
-  const isLast = step === steps.length - 1;
-  const isFirst = step === 0;
-
-  function close() {
-    try {
-      window.localStorage.setItem(STORAGE_KEY, new Date().toISOString());
-    } catch {
-      // ignore — worst case the modal re-opens, which is harmless
+  // Advance the floating card when the user reaches the step's target page.
+  // Show a brief "arrived" confirmation before moving on to the next CTA.
+  useEffect(() => {
+    if (phase !== "card") return;
+    if (step >= STEPS.length) return;
+    if (arrived) return;
+    if (STEPS[step].match(location.pathname)) {
+      setArrived(true);
     }
-    setOpen(false);
+  }, [phase, step, arrived, location.pathname]);
+
+  function startTour() {
+    try {
+      window.localStorage.setItem(STEP_KEY, "0");
+    } catch {
+      // ignore
+    }
+    setStep(0);
+    setArrived(false);
+    setPhase("card");
   }
 
-  function goTo(nextStep: number) {
-    const target = steps[nextStep];
-    setStep(nextStep);
-    if (target.to) navigate(target.to);
+  function finishTour() {
+    try {
+      window.localStorage.setItem(DONE_KEY, new Date().toISOString());
+      window.localStorage.removeItem(STEP_KEY);
+    } catch {
+      // ignore
+    }
+    setPhase("done");
   }
 
-  if (!open) return null;
+  function advance() {
+    const next = step + 1;
+    try {
+      window.localStorage.setItem(STEP_KEY, String(next));
+    } catch {
+      // ignore
+    }
+    setStep(next);
+    setArrived(false);
+  }
+
+  if (phase === "done") return null;
+
+  if (phase === "modal") {
+    return (
+      <Modal open onClose={finishTour} labelledBy={titleId}>
+        <div className="flex flex-col gap-4">
+          <div className="flex items-center justify-between">
+            <span className="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-accent-coral">
+              <Sparkles className="w-4 h-4" />
+              Welcome
+            </span>
+            <button
+              type="button"
+              onClick={finishTour}
+              className="text-xs text-muted-foreground hover:text-foreground"
+            >
+              Skip
+            </button>
+          </div>
+          <div>
+            <h2
+              id={titleId}
+              className="font-heading text-xl font-bold text-foreground"
+            >
+              Hey {firstName} — welcome to DALIos
+            </h2>
+            <p className="text-sm text-muted-foreground mt-2 leading-relaxed">
+              This is the new home for everything DALI. Want a quick tour? We'll
+              point you at a few spots in the sidebar — click as you go.
+            </p>
+          </div>
+          <div className="flex items-center justify-end gap-2 pt-2">
+            <button
+              type="button"
+              onClick={finishTour}
+              className="text-sm text-muted-foreground hover:text-foreground px-3 py-2"
+            >
+              Maybe later
+            </button>
+            <button
+              type="button"
+              onClick={startTour}
+              className="inline-flex items-center gap-1.5 rounded-lg bg-accent-coral px-4 py-2 text-sm font-semibold text-white hover:bg-accent-coral/90"
+            >
+              Show me around
+              <ArrowRight className="w-4 h-4" />
+            </button>
+          </div>
+        </div>
+      </Modal>
+    );
+  }
+
+  // phase === "card" — floating coach card in bottom-right.
+  const isFinal = step >= STEPS.length;
+  const current = isFinal ? null : STEPS[step];
 
   return (
-    <Modal open={open} onClose={close} labelledBy={titleId}>
-      <div className="flex flex-col gap-4">
-        <div className="flex items-center justify-between">
+    <div className="fixed bottom-4 right-4 z-40 w-80 max-w-[calc(100vw-2rem)] pointer-events-auto">
+      <div className="bg-card border border-border rounded-2xl shadow-brand-2 p-4 flex flex-col gap-3">
+        <div className="flex items-start justify-between gap-2">
           <span className="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-accent-coral">
-            {current.icon}
-            {current.eyebrow}
+            {isFinal ? (
+              <PartyPopper className="w-4 h-4" />
+            ) : arrived ? (
+              <Check className="w-4 h-4" />
+            ) : (
+              current!.icon
+            )}
+            {isFinal
+              ? "Launch party"
+              : arrived
+                ? "You're here"
+                : `Step ${step + 1} of ${STEPS.length}`}
           </span>
           <button
             type="button"
-            onClick={close}
-            className="text-xs text-muted-foreground hover:text-foreground"
+            onClick={finishTour}
+            className="text-muted-foreground hover:text-foreground -mt-1 -mr-1 p-1"
+            aria-label="Dismiss tour"
           >
-            Skip
+            <XIcon className="w-4 h-4" />
           </button>
         </div>
 
-        <div>
-          <h2
-            id={titleId}
-            className="font-heading text-xl font-bold text-foreground"
-          >
-            {current.title}
-          </h2>
-          <p className="text-sm text-muted-foreground mt-2 leading-relaxed">
-            {current.body}
-          </p>
-        </div>
+        <p className="text-sm text-foreground leading-relaxed">
+          {isFinal ? (
+            <>
+              That's the tour! 🎉 The site launch party is right around the
+              corner — keep an eye on the calendar for the invite.
+            </>
+          ) : arrived ? (
+            current!.arrived
+          ) : (
+            current!.cta
+          )}
+        </p>
 
         <div
-          className="flex items-center justify-center gap-1.5 pt-1"
+          className="flex items-center gap-1.5"
           aria-hidden="true"
         >
-          {steps.map((_, i) => (
+          {STEPS.map((_, i) => (
             <span
               key={i}
               className={
-                "h-1.5 rounded-full transition-all " +
-                (i === step
-                  ? "w-6 bg-accent-coral"
-                  : "w-1.5 bg-muted-foreground/30")
+                "h-1 rounded-full flex-1 " +
+                (i < step || (i === step && arrived) || isFinal
+                  ? "bg-accent-coral"
+                  : "bg-muted-foreground/20")
               }
             />
           ))}
         </div>
 
-        <div className="flex items-center justify-between gap-2 pt-2">
-          <button
-            type="button"
-            onClick={() => goTo(Math.max(0, step - 1))}
-            disabled={isFirst}
-            className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground disabled:opacity-0 disabled:pointer-events-none"
-          >
-            <ArrowLeft className="w-4 h-4" />
-            Back
-          </button>
-          <button
-            type="button"
-            onClick={() => (isLast ? close() : goTo(step + 1))}
-            className="inline-flex items-center gap-1.5 rounded-lg bg-accent-coral px-4 py-2 text-sm font-semibold text-white hover:bg-accent-coral/90"
-          >
-            {isLast ? "Let's go" : "Next"}
-            {!isLast && <ArrowRight className="w-4 h-4" />}
-          </button>
+        <div className="flex items-center justify-end gap-2 pt-1">
+          {isFinal ? (
+            <button
+              type="button"
+              onClick={finishTour}
+              className="inline-flex items-center gap-1.5 rounded-lg bg-accent-coral px-3 py-1.5 text-sm font-semibold text-white hover:bg-accent-coral/90"
+            >
+              Let's go
+            </button>
+          ) : arrived ? (
+            <button
+              type="button"
+              onClick={advance}
+              className="inline-flex items-center gap-1.5 rounded-lg bg-accent-coral px-3 py-1.5 text-sm font-semibold text-white hover:bg-accent-coral/90"
+            >
+              Next
+              <ArrowRight className="w-4 h-4" />
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={finishTour}
+              className="text-xs text-muted-foreground hover:text-foreground"
+            >
+              Skip tour
+            </button>
+          )}
         </div>
       </div>
-    </Modal>
+    </div>
   );
 }

--- a/dali-api/app/components/LaunchWelcome.tsx
+++ b/dali-api/app/components/LaunchWelcome.tsx
@@ -1,0 +1,163 @@
+import { useEffect, useId, useState } from "react";
+import { Sparkles, ArrowRight, ArrowLeft, PartyPopper } from "lucide-react";
+import { Modal } from "./Modal";
+
+const STORAGE_KEY = "dalios-launch-welcome-seen-v1";
+
+type Step = {
+  icon: React.ReactNode;
+  eyebrow: string;
+  title: string;
+  body: React.ReactNode;
+};
+
+function buildSteps(firstName: string): Step[] {
+  return [
+    {
+      icon: <Sparkles className="w-6 h-6 text-accent-coral" />,
+      eyebrow: "Welcome",
+      title: `Hey ${firstName} — welcome to DALIos`,
+      body: (
+        <>
+          This is the new home for everything DALI: projects, staffing,
+          mentorship, the calendar, your profile, and more. Take a quick tour —
+          it&apos;s short, promise.
+        </>
+      ),
+    },
+    {
+      icon: <Sparkles className="w-6 h-6 text-accent-coral" />,
+      eyebrow: "Your home",
+      title: "Start here every day",
+      body: (
+        <>
+          The home tab surfaces what needs your attention: open tasks, meeting
+          invites, and the lab&apos;s week at a glance. If something is on fire,
+          it shows up here first.
+        </>
+      ),
+    },
+    {
+      icon: <Sparkles className="w-6 h-6 text-accent-coral" />,
+      eyebrow: "Explore",
+      title: "Projects, profiles, and more",
+      body: (
+        <>
+          Use the sidebar to jump between projects, the calendar, and your
+          profile. Hover any project to see its team — click in to see sprints,
+          tasks, and updates.
+        </>
+      ),
+    },
+    {
+      icon: <PartyPopper className="w-6 h-6 text-accent-coral" />,
+      eyebrow: "Launch party",
+      title: "Come celebrate with us",
+      body: (
+        <>
+          We&apos;re throwing a launch party to christen the new site. Food,
+          demos, and a few surprises. Keep an eye on the calendar for the
+          invite — we&apos;d love to see you there.
+        </>
+      ),
+    },
+  ];
+}
+
+export function LaunchWelcome({ firstName }: { firstName: string }) {
+  const [open, setOpen] = useState(false);
+  const [step, setStep] = useState(0);
+  const titleId = useId();
+
+  useEffect(() => {
+    try {
+      if (window.localStorage.getItem(STORAGE_KEY)) return;
+    } catch {
+      return;
+    }
+    setOpen(true);
+  }, []);
+
+  const steps = buildSteps(firstName);
+  const current = steps[step];
+  const isLast = step === steps.length - 1;
+  const isFirst = step === 0;
+
+  function close() {
+    try {
+      window.localStorage.setItem(STORAGE_KEY, new Date().toISOString());
+    } catch {
+      // ignore — worst case the modal re-opens, which is harmless
+    }
+    setOpen(false);
+  }
+
+  return (
+    <Modal open={open} onClose={close} labelledBy={titleId}>
+      <div className="flex flex-col gap-4">
+        <div className="flex items-center justify-between">
+          <span className="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-accent-coral">
+            {current.icon}
+            {current.eyebrow}
+          </span>
+          <button
+            type="button"
+            onClick={close}
+            className="text-xs text-muted-foreground hover:text-foreground"
+          >
+            Skip
+          </button>
+        </div>
+
+        <div>
+          <h2
+            id={titleId}
+            className="font-heading text-xl font-bold text-foreground"
+          >
+            {current.title}
+          </h2>
+          <p className="text-sm text-muted-foreground mt-2 leading-relaxed">
+            {current.body}
+          </p>
+        </div>
+
+        <div
+          className="flex items-center justify-center gap-1.5 pt-1"
+          aria-hidden="true"
+        >
+          {steps.map((_, i) => (
+            <span
+              key={i}
+              className={
+                "h-1.5 rounded-full transition-all " +
+                (i === step
+                  ? "w-6 bg-accent-coral"
+                  : "w-1.5 bg-muted-foreground/30")
+              }
+            />
+          ))}
+        </div>
+
+        <div className="flex items-center justify-between gap-2 pt-2">
+          <button
+            type="button"
+            onClick={() => setStep((s) => Math.max(0, s - 1))}
+            disabled={isFirst}
+            className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground disabled:opacity-0 disabled:pointer-events-none"
+          >
+            <ArrowLeft className="w-4 h-4" />
+            Back
+          </button>
+          <button
+            type="button"
+            onClick={() => (isLast ? close() : setStep((s) => s + 1))}
+            className="inline-flex items-center gap-1.5 rounded-lg bg-accent-coral px-4 py-2 text-sm font-semibold text-white hover:bg-accent-coral/90"
+          >
+            {isLast ? "Let's go" : "Next"}
+            {!isLast && <ArrowRight className="w-4 h-4" />}
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/dali-api/app/routes/home.tsx
+++ b/dali-api/app/routes/home.tsx
@@ -14,6 +14,7 @@ import { prisma } from "~/lib/db";
 import { listOpenTasks, type Task } from "~/lib/tasks";
 import { fetchGeneralCalendarEvents } from "~/lib/general-calendar";
 import { getZonedYMD, zonedDayStartUtc } from "~/lib/timezone";
+import { LaunchWelcome } from "~/components/LaunchWelcome";
 import type { Route } from "./+types/home";
 
 // The home week calendar is rendered in this fixed lab timezone, matching the
@@ -143,6 +144,7 @@ export default function Home() {
 
   return (
     <div className="flex flex-col gap-6">
+      <LaunchWelcome firstName={firstName} />
       <header>
         <h1 className="font-heading text-2xl font-bold text-foreground">
           Welcome back, {firstName}

--- a/dali-api/app/routes/home.tsx
+++ b/dali-api/app/routes/home.tsx
@@ -14,7 +14,6 @@ import { prisma } from "~/lib/db";
 import { listOpenTasks, type Task } from "~/lib/tasks";
 import { fetchGeneralCalendarEvents } from "~/lib/general-calendar";
 import { getZonedYMD, zonedDayStartUtc } from "~/lib/timezone";
-import { LaunchWelcome } from "~/components/LaunchWelcome";
 import type { Route } from "./+types/home";
 
 // The home week calendar is rendered in this fixed lab timezone, matching the
@@ -144,7 +143,6 @@ export default function Home() {
 
   return (
     <div className="flex flex-col gap-6">
-      <LaunchWelcome firstName={firstName} />
       <header>
         <h1 className="font-heading text-2xl font-bold text-foreground">
           Welcome back, {firstName}

--- a/dali-api/app/routes/layout.tsx
+++ b/dali-api/app/routes/layout.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { Outlet, redirect, useLoaderData, useLocation, useNavigate, useSearchParams } from 'react-router'
 import { Layout } from '~/components/Layout'
+import { LaunchWelcome } from '~/components/LaunchWelcome'
 import { requireAuth } from "~/lib/auth";
 import { getUserRoles } from '~/lib/roles'
 import { getActiveCycle } from '~/hiring/lib/cycles'
@@ -197,6 +198,9 @@ export default function AppLayoutRoute() {
   }
 
   return (
-    <Layout user={user} photoUrl={photoUrl} isCore={isCore} isAdmin={isAdmin} isDomainLead={isDomainLead} canViewForms={canViewForms} canViewStaffing={canViewStaffing} isInterviewer={isInterviewer} />
+    <>
+      <Layout user={user} photoUrl={photoUrl} isCore={isCore} isAdmin={isAdmin} isDomainLead={isDomainLead} canViewForms={canViewForms} canViewStaffing={canViewStaffing} isInterviewer={isInterviewer} />
+      <LaunchWelcome firstName={user.firstName || user.email.split('@')[0]} />
+    </>
   )
 }

--- a/dali-api/e2e/fixtures.ts
+++ b/dali-api/e2e/fixtures.ts
@@ -2,7 +2,23 @@ import { test as base } from '@playwright/test';
 
 type LoginOptions = { netId?: string; daliEmail?: string };
 
+// First-run launch welcome modal (app/components/LaunchWelcome.tsx) renders a
+// full-screen dialog overlay that intercepts pointer events on a fresh
+// localStorage. Mark it seen before any page script runs so it never blocks
+// clicks in tests. Keep this key in sync with DONE_KEY in that component.
+const LAUNCH_WELCOME_SEEN_KEY = 'dalios-launch-welcome-seen-v1';
+
 export const test = base.extend<{ loginAs: (opts: LoginOptions) => Promise<void> }>({
+  page: async ({ page }, use) => {
+    await page.addInitScript((key) => {
+      try {
+        window.localStorage.setItem(key, 'e2e');
+      } catch {
+        // localStorage unavailable (e.g. about:blank) — ignore.
+      }
+    }, LAUNCH_WELCOME_SEEN_KEY);
+    await use(page);
+  },
   loginAs: async ({ page }, use) => {
     await use(async ({ netId, daliEmail }: LoginOptions) => {
       const params = new URLSearchParams();


### PR DESCRIPTION
## Summary
- New `LaunchWelcome` component: 4-step modal shown once per browser via `localStorage` (key `dalios-launch-welcome-seen-v1`)
- Mounted in `home.tsx`, personalized with the user's first name
- Steps: Welcome → Home tab orientation → Sidebar/projects → Launch party CTA
- Designed as a throwaway for the site launch — to remove, delete `LaunchWelcome.tsx` and the two lines in `home.tsx` (import + render)

## Notes
- No DB migration, no new dependencies — composes on top of the existing `Modal.tsx` (focus trap, escape, overlay click, scroll lock already handled there)
- `localStorage` only: resets per device/browser, which is acceptable (and arguably good reinforcement) for a short-lived launch hype modal
- Copy is placeholder-quality — happy to revise before merge

## Test plan
- [ ] Log into home for the first time → modal appears with correct first name
- [ ] Click through all 4 steps → progress dots advance, Back/Next behave at boundaries
- [ ] Click "Skip" or "Let's go" on the last step → modal closes
- [ ] Reload home → modal does not reappear
- [ ] Clear `dalios-launch-welcome-seen-v1` from localStorage → modal reappears on next load
- [ ] Modal renders correctly in light + dark mode
- [ ] Focus trap, Escape-to-close, and overlay-click-to-close all work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/717"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782476861&installation_id=133523038&pr_number=717&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F717&signature=037125c9505b7face7d397dd2d5a8dcd5f7e31f9783801971ff4ed66d12817e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->