### PR TITLE
Upgrade partner expectedChallenges + InternToFull info-block to rich text

### DIFF
--- a/dali-api/app/hiring/components/ChallengePreview.tsx
+++ b/dali-api/app/hiring/components/ChallengePreview.tsx
@@ -1,6 +1,7 @@
 import type { Question } from "~/types";
 import { ChallengeQuestionField } from "~/hiring/components/ChallengeQuestionField";
 import { RichTextViewer, isEmptyDoc } from "~/components/RichTextViewer";
+import { InfoBody } from "~/hiring/lib/info-body";
 
 export interface ChallengePreviewProps {
   description?: unknown;
@@ -31,9 +32,9 @@ export function ChallengePreview({ description, questions }: ChallengePreviewPro
               return (
                 <div
                   key={q.key}
-                  className="rounded-lg border border-border bg-muted/30 px-4 py-3 text-sm text-muted-foreground whitespace-pre-wrap"
+                  className="rounded-lg border border-border bg-muted/30 px-4 py-3 text-sm text-muted-foreground"
                 >
-                  {q.data.body ?? ""}
+                  <InfoBody body={q.data.body} />
                 </div>
               );
             }

--- a/dali-api/app/hiring/lib/info-body.tsx
+++ b/dali-api/app/hiring/lib/info-body.tsx
@@ -1,0 +1,20 @@
+import { RichTextViewer, isEmptyDoc } from "~/components/RichTextViewer";
+
+// Question.data.body for `type: "info"` is a ProseMirror JSON doc for rows
+// written after the rich-text upgrade, and a plain string for legacy rows in
+// older InternToFullFormVersion snapshots. The helpers here paper over the
+// shape difference so callers don't have to.
+
+export function hasInfoBody(body: unknown): boolean {
+  if (typeof body === "string") return body.trim().length > 0;
+  return !isEmptyDoc(body);
+}
+
+export function InfoBody({ body }: { body: unknown }) {
+  if (typeof body === "string") {
+    if (!body.trim()) return null;
+    return <p className="whitespace-pre-wrap">{body}</p>;
+  }
+  if (isEmptyDoc(body)) return null;
+  return <RichTextViewer content={body} />;
+}

--- a/dali-api/app/hiring/routes/lead.intern-to-full-cycle.$id.tsx
+++ b/dali-api/app/hiring/routes/lead.intern-to-full-cycle.$id.tsx
@@ -8,6 +8,9 @@ import type { Question } from "~/types";
 import type { Prisma } from "~/generated/prisma/client";
 import { CycleSetupSection as Section } from "~/hiring/components/CycleSetupSection";
 import { ChallengePreviewModal } from "~/hiring/components/ChallengePreviewModal";
+import { RichTextEditor } from "~/components/RichTextEditor";
+import { hasInfoBody } from "~/hiring/lib/info-body";
+
 import {
   zonedDayEndUtc,
   getZonedYMD,
@@ -556,7 +559,7 @@ function CreateFormVersionModal({
   function addInfo() {
     setQs((prev) => [
       ...prev,
-      { key: crypto.randomUUID(), type: "info", required: false, data: { label: "", body: "" } },
+      { key: crypto.randomUUID(), type: "info", required: false, data: { label: "" } },
     ]);
   }
   function removeQ(idx: number) {
@@ -623,12 +626,10 @@ function CreateFormVersionModal({
                   </div>
                 </div>
                 {isInfo ? (
-                  <textarea
-                    value={q.data.body ?? ""}
-                    onChange={(e) => update(idx, { data: { body: e.target.value } })}
+                  <RichTextEditor
+                    value={q.data.body}
+                    onChange={(body) => update(idx, { data: { body } })}
                     placeholder="Free-form text shown to the applicant (e.g. instructions or context)."
-                    rows={4}
-                    className="w-full px-2 py-1.5 text-sm border border-border rounded-md"
                   />
                 ) : (
                   <>
@@ -695,7 +696,7 @@ function CreateFormVersionModal({
           <button
             onClick={() => {
               const cleaned = qs.filter((q) =>
-                q.type === "info" ? (q.data.body ?? "").trim() : q.data.label.trim(),
+                q.type === "info" ? hasInfoBody(q.data.body) : q.data.label.trim(),
               );
               if (cleaned.length === 0) return;
               onSubmit(cleaned);
@@ -715,7 +716,7 @@ function CreateFormVersionModal({
             challengeName="Shortform"
             versionLabel="Draft"
             questions={qs.filter((q) =>
-              q.type === "info" ? (q.data.body ?? "").trim() : q.data.label.trim(),
+              q.type === "info" ? hasInfoBody(q.data.body) : q.data.label.trim(),
             )}
             onClose={() => setPreviewing(false)}
           />

--- a/dali-api/app/partners/routes/api.partner-application-domains.$id.ts
+++ b/dali-api/app/partners/routes/api.partner-application-domains.$id.ts
@@ -1,11 +1,13 @@
 import type { Route } from "./+types/api.partner-application-domains.$id";
+import { Prisma } from "~/generated/prisma/client";
 import { prisma } from "~/lib/db";
 import { requireAuth } from "~/lib/auth";
 import { isCore } from "~/lib/roles";
 import { withCors, handlePreflight } from "~/lib/cors";
+import { isEmptyDoc } from "~/components/RichTextViewer";
 
 // POST   /api/partner-application-domains/:id — update expected scope.
-//          Body: { expectedMembers: number, expectedChallenges: string|null }
+//          Body: { expectedMembers: number, expectedChallenges: ProseMirrorDoc|null }
 // DELETE /api/partner-application-domains/:id — detach the domain from the
 //          application (hard delete; the row is pure join+scope data, nothing
 //          references it).
@@ -15,14 +17,19 @@ import { withCors, handlePreflight } from "~/lib/cors";
 
 type Body = {
   expectedMembers: number;
-  expectedChallenges: string | null;
+  expectedChallenges: unknown;
 };
+
+function isProseMirrorDoc(x: unknown): boolean {
+  if (!x || typeof x !== "object") return false;
+  return (x as { type?: unknown }).type === "doc";
+}
 
 function isBody(x: unknown): x is Body {
   if (!x || typeof x !== "object") return false;
   const r = x as Record<string, unknown>;
   if (typeof r.expectedMembers !== "number") return false;
-  if (r.expectedChallenges !== null && typeof r.expectedChallenges !== "string")
+  if (r.expectedChallenges !== null && !isProseMirrorDoc(r.expectedChallenges))
     return false;
   return true;
 }
@@ -89,10 +96,9 @@ export async function action({ request, params }: Route.ActionArgs) {
   }
 
   const expectedMembers = Math.max(0, Math.floor(body.expectedMembers));
-  const expectedChallenges =
-    body.expectedChallenges && body.expectedChallenges.trim() !== ""
-      ? body.expectedChallenges.trim()
-      : null;
+  const expectedChallenges = isEmptyDoc(body.expectedChallenges)
+    ? Prisma.JsonNull
+    : (body.expectedChallenges as Prisma.InputJsonValue);
 
   try {
     await prisma.partnerApplicationDomain.update({

--- a/dali-api/app/partners/routes/partners.applications.$id.tsx
+++ b/dali-api/app/partners/routes/partners.applications.$id.tsx
@@ -23,6 +23,8 @@ import {
 import { CollaborativeEditor } from "~/components/CollaborativeEditor";
 import { PresenceProvider } from "~/components/collab/PresenceProvider";
 import { EditModeToggle, useEditMode } from "~/components/EditModeToggle";
+import { RichTextEditor } from "~/components/RichTextEditor";
+import { RichTextViewer, isEmptyDoc } from "~/components/RichTextViewer";
 
 export const meta: Route.MetaFunction = ({ data }) => {
   const a = (data as { application?: { title: string } } | undefined)
@@ -750,78 +752,25 @@ function DomainScopeBlock({
         <div className="flex flex-col divide-y divide-border">
           {domains.map((d) =>
             editId === d.id ? (
-              <form
+              <DomainScopeEditRow
                 key={d.id}
-                onSubmit={(e) => {
-                  e.preventDefault();
-                  const fd = new FormData(e.currentTarget);
-                  const members = Math.max(
-                    0,
-                    Number(fd.get("expectedMembers")) || 0,
-                  );
-                  const challenges = (
-                    (fd.get("expectedChallenges") as string | null) ?? ""
-                  ).trim();
+                row={d}
+                busy={busy}
+                onCancel={() => setEditId(null)}
+                onSave={(members, challenges) => {
                   run(async () => {
                     await call(
                       `/api/partner-application-domains/${d.id}`,
                       "POST",
                       {
                         expectedMembers: members,
-                        expectedChallenges: challenges || null,
+                        expectedChallenges: challenges,
                       },
                     );
                     setEditId(null);
                   });
                 }}
-                className="py-3 flex flex-col gap-2"
-              >
-                <div className="flex items-center justify-between">
-                  <span className="text-sm font-medium text-foreground">
-                    {d.domainName}
-                  </span>
-                  <div className="flex items-center gap-2">
-                    <button
-                      type="submit"
-                      disabled={busy}
-                      className="px-3 py-1.5 text-xs font-medium rounded-md bg-accent-coral text-white hover:bg-accent-coral/90 disabled:opacity-60 transition-colors"
-                    >
-                      Save
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => setEditId(null)}
-                      className="px-3 py-1.5 text-xs font-medium rounded-md border border-border hover:bg-muted transition-colors"
-                    >
-                      Cancel
-                    </button>
-                  </div>
-                </div>
-                <label className="flex flex-col gap-1 text-xs sm:max-w-[180px]">
-                  <span className="text-muted-foreground">
-                    Expected members
-                  </span>
-                  <input
-                    name="expectedMembers"
-                    type="number"
-                    min={0}
-                    defaultValue={d.expectedMembers}
-                    className="px-2 py-1.5 text-sm border border-border rounded-md bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-accent-coral/30"
-                  />
-                </label>
-                <label className="flex flex-col gap-1 text-xs">
-                  <span className="text-muted-foreground">
-                    Expected challenges / scope
-                  </span>
-                  <textarea
-                    name="expectedChallenges"
-                    rows={3}
-                    defaultValue={d.expectedChallenges ?? ""}
-                    placeholder="What does the partner expect this domain to deliver?"
-                    className="px-2 py-1.5 text-sm border border-border rounded-md bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-accent-coral/30"
-                  />
-                </label>
-              </form>
+              />
             ) : (
               <div key={d.id} className="py-3">
                 <div className="flex items-start justify-between gap-3">
@@ -835,10 +784,11 @@ function DomainScopeBlock({
                         {d.expectedMembers === 1 ? "member" : "members"}
                       </span>
                     </div>
-                    {d.expectedChallenges ? (
-                      <p className="text-sm text-muted-foreground mt-1 whitespace-pre-wrap">
-                        {d.expectedChallenges}
-                      </p>
+                    {!isEmptyDoc(d.expectedChallenges) ? (
+                      <RichTextViewer
+                        content={d.expectedChallenges}
+                        className="text-sm text-muted-foreground mt-1"
+                      />
                     ) : (
                       <p className="text-xs text-muted-foreground italic mt-1">
                         No scope description.
@@ -894,6 +844,73 @@ function DomainScopeBlock({
         </div>
       )}
     </section>
+  );
+}
+
+function DomainScopeEditRow({
+  row,
+  busy,
+  onCancel,
+  onSave,
+}: {
+  row: LoaderData["application"]["domains"][number];
+  busy: boolean;
+  onCancel: () => void;
+  onSave: (expectedMembers: number, expectedChallenges: unknown) => void;
+}) {
+  const [members, setMembers] = useState<string>(String(row.expectedMembers));
+  const [challenges, setChallenges] = useState<unknown>(row.expectedChallenges);
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        const n = Math.max(0, Number(members) || 0);
+        onSave(n, isEmptyDoc(challenges) ? null : challenges);
+      }}
+      className="py-3 flex flex-col gap-2"
+    >
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-medium text-foreground">
+          {row.domainName}
+        </span>
+        <div className="flex items-center gap-2">
+          <button
+            type="submit"
+            disabled={busy}
+            className="px-3 py-1.5 text-xs font-medium rounded-md bg-accent-coral text-white hover:bg-accent-coral/90 disabled:opacity-60 transition-colors"
+          >
+            Save
+          </button>
+          <button
+            type="button"
+            onClick={onCancel}
+            className="px-3 py-1.5 text-xs font-medium rounded-md border border-border hover:bg-muted transition-colors"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+      <label className="flex flex-col gap-1 text-xs sm:max-w-[180px]">
+        <span className="text-muted-foreground">Expected members</span>
+        <input
+          type="number"
+          min={0}
+          value={members}
+          onChange={(e) => setMembers(e.target.value)}
+          className="px-2 py-1.5 text-sm border border-border rounded-md bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-accent-coral/30"
+        />
+      </label>
+      <label className="flex flex-col gap-1 text-xs">
+        <span className="text-muted-foreground">
+          Expected challenges / scope
+        </span>
+        <RichTextEditor
+          value={challenges}
+          onChange={setChallenges}
+          placeholder="What does the partner expect this domain to deliver?"
+        />
+      </label>
+    </form>
   );
 }
 

--- a/dali-api/app/routes/intern-to-full.tsx
+++ b/dali-api/app/routes/intern-to-full.tsx
@@ -11,6 +11,7 @@ import {
   currentInternDomains,
 } from "~/hiring/lib/intern-eligibility";
 import type { Question } from "~/types";
+import { InfoBody } from "~/hiring/lib/info-body";
 import { ChallengeQuestionField } from "~/hiring/components/ChallengeQuestionField";
 import { APPLICATION_TZ, APPLICATION_TZ_LABEL } from "~/lib/timezone";
 
@@ -404,9 +405,9 @@ function FormView({
               return (
                 <div
                   key={q.key}
-                  className="rounded-lg border border-border bg-muted/30 px-4 py-3 text-sm text-muted-foreground whitespace-pre-wrap"
+                  className="rounded-lg border border-border bg-muted/30 px-4 py-3 text-sm text-muted-foreground"
                 >
-                  {q.data.body ?? ""}
+                  <InfoBody body={q.data.body} />
                 </div>
               );
             }

--- a/dali-api/app/types.ts
+++ b/dali-api/app/types.ts
@@ -131,8 +131,10 @@ export interface Question {
     // save-version rebuilds `data` and drops it.
     referenceOptions?: { value: string; label: string }[]
     // For type === 'info': free-form prose rendered as a non-question text
-    // block in the form. Plain text; line breaks preserved.
-    body?: string
+    // block in the form. Stored as a ProseMirror JSON doc (Tiptap StarterKit
+    // + Link). Legacy rows written before the rich-text upgrade may still be
+    // a plain string; readers should handle both.
+    body?: unknown
   }
 }
 

--- a/dali-api/prisma/migrations/20260527120000_partner_app_expected_challenges_to_json/migration.sql
+++ b/dali-api/prisma/migrations/20260527120000_partner_app_expected_challenges_to_json/migration.sql
@@ -1,0 +1,23 @@
+-- Convert PartnerApplicationDomain.expectedChallenges from free text to a
+-- ProseMirror JSON document. Existing rows are wrapped into a single-paragraph
+-- doc so the new RichTextViewer can render them unchanged; empty/whitespace
+-- values become NULL.
+
+ALTER TABLE "PartnerApplicationDomain"
+ALTER COLUMN "expectedChallenges" TYPE JSONB
+USING (
+  CASE
+    WHEN "expectedChallenges" IS NULL OR btrim("expectedChallenges") = '' THEN NULL
+    ELSE jsonb_build_object(
+      'type', 'doc',
+      'content', jsonb_build_array(
+        jsonb_build_object(
+          'type', 'paragraph',
+          'content', jsonb_build_array(
+            jsonb_build_object('type', 'text', 'text', "expectedChallenges")
+          )
+        )
+      )
+    )
+  END
+);

--- a/dali-api/prisma/schema.prisma
+++ b/dali-api/prisma/schema.prisma
@@ -3107,7 +3107,9 @@ model PartnerApplicationDomain {
   id                 String  @id @default(cuid())
   applicationId      String
   domainId           String
-  expectedChallenges String?
+  // Rich-text ProseMirror JSON doc (Tiptap StarterKit + Link). Pre-migration
+  // rows were free text and have been wrapped into a single-paragraph doc.
+  expectedChallenges Json?
   expectedMembers    Int     @default(0)
 
   application PartnerApplication @relation(fields: [applicationId], references: [id], onDelete: Cascade)


### PR DESCRIPTION
## Summary

Two long-form text fields move from plain `<textarea>` to the existing `RichTextEditor` (Tiptap StarterKit + Link). Both are full-display fields — readers see the whole prose, so formatting actually pays off.

- **`PartnerApplicationDomain.expectedChallenges`** — column moves from `String?` to `Json?` via a data-preserving migration that wraps each existing row into a single-paragraph ProseMirror doc. Editor + display swapped; the per-domain edit form was extracted into a `DomainScopeEditRow` sub-component so it owns its rich-text state cleanly.
- **InternToFull form's `type: "info"` body** — lives inside the existing `InternToFullFormVersion.questions` Json column, so no schema change. `Question.data.body` widens from `string` to `unknown`; new `hasInfoBody` helper and `<InfoBody>` component handle both legacy strings and new docs in the validator and the two display sites (`ChallengePreview`, `intern-to-full`).

## Scope-down vs. the original audit

The investigation considered upgrading six fields. After re-reading the schema and rendering paths, three were dropped:

- `Project.description` / `PartnerApplication.summary` — schema comments explicitly say the long-form authored content lives on the adjacent collab page / SOW doc; the inline field is intentionally a short plain blurb.
- `Notification.body` (announcement body) — the only render site is a `line-clamp-2` preview on the home tile (`app/routes/home.tsx:580`); rich formatting would never reach the recipient. Worth revisiting once an announcement detail view exists.

## Migration safety

`20260527120000_partner_app_expected_challenges_to_json`:

- `ALTER COLUMN ... TYPE JSONB USING (...)` — data-preserving wrap, NULL/empty rows stay NULL.
- Takes an exclusive lock on `PartnerApplicationDomain`; expected row count is small (one per (application, domain) pair).
- No drops, no NOT-NULL additions, no concurrent-index work.

## Test plan

- [x] `npm run typecheck` — all errors are pre-existing in `scripts/` and unrelated.
- [x] `npm test` — 1020/1020 pass.
- [ ] Manual: edit a partner application's per-domain scope, save, reload — formatting persists.
- [ ] Manual: create a new InternToFull form version with an info block containing bold/italic/links + an applicant view; renders correctly.
- [ ] Manual: an existing partner application with a pre-migration scope row still renders cleanly (single paragraph).
- [ ] Manual: an existing InternToFull form version whose `data.body` is still a plain string renders cleanly (legacy string path in `<InfoBody>`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/719"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782477317&installation_id=133523038&pr_number=719&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F719&signature=fcf9c01f5ba554407b54f21084b83c28b80b83403320d3f2d0f1641844a2fd13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->