### PR TITLE
InternToFull: single cycle rubric, drop per-domain rubric requirement

### DIFF
--- a/dali-api/app/hiring/routes/__tests__/api.auto-assign.test.ts
+++ b/dali-api/app/hiring/routes/__tests__/api.auto-assign.test.ts
@@ -90,3 +90,42 @@ describe("auto-assign action — withdrawn applications are skipped", () => {
     expect(body).toEqual({ assigned: 0 });
   });
 });
+
+describe("auto-assign action — InternToFull cycles", () => {
+  it("skips the per-domain rubric requirement on InternToFull cycles", async () => {
+    mockPrisma.applicationCycle.findUniqueOrThrow.mockResolvedValueOnce({
+      id: CYCLE_ID,
+      generalRubricVersionId: "rubric-general",
+      cycleType: "InternToFull",
+    });
+    mockPrisma.domainApplicationCycle.findUnique.mockResolvedValueOnce({
+      reviewersPerApplication: 2,
+      rubricVersionId: null,
+    });
+
+    const res = await callAction();
+
+    // Doesn't bail out at the per-domain rubric check.
+    expect((res as Response).status).toBe(200);
+    expect(mockPrisma.domainApplication.findMany).toHaveBeenCalledTimes(1);
+  });
+
+  it("still requires the cycle-level general rubric on InternToFull cycles", async () => {
+    mockPrisma.applicationCycle.findUniqueOrThrow.mockResolvedValueOnce({
+      id: CYCLE_ID,
+      generalRubricVersionId: null,
+      cycleType: "InternToFull",
+    });
+
+    const res = await callAction();
+    expect((res as Response).status).toBe(400);
+    expect(mockPrisma.domainApplication.findMany).not.toHaveBeenCalled();
+  });
+
+  it("filters DomainApplications by direct domainId (works for InternToFull with no challengeVersion)", async () => {
+    await callAction();
+
+    const where = mockPrisma.domainApplication.findMany.mock.calls[0][0].where;
+    expect(where.domainId).toBe(DOMAIN_ID);
+  });
+});

--- a/dali-api/app/hiring/routes/__tests__/api.domain-applications.$id.reviews.test.ts
+++ b/dali-api/app/hiring/routes/__tests__/api.domain-applications.$id.reviews.test.ts
@@ -223,4 +223,71 @@ describe("POST /api/hiring/domain-applications/:id/reviews", () => {
     expect(res.status).toBe(400);
     expect(mockPrisma.applicationReview.create).not.toHaveBeenCalled();
   });
+
+  it("skips the per-domain rubric check on InternToFull cycles (201)", async () => {
+    vi.mocked(isCore).mockResolvedValue(true);
+    mockPrisma.applicationCycle.findUniqueOrThrow.mockResolvedValueOnce({
+      id: CYCLE_ID,
+      generalRubricVersionId: "grv-1",
+      cycleType: "InternToFull",
+    });
+    // No per-domain rubric — would be a 400 on Standard, but allowed here.
+    mockPrisma.domainApplicationCycle.findUnique.mockResolvedValueOnce(null);
+
+    const res = await action({
+      request: makeRequest(),
+      params: { id: DA_ID },
+      context: {},
+    } as any);
+
+    expect(res.status).toBe(201);
+    expect(mockPrisma.domainApplicationCycle.findUnique).not.toHaveBeenCalled();
+    expect(mockPrisma.applicationReview.create).toHaveBeenCalledWith({
+      data: { domainApplicationId: DA_ID, cycleReviewerId: CYCLE_REVIEWER_ID },
+    });
+  });
+
+  it("still requires the general rubric on InternToFull cycles (400)", async () => {
+    vi.mocked(isCore).mockResolvedValue(true);
+    mockPrisma.applicationCycle.findUniqueOrThrow.mockResolvedValueOnce({
+      id: CYCLE_ID,
+      generalRubricVersionId: null,
+      cycleType: "InternToFull",
+    });
+
+    const res = await action({
+      request: makeRequest(),
+      params: { id: DA_ID },
+      context: {},
+    } as any);
+
+    expect(res.status).toBe(400);
+    expect(mockPrisma.applicationReview.create).not.toHaveBeenCalled();
+  });
+
+  it("resolves the domain via DomainApplication.domainId on InternToFull (no challengeVersion)", async () => {
+    vi.mocked(isCore).mockResolvedValue(true);
+    // InternToFull DAs link Domain directly — challengeVersion is null.
+    mockPrisma.domainApplication.findUniqueOrThrow.mockResolvedValueOnce({
+      id: DA_ID,
+      selected: true,
+      application: { applicationCycleId: CYCLE_ID },
+      challengeVersion: null,
+      domainId: DOMAIN_ID,
+    });
+    mockPrisma.applicationCycle.findUniqueOrThrow.mockResolvedValueOnce({
+      id: CYCLE_ID,
+      generalRubricVersionId: "grv-1",
+      cycleType: "InternToFull",
+    });
+
+    const res = await action({
+      request: makeRequest(),
+      params: { id: DA_ID },
+      context: {},
+    } as any);
+
+    expect(res.status).toBe(201);
+    expect(mockPrisma.applicationReview.create).toHaveBeenCalled();
+  });
 });

