### PR TITLE
Make availability settings sidebar collapsible

### DIFF
--- a/dali-api/app/calendar/routes/calendar.tsx
+++ b/dali-api/app/calendar/routes/calendar.tsx
@@ -667,23 +667,51 @@ function AvailabilityView({ data }: { data: LoaderData }) {
   // clipped by the inner overflow-hidden on short viewports.
   // Drag-to-create now lives inside AvailabilityWeekGrid: the selection stays
   // drawn on the grid and the editor opens as a popover anchored beside it.
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   return (
-    <div className="grid grid-cols-1 lg:grid-cols-[400px_1fr] gap-6 lg:h-[max(calc(100vh-9rem),56rem)] lg:min-h-0 px-3 pt-2">
-      <aside className="flex flex-col gap-6 lg:overflow-y-auto lg:overflow-x-hidden lg:pr-6 lg:min-h-0">
-        <header>
-          <h1 className="font-heading text-2xl font-bold text-foreground">Availability</h1>
-          <p className="text-sm text-muted-foreground mt-1">
-            Configure when you're available for meetings and pairing.
-          </p>
-        </header>
-        <CalendarIntegrationsCard links={data.calendarLinks} ingestionError={data.ingestionError} />
-        <WorkingHoursCard
-          workingHours={data.workingHours}
-          hasPersisted={data.hasPersistedWorkingHours}
-        />
-        <EventBuffersCard bufferMin={data.defaultEventBufferMin} />
-        <ManualBlocksCard blocks={data.manualBlocks} timezone={data.timezone} />
-      </aside>
+    <div
+      className={`grid grid-cols-1 gap-6 lg:h-[max(calc(100vh-9rem),56rem)] lg:min-h-0 px-3 pt-2 ${
+        sidebarCollapsed ? "lg:grid-cols-[3rem_1fr]" : "lg:grid-cols-[400px_1fr]"
+      }`}
+    >
+      {sidebarCollapsed ? (
+        <button
+          type="button"
+          onClick={() => setSidebarCollapsed(false)}
+          className="hidden lg:flex lg:flex-col lg:items-center lg:min-h-0 rounded-lg border border-border py-3 text-muted-foreground hover:bg-muted hover:text-foreground"
+          aria-label="Expand availability settings"
+          title="Expand settings"
+        >
+          <ChevronRight className="h-5 w-5 shrink-0" />
+        </button>
+      ) : (
+        <aside className="flex flex-col gap-6 lg:overflow-y-auto lg:overflow-x-hidden lg:pr-6 lg:min-h-0">
+          <header className="flex items-start justify-between gap-2">
+            <div>
+              <h1 className="font-heading text-2xl font-bold text-foreground">Availability</h1>
+              <p className="text-sm text-muted-foreground mt-1">
+                Configure when you're available for meetings and pairing.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={() => setSidebarCollapsed(true)}
+              className="hidden lg:inline-flex shrink-0 rounded-md border border-border p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+              aria-label="Collapse availability settings"
+              title="Collapse settings"
+            >
+              <ChevronLeft className="h-4 w-4" />
+            </button>
+          </header>
+          <CalendarIntegrationsCard links={data.calendarLinks} ingestionError={data.ingestionError} />
+          <WorkingHoursCard
+            workingHours={data.workingHours}
+            hasPersisted={data.hasPersistedWorkingHours}
+          />
+          <EventBuffersCard bufferMin={data.defaultEventBufferMin} />
+          <ManualBlocksCard blocks={data.manualBlocks} timezone={data.timezone} />
+        </aside>
+      )}
       <div className="lg:overflow-hidden lg:min-h-0">
         <AvailabilityWeekGrid data={data} enableDragCreate />
       </div>


### PR DESCRIPTION
## What

Adds a collapse toggle to the left settings column on the Availability calendar page (`app/calendar/routes/calendar.tsx`).

- A **collapse** chevron sits in the sidebar header next to the "Availability" title.
- When collapsed, the left column shrinks from `400px` to a thin (`3rem`) full-height bordered rail with an **expand** chevron, giving the week grid more horizontal room.
- The toggle is `lg:`-only, since the layout already stacks into a single column on mobile.

## Notes

- UI-only change, local component state (`sidebarCollapsed`); no data, schema, or collab-doc impact.
- Reuses existing `lucide-react` chevron icons and the page's existing `border-border` / `hover:bg-muted` styling.
- `npm run typecheck` is clean for the changed file (pre-existing errors in unrelated `scripts/` files are untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/723"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782493234&installation_id=133523038&pr_number=723&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F723&signature=8b55f6c3cb8713877c407fda25ce32bfde87d66c9324fff5fce24e27eead6da8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->