### PR TITLE
Preserve selected term across staffing bid detail navigation

### DIFF
--- a/dali-api/app/projects/components/StaffingBoard.tsx
+++ b/dali-api/app/projects/components/StaffingBoard.tsx
@@ -37,6 +37,9 @@ type Props = {
   projects: ProjectMeta[];
   members: MemberInput[];
   initialAssignments: Assignment[];
+  // Project id → name for label resolution. Covers archived projects a member
+  // ranked that aren't board columns, so cards/modal never show a raw id.
+  projectNames: Record<string, string>;
   domainNames: Record<string, string>;
   demandByProject: Record<string, DomainDemand[]>;
   /** Staffing leads can drag. Members get a read-only board. */
@@ -50,6 +53,7 @@ export function StaffingBoard({
   projects,
   members,
   initialAssignments,
+  projectNames,
   domainNames,
   demandByProject,
   canManage,
@@ -61,10 +65,6 @@ export function StaffingBoard({
   // Project id whose finalize modal is open, or null.
   const [finalizeProjectId, setFinalizeProjectId] = useState<string | null>(null);
 
-  const projectNames = useMemo(
-    () => Object.fromEntries(projects.map((p) => [p.id, p.name])),
-    [projects],
-  );
   const projectIds = useMemo(() => projects.map((p) => p.id), [projects]);
 
   const board = useMemo(

--- a/dali-api/app/projects/components/SubmissionDatabase.tsx
+++ b/dali-api/app/projects/components/SubmissionDatabase.tsx
@@ -25,12 +25,19 @@ export function SubmissionDatabase({
 }: {
   columns: DbColumn[];
   rows: DbRow[];
-  // Row links to `${detailBase}/${userId}` (term query string already on it
-  // if needed — caller builds it).
+  // Path the row links under: `${detailBase-path}/${userId}`. May carry a
+  // `?term=` query string (caller builds it); we splice the userId into the
+  // path so the query stays after it: `/base/userId?term=...`.
   detailBase: string;
   emptyMessage: string;
 }) {
   const navigate = useNavigate();
+
+  const detailUrl = (userId: string) => {
+    const [path, query] = detailBase.split("?");
+    const base = `${path.replace(/\/$/, "")}/${userId}`;
+    return query ? `${base}?${query}` : base;
+  };
 
   if (rows.length === 0) {
     return (
@@ -58,7 +65,7 @@ export function SubmissionDatabase({
             <tr
               key={r.userId}
               onClick={() => {
-                const url = `${detailBase}/${r.userId}`;
+                const url = detailUrl(r.userId);
                 if (!requestOpenTabIfEmbedded(url, r.name)) navigate(url);
               }}
               className="border-t border-border hover:bg-muted/20 cursor-pointer"

--- a/dali-api/app/projects/routes/projects.intent-to-work.$userId.tsx
+++ b/dali-api/app/projects/routes/projects.intent-to-work.$userId.tsx
@@ -5,7 +5,7 @@ import { canViewStaffing, currentTerm } from "~/lib/roles";
 import { prisma } from "~/lib/db";
 import { ensureStaffingCycle } from "../lib/staffing-cycle";
 import { getSlotBinding } from "../lib/form-slots";
-import { resolveTermFilter } from "~/lib/terms";
+import { ALL_TERMS, resolveTermFilter } from "~/lib/terms";
 import { buildSubmissionView } from "../lib/submission-view.server";
 
 const SLOT = "intent-to-work" as const;
@@ -61,6 +61,11 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     // can see they're not currently surfaced in the board table.
     fields: row.detailFields,
     cycleName: cycle.name,
+    // Preserve the viewed term on the way back, so the list reopens on the
+    // same term instead of resetting to the current one.
+    backTo: `/projects/intent-to-work?term=${encodeURIComponent(
+      isAll ? ALL_TERMS : term.id,
+    )}`,
   };
 }
 
@@ -70,7 +75,7 @@ export default function IntentSubmissionDetail() {
     <div className="flex flex-col gap-6">
       <div>
         <Link
-          to="/projects/intent-to-work"
+          to={data.backTo}
           className="text-sm text-accent-coral hover:underline"
         >
           ← Back to Intent to Work

--- a/dali-api/app/projects/routes/projects.intent-to-work.tsx
+++ b/dali-api/app/projects/routes/projects.intent-to-work.tsx
@@ -344,7 +344,9 @@ function Loaded({
           <SubmissionDatabase
             columns={data.tableColumns}
             rows={filtered}
-            detailBase="/projects/intent-to-work"
+            // Carry the viewed term to the detail page; without it the detail
+            // loader falls back to currentTerm() and opens the wrong term.
+            detailBase={`/projects/intent-to-work?term=${encodeURIComponent(data.selectedTerm)}`}
             emptyMessage={
               data.submissions.length === 0
                 ? "No intent submissions yet."

--- a/dali-api/app/projects/routes/projects.project-bids.$userId.tsx
+++ b/dali-api/app/projects/routes/projects.project-bids.$userId.tsx
@@ -5,7 +5,7 @@ import { canViewStaffing, currentTerm } from "~/lib/roles";
 import { prisma } from "~/lib/db";
 import { ensureStaffingCycle } from "../lib/staffing-cycle";
 import { getSlotBinding } from "../lib/form-slots";
-import { resolveTermFilter } from "~/lib/terms";
+import { ALL_TERMS, resolveTermFilter } from "~/lib/terms";
 import { buildSubmissionView } from "../lib/submission-view.server";
 
 const SLOT = "project-bids" as const;
@@ -64,6 +64,11 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     // can see they're not currently surfaced in the board table.
     fields: row.detailFields,
     cycleName: cycle.name,
+    // Preserve the viewed term on the way back, so the list reopens on the
+    // same term instead of resetting to the current one.
+    backTo: `/projects/project-bids?term=${encodeURIComponent(
+      isAll ? ALL_TERMS : term.id,
+    )}`,
   };
 }
 
@@ -73,7 +78,7 @@ export default function ProjectBidSubmissionDetail() {
     <div className="flex flex-col gap-6">
       <div>
         <Link
-          to="/projects/project-bids"
+          to={data.backTo}
           className="text-sm text-accent-coral hover:underline"
         >
           ← Back to Project Bids

--- a/dali-api/app/projects/routes/projects.project-bids.tsx
+++ b/dali-api/app/projects/routes/projects.project-bids.tsx
@@ -342,7 +342,11 @@ function Loaded({
           <SubmissionDatabase
             columns={data.tableColumns}
             rows={filtered}
-            detailBase="/projects/project-bids"
+            // Carry the viewed term through to the detail page. Without it the
+            // detail loader falls back to currentTerm(), so a bid opened from
+            // 26X would load 26S. selectedTerm is a term id (or the ALL_TERMS
+            // sentinel, which the detail loader resolves the same way).
+            detailBase={`/projects/project-bids?term=${encodeURIComponent(data.selectedTerm)}`}
             emptyMessage={
               data.submissions.length === 0
                 ? "No bid submissions yet."

--- a/dali-api/app/projects/routes/projects.staffing.tsx
+++ b/dali-api/app/projects/routes/projects.staffing.tsx
@@ -245,6 +245,26 @@ export async function loader({ request }: Route.LoaderArgs) {
 
   const domainNames = Object.fromEntries(domains.map((d) => [d.id, d.displayName]));
 
+  // Project columns are non-archived only (you can't staff into an archived
+  // project), but a member can still have ranked one that was later archived.
+  // Resolve names for every project any preference references so the card/modal
+  // shows the project name instead of leaking the raw id. Archived projects
+  // stay out of `projects` (no droppable column) — this map is labels only.
+  const referencedProjectIds = Array.from(
+    new Set(preferences.map((p) => p.projectId)),
+  ).filter((id) => !projects.some((p) => p.id === id));
+  const extraProjectNames =
+    referencedProjectIds.length > 0
+      ? await prisma.project.findMany({
+          where: { id: { in: referencedProjectIds } },
+          select: { id: true, name: true },
+        })
+      : [];
+  const projectNames: Record<string, string> = {
+    ...Object.fromEntries(projects.map((p) => [p.id, p.name])),
+    ...Object.fromEntries(extraProjectNames.map((p) => [p.id, p.name])),
+  };
+
   // Sum slots per (project, domain), drop zero rows, sort the per-project
   // list alphabetically so the chip order is stable run-to-run.
   const demandTotals = new Map<string, number>();
@@ -286,6 +306,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     projects,
     members,
     initialAssignments,
+    projectNames,
     domainNames,
     demandByProject,
     bidsFormBound,
@@ -334,6 +355,7 @@ export default function StaffingPage() {
         projects={data.projects}
         members={data.members}
         initialAssignments={data.initialAssignments}
+        projectNames={data.projectNames}
         domainNames={data.domainNames}
         demandByProject={data.demandByProject}
         canManage={data.canManage}


### PR DESCRIPTION
## What

The Project Bids and Intent to Work boards are term-scoped via a `?term=` filter, but the per-member detail links dropped it. Opening a submission from term **26X** — or hitting **Back** afterwards — fell through to the detail loader's `currentTerm()` fallback and silently landed on **26S**.

## Changes

- **Forward navigation:** each board's row link now carries the viewed term (`?term=<selectedTerm>`). `SubmissionDatabase` splices the `userId` into the path so the query string stays after it (`/base/userId?term=…`).
- **Back navigation:** the detail loaders (`projects.project-bids.$userId`, `projects.intent-to-work.$userId`) now return a `backTo` that re-applies the term, so the list reopens on the same term instead of resetting to the current one. The all-terms view round-trips via the `ALL_TERMS` sentinel.
- **Archived-project id leak:** the staffing board showed a raw project id (a cuid) when a member ranked a project that was later archived, because the column query excludes archived projects. Columns stay non-archived (you can't staff into an archived project), but the label map now resolves names for *every* project a preference references, so the card and bid modal show the project name.

## Scope

Both boards share the same `?term=`/`resolveTermFilter` pattern, so the fix is applied to both even though the bug was reported on Project Bids and Intent to Work individually.

## Testing

- `npm run typecheck` — clean for the touched files.
- Layout/label-only and link-construction changes; no schema or migration changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/724"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782498974&installation_id=133523038&pr_number=724&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F724&signature=8f3c5e175dd4c9115243922c999fccd3087cf9d6c8c5c89ae97d36f62a6e8306"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->