--- a/dali-api/app/hiring/routes/api.cycles.$cycleId.domains.$domainId.auto-assign.ts
+++ b/dali-api/app/hiring/routes/api.cycles.$cycleId.domains.$domainId.auto-assign.ts
@@ -50,7 +50,9 @@ export async function action({ request, params }: Route.ActionArgs) {
   if (!domainCycle) {
     return Response.json({ error: "Domain not part of this cycle" }, { status: 404 });
   }
-  if (!domainCycle.rubricVersionId) {
+  // InternToFull cycles only require the cycle-level general rubric — there
+  // are no per-domain rubrics in that flow.
+  if (cycle.cycleType !== "InternToFull" && !domainCycle.rubricVersionId) {
     return Response.json({ error: "A domain rubric must be set before assigning reviewers to applications" }, { status: 400 });
   }
 
@@ -65,10 +67,15 @@ export async function action({ request, params }: Route.ActionArgs) {
     return Response.json({ error: "No reviewers assigned to this domain" }, { status: 400 });
   }
 
+  // DomainApplication.domainId is denormalized (set for both Standard and
+  // InternToFull rows). On Standard cycles it's backfilled from
+  // challengeVersion.domain; on InternToFull there is no challengeVersion, so
+  // we must match on the direct relation. Filtering by domainId works for
+  // both.
   const domainApps = await prisma.domainApplication.findMany({
     where: {
       selected: true,
-      challengeVersion: { domainId: domainId! },
+      domainId: domainId!,
       application: {
         applicationCycleId: cycleId!,
         ...inReviewPipelineFilter,

--- a/dali-api/app/hiring/routes/api.domain-applications.$id.reviews.ts
+++ b/dali-api/app/hiring/routes/api.domain-applications.$id.reviews.ts
@@ -104,11 +104,15 @@ export async function action({ request, params }: Route.ActionArgs) {
     return Response.json({ error: "A general application rubric must be set before assigning reviewers to applications" }, { status: 400 });
   }
 
-  const domainCycle = await prisma.domainApplicationCycle.findUnique({
-    where: { domainId_applicationCycleId: { domainId, applicationCycleId: cycle.id } },
-  });
-  if (!domainCycle?.rubricVersionId) {
-    return Response.json({ error: "A domain rubric must be set before assigning reviewers to applications in this domain" }, { status: 400 });
+  // InternToFull cycles use only the cycle-level general rubric; per-domain
+  // rubrics aren't part of that flow, so skip the per-domain check.
+  if (cycle.cycleType !== "InternToFull") {
+    const domainCycle = await prisma.domainApplicationCycle.findUnique({
+      where: { domainId_applicationCycleId: { domainId, applicationCycleId: cycle.id } },
+    });
+    if (!domainCycle?.rubricVersionId) {
+      return Response.json({ error: "A domain rubric must be set before assigning reviewers to applications in this domain" }, { status: 400 });
+    }
   }
 
   const review = await prisma.applicationReview.create({

--- a/dali-api/app/hiring/routes/domain-lead.tsx
+++ b/dali-api/app/hiring/routes/domain-lead.tsx
@@ -818,29 +818,25 @@ export default function DomainLeadDashboard() {
                     </div>
                   )}
 
-                  {/* Rubric — scoring criteria for this domain */}
-                  <Section
-                    title="Rubric"
-                    subtitle="Scoring criteria reviewers use for this domain."
-                    badge={
-                      currentRubricVersionId
-                        ? <span className="text-xs text-green-700 bg-green-100 border border-green-200 px-2 py-0.5 rounded-full font-medium">Set</span>
-                        : <span className="text-xs text-yellow-700 bg-yellow-100 border border-yellow-200 px-2 py-0.5 rounded-full font-medium">Not set</span>
-                    }
-                    defaultOpen={!currentRubricVersionId}
-                  >
-                    <div>
-                      <RubricPicker
-                        cycleId={cycle.id}
-                        domainId={assignment.domainId}
-                        options={rubricVersionOptions ?? []}
-                        selectedId={currentRubricVersionId}
-                        locked={hasApplicationReviews}
-                      />
+                  {/* Rubric — scoring criteria.
+                      InternToFull cycles use only the cycle-level general
+                      rubric (set by the hiring lead), so the per-domain picker
+                      is hidden and replaced with a read-only summary. */}
+                  {isInternToFull ? (
+                    <Section
+                      title="Rubric"
+                      subtitle="Cycle-wide rubric set by the hiring lead — applies to every application."
+                      badge={
+                        cycle.generalRubricVersionId
+                          ? <span className="text-xs text-green-700 bg-green-100 border border-green-200 px-2 py-0.5 rounded-full font-medium">Set</span>
+                          : <span className="text-xs text-yellow-700 bg-yellow-100 border border-yellow-200 px-2 py-0.5 rounded-full font-medium">Not set</span>
+                      }
+                      defaultOpen={!cycle.generalRubricVersionId}
+                    >
                       {!cycle.generalRubricVersionId && (
-                        <div className="mt-3 flex items-center gap-2 text-sm text-yellow-800 bg-yellow-50 border border-yellow-200 rounded-lg px-4 py-2">
+                        <div className="flex items-center gap-2 text-sm text-yellow-800 bg-yellow-50 border border-yellow-200 rounded-lg px-4 py-2">
                           <Clock className="w-4 h-4 flex-shrink-0" />
-                          <span>Waiting on hiring lead to set the general application rubric — reviewer assignment is blocked until both rubrics are set.</span>
+                          <span>Waiting on hiring lead to set the cycle rubric — reviewer assignment is blocked until it's set.</span>
                         </div>
                       )}
                       <div className="mt-2">
@@ -848,8 +844,40 @@ export default function DomainLeadDashboard() {
                           All Rubrics →
                         </Link>
                       </div>
-                    </div>
-                  </Section>
+                    </Section>
+                  ) : (
+                    <Section
+                      title="Rubric"
+                      subtitle="Scoring criteria reviewers use for this domain."
+                      badge={
+                        currentRubricVersionId
+                          ? <span className="text-xs text-green-700 bg-green-100 border border-green-200 px-2 py-0.5 rounded-full font-medium">Set</span>
+                          : <span className="text-xs text-yellow-700 bg-yellow-100 border border-yellow-200 px-2 py-0.5 rounded-full font-medium">Not set</span>
+                      }
+                      defaultOpen={!currentRubricVersionId}
+                    >
+                      <div>
+                        <RubricPicker
+                          cycleId={cycle.id}
+                          domainId={assignment.domainId}
+                          options={rubricVersionOptions ?? []}
+                          selectedId={currentRubricVersionId}
+                          locked={hasApplicationReviews}
+                        />
+                        {!cycle.generalRubricVersionId && (
+                          <div className="mt-3 flex items-center gap-2 text-sm text-yellow-800 bg-yellow-50 border border-yellow-200 rounded-lg px-4 py-2">
+                            <Clock className="w-4 h-4 flex-shrink-0" />
+                            <span>Waiting on hiring lead to set the general application rubric — reviewer assignment is blocked until both rubrics are set.</span>
+                          </div>
+                        )}
+                        <div className="mt-2">
+                          <Link to="/hiring/library?tab=rubrics" className="text-xs text-blue-600 hover:text-blue-800 font-medium">
+                            All Rubrics →
+                          </Link>
+                        </div>
+                      </div>
+                    </Section>
+                  )}
 
                   {/* Team — Reviewers (+ Interviewers for Standard cycles only). */}
                   <Section
@@ -920,7 +948,7 @@ export default function DomainLeadDashboard() {
                           cycleId={cycle.id}
                           domainId={assignment.domainId}
                           currentStatus={currentStatus}
-                          canAssignReviewers={!!currentRubricVersionId && !!cycle.generalRubricVersionId}
+                          canAssignReviewers={isInternToFull ? !!cycle.generalRubricVersionId : !!currentRubricVersionId && !!cycle.generalRubricVersionId}
                           rubricCriteria={rubricCriteria ?? []}
                         />
                       ) : (

--- a/dali-api/app/hiring/routes/lead.intern-to-full-cycle.$id.tsx
+++ b/dali-api/app/hiring/routes/lead.intern-to-full-cycle.$id.tsx
@@ -31,6 +31,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     include: {
       statusUpdates: { orderBy: { createdAt: "desc" }, take: 1 },
       internToFullFormVersion: true,
+      generalRubricVersion: { include: { rubric: true } },
       domains: {
         include: {
           domain: true,
@@ -84,14 +85,14 @@ export async function loader({ request, params }: Route.LoaderArgs) {
             questions: (cycle.internToFullFormVersion.questions as unknown as Question[]) ?? [],
           }
         : null,
+      generalRubricVersionId: cycle.generalRubricVersionId,
+      generalRubricLabel: cycle.generalRubricVersion
+        ? `${cycle.generalRubricVersion.rubric.name} v${cycle.generalRubricVersion.versionNumber}`
+        : null,
       targetDomains: cycle.domains.map((d) => ({
         domainId: d.domainId,
         code: d.domain.code,
         displayName: d.domain.displayName,
-        rubricVersionId: d.rubricVersionId,
-        rubricLabel: d.rubricVersion
-          ? `${d.rubricVersion.rubric.name} v${d.rubricVersion.versionNumber}`
-          : null,
         isReady: d.isReady,
       })),
       // InternToFull uses a single reviewer pool: each member reads every DA
@@ -275,14 +276,11 @@ export async function action({ request, params }: Route.ActionArgs) {
     return { ok: true };
   }
 
-  if (intent === "set-domain-rubric") {
-    const domainId = formData.get("domainId") as string;
+  if (intent === "set-general-rubric") {
     const rubricVersionId = (formData.get("rubricVersionId") as string) || null;
-    await prisma.domainApplicationCycle.update({
-      where: {
-        domainId_applicationCycleId: { domainId, applicationCycleId: cycleId },
-      },
-      data: { rubricVersionId },
+    await prisma.applicationCycle.update({
+      where: { id: cycleId },
+      data: { generalRubricVersionId: rubricVersionId },
     });
     return { ok: true };
   }
@@ -371,11 +369,17 @@ export default function InternToFullCycleSetup() {
         disabled={isOpen}
       />
 
+      <GeneralRubricSection
+        cycleId={cycle.id}
+        currentRubricVersionId={cycle.generalRubricVersionId}
+        currentRubricLabel={cycle.generalRubricLabel}
+        allRubricVersions={allRubricVersions}
+      />
+
       <TargetDomainsSection
         cycleId={cycle.id}
         targetDomains={cycle.targetDomains}
         allDomains={allDomains}
-        allRubricVersions={allRubricVersions}
         disabled={isOpen}
       />
 
@@ -729,7 +733,6 @@ function TargetDomainsSection({
   cycleId,
   targetDomains,
   allDomains,
-  allRubricVersions,
   disabled,
 }: {
   cycleId: string;
@@ -737,12 +740,9 @@ function TargetDomainsSection({
     domainId: string;
     code: string;
     displayName: string;
-    rubricVersionId: string | null;
-    rubricLabel: string | null;
     isReady: boolean;
   }[];
   allDomains: { id: string; code: string; displayName: string }[];
-  allRubricVersions: { id: string; label: string }[];
   disabled: boolean;
 }) {
   const fetcher = useFetcher();
@@ -761,7 +761,7 @@ function TargetDomainsSection({
   return (
     <Section
       title="Target domains"
-      description="Domains interns can apply to convert into. Each gets its own rubric and reviewer pool."
+      description="Domains interns can apply to convert into. All domains share the cycle's general rubric and a single reviewer pool."
     >
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 mb-4">
         {allDomains.map((d) => {
@@ -796,7 +796,6 @@ function TargetDomainsSection({
               key={d.domainId}
               cycleId={cycleId}
               domain={d}
-              allRubricVersions={allRubricVersions}
               disabled={disabled}
             />
           ))}
@@ -807,70 +806,92 @@ function TargetDomainsSection({
 }
 
 function DomainConfigRow({
-  cycleId,
+  cycleId: _cycleId,
   domain,
-  allRubricVersions,
   disabled,
 }: {
   cycleId: string;
   domain: {
     domainId: string;
     displayName: string;
-    rubricVersionId: string | null;
-    rubricLabel: string | null;
     isReady: boolean;
   };
-  allRubricVersions: { id: string; label: string }[];
   disabled: boolean;
 }) {
   const fetcher = useFetcher();
   return (
     <div className="flex flex-wrap items-center justify-between gap-3 py-2">
       <div className="text-sm font-medium text-dark-blue min-w-32">{domain.displayName}</div>
-      <div className="flex items-center gap-2 text-xs">
-        <span className="text-muted-foreground">Rubric:</span>
-        <select
-          value={domain.rubricVersionId ?? ""}
+      <label className="flex items-center gap-1 text-xs">
+        <input
+          type="checkbox"
+          checked={domain.isReady}
+          disabled={disabled}
           onChange={(e) =>
             fetcher.submit(
               {
-                intent: "set-domain-rubric",
+                intent: "toggle-domain-ready",
                 domainId: domain.domainId,
-                rubricVersionId: e.target.value,
+                ready: String(e.target.checked),
               },
               { method: "post" },
             )
           }
-          disabled={disabled}
-          className="px-2 py-1 border border-border rounded text-xs"
+        />
+        Ready
+      </label>
+    </div>
+  );
+}
+
+function GeneralRubricSection({
+  cycleId: _cycleId,
+  currentRubricVersionId,
+  currentRubricLabel,
+  allRubricVersions,
+}: {
+  cycleId: string;
+  currentRubricVersionId: string | null;
+  currentRubricLabel: string | null;
+  allRubricVersions: { id: string; label: string }[];
+}) {
+  const fetcher = useFetcher();
+  return (
+    <Section
+      title="Rubric"
+      description="Scoring criteria reviewers use for every application in this cycle. Required before reviewers can be assigned."
+    >
+      {currentRubricLabel ? (
+        <p className="text-sm font-medium text-dark-blue mb-3">{currentRubricLabel}</p>
+      ) : (
+        <p className="text-sm text-muted-foreground mb-3">No rubric pinned yet.</p>
+      )}
+      <div className="flex flex-wrap items-center gap-2">
+        <select
+          value={currentRubricVersionId ?? ""}
+          onChange={(e) => {
+            fetcher.submit(
+              { intent: "set-general-rubric", rubricVersionId: e.target.value },
+              { method: "post" },
+            );
+          }}
+          className="px-3 py-2 text-sm border border-border rounded-md"
         >
-          <option value="">— none —</option>
+          <option value="">— pick a rubric version —</option>
           {allRubricVersions.map((rv) => (
             <option key={rv.id} value={rv.id}>
               {rv.label}
             </option>
           ))}
         </select>
-        <label className="flex items-center gap-1 ml-3">
-          <input
-            type="checkbox"
-            checked={domain.isReady}
-            disabled={disabled}
-            onChange={(e) =>
-              fetcher.submit(
-                {
-                  intent: "toggle-domain-ready",
-                  domainId: domain.domainId,
-                  ready: String(e.target.checked),
-                },
-                { method: "post" },
-              )
-            }
-          />
-          Ready
-        </label>
+        <Link
+          to="/hiring/library?tab=rubrics"
+          className="text-xs font-medium text-blue-700 hover:underline"
+        >
+          Manage rubrics →
+        </Link>
       </div>
-    </div>
+    </Section>
   );
 }
 

--- a/dali-api/app/hiring/routes/reviewer.application.$id.tsx
+++ b/dali-api/app/hiring/routes/reviewer.application.$id.tsx
@@ -199,9 +199,10 @@ export async function action({ request, params }: Route.ActionArgs) {
     })
 
     if (existing) {
-      // Pin the domain rubric version these score keys belong to, so a later
-      // rubric edit (which mints new crit-<ts> keys) doesn't orphan them at
-      // render time. Resolve the domain from the review's domain application.
+      // Pin the rubric version these score keys belong to, so a later rubric
+      // edit (which mints new crit-<ts> keys) doesn't orphan them at render
+      // time. Prefer the per-domain rubric (Standard cycles); fall back to the
+      // cycle-level general rubric (InternToFull, which has no per-domain).
       const da = existing.domainApplication
       const domainId = da.domainId ?? da.challengeVersion?.domainId ?? null
       let rubricVersionId: string | null = existing.rubricVersionId ?? null
@@ -216,6 +217,13 @@ export async function action({ request, params }: Route.ActionArgs) {
           select: { rubricVersionId: true },
         })
         if (dac?.rubricVersionId) rubricVersionId = dac.rubricVersionId
+      }
+      if (!rubricVersionId) {
+        const ac = await prisma.applicationCycle.findUnique({
+          where: { id: da.application.applicationCycleId },
+          select: { generalRubricVersionId: true },
+        })
+        if (ac?.generalRubricVersionId) rubricVersionId = ac.generalRubricVersionId
       }
 
       await prisma.applicationReview.update({


### PR DESCRIPTION
## Summary

- **InternToFull (Fellowship) cycles** use one cycle-level general rubric for every application; the per-domain rubric requirement is dropped on this cycle type. The InternToFull setup page gets a new **Rubric** picker so the hiring lead can actually set it from the UI.
- **Standard hire cycles** are unchanged — same validation, same UI, same pinning behavior.
- **Auto-assign on InternToFull** now actually works: query filters `DomainApplication` by direct `domainId` instead of `challengeVersion.domainId` (InternToFull rows have no `challengeVersion`).

## Why

Reviewer-assignment endpoints (`api.domain-applications.$id.reviews.ts`, `api.cycles.$cycleId.domains.$domainId.auto-assign.ts`) and the domain-lead UI all required `ApplicationCycle.generalRubricVersionId` to be set — but the InternToFull cycle setup page never exposed a picker for it. So on a Fellowship cycle, the domain lead would see "Waiting on hiring lead to set the general application rubric" with no way to clear it, and `auto-assign` would also have silently picked up zero DAs because of the `challengeVersion.domainId` filter.

InternToFull's data model intentionally only has per-domain rubrics as a leftover from Standard; the cleaner shape is a single cycle-level rubric (matches the single reviewer pool model the schema already enforces).

## Changes

- `lead.intern-to-full-cycle.$id.tsx` — new `GeneralRubricSection`, `set-general-rubric` action handler, per-domain rubric `<select>` removed from `DomainConfigRow` (the "Ready" toggle stays).
- `domain-lead.tsx` — when `isInternToFull`, the per-domain Rubric section becomes a read-only "cycle-wide rubric set by hiring lead" summary; `canAssignReviewers` requires only the general rubric.
- `api.domain-applications.$id.reviews.ts` — per-domain rubric check skipped on InternToFull (general rubric still required).
- `api.cycles.$cycleId.domains.$domainId.auto-assign.ts` — same skip; query filters DAs by `domainId` directly so InternToFull rows match.
- `reviewer.application.$id.tsx` — save action falls back to pinning `ApplicationCycle.generalRubricVersionId` when no per-domain rubric is set, so score keys remain resolvable after later rubric edits.

## Test plan

- [x] `npm test` (Vitest) — 1026/1026 pass; added 5 new InternToFull cases to `api.domain-applications.$id.reviews.test.ts` and 3 to `api.auto-assign.test.ts`.
- [x] `npm run typecheck` — clean for all touched files (only pre-existing `scripts/*` errors remain on dev).
- [ ] Manual: open an existing InternToFull cycle, confirm new "Rubric" card appears between Shortform and Target domains; set a rubric version; verify the Fullstack/UI-UX domain-lead views drop the warning and the Auto-assign button enables.
- [ ] Manual: open a Standard hire cycle, confirm no UI changes — general rubric picker still in `lead.cycle.$id.tsx`, per-domain rubric still required, warning still appears when general rubric is missing.
- [ ] Manual: assign a reviewer on the InternToFull cycle, score one application, confirm the saved `ApplicationReview.rubricVersionId` matches `cycle.generalRubricVersionId`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/718"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782476870&installation_id=133523038&pr_number=718&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F718&signature=9b9df17651da8055e0d946f349231e5adc6b371441c55cbdd8c91fd1a15857d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->