### PR TITLE
Launch welcome polish: pulse Next, less-AI copy (#727)

### DIFF
--- a/dali-api/app/calendar/routes/calendar.tsx
+++ b/dali-api/app/calendar/routes/calendar.tsx
@@ -613,9 +613,30 @@ function coerceFormToAction(raw: Record<string, FormDataEntryValue>): unknown {
 
 type Tab = "availability" | "schedule";
 
+const CALENDAR_TAB_STORAGE_KEY = "dali:calendar:tab";
+const AVAILABILITY_SIDEBAR_COLLAPSED_KEY = "dali:calendar:availability:sidebar-collapsed";
+
 export default function CalendarPage() {
   const data = useLoaderData<typeof loader>() as LoaderData;
-  const [tab, setTab] = useState<Tab>("availability");
+  // Persist the active tab in sessionStorage so navigating away and back
+  // (or the workspace iframe re-mounting on tab focus) restores where the
+  // user left off rather than always snapping back to Availability.
+  const [tab, setTab] = useState<Tab>(() => {
+    if (typeof window === "undefined") return "availability";
+    try {
+      const stored = window.sessionStorage.getItem(CALENDAR_TAB_STORAGE_KEY);
+      return stored === "schedule" ? "schedule" : "availability";
+    } catch {
+      return "availability";
+    }
+  });
+  useEffect(() => {
+    try {
+      window.sessionStorage.setItem(CALENDAR_TAB_STORAGE_KEY, tab);
+    } catch {
+      // sessionStorage disabled / quota — ignore
+    }
+  }, [tab]);
 
   return (
     <div className="flex flex-col gap-5">
@@ -667,7 +688,27 @@ function AvailabilityView({ data }: { data: LoaderData }) {
   // clipped by the inner overflow-hidden on short viewports.
   // Drag-to-create now lives inside AvailabilityWeekGrid: the selection stays
   // drawn on the grid and the editor opens as a popover anchored beside it.
-  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  //
+  // Collapse state is a deliberate user preference ("I want more grid room"),
+  // so it lives in localStorage and sticks across sessions.
+  const [sidebarCollapsed, setSidebarCollapsed] = useState<boolean>(() => {
+    if (typeof window === "undefined") return false;
+    try {
+      return window.localStorage.getItem(AVAILABILITY_SIDEBAR_COLLAPSED_KEY) === "1";
+    } catch {
+      return false;
+    }
+  });
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(
+        AVAILABILITY_SIDEBAR_COLLAPSED_KEY,
+        sidebarCollapsed ? "1" : "0",
+      );
+    } catch {
+      // localStorage disabled / quota — ignore
+    }
+  }, [sidebarCollapsed]);
   return (
     <div
       className={`grid grid-cols-1 gap-6 lg:h-[max(calc(100vh-9rem),56rem)] lg:min-h-0 px-3 pt-2 ${

--- a/dali-api/app/components/LaunchWelcome.tsx
+++ b/dali-api/app/components/LaunchWelcome.tsx
@@ -1,13 +1,16 @@
-import { useCallback, useEffect, useId, useState } from "react";
+import { useCallback, useEffect, useId, useRef, useState } from "react";
 import {
-  Sparkles,
   PartyPopper,
   FolderKanban,
   CalendarDays,
+  CalendarPlus,
   UserCircle2,
+  Users,
   ArrowRight,
   X as XIcon,
   Check,
+  Bot,
+  MonitorDown,
 } from "lucide-react";
 import { Modal } from "./Modal";
 
@@ -18,15 +21,63 @@ type Phase = "modal" | "card" | "done";
 
 type TourStep = {
   icon: React.ReactNode;
-  /** Short, action-oriented prompt. */
+  /** Short eyebrow label shown above the title on the card. */
+  eyebrow: string;
+  /** Step body — either a CTA to click a sidebar item or an info blurb. */
   cta: React.ReactNode;
-  /** Confirmation shown once the user lands on the matched page. */
-  arrived: React.ReactNode;
-  /** True if the iframe-reported URL means this step is satisfied. */
-  matches: (pathname: string) => boolean;
-  /** Locates the sidebar element to highlight, or null if not currently in DOM. */
-  findTarget: () => HTMLElement | null;
+  /** Confirmation shown after the user lands on the matched page. Required
+   *  for click-driven steps; omitted for info-only steps. */
+  arrived?: React.ReactNode;
+  /** True if the iframe-reported URL means this step is satisfied. Omitted
+   *  for info-only steps. */
+  matches?: (pathname: string) => boolean;
+  /** Locates the sidebar element to highlight. Omitted for info-only steps. */
+  findTarget?: () => HTMLElement | null;
+  /** Optional primary action for info-only steps. Click runs onClick AND
+   *  advances the tour. */
+  action?: { label: string; onClick: () => void };
 };
+
+/** Walks up through any iframe ancestors so the rect is in the parent
+ *  document's viewport coordinates (used by Spotlight on in-iframe targets). */
+function getRectInParent(el: HTMLElement): DOMRect {
+  let rect = el.getBoundingClientRect();
+  let doc: Document | null = el.ownerDocument;
+  while (doc && doc !== document) {
+    const frame = doc.defaultView?.frameElement as HTMLIFrameElement | null;
+    if (!frame) break;
+    const frameRect = frame.getBoundingClientRect();
+    rect = new DOMRect(
+      rect.left + frameRect.left,
+      rect.top + frameRect.top,
+      rect.width,
+      rect.height,
+    );
+    doc = frame.ownerDocument;
+  }
+  return rect;
+}
+
+/** Search any same-origin iframe for a button matching the predicate. Used
+ *  to target in-iframe tab pills (e.g. "Schedule Meeting" on the calendar). */
+function findInIframes(
+  predicate: (el: HTMLButtonElement) => boolean,
+): HTMLElement | null {
+  const iframes = document.querySelectorAll<HTMLIFrameElement>("iframe");
+  for (const iframe of iframes) {
+    try {
+      const doc = iframe.contentDocument;
+      if (!doc) continue;
+      const buttons = doc.querySelectorAll<HTMLButtonElement>("button");
+      for (const btn of buttons) {
+        if (predicate(btn)) return btn;
+      }
+    } catch {
+      // cross-origin iframe or detached — skip
+    }
+  }
+  return null;
+}
 
 function findInSidebar(predicate: (el: HTMLButtonElement) => boolean): HTMLElement | null {
   // Look in both desktop sidebar (<aside>) and the mobile nav panel. We can't
@@ -55,43 +106,112 @@ function findByExactText(text: string) {
 const STEPS: TourStep[] = [
   {
     icon: <FolderKanban className="w-4 h-4" />,
+    eyebrow: "Projects",
     cta: (
       <>
-        Click <strong>Projects</strong> in the sidebar to see every active
-        project.
+        Open <strong>Projects</strong> from the sidebar.
       </>
     ),
-    arrived: <>Nice — every active project lives here.</>,
+    arrived: <>All active projects live here.</>,
     matches: (p) => p.startsWith("/projects"),
     findTarget: () => findByExactText("Projects"),
   },
   {
     icon: <CalendarDays className="w-4 h-4" />,
+    eyebrow: "Calendar",
     cta: (
       <>
-        Now click <strong>Calendar</strong> to see lab meetings and events.
+        Open <strong>Calendar</strong> from the sidebar.
       </>
     ),
-    arrived: <>Lab meetings, standups, and your own events — all in lab time.</>,
+    arrived: <>Lab meetings and events.</>,
     matches: (p) => p.startsWith("/calendar"),
     findTarget: () => findByExactText("Calendar"),
   },
   {
-    icon: <UserCircle2 className="w-4 h-4" />,
+    icon: <CalendarPlus className="w-4 h-4" />,
+    eyebrow: "Schedule Meeting",
     cta: (
       <>
-        Last one — click your <strong>profile</strong> (bottom of the sidebar)
-        to make it yours.
+        At the top of the Calendar, switch to{" "}
+        <strong>Schedule Meeting</strong>.
       </>
     ),
     arrived: (
       <>
-        Add a photo and a few words — this is how the lab gets to know you.
+        See everyone&apos;s availability and create a meeting. No more
+        when2meets.
       </>
     ),
+    // No URL change happens when the pill is clicked (tab state lives in
+    // React state on the calendar page), so this step advances via a DOM
+    // click listener attached to the spotlit element instead of via
+    // dali:tabNavigated. See the find-target effect below.
+    findTarget: () =>
+      findInIframes(
+        (btn) => (btn.textContent || "").trim() === "Schedule Meeting",
+      ),
+  },
+  {
+    icon: <UserCircle2 className="w-4 h-4" />,
+    eyebrow: "Profile",
+    cta: (
+      <>
+        Open your <strong>profile</strong> from the bottom of the sidebar.
+      </>
+    ),
+    arrived: <>Add a photo and your details here.</>,
     matches: (p) => p.startsWith("/profile"),
     findTarget: () =>
       findInSidebar((btn) => btn.getAttribute("aria-label") === "Open profile"),
+  },
+  {
+    icon: <Users className="w-4 h-4" />,
+    eyebrow: "Members",
+    cta: (
+      <>
+        Open <strong>Members</strong> from the sidebar.
+      </>
+    ),
+    arrived: <>Everyone in the lab.</>,
+    matches: (p) => p.startsWith("/members"),
+    findTarget: () => findByExactText("Members"),
+  },
+  {
+    icon: <MonitorDown className="w-4 h-4" />,
+    eyebrow: "Install the app",
+    cta: (
+      <>
+        Pin <strong>DALI OS</strong> to your taskbar. In Chrome, click the
+        install icon at the right of the address bar (or <strong>⋮ →
+        Install DALI OS</strong>).
+      </>
+    ),
+  },
+  {
+    icon: <Bot className="w-4 h-4" />,
+    eyebrow: "Connect any AI",
+    cta: (
+      <>
+        Connect any AI assistant to the <strong>DALI OS MCP</strong> and let
+        it read your DALI data for you.
+      </>
+    ),
+    action: {
+      label: "Open docs",
+      onClick: () => {
+        // Layout listens for dali:openTab on the parent window and opens it
+        // in the workspace iframe rather than navigating the top frame.
+        window.postMessage(
+          {
+            type: "dali:openTab",
+            url: "/help/mcp",
+            label: "Connect AI to DALI OS",
+          },
+          window.location.origin,
+        );
+      },
+    },
   },
 ];
 
@@ -116,19 +236,27 @@ function readStep(): number {
   }
 }
 
-function Spotlight({ target }: { target: HTMLElement }) {
-  const [rect, setRect] = useState<DOMRect | null>(() => target.getBoundingClientRect());
-
+/**
+ * Tracks a target element's bounding rect, polling on resize/scroll plus a
+ * cheap interval so transitions (sidebar collapse, mobile drawer, iframe
+ * scroll) stay glued. Uses getRectInParent so in-iframe targets resolve to
+ * the parent document's viewport coordinates.
+ */
+function useTargetRect(target: HTMLElement | null): DOMRect | null {
+  const [rect, setRect] = useState<DOMRect | null>(() =>
+    target ? getRectInParent(target) : null,
+  );
   useEffect(() => {
+    if (!target) {
+      setRect(null);
+      return;
+    }
     let alive = true;
     function measure() {
-      if (!alive) return;
-      setRect(target.getBoundingClientRect());
+      if (!alive || !target) return;
+      setRect(getRectInParent(target));
     }
     measure();
-    // Sidebar can collapse, page can scroll, mobile drawer can open — poll
-    // cheaply so the spotlight stays glued to the element. Throwaway tour
-    // code, a 150ms tick is plenty smooth.
     const id = window.setInterval(measure, 150);
     window.addEventListener("resize", measure);
     window.addEventListener("scroll", measure, true);
@@ -139,37 +267,51 @@ function Spotlight({ target }: { target: HTMLElement }) {
       window.removeEventListener("scroll", measure, true);
     };
   }, [target]);
+  return rect;
+}
 
+/** Pulsing coral ring positioned around an element. No dim. */
+function PulseRing({ target, zIndex }: { target: HTMLElement; zIndex: number }) {
+  const rect = useTargetRect(target);
   if (!rect) return null;
-
   const PAD = 6;
-  const top = rect.top - PAD;
-  const left = rect.left - PAD;
-  const width = rect.width + PAD * 2;
-  const height = rect.height + PAD * 2;
+  return (
+    <div
+      aria-hidden="true"
+      className="pointer-events-none fixed rounded-md launch-tour-pulse"
+      style={{
+        top: rect.top - PAD,
+        left: rect.left - PAD,
+        width: rect.width + PAD * 2,
+        height: rect.height + PAD * 2,
+        zIndex,
+      }}
+    />
+  );
+}
 
+/** Full spotlight: dims the page everywhere except a cut-out over `target`,
+ *  with a pulsing ring on top. */
+function Spotlight({ target }: { target: HTMLElement }) {
+  const rect = useTargetRect(target);
+  if (!rect) return null;
+  const PAD = 6;
+  const box = {
+    top: rect.top - PAD,
+    left: rect.left - PAD,
+    width: rect.width + PAD * 2,
+    height: rect.height + PAD * 2,
+  };
   return (
     <>
-      {/* Cut-out: a transparent rectangle sitting where the target is, with
-          a massive box-shadow extending outward to dim the rest of the page.
-          pointer-events: none so the user can still click the real element. */}
+      {/* Cut-out: transparent rect with huge outward box-shadow dims the rest
+          of the page. pointer-events: none so clicks pass through. */}
       <div
         aria-hidden="true"
         className="pointer-events-none fixed z-40 rounded-md"
-        style={{
-          top,
-          left,
-          width,
-          height,
-          boxShadow: "0 0 0 9999px rgba(0, 0, 0, 0.55)",
-        }}
+        style={{ ...box, boxShadow: "0 0 0 9999px rgba(0, 0, 0, 0.55)" }}
       />
-      {/* Pulsing coral ring on top of the cut-out for emphasis. */}
-      <div
-        aria-hidden="true"
-        className="pointer-events-none fixed z-40 rounded-md launch-tour-pulse"
-        style={{ top, left, width, height }}
-      />
+      <PulseRing target={target} zIndex={41} />
     </>
   );
 }
@@ -178,7 +320,9 @@ export function LaunchWelcome({ firstName }: { firstName: string }) {
   const [phase, setPhase] = useState<Phase>("done");
   const [step, setStep] = useState(0);
   const [arrived, setArrived] = useState(false);
-  const [target, setTarget] = useState<HTMLElement | null>(null);
+  const [sidebarTarget, setSidebarTarget] = useState<HTMLElement | null>(null);
+  const nextButtonRef = useRef<HTMLButtonElement | null>(null);
+  const [nextTarget, setNextTarget] = useState<HTMLElement | null>(null);
   const titleId = useId();
 
   useEffect(() => {
@@ -186,37 +330,78 @@ export function LaunchWelcome({ firstName }: { firstName: string }) {
     setStep(readStep());
   }, []);
 
-  // Re-resolve the highlight target whenever the active step changes or the
-  // sidebar DOM might have shifted (mobile drawer open/close). Cheap interval
-  // because the sidebar isn't always present at mount time.
+  // Re-resolve the highlight target whenever the active step changes.
+  // Cheap interval because the target may not be present at mount time
+  // (sidebar not laid out yet, calendar iframe still loading, etc.).
+  // Info-only steps (no findTarget) never show a spotlight.
+  //
+  // For steps that have no URL `matches` (e.g. the in-page Schedule Meeting
+  // pill), there's no dali:tabNavigated to advance on, so we attach a DOM
+  // click listener to the resolved target instead. Clicking the spotlit
+  // element flips the step to "arrived" the same way a URL change would.
   useEffect(() => {
     if (phase !== "card") return;
     if (step >= STEPS.length) return;
-    if (arrived) {
-      setTarget(null);
+    const s = STEPS[step];
+    const find = s.findTarget;
+    if (!find || arrived) {
+      setSidebarTarget(null);
       return;
     }
-    const find = STEPS[step].findTarget;
+    const advanceOnClick = !s.matches;
+    let attached: HTMLElement | null = null;
+    function onClick() {
+      setArrived(true);
+    }
     function resolve() {
-      const el = find();
-      setTarget(el);
+      const found = find!();
+      setSidebarTarget(found);
+      if (advanceOnClick && found !== attached) {
+        if (attached) attached.removeEventListener("click", onClick);
+        if (found) found.addEventListener("click", onClick);
+        attached = found;
+      }
     }
     resolve();
     const id = window.setInterval(resolve, 300);
-    return () => window.clearInterval(id);
+    return () => {
+      window.clearInterval(id);
+      if (attached) attached.removeEventListener("click", onClick);
+    };
+  }, [phase, step, arrived]);
+
+  // Pulse the card's primary action button. For click-driven steps this is
+  // the Next button after the user arrives at the matched page. For info-only
+  // steps (e.g. MCP) the primary action is shown immediately, so pulse it
+  // from the start. Refs alone don't trigger re-renders, so we copy the
+  // current DOM node into state once it's in the tree.
+  useEffect(() => {
+    if (phase !== "card") {
+      setNextTarget(null);
+      return;
+    }
+    if (step >= STEPS.length) {
+      setNextTarget(null);
+      return;
+    }
+    const s = STEPS[step];
+    const shouldPulse = s.findTarget ? arrived : true;
+    setNextTarget(shouldPulse ? nextButtonRef.current : null);
   }, [phase, step, arrived]);
 
   // Listen for iframe-reported tab navigation — that's how the workspace
-  // signals "the user is now looking at X". Falls back to top-level pathname
-  // for routes that aren't tab-wrapped.
+  // signals "the user is now looking at X". Sidebar clicks open iframe tabs,
+  // so useLocation on the parent shell never fires.
   const handleUrl = useCallback(
     (url: string) => {
       if (phase !== "card") return;
       if (arrived) return;
       if (step >= STEPS.length) return;
+      const match = STEPS[step].matches;
+      if (!match) return; // info-only step — URL changes don't advance it
       try {
         const path = new URL(url, window.location.origin).pathname;
-        if (STEPS[step].matches(path)) setArrived(true);
+        if (match(path)) setArrived(true);
       } catch {
         // Bad URL — ignore.
       }
@@ -246,6 +431,14 @@ export function LaunchWelcome({ firstName }: { firstName: string }) {
     setPhase("card");
   }
 
+  function finishAndGoHome() {
+    window.postMessage(
+      { type: "dali:openTab", url: "/", label: "Home" },
+      window.location.origin,
+    );
+    finishTour();
+  }
+
   function finishTour() {
     try {
       window.localStorage.setItem(DONE_KEY, new Date().toISOString());
@@ -273,11 +466,7 @@ export function LaunchWelcome({ firstName }: { firstName: string }) {
     return (
       <Modal open onClose={finishTour} labelledBy={titleId}>
         <div className="flex flex-col gap-4">
-          <div className="flex items-center justify-between">
-            <span className="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-accent-coral">
-              <Sparkles className="w-4 h-4" />
-              Welcome
-            </span>
+          <div className="flex items-center justify-end">
             <button
               type="button"
               onClick={finishTour}
@@ -291,21 +480,15 @@ export function LaunchWelcome({ firstName }: { firstName: string }) {
               id={titleId}
               className="font-heading text-xl font-bold text-foreground"
             >
-              Hey {firstName} — welcome to DALIos
+              Welcome to DALI OS
             </h2>
             <p className="text-sm text-muted-foreground mt-2 leading-relaxed">
-              This is the new home for everything DALI. Want a quick tour? We'll
-              point you at a few spots in the sidebar — click as you go.
+              Hi {firstName}. DALI OS is the home of everything DALI,
+              replacing Notion as the lab&apos;s internal site. Want a quick
+              tour?
             </p>
           </div>
           <div className="flex items-center justify-end gap-2 pt-2">
-            <button
-              type="button"
-              onClick={finishTour}
-              className="text-sm text-muted-foreground hover:text-foreground px-3 py-2"
-            >
-              Maybe later
-            </button>
             <button
               type="button"
               onClick={startTour}
@@ -325,8 +508,6 @@ export function LaunchWelcome({ firstName }: { firstName: string }) {
 
   return (
     <>
-      {/* CSS keyframes for the spotlight pulse. Scoped to this component via
-          the .launch-tour-pulse class so removal = delete file. */}
       <style>{`
         @keyframes launch-tour-pulse {
           0%, 100% {
@@ -347,7 +528,13 @@ export function LaunchWelcome({ firstName }: { firstName: string }) {
         }
       `}</style>
 
-      {target && !arrived && !isFinal && <Spotlight target={target} />}
+      {/* Sidebar spotlight before they click. */}
+      {sidebarTarget && !arrived && !isFinal && <Spotlight target={sidebarTarget} />}
+
+      {/* Next-button ring after they arrive (no dim — card is already prominent). */}
+      {nextTarget && arrived && !isFinal && (
+        <PulseRing target={nextTarget} zIndex={60} />
+      )}
 
       <div className="fixed bottom-4 right-4 z-50 w-80 max-w-[calc(100vw-2rem)] pointer-events-auto">
         <div className="bg-card border border-border rounded-2xl shadow-brand-2 p-4 flex flex-col gap-3">
@@ -364,7 +551,7 @@ export function LaunchWelcome({ firstName }: { firstName: string }) {
                 ? "Launch party"
                 : arrived
                   ? "You're here"
-                  : `Step ${step + 1} of ${STEPS.length}`}
+                  : current!.eyebrow}
             </span>
             <button
               type="button"
@@ -376,18 +563,15 @@ export function LaunchWelcome({ firstName }: { firstName: string }) {
             </button>
           </div>
 
-          <p className="text-sm text-foreground leading-relaxed">
+          <div className="text-sm text-foreground leading-relaxed">
             {isFinal ? (
-              <>
-                That's the tour! 🎉 The site launch party is right around the
-                corner — keep an eye on the calendar for the invite.
-              </>
+              <>Welcome to DALI OS!</>
             ) : arrived ? (
               current!.arrived
             ) : (
               current!.cta
             )}
-          </p>
+          </div>
 
           <div className="flex items-center gap-1.5" aria-hidden="true">
             {STEPS.map((_, i) => (
@@ -407,13 +591,14 @@ export function LaunchWelcome({ firstName }: { firstName: string }) {
             {isFinal ? (
               <button
                 type="button"
-                onClick={finishTour}
+                onClick={finishAndGoHome}
                 className="inline-flex items-center gap-1.5 rounded-lg bg-accent-coral px-3 py-1.5 text-sm font-semibold text-white hover:bg-accent-coral/90"
               >
-                Let's go
+                Back to home
               </button>
             ) : arrived ? (
               <button
+                ref={nextButtonRef}
                 type="button"
                 onClick={advance}
                 className="inline-flex items-center gap-1.5 rounded-lg bg-accent-coral px-3 py-1.5 text-sm font-semibold text-white hover:bg-accent-coral/90"
@@ -421,6 +606,28 @@ export function LaunchWelcome({ firstName }: { firstName: string }) {
                 Next
                 <ArrowRight className="w-4 h-4" />
               </button>
+            ) : current && !current.findTarget ? (
+              <>
+                <button
+                  type="button"
+                  onClick={advance}
+                  className="text-xs text-muted-foreground hover:text-foreground"
+                >
+                  Skip
+                </button>
+                <button
+                  ref={nextButtonRef}
+                  type="button"
+                  onClick={() => {
+                    current.action?.onClick();
+                    advance();
+                  }}
+                  className="inline-flex items-center gap-1.5 rounded-lg bg-accent-coral px-3 py-1.5 text-sm font-semibold text-white hover:bg-accent-coral/90"
+                >
+                  {current.action?.label ?? "Next"}
+                  <ArrowRight className="w-4 h-4" />
+                </button>
+              </>
             ) : (
               <>
                 <button
@@ -436,7 +643,7 @@ export function LaunchWelcome({ firstName }: { firstName: string }) {
                   className="text-xs text-muted-foreground hover:text-foreground"
                   title="Skip this step"
                 >
-                  I'm there →
+                  I&apos;m there
                 </button>
               </>
             )}

--- a/dali-api/app/components/Layout.tsx
+++ b/dali-api/app/components/Layout.tsx
@@ -33,6 +33,7 @@ import {
   Megaphone,
   SplitSquareHorizontal,
   ExternalLink,
+  HelpCircle,
 } from 'lucide-react'
 import { userInitials } from '~/lib/display'
 import { TabWorkspace, type TabWorkspaceHandle, type OpenTabRequest } from '~/components/TabWorkspace'
@@ -888,18 +889,40 @@ export function Layout({ user, photoUrl, isCore = false, isAdmin = false, isDoma
               )}
             </div>
             {!collapsed && (
-              <span className="text-xs text-white/80 truncate min-w-0">{user.email}</span>
+              <span className="text-xs text-white/80 truncate min-w-0">
+                {user.firstName}
+              </span>
             )}
           </button>
           {!collapsed && (
-            <a
-              href="/logout"
-              className="p-1.5 text-white/40 hover:text-white/70 hover:bg-white/5 rounded-md transition flex-shrink-0"
-              title="Log out"
-              aria-label="Log out"
-            >
-              <LogOut className="w-4 h-4" />
-            </a>
+            <>
+              <button
+                type="button"
+                {...tabClickProps({ url: '/settings/connected-apps', label: 'Settings' })}
+                className="p-1.5 text-white/40 hover:text-white/70 hover:bg-white/5 rounded-md transition flex-shrink-0"
+                title="Settings"
+                aria-label="Settings"
+              >
+                <Settings className="w-4 h-4" />
+              </button>
+              <button
+                type="button"
+                {...tabClickProps({ url: '/help/mcp', label: 'Help' })}
+                className="p-1.5 text-white/40 hover:text-white/70 hover:bg-white/5 rounded-md transition flex-shrink-0"
+                title="Help"
+                aria-label="Help"
+              >
+                <HelpCircle className="w-4 h-4" />
+              </button>
+              <a
+                href="/logout"
+                className="p-1.5 text-white/40 hover:text-white/70 hover:bg-white/5 rounded-md transition flex-shrink-0"
+                title="Log out"
+                aria-label="Log out"
+              >
+                <LogOut className="w-4 h-4" />
+              </a>
+            </>
           )}
         </div>
       </div>

--- a/dali-api/app/routes/help.mcp.tsx
+++ b/dali-api/app/routes/help.mcp.tsx
@@ -1,32 +1,64 @@
-// Member-facing docs for connecting Claude to DALI OS via MCP.
+// Member-facing docs for connecting an AI assistant to DALI OS via MCP.
 
+import { useState } from "react";
+import { Check, Copy } from "lucide-react";
 import type { Route } from "./+types/help.mcp";
 
 export async function loader() {
-  const base = process.env.API_BASE_URL ?? "https://dalios.dartmouth.edu";
+  const base = process.env.API_BASE_URL ?? "https://os.dali.dartmouth.edu";
   return { mcpUrl: `${base}/mcp` };
+}
+
+function CopyBlock({ content }: { content: string }) {
+  const [copied, setCopied] = useState(false);
+  function copy() {
+    try {
+      navigator.clipboard.writeText(content);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // clipboard unavailable — give up silently
+    }
+  }
+  return (
+    <div className="relative mt-2">
+      <pre className="overflow-x-auto rounded bg-zinc-900 p-3 pr-10 text-xs text-zinc-100 whitespace-pre">
+        {content}
+      </pre>
+      <button
+        type="button"
+        onClick={copy}
+        aria-label="Copy to clipboard"
+        className="absolute top-2 right-2 p-1.5 rounded text-zinc-400 hover:text-white hover:bg-white/10"
+      >
+        {copied ? <Check className="w-3.5 h-3.5" /> : <Copy className="w-3.5 h-3.5" />}
+      </button>
+    </div>
+  );
 }
 
 export default function McpHelpPage({ loaderData }: Route.ComponentProps) {
   const { mcpUrl } = loaderData;
   return (
     <main className="mx-auto max-w-3xl p-8">
-      <h1 className="text-2xl font-semibold">Connect Claude to DALI OS</h1>
+      <h1 className="text-2xl font-semibold">Connect AI to DALI OS</h1>
       <p className="mt-2 text-sm text-zinc-600">
-        DALI OS exposes an MCP server so AI assistants like Claude can read your
-        DALI data on your behalf. v1 ships a single tool —{" "}
-        <code className="font-mono">whoami</code> — to validate the auth flow.
+        DALI OS exposes an MCP server so AI assistants can read your DALI data
+        on your behalf.
       </p>
 
       <section className="mt-6">
         <h2 className="text-lg font-semibold">Claude Code</h2>
-        <pre className="mt-2 overflow-x-auto rounded bg-zinc-900 p-3 text-xs text-zinc-100">
-          claude mcp add --transport http dali-os {mcpUrl}
-        </pre>
+        <CopyBlock content={`claude mcp add --transport http dalios ${mcpUrl}`} />
         <p className="mt-2 text-sm text-zinc-600">
           Claude Code will open a browser to authorize you and then keep the
           bearer in its credential store.
         </p>
+      </section>
+
+      <section className="mt-6">
+        <h2 className="text-lg font-semibold">Codex</h2>
+        <CopyBlock content={`codex mcp add dalios ${mcpUrl}`} />
       </section>
 
       <section className="mt-6">
@@ -35,15 +67,15 @@ export default function McpHelpPage({ loaderData }: Route.ComponentProps) {
           Add this entry to your Claude Desktop config (<code>claude_desktop_config.json</code>)
           and restart the app:
         </p>
-        <pre className="mt-2 overflow-x-auto rounded bg-zinc-900 p-3 text-xs text-zinc-100">
-{`{
+        <CopyBlock
+          content={`{
   "mcpServers": {
-    "dali-os": {
+    "dalios": {
       "transport": { "type": "http", "url": "${mcpUrl}" }
     }
   }
 }`}
-        </pre>
+        />
       </section>
 
       <section className="mt-6">

--- a/dali-api/e2e/calendar-settings.spec.ts
+++ b/dali-api/e2e/calendar-settings.spec.ts
@@ -1,24 +1,40 @@
 import { test, expect } from './fixtures';
 
+// Mon–Fri 9–5 InPerson, the same shape the UI's "turn working hours on" button
+// seeds. Materialized directly so each run starts from a known state instead of
+// inheriting whatever the previous run left behind.
+const SEEDED_WEEK = JSON.stringify(
+  Array.from({ length: 7 }, (_, dow) => ({
+    dayOfWeek: dow,
+    segments:
+      dow >= 1 && dow <= 5
+        ? [{ startMinute: 9 * 60, endMinute: 17 * 60, location: 'InPerson' }]
+        : [],
+  })),
+);
+
 test.describe('calendar settings persistence', () => {
   test.beforeEach(async ({ loginAs }) => {
     await loginAs({ daliEmail: 'jordan.taylor@dali.dartmouth.edu' });
   });
 
   test('Monday toggle persists across reloads', async ({ page }) => {
+    // Establish a deterministic starting state: working hours on, Mon–Fri
+    // enabled. This test mutates persistent DB rows, and an interrupted prior
+    // run can leave Monday disabled or working hours off — seeding up front
+    // makes it independent of inherited state rather than relying on a cleanup
+    // step that only runs if the test reaches the end.
+    const seedRes = await page.request.post('/calendar', {
+      form: { intent: 'seed-working-hours', days: SEEDED_WEEK },
+    });
+    expect(seedRes.ok()).toBeTruthy();
+
     // Render the calendar route standalone (skip workspace shell).
     await page.goto('/calendar?embed=1');
     await expect(page.getByRole('heading', { name: 'Availability' })).toBeVisible();
 
-    // Working Hours is off by default and the per-day editor is hidden until
-    // the master switch is on. Turn it on, which seeds the Mon–Fri default so
-    // Monday's segment editor appears.
-    const masterSwitch = page.getByRole('switch', { name: /Working hours enabled/i });
-    if ((await page.getByLabel('Mon segment 1 start').count()) === 0) {
-      await masterSwitch.click();
-      await expect(page.getByLabel('Mon segment 1 start')).toBeVisible();
-      await page.waitForLoadState('networkidle');
-    }
+    // The seed turned working hours on, so Monday's segment editor is present.
+    await expect(page.getByLabel('Mon segment 1 start')).toBeVisible();
 
     // Disable Monday via its per-day toggle (only present while the master
     // switch is on).
@@ -32,7 +48,7 @@ test.describe('calendar settings persistence', () => {
     await page.reload();
     await expect(page.getByLabel('Mon segment 1 start')).toHaveCount(0);
 
-    // Toggle Monday back on (leaves DB in enabled state for the next run).
+    // Toggle Monday back on and confirm the segment reappears.
     await page.getByRole('button', { name: /Mon enabled/i }).click();
     await expect(page.getByLabel('Mon segment 1 start')).toBeVisible();
     await page.waitForLoadState('networkidle');

--- a/dali-api/e2e/smoke.spec.ts
+++ b/dali-api/e2e/smoke.spec.ts
@@ -9,7 +9,9 @@ test('admin can log in and reach reviewer page', async ({ page, loginAs }) => {
   await loginAs({ daliEmail: 'admin@dali.dartmouth.edu' });
   await page.goto('/hiring/reviewer');
   await expect(page).toHaveURL(/\/hiring\/reviewer/);
-  await expect(page.locator('body')).toContainText('admin@dali.dartmouth.edu');
+  // Sidebar footer shows the user's first name; assert it inside <aside>
+  // to avoid matching the "Admin" copy that appears elsewhere on the page.
+  await expect(page.locator('aside').first()).toContainText('Admin');
 });
 
 test('domain lead can access domain-lead page', async ({ page, loginAs }) => {


### PR DESCRIPTION
* Pulse the Next button after arrival + rewrite tour copy

Two changes:
- After the user clicks the highlighted sidebar item and lands on the matching page, the coach card's Next button gets its own pulsing coral ring so the eye knows where to go next. The full-screen dim/cut-out is only used for sidebar targets; the Next button gets ring-only since the card is already prominent at z-50.
- Rewrites all the tour copy to sound less like marketing/AI: short sentences, no em-dash flourishes, lab-insider voice. Welcome modal now reads "DALI OS is live" with a one-sentence intro; step CTAs and arrival confirmations are pared down; final card points at the launch party without exclamations.



* Reframe tour copy for the launch party (factual, Notion-replacement context)

The modal is shown to users at the in-person DALI OS launch party, so:
- Welcome modal frames DALI OS as the lab's new internal site replacing Notion (the actual context users need)
- Step arrival messages are brief and factual ("All active projects live here", "Lab meetings and events", "Add a photo and your details here") — no quirky phrasings
- Step CTAs all start with "Open …" for consistency
- Final card thanks the user for coming and points at the in-progress party (the modal is the party experience, not a future reference)



* Frame DALI OS as the home of everything DALI in welcome body



* Add an MCP step to the tour for connecting AI to DALI OS

A 4th tour step introduces the MCP endpoint: "DALI OS speaks MCP, so you can connect any AI assistant to read your DALI data on your behalf." Since there's no sidebar entry for /help/mcp, this step is info-only — no spotlight, primary "Open docs" button that posts dali:openTab to the parent shell (which opens the docs in a workspace tab) and advances the tour. The action button gets the same pulsing-ring treatment as the post-arrival Next button on click-driven steps. TourStep type now carries an eyebrow field so each step has a meaningful label instead of "Step N of M".



* Reword MCP step in plain English

"DALI OS speaks MCP" was opaque jargon. Lead with the action instead: "Connect any AI assistant to the DALI OS MCP..."



* Show the Claude Code MCP-add command in the AI step

Adds a CopyableCommand widget (dark code block + copy button with check confirmation) inline in the MCP step's CTA so users can paste it straight into their terminal. Also switches the card body wrapper from <p> to <div> since the command block is a block-level element.



* Use dalios (no hyphen) as the default MCP server name



* Add Codex CLI snippet (tour step + /help/mcp), unify on "dalios" server name

- Tour MCP step now shows two labelled snippets (Claude Code + Codex), each with its own copy button.
- /help/mcp page mirrors the same: adds a Codex section, renames the server from "dali-os" to "dalios" everywhere (CLI snippet + desktop JSON), and fixes the default API_BASE_URL fallback to os.dali.dartmouth.edu.



* Generalize /help/mcp intro to any AI assistant

Drops "like Claude" from the body, removes the v1/whoami sentence (no longer accurate as tools land), and retitles the page to "Connect AI to DALI OS" so it matches the tour step's framing.



* Move MCP commands out of the tour popup into /help/mcp with copy buttons

- LaunchWelcome MCP step is now just a one-line blurb plus the "Open docs" button — the popup is too cramped to hold real commands. Drops the inline CopyableCommand widget and the hardcoded command constants.
- /help/mcp wraps each command block in a CopyBlock with a corner copy/check toggle, so users can grab the Claude Code, Codex, or Claude Desktop snippets in one click.



* Surface /settings/connected-apps and /help/mcp in the sidebar footer

Both pages were previously orphaned — only reachable from /privacy, /login, or the launch tour. Adds a Settings and a Help icon button to the sidebar footer between the profile avatar and Logout, opening each in the workspace tab so they live alongside other content. Both hide when the sidebar is collapsed, matching the existing Logout behavior.



* e2e: deterministically seed working hours in calendar settings test

The "Monday toggle persists" test mutated jordan.taylor's persistent WorkingHoursDay rows and depended on inherited DB state plus a cleanup step that only ran if the test reached the end. An interrupted prior run (or the in-test retry after a timeout) could leave working hours off or Monday disabled, so the next run's master-switch path failed to reveal the segment editor — the flake seen in CI.

Seed the full Mon–Fri default via POST /calendar in the test body so it starts from a known state regardless of what a previous run left behind, matching the existing global-setup cleanup pattern.



* Tour: highlight in-iframe Schedule Meeting pill + show first name in footer

LaunchWelcome:
- New "Schedule Meeting" step inserted between Calendar and Profile.
- Adds iframe-aware target finding (findInIframes) and a parent-coordinate rect translator (getRectInParent) so the spotlight can land on the pill button inside the calendar workspace iframe.
- For steps with a findTarget but no URL matches function (like this one, where clicking the pill is pure React state with no URL change), the find-target effect attaches a DOM click listener to the resolved element and advances the tour on click instead of waiting for dali:tabNavigated.

Layout:
- Sidebar profile footer now shows the user's first name instead of their full email (less noisy, more personal).



* Final tour button takes the user back to Home

Replaces the no-op "Done" button on the launch-party card with "Back to home". Clicking it posts dali:openTab for "/" (so it opens in the workspace tab system instead of changing the top-level URL) and finishes the tour the same way Done used to. Lands the user back where they started.



* Fix smoke e2e + persist Calendar inner tab in sessionStorage

- e2e/smoke.spec.ts: the assertion looked for the admin's email in the page body, which broke when the sidebar footer switched from email to first name. Assert "Admin" inside <aside> instead (avoids picking up the word in other UI text).
- app/calendar/routes/calendar.tsx: the Availability/Schedule Meeting pill toggle was React state with a fixed default, so navigating away from the calendar tab and back snapped you to Availability every time. Now reads/writes sessionStorage so the inner tab survives re-mounts within a session.



* Persist the Availability sidebar collapse state in localStorage

Collapsing the left panel on Calendar > My Availability is a deliberate "give me more grid room" preference, not a one-time interaction, so it should outlive the session. Reads/writes
dali:calendar:availability:sidebar-collapsed and restores on mount.



* Trim the final tour card to "Welcome to DALI OS."

Bookends the welcome modal's opening line without the templated "that's the tour / thanks for coming" closer.



* Final card uses an exclamation: "Welcome to DALI OS!"



* Trim welcome modal: drop sparkle eyebrow and redundant "Not now" button

The "Sparkles + Welcome" eyebrow was redundant against the h2 directly below ("Welcome to DALI OS"). The "Not now" footer button did the exact same thing as the top-right Skip link, so it's gone too. Skip stays as the single dismiss path; "Show me around" is the only primary action.



* Add Members tour step

Inserts between Profile and the AI/MCP step so the tour goes: Projects → Calendar → Schedule Meeting → Profile → Members → AI → Final. Copy matches the style of the other sidebar steps:

  CTA:     Open Members from the sidebar.
  Arrived: Everyone in the lab.



* Add Install-the-app tour step

Info-only step after the AI/MCP step that points users at Chrome's PWA install path so they can pin DALI OS to their taskbar. No action button — PWAs have no shareable install URL and we don't have a service worker registered to wire up programmatic beforeinstallprompt. Plain text instructions are enough for the launch.



* Move Install step before AI step

So the AI step stays the last "extra" before the final welcome card.



---------

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/728"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782509081&installation_id=133523038&pr_number=728&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F728&signature=051a5d110cb0a6d82a6ffb9fcf7b2db913a85e97375af0fe97fb81976e5dd995"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->