### PR TITLE
Page presence: photo chips, hover cards, click-to-profile

### DIFF
--- a/dali-api/app/components/DocumentEditor.tsx
+++ b/dali-api/app/components/DocumentEditor.tsx
@@ -3,6 +3,7 @@ import { useRevalidator } from "react-router";
 import { FileDown } from "lucide-react";
 import { CollaborativeEditor, type CommentAnchor } from "./CollaborativeEditor";
 import { PresenceProvider } from "./collab/PresenceProvider";
+import { PresenceBar } from "./collab/PresenceBar";
 import { CommentsRail, type Comment } from "./collab/CommentsRail";
 import { TagPicker, type DocTag } from "./TagPicker";
 
@@ -21,6 +22,8 @@ export function DocumentEditor({
   collabToken,
   userName,
   currentUserId,
+  photoUrl,
+  subtitle,
   canEdit,
   tags,
   allTags,
@@ -30,6 +33,8 @@ export function DocumentEditor({
   collabToken: string | null;
   userName: string;
   currentUserId: string;
+  photoUrl?: string | null;
+  subtitle?: string | null;
   canEdit: boolean;
   tags: DocTag[];
   allTags: DocTag[];
@@ -85,7 +90,7 @@ export function DocumentEditor({
     [],
   );
 
-  return (
+  const body = (
     <div className="grid grid-cols-1 lg:grid-cols-[1fr_320px] gap-6">
       <div className="min-w-0">
         {/* Notion-style title — large, bold, borderless; doubles as the doc
@@ -111,6 +116,7 @@ export function DocumentEditor({
             />
             <div className="flex items-center gap-2 text-xs">
               {savingTitle && <span className="text-muted-foreground">Saving…</span>}
+              <PresenceBar />
               <a
                 href={`/documents/${pageId}/export?format=pdf`}
                 className="inline-flex items-center gap-1 px-2 py-1 rounded border border-border hover:bg-muted text-muted-foreground hover:text-foreground"
@@ -128,25 +134,23 @@ export function DocumentEditor({
         </div>
 
         {collabToken ? (
-          <PresenceProvider pageId={`doc:${pageId}`} token={collabToken} userName={userName}>
-            <CollaborativeEditor
-              editorId={`doc:${pageId}:body`}
-              documentName={`doc:${pageId}:body`}
-              token={collabToken}
-              userName={userName}
-              disabled={!canEdit}
-              placeholder="Start writing…"
-              className="min-h-[60vh]"
-              inlineComments={{
-                enabled: true,
-                anchors,
-                onRequestComment: (a) => setPendingAnchor(a),
-                onReady: (api) => {
-                  focusAnchorRef.current = api.focusAnchor;
-                },
-              }}
-            />
-          </PresenceProvider>
+          <CollaborativeEditor
+            editorId={`doc:${pageId}:body`}
+            documentName={`doc:${pageId}:body`}
+            token={collabToken}
+            userName={userName}
+            disabled={!canEdit}
+            placeholder="Start writing…"
+            className="min-h-[60vh]"
+            inlineComments={{
+              enabled: true,
+              anchors,
+              onRequestComment: (a) => setPendingAnchor(a),
+              onReady: (api) => {
+                focusAnchorRef.current = api.focusAnchor;
+              },
+            }}
+          />
         ) : (
           <p className="text-sm text-muted-foreground italic">
             Sign in again to edit this document.
@@ -167,5 +171,22 @@ export function DocumentEditor({
         />
       </aside>
     </div>
+  );
+
+  // Provider wraps the whole surface so PresenceBar (in the header row) and
+  // the editor share one presence room.
+  return collabToken ? (
+    <PresenceProvider
+      pageId={`doc:${pageId}`}
+      token={collabToken}
+      userName={userName}
+      userId={currentUserId}
+      photoUrl={photoUrl}
+      subtitle={subtitle}
+    >
+      {body}
+    </PresenceProvider>
+  ) : (
+    body
   );
 }

--- a/dali-api/app/components/collab/PresenceBar.tsx
+++ b/dali-api/app/components/collab/PresenceBar.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import { Link } from "react-router";
 import { usePresence, type Peer } from "./PresenceProvider";
 import { initialsFromName } from "./util";
 
@@ -12,12 +13,11 @@ interface PresenceBarProps {
 }
 
 /**
- * Minimal page-level presence indicator: an overlapping avatar stack with
- * a tiny connection dot. No card chrome, no sticky positioning — meant to
- * be tucked inline (e.g. into a header row), Notion-style.
+ * Page-level presence indicator: an overlapping avatar stack with photos
+ * (initials fallback), a hover card per peer, and click-to-profile.
  *
  * Reads from the surrounding <PresenceProvider>; renders nothing if none is
- * in tree, or if the only peer is "me".
+ * in tree, or if the only peer present is the local user.
  */
 export function PresenceBar({ className, max = 4 }: PresenceBarProps) {
   const ctx = usePresence();
@@ -25,11 +25,12 @@ export function PresenceBar({ className, max = 4 }: PresenceBarProps) {
 
   const visiblePeers = useMemo<Peer[]>(() => {
     if (!peers) return [];
-    // Dedupe by name+color so multiple tabs from the same human collapse.
-    // Prefer active over idle, and the "me" record over duplicates.
+    // Dedupe key prefers userId (stable across tabs/renames). Falls back to
+    // name+color for peers broadcast before the infra upgrade landed. Keep
+    // the active record over an idle dupe, and the "me" record over others.
     const seen = new Map<string, Peer>();
     for (const p of peers) {
-      const key = `${p.name}|${p.color}`;
+      const key = p.userId ? `id:${p.userId}` : `nc:${p.name}|${p.color}`;
       const existing = seen.get(key);
       if (
         !existing ||
@@ -48,7 +49,8 @@ export function PresenceBar({ className, max = 4 }: PresenceBarProps) {
 
   if (!ctx) return null;
   // Hide entirely when nobody else is here.
-  if (visiblePeers.length <= 1 && ctx.connected) return null;
+  const remoteCount = visiblePeers.filter((p) => !p.isMe).length;
+  if (remoteCount === 0 && ctx.connected) return null;
 
   const shown = visiblePeers.slice(0, max);
   const overflow = Math.max(0, visiblePeers.length - shown.length);
@@ -56,44 +58,21 @@ export function PresenceBar({ className, max = 4 }: PresenceBarProps) {
   return (
     <div
       className={`inline-flex items-center gap-2 text-xs text-muted-foreground/70 ${className ?? ""}`}
-      title={
-        ctx.connected
-          ? `${visiblePeers.length} viewing`
-          : "Connecting to presence..."
-      }
     >
       {!ctx.connected && (
         <span
           className="w-1.5 h-1.5 rounded-full bg-yellow-500 animate-pulse"
-          aria-label="Connecting"
+          aria-label="Connecting to presence"
         />
       )}
       <div className="flex items-center -space-x-1.5">
-        {shown.map((p) => {
-          const followable = !p.isMe && !!p.currentEditor;
-          const tooltip = p.isMe
-            ? `${p.name} (you)`
-            : !p.currentEditor
-              ? `${p.name}${p.idle ? " (idle)" : ""}`
-              : `${p.name}${p.idle ? " (idle)" : ""} — click to jump to their cursor`;
-          return (
-            <button
-              key={p.clientId}
-              type="button"
-              onClick={() => followable && ctx.followPeer(p.clientId)}
-              disabled={!followable}
-              title={tooltip}
-              className={`relative inline-flex items-center justify-center w-6 h-6 rounded-full text-[10px] font-semibold text-white ring-2 ring-white transition-transform ${
-                followable
-                  ? "cursor-pointer hover:z-10 hover:scale-110"
-                  : "cursor-default"
-              } ${p.idle ? "opacity-50" : "opacity-100"}`}
-              style={{ backgroundColor: p.color }}
-            >
-              {initialsFromName(p.name)}
-            </button>
-          );
-        })}
+        {shown.map((p) => (
+          <PresenceChip
+            key={p.clientId}
+            peer={p}
+            onFollow={ctx.followPeer}
+          />
+        ))}
         {overflow > 0 && (
           <span
             className="relative inline-flex items-center justify-center w-6 h-6 rounded-full text-[10px] font-semibold text-muted-foreground bg-muted ring-2 ring-white"
@@ -101,6 +80,139 @@ export function PresenceBar({ className, max = 4 }: PresenceBarProps) {
           >
             +{overflow}
           </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ChipAvatar({ peer }: { peer: Peer }) {
+  if (peer.photoUrl) {
+    return (
+      <img
+        src={peer.photoUrl}
+        alt=""
+        className="w-full h-full rounded-full object-cover"
+        draggable={false}
+      />
+    );
+  }
+  return (
+    <span
+      className="w-full h-full rounded-full flex items-center justify-center text-white text-[10px] font-semibold"
+      style={{ backgroundColor: peer.color }}
+    >
+      {initialsFromName(peer.name)}
+    </span>
+  );
+}
+
+function PresenceChip({
+  peer,
+  onFollow,
+}: {
+  peer: Peer;
+  onFollow: (clientId: number) => void;
+}) {
+  const followable = !peer.isMe && !!peer.currentEditor;
+  const linkable = !!peer.userId && !peer.isMe;
+  const idleClass = peer.idle ? "opacity-50" : "opacity-100";
+  const interactiveClass =
+    linkable || peer.isMe
+      ? "cursor-pointer hover:z-10 hover:scale-110"
+      : "cursor-default";
+
+  const chipInner = (
+    <span
+      className={`relative inline-flex items-center justify-center w-6 h-6 rounded-full overflow-hidden ring-2 ring-white transition-transform ${interactiveClass} ${idleClass}`}
+    >
+      <ChipAvatar peer={peer} />
+    </span>
+  );
+
+  return (
+    <div className="relative group">
+      {linkable ? (
+        <Link
+          to={`/members/${peer.userId}`}
+          aria-label={`View ${peer.name}'s profile`}
+          className="block focus:outline-none focus-visible:ring-2 focus-visible:ring-foreground rounded-full"
+        >
+          {chipInner}
+        </Link>
+      ) : peer.isMe && peer.userId ? (
+        <Link
+          to={`/members/${peer.userId}`}
+          aria-label="Your profile"
+          className="block focus:outline-none focus-visible:ring-2 focus-visible:ring-foreground rounded-full"
+        >
+          {chipInner}
+        </Link>
+      ) : (
+        chipInner
+      )}
+      <HoverCard peer={peer} followable={followable} onFollow={onFollow} />
+    </div>
+  );
+}
+
+function HoverCard({
+  peer,
+  followable,
+  onFollow,
+}: {
+  peer: Peer;
+  followable: boolean;
+  onFollow: (clientId: number) => void;
+}) {
+  const meTag = peer.isMe ? " (you)" : "";
+  const idleTag = peer.idle ? " · idle" : "";
+
+  return (
+    <div
+      role="tooltip"
+      className="pointer-events-none absolute left-1/2 top-full z-20 mt-2 -translate-x-1/2 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity"
+    >
+      <div className="pointer-events-auto min-w-[12rem] max-w-[16rem] rounded-md border border-border bg-popover text-popover-foreground shadow-lg p-2.5 text-left">
+        <div className="flex items-center gap-2">
+          <div className="w-8 h-8 shrink-0 rounded-full overflow-hidden">
+            <ChipAvatar peer={peer} />
+          </div>
+          <div className="min-w-0">
+            <div className="text-sm font-medium text-foreground truncate">
+              {peer.name}
+              <span className="text-muted-foreground font-normal">
+                {meTag}
+                {idleTag}
+              </span>
+            </div>
+            {peer.subtitle && (
+              <div className="text-[11px] text-muted-foreground truncate">
+                {peer.subtitle}
+              </div>
+            )}
+          </div>
+        </div>
+        {!peer.isMe && (peer.userId || followable) && (
+          <div className="mt-2 flex items-center gap-2">
+            {peer.userId && (
+              <Link
+                to={`/members/${peer.userId}`}
+                className="text-[11px] text-foreground underline-offset-2 hover:underline"
+              >
+                View profile →
+              </Link>
+            )}
+            {followable && (
+              <button
+                type="button"
+                onClick={() => onFollow(peer.clientId)}
+                className="text-[11px] text-foreground underline-offset-2 hover:underline"
+              >
+                Jump to cursor
+              </button>
+            )}
+          </div>
         )}
       </div>
     </div>

--- a/dali-api/app/components/collab/PresenceProvider.tsx
+++ b/dali-api/app/components/collab/PresenceProvider.tsx
@@ -38,6 +38,9 @@ export interface Peer {
   idle: boolean;
   isMe: boolean;
   currentEditor?: string;
+  userId?: string;
+  photoUrl?: string | null;
+  subtitle?: string | null;
 }
 
 interface EditorRegistration {
@@ -123,7 +126,10 @@ function peersEqual(a: Peer[], b: Peer[]): boolean {
       x.color !== y.color ||
       x.idle !== y.idle ||
       x.isMe !== y.isMe ||
-      x.currentEditor !== y.currentEditor
+      x.currentEditor !== y.currentEditor ||
+      x.userId !== y.userId ||
+      x.photoUrl !== y.photoUrl ||
+      x.subtitle !== y.subtitle
     ) {
       return false;
     }
@@ -136,6 +142,9 @@ interface PresenceProviderProps {
   token: string | null | undefined;
   userName: string;
   userColor?: string;
+  userId?: string;
+  photoUrl?: string | null;
+  subtitle?: string | null;
   children: ReactNode;
 }
 
@@ -144,6 +153,9 @@ export function PresenceProvider({
   token,
   userName,
   userColor,
+  userId,
+  photoUrl,
+  subtitle,
   children,
 }: PresenceProviderProps) {
   const [entry, setEntry] = useState<DocEntry | null>(null);
@@ -156,9 +168,15 @@ export function PresenceProvider({
   // followPeer stay identity-stable across awareness ticks.
   const userNameRef = useRef(userName);
   const colorRef = useRef(color);
+  const userIdRef = useRef(userId);
+  const photoUrlRef = useRef(photoUrl);
+  const subtitleRef = useRef(subtitle);
   const peersRef = useRef<Peer[]>([]);
   userNameRef.current = userName;
   colorRef.current = color;
+  userIdRef.current = userId;
+  photoUrlRef.current = photoUrl;
+  subtitleRef.current = subtitle;
   peersRef.current = peers;
 
   const editorsRef = useRef(new Map<string, EditorRegistration>());
@@ -194,6 +212,9 @@ export function PresenceProvider({
           idle: !!u.idle,
           isMe: clientId === entry.ydoc.clientID,
           currentEditor: u.currentEditor,
+          userId: u.userId,
+          photoUrl: u.photoUrl ?? null,
+          subtitle: u.subtitle ?? null,
         });
       });
       // Bail when shape-relevant fields are unchanged. Awareness fires on
@@ -223,6 +244,9 @@ export function PresenceProvider({
         ...patch,
         name: userNameRef.current,
         color: colorRef.current,
+        userId: userIdRef.current,
+        photoUrl: photoUrlRef.current ?? null,
+        subtitle: subtitleRef.current ?? null,
       } satisfies AwarenessUser);
     },
     [entry],

--- a/dali-api/app/components/collab/util.ts
+++ b/dali-api/app/components/collab/util.ts
@@ -38,4 +38,10 @@ export interface AwarenessUser {
    * across blur — peer remains associated with their last-focused editor.
    */
   currentEditor?: string;
+  /** User.id — when present, drives dedupe and the "click to profile" link. */
+  userId?: string;
+  /** Resolved photo URL; chips fall back to colored initials when null. */
+  photoUrl?: string | null;
+  /** One-line headline shown in the hover card (e.g. email · class-year). */
+  subtitle?: string | null;
 }

--- a/dali-api/app/hiring/routes/interviewer.interview.$interviewId.tsx
+++ b/dali-api/app/hiring/routes/interviewer.interview.$interviewId.tsx
@@ -15,6 +15,7 @@ import {
 import { prisma } from '~/lib/db'
 import { requireAuth } from "~/lib/auth";
 import { parseSessionCookie } from '~/lib/cookies'
+import { getPresenceUser } from '~/lib/presence-user'
 import { requirePageSignedOrRedirect } from '~/hiring/lib/confidentiality'
 import { presignAnswers } from '~/hiring/lib/presign'
 import { CollaborativeEditor } from '~/components/CollaborativeEditor'
@@ -166,7 +167,9 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   }
 
   // Build user display name for cursors
-  const userName = [member.firstName, member.lastName].filter(Boolean).join(' ') || auth.user.email
+  const fallbackName = [member.firstName, member.lastName].filter(Boolean).join(' ') || auth.user.email
+  const presenceUser = await getPresenceUser(auth.user.sub, fallbackName)
+  const userName = presenceUser?.name ?? fallbackName
 
   return {
       interview: interviewWithPresignedAnswers,
@@ -174,12 +177,23 @@ export async function loader({ request, params }: Route.LoaderArgs) {
       criteriaByKey,
       collabToken,
       userName,
+      currentUserId: auth.user.sub,
+      presencePhotoUrl: presenceUser?.photoUrl ?? null,
+      presenceSubtitle: presenceUser?.subtitle ?? null,
     }
 }
 
 export default function InterviewDetailPage() {
-  const { interview, myAssignment, criteriaByKey, collabToken, userName } =
-    useLoaderData<typeof loader>() as any
+  const {
+    interview,
+    myAssignment,
+    criteriaByKey,
+    collabToken,
+    userName,
+    currentUserId,
+    presencePhotoUrl,
+    presenceSubtitle,
+  } = useLoaderData<typeof loader>() as any
 
   const applicant = interview.domainApplication?.application?.user
   const domain = interview.domainApplication?.challengeVersion?.domain?.name
@@ -310,6 +324,9 @@ export default function InterviewDetailPage() {
       pageId={`interview:${interview.id}`}
       token={collabToken}
       userName={userName}
+      userId={currentUserId}
+      photoUrl={presencePhotoUrl}
+      subtitle={presenceSubtitle}
     >
     <div className="space-y-8 max-w-6xl mx-auto">
       {/* Back button + presence avatars inline */}

--- a/dali-api/app/hiring/routes/lead.cycle.$id.tsx
+++ b/dali-api/app/hiring/routes/lead.cycle.$id.tsx
@@ -4,6 +4,10 @@ import type { Route } from "./+types/lead.cycle.$id";
 import { prisma } from "~/lib/db";
 import { requireAuth } from "~/lib/auth";
 import { isCore } from "~/lib/roles";
+import { parseSessionCookie } from "~/lib/cookies";
+import { getPresenceUser } from "~/lib/presence-user";
+import { PresenceProvider } from "~/components/collab/PresenceProvider";
+import { PresenceBar } from "~/components/collab/PresenceBar";
 import { renderEmail } from "~/lib/email";
 import {
   TEMPLATE_VARIABLES,
@@ -389,6 +393,9 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     })),
   };
 
+  const collabToken = parseSessionCookie(request);
+  const presenceUser = await getPresenceUser(auth.user.sub);
+
   return {
       cycle: cycleWithCvNumbers,
       allDomains,
@@ -408,6 +415,11 @@ export async function loader({ request, params }: Route.LoaderArgs) {
       currentConfidentialityBinding,
       confidentialitySignatures,
       confidentialityRequired,
+      collabToken,
+      currentUserId: auth.user.sub,
+      presenceUserName: presenceUser?.name ?? auth.user.email,
+      presencePhotoUrl: presenceUser?.photoUrl ?? null,
+      presenceSubtitle: presenceUser?.subtitle ?? null,
     };
 }
 
@@ -1466,13 +1478,16 @@ export default function HiringLeadCycleDetails() {
     }
   }
 
-  return (
+  const page = (
     <div className="space-y-6">
       <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
         <h1 className="text-2xl font-bold text-foreground">{cycle?.name ?? 'Cycle Management'}</h1>
         <span className={`inline-flex items-center px-3 py-1 rounded-full text-sm font-bold ${STATUS_COLORS[cycleStatus] ?? ''}`}>
           {STATUS_LABELS[cycleStatus] ?? cycleStatus}
         </span>
+        <div className="ml-auto">
+          <PresenceBar />
+        </div>
         <p className="w-full text-xs text-muted-foreground">
           Cycle ID <span className="font-mono bg-muted px-1.5 py-0.5 rounded">{cycleId}</span>
         </p>
@@ -3212,6 +3227,26 @@ export default function HiringLeadCycleDetails() {
         )
       })()}
     </div>
+  )
+
+  const collabToken = loaderData?.collabToken as string | null | undefined
+  const currentUserId = loaderData?.currentUserId as string | undefined
+  const presenceUserName = (loaderData?.presenceUserName as string | undefined) ?? ''
+  const presencePhotoUrl = (loaderData?.presencePhotoUrl as string | null | undefined) ?? null
+  const presenceSubtitle = (loaderData?.presenceSubtitle as string | null | undefined) ?? null
+  return collabToken ? (
+    <PresenceProvider
+      pageId={`cycle:${cycleId}`}
+      token={collabToken}
+      userName={presenceUserName}
+      userId={currentUserId}
+      photoUrl={presencePhotoUrl}
+      subtitle={presenceSubtitle}
+    >
+      {page}
+    </PresenceProvider>
+  ) : (
+    page
   )
 }
 

--- a/dali-api/app/hiring/routes/reviewer.application.$id.tsx
+++ b/dali-api/app/hiring/routes/reviewer.application.$id.tsx
@@ -5,6 +5,7 @@ import { prisma } from '~/lib/db'
 import { requireAuth } from "~/lib/auth";
 import { hasCycleAccess } from '~/lib/roles'
 import { parseSessionCookie } from '~/lib/cookies'
+import { getPresenceUser } from '~/lib/presence-user'
 import { requirePageSignedOrRedirect } from '~/hiring/lib/confidentiality'
 import { presignAnswers } from '~/hiring/lib/presign'
 import type { Route } from './+types/reviewer.application.$id'
@@ -165,9 +166,21 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 
   // Pass JWT for WebSocket auth
   const collabToken = parseSessionCookie(request)
-  const userName = [reviewer.firstName, reviewer.lastName].filter(Boolean).join(' ') || auth.user.email
+  const fallbackName =
+    [reviewer.firstName, reviewer.lastName].filter(Boolean).join(' ') || auth.user.email
+  const presenceUser = await getPresenceUser(auth.user.sub, fallbackName)
+  const userName = presenceUser?.name ?? fallbackName
 
-  return { application, reviewer, existingReview: review, collabToken, userName }
+  return {
+    application,
+    reviewer,
+    existingReview: review,
+    collabToken,
+    userName,
+    currentUserId: auth.user.sub,
+    presencePhotoUrl: presenceUser?.photoUrl ?? null,
+    presenceSubtitle: presenceUser?.subtitle ?? null,
+  }
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
@@ -231,7 +244,16 @@ export async function action({ request, params }: Route.ActionArgs) {
 const RECOMMENDATIONS = ['Strong Hire', 'Hire', 'Lean Hire', 'Lean No Hire', 'No Hire'] as const
 
 export default function ReviewerApplicationReview() {
-  const { application, reviewer, existingReview, collabToken, userName } = useLoaderData<typeof loader>()
+  const {
+    application,
+    reviewer,
+    existingReview,
+    collabToken,
+    userName,
+    currentUserId,
+    presencePhotoUrl,
+    presenceSubtitle,
+  } = useLoaderData<typeof loader>()
   const submit = useSubmit()
 
   const cycle = application.applicationCycle
@@ -340,6 +362,9 @@ export default function ReviewerApplicationReview() {
       pageId={`review:${existingReview?.id ?? application.id}`}
       token={collabToken}
       userName={userName}
+      userId={currentUserId}
+      photoUrl={presencePhotoUrl}
+      subtitle={presenceSubtitle}
     >
     <div className="space-y-6 pb-12 relative">
       <div>

--- a/dali-api/app/lib/collabAuth.ts
+++ b/dali-api/app/lib/collabAuth.ts
@@ -105,15 +105,17 @@ export async function authorizeCollabDoc(
     return false;
   }
 
-  // doc:{pageId}:body — project document pages. Access mirrors the project
-  // edit gate used by the project document API routes (isCore ===
-  // Admin || Core). The page must be a live (non-archived) Project page.
+  // doc:{pageId}:body — any live FreeForm page. Access mirrors the page edit
+  // gate used by the document API routes (isCore === Admin || Core). The
+  // page must be a live (non-archived) Page; workspaceType is unrestricted
+  // so Lab + EducationOffering pages can be edited the same way as Project
+  // pages.
   if (entity === "doc") {
     const page = await prisma.page.findUnique({
       where: { id },
-      select: { workspaceType: true, archivedAt: true },
+      select: { archivedAt: true },
     });
-    if (!page || page.workspaceType !== "Project" || page.archivedAt !== null) {
+    if (!page || page.archivedAt !== null) {
       return false;
     }
     return isCore(userSub);

--- a/dali-api/app/lib/presence-user.ts
+++ b/dali-api/app/lib/presence-user.ts
@@ -1,0 +1,64 @@
+import { prisma } from "./db";
+import { resolvePhotoUrl } from "./photo";
+
+export interface PresenceUser {
+  userId: string;
+  name: string;
+  photoUrl: string | null;
+  subtitle: string | null;
+}
+
+// Subtitle convention mirrors the profile page header:
+//   "kiran@dali.org · '26"
+// Falls back to whichever email exists, then class-year if present.
+function buildSubtitle(args: {
+  daliEmail: string | null;
+  dartmouthEmail: string | null;
+  email: string;
+  classYear: number | null;
+}): string | null {
+  const email = args.daliEmail ?? args.dartmouthEmail ?? args.email ?? null;
+  const yearTail = args.classYear ? `'${String(args.classYear).slice(-2)}` : null;
+  if (email && yearTail) return `${email} · ${yearTail}`;
+  return email ?? yearTail ?? null;
+}
+
+/**
+ * Fetch the fields PresenceProvider/PresenceBar need for a given user.
+ * Resolves photoUrl through the S3-aware resolver so callers can pass the
+ * result straight to the browser.
+ */
+export async function getPresenceUser(
+  userId: string,
+  fallbackName?: string,
+): Promise<PresenceUser | null> {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: {
+      id: true,
+      firstName: true,
+      lastName: true,
+      email: true,
+      daliEmail: true,
+      dartmouthEmail: true,
+      photoUrl: true,
+      classYear: true,
+    },
+  });
+  if (!user) {
+    if (!fallbackName) return null;
+    return { userId, name: fallbackName, photoUrl: null, subtitle: null };
+  }
+  const name =
+    [user.firstName, user.lastName].filter(Boolean).join(" ") ||
+    fallbackName ||
+    user.email;
+  const photoUrl = await resolvePhotoUrl(user.photoUrl);
+  const subtitle = buildSubtitle({
+    daliEmail: user.daliEmail,
+    dartmouthEmail: user.dartmouthEmail,
+    email: user.email,
+    classYear: user.classYear,
+  });
+  return { userId: user.id, name, photoUrl, subtitle };
+}

--- a/dali-api/app/lib/presence-user.ts
+++ b/dali-api/app/lib/presence-user.ts
@@ -10,14 +10,14 @@ export interface PresenceUser {
 
 // Subtitle convention mirrors the profile page header:
 //   "kiran@dali.org · '26"
-// Falls back to whichever email exists, then class-year if present.
+// Falls back to whichever email column has a value, then class-year alone.
 function buildSubtitle(args: {
   daliEmail: string | null;
   dartmouthEmail: string | null;
-  email: string;
+  personalEmail: string | null;
   classYear: number | null;
 }): string | null {
-  const email = args.daliEmail ?? args.dartmouthEmail ?? args.email ?? null;
+  const email = args.daliEmail ?? args.dartmouthEmail ?? args.personalEmail ?? null;
   const yearTail = args.classYear ? `'${String(args.classYear).slice(-2)}` : null;
   if (email && yearTail) return `${email} · ${yearTail}`;
   return email ?? yearTail ?? null;
@@ -38,9 +38,9 @@ export async function getPresenceUser(
       id: true,
       firstName: true,
       lastName: true,
-      email: true,
       daliEmail: true,
       dartmouthEmail: true,
+      personalEmail: true,
       photoUrl: true,
       classYear: true,
     },
@@ -52,12 +52,15 @@ export async function getPresenceUser(
   const name =
     [user.firstName, user.lastName].filter(Boolean).join(" ") ||
     fallbackName ||
-    user.email;
+    user.daliEmail ||
+    user.dartmouthEmail ||
+    user.personalEmail ||
+    userId;
   const photoUrl = await resolvePhotoUrl(user.photoUrl);
   const subtitle = buildSubtitle({
     daliEmail: user.daliEmail,
     dartmouthEmail: user.dartmouthEmail,
-    email: user.email,
+    personalEmail: user.personalEmail,
     classYear: user.classYear,
   });
   return { userId: user.id, name, photoUrl, subtitle };

--- a/dali-api/app/members/routes/members.$id.tsx
+++ b/dali-api/app/members/routes/members.$id.tsx
@@ -6,8 +6,12 @@ import { requireAuth } from "~/lib/auth";
 import { isAdmin, isCore } from "~/lib/roles";
 import { initialsFromName } from "~/lib/display";
 import { resolvePhotoUrl } from "~/lib/photo";
+import { parseSessionCookie } from "~/lib/cookies";
+import { getPresenceUser } from "~/lib/presence-user";
 import { EditableSection } from "~/components/EditableSection";
 import { PhotoUploadField } from "~/components/PhotoUploadField";
+import { PresenceProvider } from "~/components/collab/PresenceProvider";
+import { PresenceBar } from "~/components/collab/PresenceBar";
 import {
   ALLOWED_LEVELS,
   parseLevel,
@@ -95,6 +99,9 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   // the upload field's hidden input round-trips it unchanged on save.
   const photoUrlResolved = await resolvePhotoUrl(member.photoUrl);
 
+  const collabToken = parseSessionCookie(request);
+  const presenceUser = await getPresenceUser(auth.user.sub);
+
   return {
     member: {
       ...member,
@@ -110,6 +117,11 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     canManageEligibility,
     allDomains,
     photoUrlResolved,
+    collabToken,
+    currentUserId: auth.user.sub,
+    presenceUserName: presenceUser?.name ?? auth.user.email,
+    presencePhotoUrl: presenceUser?.photoUrl ?? null,
+    presenceSubtitle: presenceUser?.subtitle ?? null,
   };
 }
 
@@ -208,7 +220,18 @@ const FIELD_LABELS: Record<string, string> = {
 };
 
 export default function MemberDetail() {
-  const { member, canEdit, canManageEligibility, allDomains, photoUrlResolved } = useLoaderData<typeof loader>();
+  const {
+    member,
+    canEdit,
+    canManageEligibility,
+    allDomains,
+    photoUrlResolved,
+    collabToken,
+    currentUserId,
+    presenceUserName,
+    presencePhotoUrl,
+    presenceSubtitle,
+  } = useLoaderData<typeof loader>();
   const actionData = useActionData<typeof action>();
   const submit = useSubmit();
   const navigation = useNavigation();
@@ -232,11 +255,14 @@ export default function MemberDetail() {
     }
   }, [navigation.state, actionData]);
 
-  return (
+  const page = (
     <div className="flex flex-col gap-4">
-      <Link to="/members" className="text-sm text-muted-foreground hover:text-foreground">
-        ← Back to members
-      </Link>
+      <div className="flex items-center justify-between gap-3">
+        <Link to="/members" className="text-sm text-muted-foreground hover:text-foreground">
+          ← Back to members
+        </Link>
+        <PresenceBar />
+      </div>
 
       <header className="flex flex-col items-center gap-4 text-center">
         {photoUrlResolved ? (
@@ -315,6 +341,21 @@ export default function MemberDetail() {
         canManage={canManageEligibility}
       />
     </div>
+  );
+
+  return collabToken ? (
+    <PresenceProvider
+      pageId={`member:${member.id}`}
+      token={collabToken}
+      userName={presenceUserName}
+      userId={currentUserId}
+      photoUrl={presencePhotoUrl}
+      subtitle={presenceSubtitle}
+    >
+      {page}
+    </PresenceProvider>
+  ) : (
+    page
   );
 }
 

--- a/dali-api/app/projects/routes/projects.$id.tsx
+++ b/dali-api/app/projects/routes/projects.$id.tsx
@@ -13,6 +13,8 @@ import { Check, Pencil, X, Settings } from "lucide-react";
 import { Modal } from "~/components/Modal";
 import { EditableSection } from "~/components/EditableSection";
 import { TagPicker } from "~/components/TagPicker";
+import { PresenceProvider } from "~/components/collab/PresenceProvider";
+import { PresenceBar } from "~/components/collab/PresenceBar";
 import { uploadFileToS3, formatBytes } from "~/lib/upload-client";
 import type { Route } from "./+types/projects.$id";
 import { prisma } from "~/lib/db";
@@ -20,6 +22,7 @@ import { ensureProjectGroup } from "~/lib/groups";
 import { requireAuth } from "~/lib/auth";
 import { parseSessionCookie } from "~/lib/cookies";
 import { isCore, isProjectMember, canManageStaffing, currentTerm } from "~/lib/roles";
+import { getPresenceUser } from "~/lib/presence-user";
 import { TaskBoard } from "../components/TaskBoard";
 import { type TimelineEpic, type EpicStatus } from "../components/EpicsTimeline";
 import {
@@ -232,9 +235,11 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   // Collab editor wiring (same as the hiring routes): session cookie is the
   // WebSocket auth token; userName labels the presence cursor.
   const collabToken = parseSessionCookie(request);
-  const userName =
+  const fallbackName =
     [auth.user.firstName, auth.user.lastName].filter(Boolean).join(" ") ||
     auth.user.email;
+  const presenceUser = await getPresenceUser(auth.user.sub, fallbackName);
+  const userName = presenceUser?.name ?? fallbackName;
 
   // Timeline span: prefer the epic's explicit startsAt/endsAt; fall back to
   // the min/max of its sprint dates when either is unset. Each epic also
@@ -478,6 +483,8 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     collabToken,
     userName,
     currentUserId: auth.user.sub,
+    presencePhotoUrl: presenceUser?.photoUrl ?? null,
+    presenceSubtitle: presenceUser?.subtitle ?? null,
   };
 }
 
@@ -691,6 +698,9 @@ export default function ProjectDetail() {
     currentTerm,
     collabToken,
     userName,
+    currentUserId,
+    presencePhotoUrl,
+    presenceSubtitle,
   } = useLoaderData() as LoaderData;
   const actionData = useActionData<typeof action>();
   const [scopeSettingsOpen, setScopeSettingsOpen] = useState(false);
@@ -709,14 +719,17 @@ export default function ProjectDetail() {
     );
   };
 
-  return (
+  const page = (
     <div className="flex flex-col gap-4">
-      <Link
-        to="/projects/list"
-        className="text-sm text-muted-foreground hover:text-foreground"
-      >
-        ← Back to projects
-      </Link>
+      <div className="flex items-center justify-between gap-3">
+        <Link
+          to="/projects/list"
+          className="text-sm text-muted-foreground hover:text-foreground"
+        >
+          ← Back to projects
+        </Link>
+        <PresenceBar />
+      </div>
 
       {/* Overview header — always on top, not behind a tab */}
       <ProjectHeader
@@ -827,6 +840,21 @@ export default function ProjectDetail() {
         />
       )}
     </div>
+  );
+
+  return collabToken ? (
+    <PresenceProvider
+      pageId={`project:${project.id}`}
+      token={collabToken}
+      userName={userName}
+      userId={currentUserId}
+      photoUrl={presencePhotoUrl}
+      subtitle={presenceSubtitle}
+    >
+      {page}
+    </PresenceProvider>
+  ) : (
+    page
   );
 }
 

--- a/dali-api/app/projects/routes/projects.staffing.tsx
+++ b/dali-api/app/projects/routes/projects.staffing.tsx
@@ -4,6 +4,10 @@ import { requireAuth } from "~/lib/auth";
 import { canManageStaffing, canViewStaffing } from "~/lib/roles";
 import { prisma } from "~/lib/db";
 import { resolvePhotoUrl } from "~/lib/photo";
+import { parseSessionCookie } from "~/lib/cookies";
+import { getPresenceUser } from "~/lib/presence-user";
+import { PresenceProvider } from "~/components/collab/PresenceProvider";
+import { PresenceBar } from "~/components/collab/PresenceBar";
 import { ensureStaffingCycle } from "../lib/staffing-cycle";
 import { getSlotBinding } from "../lib/form-slots";
 import { buildSubmissionView } from "../lib/submission-view.server";
@@ -44,8 +48,18 @@ export async function loader({ request }: Route.LoaderArgs) {
       sortKey: true,
     },
   });
+  const collabToken = parseSessionCookie(request);
+  const presenceUser = await getPresenceUser(auth.user.sub);
+  const presence = {
+    collabToken,
+    currentUserId: auth.user.sub,
+    presenceUserName: presenceUser?.name ?? auth.user.email,
+    presencePhotoUrl: presenceUser?.photoUrl ?? null,
+    presenceSubtitle: presenceUser?.subtitle ?? null,
+  };
+
   if (terms.length === 0) {
-    return { cycle: null, canManage, terms: [] };
+    return { cycle: null, canManage, terms: [], ...presence };
   }
 
   // Current term = the one bracketing now(); if we're between terms, the next
@@ -289,6 +303,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     domainNames,
     demandByProject,
     bidsFormBound,
+    ...presence,
   };
 }
 
@@ -308,15 +323,18 @@ export default function StaffingPage() {
     );
   }
 
-  return (
+  const page = (
     <div className="flex flex-col gap-4">
-      <header>
-        <h1 className="font-heading text-2xl font-bold text-foreground">Staffing</h1>
-        <p className="text-sm text-muted-foreground mt-1">
-          {data.canManage
-            ? "Pick a term, then drag-and-drop project assignments. Changes are saved as Proposed staffing assignments."
-            : "Pick a term to view its proposed assignments."}
-        </p>
+      <header className="flex items-start justify-between gap-3">
+        <div>
+          <h1 className="font-heading text-2xl font-bold text-foreground">Staffing</h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            {data.canManage
+              ? "Pick a term, then drag-and-drop project assignments. Changes are saved as Proposed staffing assignments."
+              : "Pick a term to view its proposed assignments."}
+          </p>
+        </div>
+        <PresenceBar />
       </header>
 
       {!data.bidsFormBound && (
@@ -339,5 +357,20 @@ export default function StaffingPage() {
         canManage={data.canManage}
       />
     </div>
+  );
+
+  return data.collabToken ? (
+    <PresenceProvider
+      pageId={`staffing:term:${data.cycle.termId}`}
+      token={data.collabToken}
+      userName={data.presenceUserName}
+      userId={data.currentUserId}
+      photoUrl={data.presencePhotoUrl}
+      subtitle={data.presenceSubtitle}
+    >
+      {page}
+    </PresenceProvider>
+  ) : (
+    page
   );
 }

--- a/dali-api/app/routes/documents.$pageId.tsx
+++ b/dali-api/app/routes/documents.$pageId.tsx
@@ -4,6 +4,7 @@ import { prisma } from "~/lib/db";
 import { requireAuth } from "~/lib/auth";
 import { parseSessionCookie } from "~/lib/cookies";
 import { isCore } from "~/lib/roles";
+import { getPresenceUser } from "~/lib/presence-user";
 import { DocumentEditor } from "~/components/DocumentEditor";
 
 export const meta: Route.MetaFunction = ({ data }) => {
@@ -27,20 +28,21 @@ export async function loader({ request, params }: Route.LoaderArgs) {
       tags: { select: { tag: { select: { id: true, label: true, slug: true, color: true } } } },
     },
   });
-  // Mirrors the doc gate in authorizeCollabDoc: live Project page only.
-  if (!page || page.workspaceType !== "Project" || page.archivedAt !== null) {
+  // Mirrors the doc gate in authorizeCollabDoc: live page, any workspaceType.
+  if (!page || page.archivedAt !== null) {
     throw new Response("Not found", { status: 404 });
   }
 
   const canEdit = await isCore(auth.user.sub);
 
-  // Resolve the parent project for the back link + breadcrumb.
-  const project = page.workspaceId
-    ? await prisma.project.findUnique({
-        where: { id: page.workspaceId },
-        select: { id: true, name: true },
-      })
-    : null;
+  // Parent project for the back link — only present for Project pages.
+  const project =
+    page.workspaceType === "Project" && page.workspaceId
+      ? await prisma.project.findUnique({
+          where: { id: page.workspaceId },
+          select: { id: true, name: true },
+        })
+      : null;
 
   const allTags = await prisma.docTag.findMany({
     where: { archivedAt: null },
@@ -49,8 +51,9 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   });
 
   const collabToken = parseSessionCookie(request);
-  const userName =
+  const fallbackName =
     [auth.user.firstName, auth.user.lastName].filter(Boolean).join(" ") || auth.user.email;
+  const presenceUser = await getPresenceUser(auth.user.sub, fallbackName);
 
   return {
     pageId: page.id,
@@ -60,23 +63,38 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     project,
     canEdit,
     collabToken,
-    userName,
+    userName: presenceUser?.name ?? fallbackName,
     currentUserId: auth.user.sub,
+    photoUrl: presenceUser?.photoUrl ?? null,
+    subtitle: presenceUser?.subtitle ?? null,
   };
 }
 
 export default function DocumentPage() {
-  const { pageId, title, tags, allTags, project, canEdit, collabToken, userName, currentUserId } =
-    useLoaderData() as Exclude<Awaited<ReturnType<typeof loader>>, Response>;
+  const {
+    pageId,
+    title,
+    tags,
+    allTags,
+    project,
+    canEdit,
+    collabToken,
+    userName,
+    currentUserId,
+    photoUrl,
+    subtitle,
+  } = useLoaderData() as Exclude<Awaited<ReturnType<typeof loader>>, Response>;
 
   return (
     <div className="flex flex-col gap-4">
-      <Link
-        to={project ? `/projects/${project.id}` : "/projects/list"}
-        className="text-sm text-muted-foreground hover:text-foreground"
-      >
-        ← {project ? `Back to ${project.name}` : "Back to projects"}
-      </Link>
+      {project && (
+        <Link
+          to={`/projects/${project.id}`}
+          className="text-sm text-muted-foreground hover:text-foreground"
+        >
+          ← Back to {project.name}
+        </Link>
+      )}
 
       <DocumentEditor
         pageId={pageId}
@@ -84,6 +102,8 @@ export default function DocumentPage() {
         collabToken={collabToken}
         userName={userName}
         currentUserId={currentUserId}
+        photoUrl={photoUrl}
+        subtitle={subtitle}
         canEdit={canEdit}
         tags={tags}
         allTags={allTags}


### PR DESCRIPTION
## Summary
Adds page-level presence indicators across the app. The Yjs awareness payload now carries `userId`, `photoUrl`, and a one-line `subtitle`; `PresenceBar` renders photo-chips (initials fallback), a hover card with profile info + actions, and click-to-profile via `/members/:userId`. Mounted on:

- `/documents/:pageId` (the FreeForm page editor)
- `/projects/:id` (project hub)
- `/members/:id` (member profile)
- `/hiring/lead/cycle/:id` (hiring cycle dashboard)
- `/projects/staffing` (staffing board)
- Existing reviewer + interviewer routes upgrade automatically via the shared loader helper

The chip hides entirely when no remote peer is connected (a single viewer sees nothing). The hover card shows photo + name + `email · 'YY` subtitle, with "View profile →" and (when an editor is focused) "Jump to cursor" actions.

## Notable bundled changes
- **Lab/Education FreeForm pages now render at `/documents/:pageId`.** Loader and `authorizeCollabDoc` no longer gate on `workspaceType === "Project"`; canEdit stays role-based (`isCore`). Lab/Education pages render with the same editor + presence bar; the project-back-link is just hidden when there's no project.
- **`getPresenceUser()` helper** in `app/lib/presence-user.ts` centralizes the photoUrl + subtitle fetch so loaders don't each copy the select.
- **Peer dedupe key** is now `userId` when present (stable across tabs), falling back to name+color for any legacy peer.

## What's NOT in this PR (deferred)
- Structured pages still have no renderer; presence will drop into their header for free once one exists.
- No richer profile card content (role, term, project membership) — keeping the awareness payload tight; we can extend `getPresenceUser` later if we want more.
- Hocuspocus presence rooms accept any signed-in user (existing behavior). Member-profile presence chips leak "person X is viewing person Y's page" to any signed-in lab member. Internal use, low risk, but flagging.

## Test plan
- [ ] Open `/documents/:pageId` from two browsers (different users); confirm the second user appears as a photo chip in the editor header, you don't see yourself when alone.
- [ ] Hover a chip: photo, name, `email · 'YY`, "View profile →" link, "Jump to cursor" action when the peer has the editor focused.
- [ ] Click chip → routes to `/members/:userId`.
- [ ] Repeat on `/projects/:id`, `/members/:id`, hiring cycle dashboard, `/projects/staffing` — chips show, hide-when-alone, click-to-profile.
- [ ] Existing `/applications/:id` + `/interviews/:id` chips now show photos (loaders extended).
- [ ] Open a Lab or EducationOffering FreeForm page via `/documents/:pageId` — renders, editor syncs.
- [ ] Idle behavior: leave a tab untouched 30s, chip dims; remote peer sees the dim.
- [ ] `npm run typecheck` clean for touched files (verified locally — 37 pre-existing errors, none in changed files).
- [ ] `vitest run app/lib/__tests__/collabAuth.test.ts` passes (verified — 18/18).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/722"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782492998&installation_id=133523038&pr_number=722&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F722&signature=50b9d44351962032ec496138640f5bcb721952d9c5acf482cfd061fcf0830665"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->