### PR TITLE
Launch welcome polish: pulse Next, less-AI copy

### DIFF
--- a/dali-api/app/calendar/routes/calendar.tsx
+++ b/dali-api/app/calendar/routes/calendar.tsx
@@ -614,6 +614,7 @@ function coerceFormToAction(raw: Record<string, FormDataEntryValue>): unknown {
 type Tab = "availability" | "schedule";
 
 const CALENDAR_TAB_STORAGE_KEY = "dali:calendar:tab";
+const AVAILABILITY_SIDEBAR_COLLAPSED_KEY = "dali:calendar:availability:sidebar-collapsed";
 
 export default function CalendarPage() {
   const data = useLoaderData<typeof loader>() as LoaderData;
@@ -687,7 +688,27 @@ function AvailabilityView({ data }: { data: LoaderData }) {
   // clipped by the inner overflow-hidden on short viewports.
   // Drag-to-create now lives inside AvailabilityWeekGrid: the selection stays
   // drawn on the grid and the editor opens as a popover anchored beside it.
-  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  //
+  // Collapse state is a deliberate user preference ("I want more grid room"),
+  // so it lives in localStorage and sticks across sessions.
+  const [sidebarCollapsed, setSidebarCollapsed] = useState<boolean>(() => {
+    if (typeof window === "undefined") return false;
+    try {
+      return window.localStorage.getItem(AVAILABILITY_SIDEBAR_COLLAPSED_KEY) === "1";
+    } catch {
+      return false;
+    }
+  });
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(
+        AVAILABILITY_SIDEBAR_COLLAPSED_KEY,
+        sidebarCollapsed ? "1" : "0",
+      );
+    } catch {
+      // localStorage disabled / quota — ignore
+    }
+  }, [sidebarCollapsed]);
   return (
     <div
       className={`grid grid-cols-1 gap-6 lg:h-[max(calc(100vh-9rem),56rem)] lg:min-h-0 px-3 pt-2 ${

--- a/dali-api/app/calendar/routes/calendar.tsx
+++ b/dali-api/app/calendar/routes/calendar.tsx
@@ -613,9 +613,29 @@ function coerceFormToAction(raw: Record<string, FormDataEntryValue>): unknown {
 
 type Tab = "availability" | "schedule";
 
+const CALENDAR_TAB_STORAGE_KEY = "dali:calendar:tab";
+
 export default function CalendarPage() {
   const data = useLoaderData<typeof loader>() as LoaderData;
-  const [tab, setTab] = useState<Tab>("availability");
+  // Persist the active tab in sessionStorage so navigating away and back
+  // (or the workspace iframe re-mounting on tab focus) restores where the
+  // user left off rather than always snapping back to Availability.
+  const [tab, setTab] = useState<Tab>(() => {
+    if (typeof window === "undefined") return "availability";
+    try {
+      const stored = window.sessionStorage.getItem(CALENDAR_TAB_STORAGE_KEY);
+      return stored === "schedule" ? "schedule" : "availability";
+    } catch {
+      return "availability";
+    }
+  });
+  useEffect(() => {
+    try {
+      window.sessionStorage.setItem(CALENDAR_TAB_STORAGE_KEY, tab);
+    } catch {
+      // sessionStorage disabled / quota — ignore
+    }
+  }, [tab]);
 
   return (
     <div className="flex flex-col gap-5">

--- a/dali-api/app/components/LaunchWelcome.tsx
+++ b/dali-api/app/components/LaunchWelcome.tsx
@@ -17,7 +17,7 @@ const DONE_KEY = "dalios-launch-welcome-seen-v1";
 const STEP_KEY = "dalios-launch-tour-step-v1";
 
 const CLAUDE_MCP_COMMAND =
-  "claude mcp add --transport http dali-os https://os.dali.dartmouth.edu/mcp";
+  "claude mcp add --transport http dalios https://os.dali.dartmouth.edu/mcp";
 
 function CopyableCommand({ command }: { command: string }) {
   const [copied, setCopied] = useState(false);

--- a/dali-api/app/components/LaunchWelcome.tsx
+++ b/dali-api/app/components/LaunchWelcome.tsx
@@ -5,6 +5,7 @@ import {
   CalendarDays,
   CalendarPlus,
   UserCircle2,
+  Users,
   ArrowRight,
   X as XIcon,
   Check,
@@ -162,6 +163,18 @@ const STEPS: TourStep[] = [
     matches: (p) => p.startsWith("/profile"),
     findTarget: () =>
       findInSidebar((btn) => btn.getAttribute("aria-label") === "Open profile"),
+  },
+  {
+    icon: <Users className="w-4 h-4" />,
+    eyebrow: "Members",
+    cta: (
+      <>
+        Open <strong>Members</strong> from the sidebar.
+      </>
+    ),
+    arrived: <>Everyone in the lab.</>,
+    matches: (p) => p.startsWith("/members"),
+    findTarget: () => findByExactText("Members"),
   },
   {
     icon: <Bot className="w-4 h-4" />,

--- a/dali-api/app/components/LaunchWelcome.tsx
+++ b/dali-api/app/components/LaunchWelcome.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useId, useState } from "react";
+import { useCallback, useEffect, useId, useRef, useState } from "react";
 import {
   Sparkles,
   PartyPopper,
@@ -18,13 +18,13 @@ type Phase = "modal" | "card" | "done";
 
 type TourStep = {
   icon: React.ReactNode;
-  /** Short, action-oriented prompt. */
+  /** Short prompt asking the user to click the highlighted thing. */
   cta: React.ReactNode;
-  /** Confirmation shown once the user lands on the matched page. */
+  /** Shown after the user lands on the matching page. */
   arrived: React.ReactNode;
   /** True if the iframe-reported URL means this step is satisfied. */
   matches: (pathname: string) => boolean;
-  /** Locates the sidebar element to highlight, or null if not currently in DOM. */
+  /** Locates the sidebar element to highlight, or null if not in DOM. */
   findTarget: () => HTMLElement | null;
 };
 
@@ -57,11 +57,10 @@ const STEPS: TourStep[] = [
     icon: <FolderKanban className="w-4 h-4" />,
     cta: (
       <>
-        Click <strong>Projects</strong> in the sidebar to see every active
-        project.
+        Open <strong>Projects</strong> from the sidebar.
       </>
     ),
-    arrived: <>Nice — every active project lives here.</>,
+    arrived: <>Everything the lab is working on.</>,
     matches: (p) => p.startsWith("/projects"),
     findTarget: () => findByExactText("Projects"),
   },
@@ -69,10 +68,10 @@ const STEPS: TourStep[] = [
     icon: <CalendarDays className="w-4 h-4" />,
     cta: (
       <>
-        Now click <strong>Calendar</strong> to see lab meetings and events.
+        Now try <strong>Calendar</strong>.
       </>
     ),
-    arrived: <>Lab meetings, standups, and your own events — all in lab time.</>,
+    arrived: <>Lab meetings, deadlines, social stuff.</>,
     matches: (p) => p.startsWith("/calendar"),
     findTarget: () => findByExactText("Calendar"),
   },
@@ -80,15 +79,11 @@ const STEPS: TourStep[] = [
     icon: <UserCircle2 className="w-4 h-4" />,
     cta: (
       <>
-        Last one — click your <strong>profile</strong> (bottom of the sidebar)
-        to make it yours.
+        Last one. Click your <strong>profile</strong> at the bottom of the
+        sidebar.
       </>
     ),
-    arrived: (
-      <>
-        Add a photo and a few words — this is how the lab gets to know you.
-      </>
-    ),
+    arrived: <>Drop a photo in. It&apos;s how the rest of the lab sees you.</>,
     matches: (p) => p.startsWith("/profile"),
     findTarget: () =>
       findInSidebar((btn) => btn.getAttribute("aria-label") === "Open profile"),
@@ -116,19 +111,25 @@ function readStep(): number {
   }
 }
 
-function Spotlight({ target }: { target: HTMLElement }) {
-  const [rect, setRect] = useState<DOMRect | null>(() => target.getBoundingClientRect());
-
+/**
+ * Tracks a target element's bounding rect, polling on resize/scroll plus a
+ * cheap interval so transitions (sidebar collapse, mobile drawer) stay glued.
+ */
+function useTargetRect(target: HTMLElement | null): DOMRect | null {
+  const [rect, setRect] = useState<DOMRect | null>(() =>
+    target ? target.getBoundingClientRect() : null,
+  );
   useEffect(() => {
+    if (!target) {
+      setRect(null);
+      return;
+    }
     let alive = true;
     function measure() {
-      if (!alive) return;
+      if (!alive || !target) return;
       setRect(target.getBoundingClientRect());
     }
     measure();
-    // Sidebar can collapse, page can scroll, mobile drawer can open — poll
-    // cheaply so the spotlight stays glued to the element. Throwaway tour
-    // code, a 150ms tick is plenty smooth.
     const id = window.setInterval(measure, 150);
     window.addEventListener("resize", measure);
     window.addEventListener("scroll", measure, true);
@@ -139,37 +140,51 @@ function Spotlight({ target }: { target: HTMLElement }) {
       window.removeEventListener("scroll", measure, true);
     };
   }, [target]);
+  return rect;
+}
 
+/** Pulsing coral ring positioned around an element. No dim. */
+function PulseRing({ target, zIndex }: { target: HTMLElement; zIndex: number }) {
+  const rect = useTargetRect(target);
   if (!rect) return null;
-
   const PAD = 6;
-  const top = rect.top - PAD;
-  const left = rect.left - PAD;
-  const width = rect.width + PAD * 2;
-  const height = rect.height + PAD * 2;
+  return (
+    <div
+      aria-hidden="true"
+      className="pointer-events-none fixed rounded-md launch-tour-pulse"
+      style={{
+        top: rect.top - PAD,
+        left: rect.left - PAD,
+        width: rect.width + PAD * 2,
+        height: rect.height + PAD * 2,
+        zIndex,
+      }}
+    />
+  );
+}
 
+/** Full spotlight: dims the page everywhere except a cut-out over `target`,
+ *  with a pulsing ring on top. */
+function Spotlight({ target }: { target: HTMLElement }) {
+  const rect = useTargetRect(target);
+  if (!rect) return null;
+  const PAD = 6;
+  const box = {
+    top: rect.top - PAD,
+    left: rect.left - PAD,
+    width: rect.width + PAD * 2,
+    height: rect.height + PAD * 2,
+  };
   return (
     <>
-      {/* Cut-out: a transparent rectangle sitting where the target is, with
-          a massive box-shadow extending outward to dim the rest of the page.
-          pointer-events: none so the user can still click the real element. */}
+      {/* Cut-out: transparent rect with huge outward box-shadow dims the rest
+          of the page. pointer-events: none so clicks pass through. */}
       <div
         aria-hidden="true"
         className="pointer-events-none fixed z-40 rounded-md"
-        style={{
-          top,
-          left,
-          width,
-          height,
-          boxShadow: "0 0 0 9999px rgba(0, 0, 0, 0.55)",
-        }}
+        style={{ ...box, boxShadow: "0 0 0 9999px rgba(0, 0, 0, 0.55)" }}
       />
-      {/* Pulsing coral ring on top of the cut-out for emphasis. */}
-      <div
-        aria-hidden="true"
-        className="pointer-events-none fixed z-40 rounded-md launch-tour-pulse"
-        style={{ top, left, width, height }}
-      />
+      <PulseRing target={target} zIndex={41} />
     </>
   );
 }
@@ -178,7 +193,9 @@ export function LaunchWelcome({ firstName }: { firstName: string }) {
   const [phase, setPhase] = useState<Phase>("done");
   const [step, setStep] = useState(0);
   const [arrived, setArrived] = useState(false);
-  const [target, setTarget] = useState<HTMLElement | null>(null);
+  const [sidebarTarget, setSidebarTarget] = useState<HTMLElement | null>(null);
+  const nextButtonRef = useRef<HTMLButtonElement | null>(null);
+  const [nextTarget, setNextTarget] = useState<HTMLElement | null>(null);
   const titleId = useId();
 
   useEffect(() => {
@@ -186,29 +203,33 @@ export function LaunchWelcome({ firstName }: { firstName: string }) {
     setStep(readStep());
   }, []);
 
-  // Re-resolve the highlight target whenever the active step changes or the
-  // sidebar DOM might have shifted (mobile drawer open/close). Cheap interval
-  // because the sidebar isn't always present at mount time.
+  // Re-resolve the sidebar highlight target whenever the active step changes.
+  // Cheap interval because the sidebar may not be present at mount time.
   useEffect(() => {
     if (phase !== "card") return;
     if (step >= STEPS.length) return;
     if (arrived) {
-      setTarget(null);
+      setSidebarTarget(null);
       return;
     }
     const find = STEPS[step].findTarget;
     function resolve() {
-      const el = find();
-      setTarget(el);
+      setSidebarTarget(find());
     }
     resolve();
     const id = window.setInterval(resolve, 300);
     return () => window.clearInterval(id);
   }, [phase, step, arrived]);
 
+  // After arriving, point the next-button ref into local state so PulseRing
+  // re-renders against a stable element. (Refs alone don't trigger re-renders.)
+  useEffect(() => {
+    setNextTarget(arrived ? nextButtonRef.current : null);
+  }, [arrived, step]);
+
   // Listen for iframe-reported tab navigation — that's how the workspace
-  // signals "the user is now looking at X". Falls back to top-level pathname
-  // for routes that aren't tab-wrapped.
+  // signals "the user is now looking at X". Sidebar clicks open iframe tabs,
+  // so useLocation on the parent shell never fires.
   const handleUrl = useCallback(
     (url: string) => {
       if (phase !== "card") return;
@@ -291,11 +312,10 @@ export function LaunchWelcome({ firstName }: { firstName: string }) {
               id={titleId}
               className="font-heading text-xl font-bold text-foreground"
             >
-              Hey {firstName} — welcome to DALIos
+              DALI OS is live
             </h2>
             <p className="text-sm text-muted-foreground mt-2 leading-relaxed">
-              This is the new home for everything DALI. Want a quick tour? We'll
-              point you at a few spots in the sidebar — click as you go.
+              Hi {firstName}. The new site is up. Want a quick spin around it?
             </p>
           </div>
           <div className="flex items-center justify-end gap-2 pt-2">
@@ -304,7 +324,7 @@ export function LaunchWelcome({ firstName }: { firstName: string }) {
               onClick={finishTour}
               className="text-sm text-muted-foreground hover:text-foreground px-3 py-2"
             >
-              Maybe later
+              Not now
             </button>
             <button
               type="button"
@@ -325,8 +345,6 @@ export function LaunchWelcome({ firstName }: { firstName: string }) {
 
   return (
     <>
-      {/* CSS keyframes for the spotlight pulse. Scoped to this component via
-          the .launch-tour-pulse class so removal = delete file. */}
       <style>{`
         @keyframes launch-tour-pulse {
           0%, 100% {
@@ -347,7 +365,13 @@ export function LaunchWelcome({ firstName }: { firstName: string }) {
         }
       `}</style>
 
-      {target && !arrived && !isFinal && <Spotlight target={target} />}
+      {/* Sidebar spotlight before they click. */}
+      {sidebarTarget && !arrived && !isFinal && <Spotlight target={sidebarTarget} />}
+
+      {/* Next-button ring after they arrive (no dim — card is already prominent). */}
+      {nextTarget && arrived && !isFinal && (
+        <PulseRing target={nextTarget} zIndex={60} />
+      )}
 
       <div className="fixed bottom-4 right-4 z-50 w-80 max-w-[calc(100vw-2rem)] pointer-events-auto">
         <div className="bg-card border border-border rounded-2xl shadow-brand-2 p-4 flex flex-col gap-3">
@@ -379,8 +403,8 @@ export function LaunchWelcome({ firstName }: { firstName: string }) {
           <p className="text-sm text-foreground leading-relaxed">
             {isFinal ? (
               <>
-                That's the tour! 🎉 The site launch party is right around the
-                corner — keep an eye on the calendar for the invite.
+                That&apos;s the tour. There&apos;s a launch party on the
+                calendar. Come celebrate.
               </>
             ) : arrived ? (
               current!.arrived
@@ -410,10 +434,11 @@ export function LaunchWelcome({ firstName }: { firstName: string }) {
                 onClick={finishTour}
                 className="inline-flex items-center gap-1.5 rounded-lg bg-accent-coral px-3 py-1.5 text-sm font-semibold text-white hover:bg-accent-coral/90"
               >
-                Let's go
+                Sounds good
               </button>
             ) : arrived ? (
               <button
+                ref={nextButtonRef}
                 type="button"
                 onClick={advance}
                 className="inline-flex items-center gap-1.5 rounded-lg bg-accent-coral px-3 py-1.5 text-sm font-semibold text-white hover:bg-accent-coral/90"
@@ -436,7 +461,7 @@ export function LaunchWelcome({ firstName }: { firstName: string }) {
                   className="text-xs text-muted-foreground hover:text-foreground"
                   title="Skip this step"
                 >
-                  I'm there →
+                  I&apos;m there
                 </button>
               </>
             )}

--- a/dali-api/app/components/LaunchWelcome.tsx
+++ b/dali-api/app/components/LaunchWelcome.tsx
@@ -18,6 +18,8 @@ const STEP_KEY = "dalios-launch-tour-step-v1";
 
 const CLAUDE_MCP_COMMAND =
   "claude mcp add --transport http dalios https://os.dali.dartmouth.edu/mcp";
+const CODEX_MCP_COMMAND =
+  "codex mcp add dalios https://os.dali.dartmouth.edu/mcp";
 
 function CopyableCommand({ command }: { command: string }) {
   const [copied, setCopied] = useState(false);
@@ -137,10 +139,21 @@ const STEPS: TourStep[] = [
       <>
         <p>
           Connect any AI assistant to the <strong>DALI OS MCP</strong> and let
-          it read your DALI data for you. In Claude Code:
+          it read your DALI data for you.
         </p>
-        <div className="mt-2">
-          <CopyableCommand command={CLAUDE_MCP_COMMAND} />
+        <div className="mt-2 space-y-2">
+          <div>
+            <div className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground mb-1">
+              Claude Code
+            </div>
+            <CopyableCommand command={CLAUDE_MCP_COMMAND} />
+          </div>
+          <div>
+            <div className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground mb-1">
+              Codex
+            </div>
+            <CopyableCommand command={CODEX_MCP_COMMAND} />
+          </div>
         </div>
       </>
     ),

--- a/dali-api/app/components/LaunchWelcome.tsx
+++ b/dali-api/app/components/LaunchWelcome.tsx
@@ -103,8 +103,8 @@ const STEPS: TourStep[] = [
     eyebrow: "Connect any AI",
     cta: (
       <>
-        DALI OS speaks <strong>MCP</strong>, so you can connect any AI
-        assistant to read your DALI data on your behalf.
+        Connect any AI assistant to the <strong>DALI OS MCP</strong> and let
+        it read your DALI data for you.
       </>
     ),
     action: {

--- a/dali-api/app/components/LaunchWelcome.tsx
+++ b/dali-api/app/components/LaunchWelcome.tsx
@@ -9,45 +9,11 @@ import {
   X as XIcon,
   Check,
   Bot,
-  Copy,
 } from "lucide-react";
 import { Modal } from "./Modal";
 
 const DONE_KEY = "dalios-launch-welcome-seen-v1";
 const STEP_KEY = "dalios-launch-tour-step-v1";
-
-const CLAUDE_MCP_COMMAND =
-  "claude mcp add --transport http dalios https://os.dali.dartmouth.edu/mcp";
-const CODEX_MCP_COMMAND =
-  "codex mcp add dalios https://os.dali.dartmouth.edu/mcp";
-
-function CopyableCommand({ command }: { command: string }) {
-  const [copied, setCopied] = useState(false);
-  function copy() {
-    try {
-      navigator.clipboard.writeText(command);
-      setCopied(true);
-      window.setTimeout(() => setCopied(false), 1500);
-    } catch {
-      // navigator.clipboard unavailable (insecure context, etc) — give up silently
-    }
-  }
-  return (
-    <div className="flex items-center gap-2 rounded-md bg-zinc-900 px-2.5 py-2 text-xs font-mono text-zinc-100">
-      <code className="flex-1 truncate" title={command}>
-        {command}
-      </code>
-      <button
-        type="button"
-        onClick={copy}
-        className="text-zinc-400 hover:text-white flex-shrink-0"
-        aria-label="Copy command"
-      >
-        {copied ? <Check className="w-3.5 h-3.5" /> : <Copy className="w-3.5 h-3.5" />}
-      </button>
-    </div>
-  );
-}
 
 type Phase = "modal" | "card" | "done";
 
@@ -137,24 +103,8 @@ const STEPS: TourStep[] = [
     eyebrow: "Connect any AI",
     cta: (
       <>
-        <p>
-          Connect any AI assistant to the <strong>DALI OS MCP</strong> and let
-          it read your DALI data for you.
-        </p>
-        <div className="mt-2 space-y-2">
-          <div>
-            <div className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground mb-1">
-              Claude Code
-            </div>
-            <CopyableCommand command={CLAUDE_MCP_COMMAND} />
-          </div>
-          <div>
-            <div className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground mb-1">
-              Codex
-            </div>
-            <CopyableCommand command={CODEX_MCP_COMMAND} />
-          </div>
-        </div>
+        Connect any AI assistant to the <strong>DALI OS MCP</strong> and let
+        it read your DALI data for you.
       </>
     ),
     action: {

--- a/dali-api/app/components/LaunchWelcome.tsx
+++ b/dali-api/app/components/LaunchWelcome.tsx
@@ -552,7 +552,7 @@ export function LaunchWelcome({ firstName }: { firstName: string }) {
 
           <div className="text-sm text-foreground leading-relaxed">
             {isFinal ? (
-              <>Welcome to DALI OS.</>
+              <>Welcome to DALI OS!</>
             ) : arrived ? (
               current!.arrived
             ) : (

--- a/dali-api/app/components/LaunchWelcome.tsx
+++ b/dali-api/app/components/LaunchWelcome.tsx
@@ -8,6 +8,7 @@ import {
   ArrowRight,
   X as XIcon,
   Check,
+  Bot,
 } from "lucide-react";
 import { Modal } from "./Modal";
 
@@ -18,14 +19,21 @@ type Phase = "modal" | "card" | "done";
 
 type TourStep = {
   icon: React.ReactNode;
-  /** Short prompt asking the user to click the highlighted thing. */
+  /** Short eyebrow label shown above the title on the card. */
+  eyebrow: string;
+  /** Step body — either a CTA to click a sidebar item or an info blurb. */
   cta: React.ReactNode;
-  /** Shown after the user lands on the matching page. */
-  arrived: React.ReactNode;
-  /** True if the iframe-reported URL means this step is satisfied. */
-  matches: (pathname: string) => boolean;
-  /** Locates the sidebar element to highlight, or null if not in DOM. */
-  findTarget: () => HTMLElement | null;
+  /** Confirmation shown after the user lands on the matched page. Required
+   *  for click-driven steps; omitted for info-only steps. */
+  arrived?: React.ReactNode;
+  /** True if the iframe-reported URL means this step is satisfied. Omitted
+   *  for info-only steps. */
+  matches?: (pathname: string) => boolean;
+  /** Locates the sidebar element to highlight. Omitted for info-only steps. */
+  findTarget?: () => HTMLElement | null;
+  /** Optional primary action for info-only steps. Click runs onClick AND
+   *  advances the tour. */
+  action?: { label: string; onClick: () => void };
 };
 
 function findInSidebar(predicate: (el: HTMLButtonElement) => boolean): HTMLElement | null {
@@ -55,6 +63,7 @@ function findByExactText(text: string) {
 const STEPS: TourStep[] = [
   {
     icon: <FolderKanban className="w-4 h-4" />,
+    eyebrow: "Projects",
     cta: (
       <>
         Open <strong>Projects</strong> from the sidebar.
@@ -66,6 +75,7 @@ const STEPS: TourStep[] = [
   },
   {
     icon: <CalendarDays className="w-4 h-4" />,
+    eyebrow: "Calendar",
     cta: (
       <>
         Open <strong>Calendar</strong> from the sidebar.
@@ -77,6 +87,7 @@ const STEPS: TourStep[] = [
   },
   {
     icon: <UserCircle2 className="w-4 h-4" />,
+    eyebrow: "Profile",
     cta: (
       <>
         Open your <strong>profile</strong> from the bottom of the sidebar.
@@ -86,6 +97,31 @@ const STEPS: TourStep[] = [
     matches: (p) => p.startsWith("/profile"),
     findTarget: () =>
       findInSidebar((btn) => btn.getAttribute("aria-label") === "Open profile"),
+  },
+  {
+    icon: <Bot className="w-4 h-4" />,
+    eyebrow: "Connect any AI",
+    cta: (
+      <>
+        DALI OS speaks <strong>MCP</strong>, so you can connect any AI
+        assistant to read your DALI data on your behalf.
+      </>
+    ),
+    action: {
+      label: "Open docs",
+      onClick: () => {
+        // Layout listens for dali:openTab on the parent window and opens it
+        // in the workspace iframe rather than navigating the top frame.
+        window.postMessage(
+          {
+            type: "dali:openTab",
+            url: "/help/mcp",
+            label: "Connect AI to DALI OS",
+          },
+          window.location.origin,
+        );
+      },
+    },
   },
 ];
 
@@ -204,27 +240,41 @@ export function LaunchWelcome({ firstName }: { firstName: string }) {
 
   // Re-resolve the sidebar highlight target whenever the active step changes.
   // Cheap interval because the sidebar may not be present at mount time.
+  // Info-only steps (no findTarget) never show a spotlight.
   useEffect(() => {
     if (phase !== "card") return;
     if (step >= STEPS.length) return;
-    if (arrived) {
+    const find = STEPS[step].findTarget;
+    if (!find || arrived) {
       setSidebarTarget(null);
       return;
     }
-    const find = STEPS[step].findTarget;
     function resolve() {
-      setSidebarTarget(find());
+      setSidebarTarget(find!());
     }
     resolve();
     const id = window.setInterval(resolve, 300);
     return () => window.clearInterval(id);
   }, [phase, step, arrived]);
 
-  // After arriving, point the next-button ref into local state so PulseRing
-  // re-renders against a stable element. (Refs alone don't trigger re-renders.)
+  // Pulse the card's primary action button. For click-driven steps this is
+  // the Next button after the user arrives at the matched page. For info-only
+  // steps (e.g. MCP) the primary action is shown immediately, so pulse it
+  // from the start. Refs alone don't trigger re-renders, so we copy the
+  // current DOM node into state once it's in the tree.
   useEffect(() => {
-    setNextTarget(arrived ? nextButtonRef.current : null);
-  }, [arrived, step]);
+    if (phase !== "card") {
+      setNextTarget(null);
+      return;
+    }
+    if (step >= STEPS.length) {
+      setNextTarget(null);
+      return;
+    }
+    const s = STEPS[step];
+    const shouldPulse = s.findTarget ? arrived : true;
+    setNextTarget(shouldPulse ? nextButtonRef.current : null);
+  }, [phase, step, arrived]);
 
   // Listen for iframe-reported tab navigation — that's how the workspace
   // signals "the user is now looking at X". Sidebar clicks open iframe tabs,
@@ -234,9 +284,11 @@ export function LaunchWelcome({ firstName }: { firstName: string }) {
       if (phase !== "card") return;
       if (arrived) return;
       if (step >= STEPS.length) return;
+      const match = STEPS[step].matches;
+      if (!match) return; // info-only step — URL changes don't advance it
       try {
         const path = new URL(url, window.location.origin).pathname;
-        if (STEPS[step].matches(path)) setArrived(true);
+        if (match(path)) setArrived(true);
       } catch {
         // Bad URL — ignore.
       }
@@ -389,7 +441,7 @@ export function LaunchWelcome({ firstName }: { firstName: string }) {
                 ? "Launch party"
                 : arrived
                   ? "You're here"
-                  : `Step ${step + 1} of ${STEPS.length}`}
+                  : current!.eyebrow}
             </span>
             <button
               type="button"
@@ -447,6 +499,28 @@ export function LaunchWelcome({ firstName }: { firstName: string }) {
                 Next
                 <ArrowRight className="w-4 h-4" />
               </button>
+            ) : current && !current.findTarget ? (
+              <>
+                <button
+                  type="button"
+                  onClick={advance}
+                  className="text-xs text-muted-foreground hover:text-foreground"
+                >
+                  Skip
+                </button>
+                <button
+                  ref={nextButtonRef}
+                  type="button"
+                  onClick={() => {
+                    current.action?.onClick();
+                    advance();
+                  }}
+                  className="inline-flex items-center gap-1.5 rounded-lg bg-accent-coral px-3 py-1.5 text-sm font-semibold text-white hover:bg-accent-coral/90"
+                >
+                  {current.action?.label ?? "Next"}
+                  <ArrowRight className="w-4 h-4" />
+                </button>
+              </>
             ) : (
               <>
                 <button

--- a/dali-api/app/components/LaunchWelcome.tsx
+++ b/dali-api/app/components/LaunchWelcome.tsx
@@ -10,6 +10,7 @@ import {
   X as XIcon,
   Check,
   Bot,
+  MonitorDown,
 } from "lucide-react";
 import { Modal } from "./Modal";
 
@@ -200,6 +201,17 @@ const STEPS: TourStep[] = [
         );
       },
     },
+  },
+  {
+    icon: <MonitorDown className="w-4 h-4" />,
+    eyebrow: "Install the app",
+    cta: (
+      <>
+        Pin <strong>DALI OS</strong> to your taskbar. In Chrome, click the
+        install icon at the right of the address bar (or <strong>⋮ →
+        Install DALI OS</strong>).
+      </>
+    ),
   },
 ];
 

--- a/dali-api/app/components/LaunchWelcome.tsx
+++ b/dali-api/app/components/LaunchWelcome.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useId, useRef, useState } from "react";
 import {
-  Sparkles,
   PartyPopper,
   FolderKanban,
   CalendarDays,
@@ -442,11 +441,7 @@ export function LaunchWelcome({ firstName }: { firstName: string }) {
     return (
       <Modal open onClose={finishTour} labelledBy={titleId}>
         <div className="flex flex-col gap-4">
-          <div className="flex items-center justify-between">
-            <span className="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-accent-coral">
-              <Sparkles className="w-4 h-4" />
-              Welcome
-            </span>
+          <div className="flex items-center justify-end">
             <button
               type="button"
               onClick={finishTour}
@@ -469,13 +464,6 @@ export function LaunchWelcome({ firstName }: { firstName: string }) {
             </p>
           </div>
           <div className="flex items-center justify-end gap-2 pt-2">
-            <button
-              type="button"
-              onClick={finishTour}
-              className="text-sm text-muted-foreground hover:text-foreground px-3 py-2"
-            >
-              Not now
-            </button>
             <button
               type="button"
               onClick={startTour}

--- a/dali-api/app/components/LaunchWelcome.tsx
+++ b/dali-api/app/components/LaunchWelcome.tsx
@@ -407,6 +407,14 @@ export function LaunchWelcome({ firstName }: { firstName: string }) {
     setPhase("card");
   }
 
+  function finishAndGoHome() {
+    window.postMessage(
+      { type: "dali:openTab", url: "/", label: "Home" },
+      window.location.origin,
+    );
+    finishTour();
+  }
+
   function finishTour() {
     try {
       window.localStorage.setItem(DONE_KEY, new Date().toISOString());
@@ -573,10 +581,10 @@ export function LaunchWelcome({ firstName }: { firstName: string }) {
             {isFinal ? (
               <button
                 type="button"
-                onClick={finishTour}
+                onClick={finishAndGoHome}
                 className="inline-flex items-center gap-1.5 rounded-lg bg-accent-coral px-3 py-1.5 text-sm font-semibold text-white hover:bg-accent-coral/90"
               >
-                Done
+                Back to home
               </button>
             ) : arrived ? (
               <button

--- a/dali-api/app/components/LaunchWelcome.tsx
+++ b/dali-api/app/components/LaunchWelcome.tsx
@@ -552,10 +552,7 @@ export function LaunchWelcome({ firstName }: { firstName: string }) {
 
           <div className="text-sm text-foreground leading-relaxed">
             {isFinal ? (
-              <>
-                That&apos;s the tour. Thanks for coming. Enjoy the launch
-                party.
-              </>
+              <>Welcome to DALI OS.</>
             ) : arrived ? (
               current!.arrived
             ) : (

--- a/dali-api/app/components/LaunchWelcome.tsx
+++ b/dali-api/app/components/LaunchWelcome.tsx
@@ -60,7 +60,7 @@ const STEPS: TourStep[] = [
         Open <strong>Projects</strong> from the sidebar.
       </>
     ),
-    arrived: <>Everything the lab is working on.</>,
+    arrived: <>All active projects live here.</>,
     matches: (p) => p.startsWith("/projects"),
     findTarget: () => findByExactText("Projects"),
   },
@@ -68,10 +68,10 @@ const STEPS: TourStep[] = [
     icon: <CalendarDays className="w-4 h-4" />,
     cta: (
       <>
-        Now try <strong>Calendar</strong>.
+        Open <strong>Calendar</strong> from the sidebar.
       </>
     ),
-    arrived: <>Lab meetings, deadlines, social stuff.</>,
+    arrived: <>Lab meetings and events.</>,
     matches: (p) => p.startsWith("/calendar"),
     findTarget: () => findByExactText("Calendar"),
   },
@@ -79,11 +79,10 @@ const STEPS: TourStep[] = [
     icon: <UserCircle2 className="w-4 h-4" />,
     cta: (
       <>
-        Last one. Click your <strong>profile</strong> at the bottom of the
-        sidebar.
+        Open your <strong>profile</strong> from the bottom of the sidebar.
       </>
     ),
-    arrived: <>Drop a photo in. It&apos;s how the rest of the lab sees you.</>,
+    arrived: <>Add a photo and your details here.</>,
     matches: (p) => p.startsWith("/profile"),
     findTarget: () =>
       findInSidebar((btn) => btn.getAttribute("aria-label") === "Open profile"),
@@ -312,10 +311,11 @@ export function LaunchWelcome({ firstName }: { firstName: string }) {
               id={titleId}
               className="font-heading text-xl font-bold text-foreground"
             >
-              DALI OS is live
+              Welcome to DALI OS
             </h2>
             <p className="text-sm text-muted-foreground mt-2 leading-relaxed">
-              Hi {firstName}. The new site is up. Want a quick spin around it?
+              Hi {firstName}. DALI OS is the lab&apos;s new internal site,
+              replacing Notion. Want a quick tour?
             </p>
           </div>
           <div className="flex items-center justify-end gap-2 pt-2">
@@ -403,8 +403,8 @@ export function LaunchWelcome({ firstName }: { firstName: string }) {
           <p className="text-sm text-foreground leading-relaxed">
             {isFinal ? (
               <>
-                That&apos;s the tour. There&apos;s a launch party on the
-                calendar. Come celebrate.
+                That&apos;s the tour. Thanks for coming. Enjoy the launch
+                party.
               </>
             ) : arrived ? (
               current!.arrived
@@ -434,7 +434,7 @@ export function LaunchWelcome({ firstName }: { firstName: string }) {
                 onClick={finishTour}
                 className="inline-flex items-center gap-1.5 rounded-lg bg-accent-coral px-3 py-1.5 text-sm font-semibold text-white hover:bg-accent-coral/90"
               >
-                Sounds good
+                Done
               </button>
             ) : arrived ? (
               <button

--- a/dali-api/app/components/LaunchWelcome.tsx
+++ b/dali-api/app/components/LaunchWelcome.tsx
@@ -9,11 +9,43 @@ import {
   X as XIcon,
   Check,
   Bot,
+  Copy,
 } from "lucide-react";
 import { Modal } from "./Modal";
 
 const DONE_KEY = "dalios-launch-welcome-seen-v1";
 const STEP_KEY = "dalios-launch-tour-step-v1";
+
+const CLAUDE_MCP_COMMAND =
+  "claude mcp add --transport http dali-os https://os.dali.dartmouth.edu/mcp";
+
+function CopyableCommand({ command }: { command: string }) {
+  const [copied, setCopied] = useState(false);
+  function copy() {
+    try {
+      navigator.clipboard.writeText(command);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // navigator.clipboard unavailable (insecure context, etc) — give up silently
+    }
+  }
+  return (
+    <div className="flex items-center gap-2 rounded-md bg-zinc-900 px-2.5 py-2 text-xs font-mono text-zinc-100">
+      <code className="flex-1 truncate" title={command}>
+        {command}
+      </code>
+      <button
+        type="button"
+        onClick={copy}
+        className="text-zinc-400 hover:text-white flex-shrink-0"
+        aria-label="Copy command"
+      >
+        {copied ? <Check className="w-3.5 h-3.5" /> : <Copy className="w-3.5 h-3.5" />}
+      </button>
+    </div>
+  );
+}
 
 type Phase = "modal" | "card" | "done";
 
@@ -103,8 +135,13 @@ const STEPS: TourStep[] = [
     eyebrow: "Connect any AI",
     cta: (
       <>
-        Connect any AI assistant to the <strong>DALI OS MCP</strong> and let
-        it read your DALI data for you.
+        <p>
+          Connect any AI assistant to the <strong>DALI OS MCP</strong> and let
+          it read your DALI data for you. In Claude Code:
+        </p>
+        <div className="mt-2">
+          <CopyableCommand command={CLAUDE_MCP_COMMAND} />
+        </div>
       </>
     ),
     action: {
@@ -453,7 +490,7 @@ export function LaunchWelcome({ firstName }: { firstName: string }) {
             </button>
           </div>
 
-          <p className="text-sm text-foreground leading-relaxed">
+          <div className="text-sm text-foreground leading-relaxed">
             {isFinal ? (
               <>
                 That&apos;s the tour. Thanks for coming. Enjoy the launch
@@ -464,7 +501,7 @@ export function LaunchWelcome({ firstName }: { firstName: string }) {
             ) : (
               current!.cta
             )}
-          </p>
+          </div>
 
           <div className="flex items-center gap-1.5" aria-hidden="true">
             {STEPS.map((_, i) => (

--- a/dali-api/app/components/LaunchWelcome.tsx
+++ b/dali-api/app/components/LaunchWelcome.tsx
@@ -314,8 +314,9 @@ export function LaunchWelcome({ firstName }: { firstName: string }) {
               Welcome to DALI OS
             </h2>
             <p className="text-sm text-muted-foreground mt-2 leading-relaxed">
-              Hi {firstName}. DALI OS is the lab&apos;s new internal site,
-              replacing Notion. Want a quick tour?
+              Hi {firstName}. DALI OS is the home of everything DALI,
+              replacing Notion as the lab&apos;s internal site. Want a quick
+              tour?
             </p>
           </div>
           <div className="flex items-center justify-end gap-2 pt-2">

--- a/dali-api/app/components/LaunchWelcome.tsx
+++ b/dali-api/app/components/LaunchWelcome.tsx
@@ -4,6 +4,7 @@ import {
   PartyPopper,
   FolderKanban,
   CalendarDays,
+  CalendarPlus,
   UserCircle2,
   ArrowRight,
   X as XIcon,
@@ -35,6 +36,47 @@ type TourStep = {
    *  advances the tour. */
   action?: { label: string; onClick: () => void };
 };
+
+/** Walks up through any iframe ancestors so the rect is in the parent
+ *  document's viewport coordinates (used by Spotlight on in-iframe targets). */
+function getRectInParent(el: HTMLElement): DOMRect {
+  let rect = el.getBoundingClientRect();
+  let doc: Document | null = el.ownerDocument;
+  while (doc && doc !== document) {
+    const frame = doc.defaultView?.frameElement as HTMLIFrameElement | null;
+    if (!frame) break;
+    const frameRect = frame.getBoundingClientRect();
+    rect = new DOMRect(
+      rect.left + frameRect.left,
+      rect.top + frameRect.top,
+      rect.width,
+      rect.height,
+    );
+    doc = frame.ownerDocument;
+  }
+  return rect;
+}
+
+/** Search any same-origin iframe for a button matching the predicate. Used
+ *  to target in-iframe tab pills (e.g. "Schedule Meeting" on the calendar). */
+function findInIframes(
+  predicate: (el: HTMLButtonElement) => boolean,
+): HTMLElement | null {
+  const iframes = document.querySelectorAll<HTMLIFrameElement>("iframe");
+  for (const iframe of iframes) {
+    try {
+      const doc = iframe.contentDocument;
+      if (!doc) continue;
+      const buttons = doc.querySelectorAll<HTMLButtonElement>("button");
+      for (const btn of buttons) {
+        if (predicate(btn)) return btn;
+      }
+    } catch {
+      // cross-origin iframe or detached — skip
+    }
+  }
+  return null;
+}
 
 function findInSidebar(predicate: (el: HTMLButtonElement) => boolean): HTMLElement | null {
   // Look in both desktop sidebar (<aside>) and the mobile nav panel. We can't
@@ -84,6 +126,30 @@ const STEPS: TourStep[] = [
     arrived: <>Lab meetings and events.</>,
     matches: (p) => p.startsWith("/calendar"),
     findTarget: () => findByExactText("Calendar"),
+  },
+  {
+    icon: <CalendarPlus className="w-4 h-4" />,
+    eyebrow: "Schedule Meeting",
+    cta: (
+      <>
+        At the top of the Calendar, switch to{" "}
+        <strong>Schedule Meeting</strong>.
+      </>
+    ),
+    arrived: (
+      <>
+        See everyone&apos;s availability and create a meeting. No more
+        when2meets.
+      </>
+    ),
+    // No URL change happens when the pill is clicked (tab state lives in
+    // React state on the calendar page), so this step advances via a DOM
+    // click listener attached to the spotlit element instead of via
+    // dali:tabNavigated. See the find-target effect below.
+    findTarget: () =>
+      findInIframes(
+        (btn) => (btn.textContent || "").trim() === "Schedule Meeting",
+      ),
   },
   {
     icon: <UserCircle2 className="w-4 h-4" />,
@@ -148,11 +214,13 @@ function readStep(): number {
 
 /**
  * Tracks a target element's bounding rect, polling on resize/scroll plus a
- * cheap interval so transitions (sidebar collapse, mobile drawer) stay glued.
+ * cheap interval so transitions (sidebar collapse, mobile drawer, iframe
+ * scroll) stay glued. Uses getRectInParent so in-iframe targets resolve to
+ * the parent document's viewport coordinates.
  */
 function useTargetRect(target: HTMLElement | null): DOMRect | null {
   const [rect, setRect] = useState<DOMRect | null>(() =>
-    target ? target.getBoundingClientRect() : null,
+    target ? getRectInParent(target) : null,
   );
   useEffect(() => {
     if (!target) {
@@ -162,7 +230,7 @@ function useTargetRect(target: HTMLElement | null): DOMRect | null {
     let alive = true;
     function measure() {
       if (!alive || !target) return;
-      setRect(target.getBoundingClientRect());
+      setRect(getRectInParent(target));
     }
     measure();
     const id = window.setInterval(measure, 150);
@@ -238,23 +306,44 @@ export function LaunchWelcome({ firstName }: { firstName: string }) {
     setStep(readStep());
   }, []);
 
-  // Re-resolve the sidebar highlight target whenever the active step changes.
-  // Cheap interval because the sidebar may not be present at mount time.
+  // Re-resolve the highlight target whenever the active step changes.
+  // Cheap interval because the target may not be present at mount time
+  // (sidebar not laid out yet, calendar iframe still loading, etc.).
   // Info-only steps (no findTarget) never show a spotlight.
+  //
+  // For steps that have no URL `matches` (e.g. the in-page Schedule Meeting
+  // pill), there's no dali:tabNavigated to advance on, so we attach a DOM
+  // click listener to the resolved target instead. Clicking the spotlit
+  // element flips the step to "arrived" the same way a URL change would.
   useEffect(() => {
     if (phase !== "card") return;
     if (step >= STEPS.length) return;
-    const find = STEPS[step].findTarget;
+    const s = STEPS[step];
+    const find = s.findTarget;
     if (!find || arrived) {
       setSidebarTarget(null);
       return;
     }
+    const advanceOnClick = !s.matches;
+    let attached: HTMLElement | null = null;
+    function onClick() {
+      setArrived(true);
+    }
     function resolve() {
-      setSidebarTarget(find!());
+      const found = find!();
+      setSidebarTarget(found);
+      if (advanceOnClick && found !== attached) {
+        if (attached) attached.removeEventListener("click", onClick);
+        if (found) found.addEventListener("click", onClick);
+        attached = found;
+      }
     }
     resolve();
     const id = window.setInterval(resolve, 300);
-    return () => window.clearInterval(id);
+    return () => {
+      window.clearInterval(id);
+      if (attached) attached.removeEventListener("click", onClick);
+    };
   }, [phase, step, arrived]);
 
   // Pulse the card's primary action button. For click-driven steps this is

--- a/dali-api/app/components/LaunchWelcome.tsx
+++ b/dali-api/app/components/LaunchWelcome.tsx
@@ -178,6 +178,17 @@ const STEPS: TourStep[] = [
     findTarget: () => findByExactText("Members"),
   },
   {
+    icon: <MonitorDown className="w-4 h-4" />,
+    eyebrow: "Install the app",
+    cta: (
+      <>
+        Pin <strong>DALI OS</strong> to your taskbar. In Chrome, click the
+        install icon at the right of the address bar (or <strong>⋮ →
+        Install DALI OS</strong>).
+      </>
+    ),
+  },
+  {
     icon: <Bot className="w-4 h-4" />,
     eyebrow: "Connect any AI",
     cta: (
@@ -201,17 +212,6 @@ const STEPS: TourStep[] = [
         );
       },
     },
-  },
-  {
-    icon: <MonitorDown className="w-4 h-4" />,
-    eyebrow: "Install the app",
-    cta: (
-      <>
-        Pin <strong>DALI OS</strong> to your taskbar. In Chrome, click the
-        install icon at the right of the address bar (or <strong>⋮ →
-        Install DALI OS</strong>).
-      </>
-    ),
   },
 ];
 

--- a/dali-api/app/components/Layout.tsx
+++ b/dali-api/app/components/Layout.tsx
@@ -889,7 +889,9 @@ export function Layout({ user, photoUrl, isCore = false, isAdmin = false, isDoma
               )}
             </div>
             {!collapsed && (
-              <span className="text-xs text-white/80 truncate min-w-0">{user.email}</span>
+              <span className="text-xs text-white/80 truncate min-w-0">
+                {user.firstName}
+              </span>
             )}
           </button>
           {!collapsed && (

--- a/dali-api/app/components/Layout.tsx
+++ b/dali-api/app/components/Layout.tsx
@@ -33,6 +33,7 @@ import {
   Megaphone,
   SplitSquareHorizontal,
   ExternalLink,
+  HelpCircle,
 } from 'lucide-react'
 import { userInitials } from '~/lib/display'
 import { TabWorkspace, type TabWorkspaceHandle, type OpenTabRequest } from '~/components/TabWorkspace'
@@ -892,14 +893,34 @@ export function Layout({ user, photoUrl, isCore = false, isAdmin = false, isDoma
             )}
           </button>
           {!collapsed && (
-            <a
-              href="/logout"
-              className="p-1.5 text-white/40 hover:text-white/70 hover:bg-white/5 rounded-md transition flex-shrink-0"
-              title="Log out"
-              aria-label="Log out"
-            >
-              <LogOut className="w-4 h-4" />
-            </a>
+            <>
+              <button
+                type="button"
+                {...tabClickProps({ url: '/settings/connected-apps', label: 'Settings' })}
+                className="p-1.5 text-white/40 hover:text-white/70 hover:bg-white/5 rounded-md transition flex-shrink-0"
+                title="Settings"
+                aria-label="Settings"
+              >
+                <Settings className="w-4 h-4" />
+              </button>
+              <button
+                type="button"
+                {...tabClickProps({ url: '/help/mcp', label: 'Help' })}
+                className="p-1.5 text-white/40 hover:text-white/70 hover:bg-white/5 rounded-md transition flex-shrink-0"
+                title="Help"
+                aria-label="Help"
+              >
+                <HelpCircle className="w-4 h-4" />
+              </button>
+              <a
+                href="/logout"
+                className="p-1.5 text-white/40 hover:text-white/70 hover:bg-white/5 rounded-md transition flex-shrink-0"
+                title="Log out"
+                aria-label="Log out"
+              >
+                <LogOut className="w-4 h-4" />
+              </a>
+            </>
           )}
         </div>
       </div>

--- a/dali-api/app/routes/help.mcp.tsx
+++ b/dali-api/app/routes/help.mcp.tsx
@@ -1,10 +1,40 @@
 // Member-facing docs for connecting an AI assistant to DALI OS via MCP.
 
+import { useState } from "react";
+import { Check, Copy } from "lucide-react";
 import type { Route } from "./+types/help.mcp";
 
 export async function loader() {
   const base = process.env.API_BASE_URL ?? "https://os.dali.dartmouth.edu";
   return { mcpUrl: `${base}/mcp` };
+}
+
+function CopyBlock({ content }: { content: string }) {
+  const [copied, setCopied] = useState(false);
+  function copy() {
+    try {
+      navigator.clipboard.writeText(content);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // clipboard unavailable — give up silently
+    }
+  }
+  return (
+    <div className="relative mt-2">
+      <pre className="overflow-x-auto rounded bg-zinc-900 p-3 pr-10 text-xs text-zinc-100 whitespace-pre">
+        {content}
+      </pre>
+      <button
+        type="button"
+        onClick={copy}
+        aria-label="Copy to clipboard"
+        className="absolute top-2 right-2 p-1.5 rounded text-zinc-400 hover:text-white hover:bg-white/10"
+      >
+        {copied ? <Check className="w-3.5 h-3.5" /> : <Copy className="w-3.5 h-3.5" />}
+      </button>
+    </div>
+  );
 }
 
 export default function McpHelpPage({ loaderData }: Route.ComponentProps) {
@@ -19,9 +49,7 @@ export default function McpHelpPage({ loaderData }: Route.ComponentProps) {
 
       <section className="mt-6">
         <h2 className="text-lg font-semibold">Claude Code</h2>
-        <pre className="mt-2 overflow-x-auto rounded bg-zinc-900 p-3 text-xs text-zinc-100">
-          claude mcp add --transport http dalios {mcpUrl}
-        </pre>
+        <CopyBlock content={`claude mcp add --transport http dalios ${mcpUrl}`} />
         <p className="mt-2 text-sm text-zinc-600">
           Claude Code will open a browser to authorize you and then keep the
           bearer in its credential store.
@@ -30,9 +58,7 @@ export default function McpHelpPage({ loaderData }: Route.ComponentProps) {
 
       <section className="mt-6">
         <h2 className="text-lg font-semibold">Codex</h2>
-        <pre className="mt-2 overflow-x-auto rounded bg-zinc-900 p-3 text-xs text-zinc-100">
-          codex mcp add dalios {mcpUrl}
-        </pre>
+        <CopyBlock content={`codex mcp add dalios ${mcpUrl}`} />
       </section>
 
       <section className="mt-6">
@@ -41,15 +67,15 @@ export default function McpHelpPage({ loaderData }: Route.ComponentProps) {
           Add this entry to your Claude Desktop config (<code>claude_desktop_config.json</code>)
           and restart the app:
         </p>
-        <pre className="mt-2 overflow-x-auto rounded bg-zinc-900 p-3 text-xs text-zinc-100">
-{`{
+        <CopyBlock
+          content={`{
   "mcpServers": {
     "dalios": {
       "transport": { "type": "http", "url": "${mcpUrl}" }
     }
   }
 }`}
-        </pre>
+        />
       </section>
 
       <section className="mt-6">

--- a/dali-api/app/routes/help.mcp.tsx
+++ b/dali-api/app/routes/help.mcp.tsx
@@ -3,7 +3,7 @@
 import type { Route } from "./+types/help.mcp";
 
 export async function loader() {
-  const base = process.env.API_BASE_URL ?? "https://dalios.dartmouth.edu";
+  const base = process.env.API_BASE_URL ?? "https://os.dali.dartmouth.edu";
   return { mcpUrl: `${base}/mcp` };
 }
 
@@ -21,12 +21,19 @@ export default function McpHelpPage({ loaderData }: Route.ComponentProps) {
       <section className="mt-6">
         <h2 className="text-lg font-semibold">Claude Code</h2>
         <pre className="mt-2 overflow-x-auto rounded bg-zinc-900 p-3 text-xs text-zinc-100">
-          claude mcp add --transport http dali-os {mcpUrl}
+          claude mcp add --transport http dalios {mcpUrl}
         </pre>
         <p className="mt-2 text-sm text-zinc-600">
           Claude Code will open a browser to authorize you and then keep the
           bearer in its credential store.
         </p>
+      </section>
+
+      <section className="mt-6">
+        <h2 className="text-lg font-semibold">Codex</h2>
+        <pre className="mt-2 overflow-x-auto rounded bg-zinc-900 p-3 text-xs text-zinc-100">
+          codex mcp add dalios {mcpUrl}
+        </pre>
       </section>
 
       <section className="mt-6">
@@ -38,7 +45,7 @@ export default function McpHelpPage({ loaderData }: Route.ComponentProps) {
         <pre className="mt-2 overflow-x-auto rounded bg-zinc-900 p-3 text-xs text-zinc-100">
 {`{
   "mcpServers": {
-    "dali-os": {
+    "dalios": {
       "transport": { "type": "http", "url": "${mcpUrl}" }
     }
   }

--- a/dali-api/app/routes/help.mcp.tsx
+++ b/dali-api/app/routes/help.mcp.tsx
@@ -1,4 +1,4 @@
-// Member-facing docs for connecting Claude to DALI OS via MCP.
+// Member-facing docs for connecting an AI assistant to DALI OS via MCP.
 
 import type { Route } from "./+types/help.mcp";
 
@@ -11,11 +11,10 @@ export default function McpHelpPage({ loaderData }: Route.ComponentProps) {
   const { mcpUrl } = loaderData;
   return (
     <main className="mx-auto max-w-3xl p-8">
-      <h1 className="text-2xl font-semibold">Connect Claude to DALI OS</h1>
+      <h1 className="text-2xl font-semibold">Connect AI to DALI OS</h1>
       <p className="mt-2 text-sm text-zinc-600">
-        DALI OS exposes an MCP server so AI assistants like Claude can read your
-        DALI data on your behalf. v1 ships a single tool —{" "}
-        <code className="font-mono">whoami</code> — to validate the auth flow.
+        DALI OS exposes an MCP server so AI assistants can read your DALI data
+        on your behalf.
       </p>
 
       <section className="mt-6">

--- a/dali-api/e2e/calendar-settings.spec.ts
+++ b/dali-api/e2e/calendar-settings.spec.ts
@@ -1,24 +1,40 @@
 import { test, expect } from './fixtures';
 
+// Mon–Fri 9–5 InPerson, the same shape the UI's "turn working hours on" button
+// seeds. Materialized directly so each run starts from a known state instead of
+// inheriting whatever the previous run left behind.
+const SEEDED_WEEK = JSON.stringify(
+  Array.from({ length: 7 }, (_, dow) => ({
+    dayOfWeek: dow,
+    segments:
+      dow >= 1 && dow <= 5
+        ? [{ startMinute: 9 * 60, endMinute: 17 * 60, location: 'InPerson' }]
+        : [],
+  })),
+);
+
 test.describe('calendar settings persistence', () => {
   test.beforeEach(async ({ loginAs }) => {
     await loginAs({ daliEmail: 'jordan.taylor@dali.dartmouth.edu' });
   });
 
   test('Monday toggle persists across reloads', async ({ page }) => {
+    // Establish a deterministic starting state: working hours on, Mon–Fri
+    // enabled. This test mutates persistent DB rows, and an interrupted prior
+    // run can leave Monday disabled or working hours off — seeding up front
+    // makes it independent of inherited state rather than relying on a cleanup
+    // step that only runs if the test reaches the end.
+    const seedRes = await page.request.post('/calendar', {
+      form: { intent: 'seed-working-hours', days: SEEDED_WEEK },
+    });
+    expect(seedRes.ok()).toBeTruthy();
+
     // Render the calendar route standalone (skip workspace shell).
     await page.goto('/calendar?embed=1');
     await expect(page.getByRole('heading', { name: 'Availability' })).toBeVisible();
 
-    // Working Hours is off by default and the per-day editor is hidden until
-    // the master switch is on. Turn it on, which seeds the Mon–Fri default so
-    // Monday's segment editor appears.
-    const masterSwitch = page.getByRole('switch', { name: /Working hours enabled/i });
-    if ((await page.getByLabel('Mon segment 1 start').count()) === 0) {
-      await masterSwitch.click();
-      await expect(page.getByLabel('Mon segment 1 start')).toBeVisible();
-      await page.waitForLoadState('networkidle');
-    }
+    // The seed turned working hours on, so Monday's segment editor is present.
+    await expect(page.getByLabel('Mon segment 1 start')).toBeVisible();
 
     // Disable Monday via its per-day toggle (only present while the master
     // switch is on).
@@ -32,7 +48,7 @@ test.describe('calendar settings persistence', () => {
     await page.reload();
     await expect(page.getByLabel('Mon segment 1 start')).toHaveCount(0);
 
-    // Toggle Monday back on (leaves DB in enabled state for the next run).
+    // Toggle Monday back on and confirm the segment reappears.
     await page.getByRole('button', { name: /Mon enabled/i }).click();
     await expect(page.getByLabel('Mon segment 1 start')).toBeVisible();
     await page.waitForLoadState('networkidle');

--- a/dali-api/e2e/smoke.spec.ts
+++ b/dali-api/e2e/smoke.spec.ts
@@ -9,7 +9,9 @@ test('admin can log in and reach reviewer page', async ({ page, loginAs }) => {
   await loginAs({ daliEmail: 'admin@dali.dartmouth.edu' });
   await page.goto('/hiring/reviewer');
   await expect(page).toHaveURL(/\/hiring\/reviewer/);
-  await expect(page.locator('body')).toContainText('admin@dali.dartmouth.edu');
+  // Sidebar footer shows the user's first name; assert it inside <aside>
+  // to avoid matching the "Admin" copy that appears elsewhere on the page.
+  await expect(page.locator('aside').first()).toContainText('Admin');
 });
 
 test('domain lead can access domain-lead page', async ({ page, loginAs }) => {


### PR DESCRIPTION
## Summary
Follow-up to #717. Two adjustments:

- **Pulse the Next button after arrival.** When the user clicks the highlighted sidebar item and lands on the matching page, the coach card's Next button now gets its own pulsing coral ring so attention transfers from the sidebar target to the next action. Sidebar targets keep the full dim + cut-out; the Next button gets a ring-only highlight since the card is already prominent at z-50.
- **Rewrite the tour copy.** Shorter, more direct, lab-insider voice. Welcome modal now reads "DALI OS is live" with a one-sentence ask; step CTAs and arrival confirmations are pared down; final card points at the launch party without exclamations.

## Test plan
- [ ] Clear `dalios-launch-welcome-seen-v1` and `dalios-launch-tour-step-v1` from localStorage
- [ ] Reload `/` → welcome modal appears with new copy
- [ ] Click "Show me around" → coach card appears bottom-right, sidebar Projects button is spotlit
- [ ] Click Projects → "You're here" + Next button pulses
- [ ] Click Next → Calendar spotlight appears, repeat
- [ ] Final card shows new launch-party copy with "Sounds good" button
- [ ] Skip / X dismiss at any step works
- [ ] Modal does not reappear on reload after dismissal

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/727"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782502821&installation_id=133523038&pr_number=727&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F727&signature=028af7e741e55e9920b22164573091eaf447398f63927110f0cd75f18d400fa8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->