### PR TITLE
Staffing: one row per ranked bid, never gated by eligibility (#730)

### DIFF
--- a/dali-api/app/projects/lib/__tests__/bid-validation.test.ts
+++ b/dali-api/app/projects/lib/__tests__/bid-validation.test.ts
@@ -43,10 +43,10 @@ describe("validateBids — domain-driven biddability", () => {
     expect(mockPrisma.projectDomain.findMany).toHaveBeenCalled();
   });
 
-  it("records a bid on a project OUTSIDE the member's eligibility domains, at the default level", async () => {
-    // Member is Engineering-only, but bids a Design-only project. The bid must
-    // still resolve (product intent: every bid shows), labeled with the
-    // project's domain at the baseline P1 since the member has no level there.
+  it("still records ONE bid on a project OUTSIDE the member's eligibility domains, at the project's domain/P1", async () => {
+    // Member is Engineering-only, but bids a Design-only project. Eligibility
+    // never gates a bid: it still resolves to one row, placed in the project's
+    // declared domain at the baseline P1.
     mockPrisma.domainEligibility.findMany.mockResolvedValue([
       { domainId: "eng", level: "P3" },
     ]);
@@ -62,9 +62,10 @@ describe("validateBids — domain-driven biddability", () => {
     ]);
   });
 
-  it("produces no rows only when the project declares no domains at all", async () => {
-    // Nothing to do with eligibility — a project with zero ProjectDomain rows
-    // has no column to place a bid in, so it contributes nothing.
+  it("records a bid on a project with NO declared domains in the member's own eligibility domain", async () => {
+    // Real case (Deserto): the project declares zero ProjectDomain rows. The bid
+    // must still resolve — fall back to the member's own highest-level
+    // eligibility domain so it lands in a real column instead of vanishing.
     mockPrisma.domainEligibility.findMany.mockResolvedValue([
       { domainId: "eng", level: "P3" },
     ]);
@@ -73,7 +74,24 @@ describe("validateBids — domain-driven biddability", () => {
     const res = await validateBids("u1", cycle, [{ projectId: "p1" }]);
     expect(res.ok).toBe(true);
     if (!res.ok) return;
-    expect(res.bids).toEqual([]);
+    expect(res.bids).toEqual([
+      { projectId: "p1", domainId: "eng", level: "P3", preferenceRank: 1, notes: null },
+    ]);
+  });
+
+  it("STILL records a bid when the project declares no domains AND the member has no eligibility (empty domain)", async () => {
+    // The bid is never dropped. With no project domain and no member domain, it
+    // falls back to the empty-string domain at P1 — the card still shows under
+    // the project column (the board places bids by project, not domain).
+    mockPrisma.domainEligibility.findMany.mockResolvedValue([]);
+    mockPrisma.projectDomain.findMany.mockResolvedValue([]);
+
+    const res = await validateBids("u1", cycle, [{ projectId: "p1" }]);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.bids).toEqual([
+      { projectId: "p1", domainId: "", level: "P1", preferenceRank: 1, notes: null },
+    ]);
   });
 
   it("uses the member's eligibility level, and ranks bids by submission order", async () => {
@@ -97,9 +115,9 @@ describe("validateBids — domain-driven biddability", () => {
     ]);
   });
 
-  it("resolves a bid even when the member has NO eligibility at all, at the default level", async () => {
-    // No eligibility no longer drops bids. The project's declared domains drive
-    // the rows; level falls back to P1 since the member has none.
+  it("still records a bid when the member has NO eligibility, in the project's first declared domain at P1", async () => {
+    // No eligibility never drops a bid. With no member domain to prefer, it
+    // lands in the project's first declared domain at the baseline P1.
     mockPrisma.domainEligibility.findMany.mockResolvedValue([]);
     mockPrisma.projectDomain.findMany.mockResolvedValue([
       { projectId: "p1", domainId: "eng" },
@@ -112,11 +130,9 @@ describe("validateBids — domain-driven biddability", () => {
     ]);
   });
 
-  it("lands a bid only in the member's eligibility domain when the project overlaps it", async () => {
-    // Member eligible in eng (P2) only; project declares eng + design. The bid
-    // lands ONLY in eng (the overlap) at P2 — design is dropped because the
-    // member is eligible somewhere in this project, so we don't spill into
-    // domains they have nothing to do with.
+  it("lands a multi-domain bid in the member's eligibility domain (single row, their level)", async () => {
+    // Member eligible in eng (P2) only; project declares eng + design. ONE row,
+    // in eng (the overlap) at P2 — never one-row-per-domain.
     mockPrisma.domainEligibility.findMany.mockResolvedValue([
       { domainId: "eng", level: "P2" },
     ]);
@@ -132,9 +148,28 @@ describe("validateBids — domain-driven biddability", () => {
     ]);
   });
 
-  it("expands across ALL project domains only when there's no eligibility overlap", async () => {
-    // Member eligible in eng; project declares design + uiux (no overlap). The
-    // bid falls back to every project domain at the default level so it shows.
+  it("picks the member's HIGHEST-level overlapping domain for a multi-domain project", async () => {
+    // Member eligible in eng (P1) and design (P3); project declares both. The
+    // single row uses design (P3) — the strongest claim wins.
+    mockPrisma.domainEligibility.findMany.mockResolvedValue([
+      { domainId: "eng", level: "P1" },
+      { domainId: "design", level: "P3" },
+    ]);
+    mockPrisma.projectDomain.findMany.mockResolvedValue([
+      { projectId: "p1", domainId: "eng" },
+      { projectId: "p1", domainId: "design" },
+    ]);
+    const res = await validateBids("u1", cycle, [{ projectId: "p1" }]);
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.bids).toEqual([
+      { projectId: "p1", domainId: "design", level: "P3", preferenceRank: 1, notes: null },
+    ]);
+  });
+
+  it("records ONE bid when the project shares no domain with eligibility (project's first domain, P1)", async () => {
+    // Member eligible in eng; project declares design + uiux (no overlap). Never
+    // gated: one row in the project's first declared domain at P1.
     mockPrisma.domainEligibility.findMany.mockResolvedValue([
       { domainId: "eng", level: "P3" },
     ]);
@@ -147,7 +182,6 @@ describe("validateBids — domain-driven biddability", () => {
     if (!res.ok) return;
     expect(res.bids).toEqual([
       { projectId: "p1", domainId: "design", level: "P1", preferenceRank: 1, notes: null },
-      { projectId: "p1", domainId: "uiux", level: "P1", preferenceRank: 1, notes: null },
     ]);
   });
 

--- a/dali-api/app/projects/lib/bid-validation.ts
+++ b/dali-api/app/projects/lib/bid-validation.ts
@@ -3,14 +3,13 @@
 //
 // A bid is JUST a projectId (rank = array index). Domain is not asked on the
 // form — instead, each bid expands server-side into StaffingPreference rows:
-// one per domain the PROJECT declares (ProjectDomain) that the member is also
-// eligible in, so a bid normally lands in the member's own domain columns at
-// their eligibility level. Eligibility does NOT gate the bid, though — when the
-// project shares no domain with the member's eligibility, the bid falls back to
-// the project's declared domains (at the default level) so it still shows on
-// the board instead of vanishing. preferenceRank carries the bid's rank, shared
-// across all expansions of bid N. (ProjectRoleRequest is headcount display
-// only; it never gates bids.)
+// exactly ONE StaffingPreference per ranked project. Eligibility NEVER gates a
+// bid — every project the member ranked produces a row, regardless of whether
+// they're eligible in any of its domains. The single row's domainId is chosen
+// (see pickDomain) just to give the board a column and satisfy the row's unique
+// key; the domains a member is actually available for are shown separately from
+// their DomainEligibility. preferenceRank carries the bid's 1-based rank.
+// (ProjectRoleRequest is headcount display only; it never gates bids.)
 
 import { prisma } from "~/lib/db";
 
@@ -85,12 +84,13 @@ export async function validateBids(
   );
 
   // Biddability is driven by the project's DECLARED DOMAINS (ProjectDomain) —
-  // never by per-term ProjectRoleRequest rows. A bid expands to a row per
-  // domain the project declares that the member is ALSO eligible in (so a
-  // member's bid normally lands in their own domain columns). Eligibility no
-  // longer GATES the bid, though: when the project shares NO domain with the
-  // member's eligibility, the bid falls back to the project's declared domains
-  // so it still shows on the board instead of vanishing.
+  // never by per-term ProjectRoleRequest rows. Eligibility NEVER gates a bid:
+  // every ranked project produces exactly ONE preference row, even when the
+  // project declares several domains and even when the member is eligible in
+  // none of them. The board lists which domains the member is actually
+  // available for separately (DomainEligibility chips); the bid itself is one
+  // entry per project. We still pick a single domainId to satisfy the row's
+  // unique key + give the board a column to place it in.
   const projectDomains = await prisma.projectDomain.findMany({
     where: { projectId: { in: effectiveBids.map((b) => b.projectId) } },
     select: { projectId: true, domainId: true },
@@ -102,28 +102,69 @@ export async function validateBids(
     domainsByProject.set(d.projectId, list);
   }
 
-  // Level shown on a bid row: the member's eligibility level in that domain if
-  // they have one, else the baseline P1 (Learner). Level never blocks a bid.
+  // Level shown on a bid row: the member's eligibility level in the chosen
+  // domain if they have one, else the baseline P1 (Learner). Level never blocks
+  // a bid.
   const DEFAULT_LEVEL: BidLevel = "P1";
+
+  // The single domain a bid lands in, in priority order:
+  //   1. a project domain the member is eligible in (their level there); if
+  //      several, the one with the highest level — that's the strongest claim.
+  //   2. else the project's first declared domain (at P1) — keeps a multi-
+  //      domain project's bid in a real column even with no overlap.
+  //   3. else (project declares no domains, e.g. Deserto) the member's own
+  //      highest-level eligibility domain — so the bid still resolves to one
+  //      row instead of vanishing.
+  //   4. else null — no domain anywhere; the bid produces no row (only when the
+  //      member has zero eligibility AND the project declares zero domains).
+  const LEVEL_RANK: Record<BidLevel, number> = { P1: 1, P2: 2, P3: 3 };
+  const memberDomainsByLevelDesc = [...levelByDomain.entries()].sort(
+    (a, b) => LEVEL_RANK[b[1] as BidLevel] - LEVEL_RANK[a[1] as BidLevel],
+  );
+  // A bid ALWAYS resolves to a row — never dropped. The domainId is only there
+  // to satisfy the row's unique key and label the card; the board places a bid
+  // by its PROJECT, not its domain. So when no domain applies at all (the
+  // project declares none AND the member has none — e.g. a no-eligibility
+  // member bidding a no-domain project like Make101/Deserto), we fall back to
+  // the empty-string domain. The card still shows under the project column.
+  const NO_DOMAIN = "";
+  const pickDomain = (
+    projDomains: string[],
+  ): { domainId: string; level: BidLevel } => {
+    const eligibleProjDomains = projDomains
+      .filter((d) => levelByDomain.has(d))
+      .sort(
+        (a, b) =>
+          LEVEL_RANK[levelByDomain.get(b) as BidLevel] -
+          LEVEL_RANK[levelByDomain.get(a) as BidLevel],
+      );
+    if (eligibleProjDomains.length > 0) {
+      const domainId = eligibleProjDomains[0];
+      return { domainId, level: levelByDomain.get(domainId) as BidLevel };
+    }
+    if (projDomains.length > 0) {
+      return { domainId: projDomains[0], level: DEFAULT_LEVEL };
+    }
+    if (memberDomainsByLevelDesc.length > 0) {
+      const [domainId, level] = memberDomainsByLevelDesc[0];
+      return { domainId, level: level as BidLevel };
+    }
+    return { domainId: NO_DOMAIN, level: DEFAULT_LEVEL };
+  };
 
   const validated: ValidatedBid[] = [];
   for (let i = 0; i < effectiveBids.length; i++) {
     const b = effectiveBids[i];
     const rank = i + 1;
     const projDomains = domainsByProject.get(b.projectId) ?? [];
-    // Prefer the project domains the member is eligible in; if there's no
-    // overlap, fall back to all the project's domains so the bid still records.
-    const eligibleOverlap = projDomains.filter((d) => levelByDomain.has(d));
-    const targetDomains = eligibleOverlap.length > 0 ? eligibleOverlap : projDomains;
-    for (const domainId of targetDomains) {
-      validated.push({
-        projectId: b.projectId,
-        domainId,
-        level: (levelByDomain.get(domainId) ?? DEFAULT_LEVEL) as BidLevel,
-        preferenceRank: rank,
-        notes: null,
-      });
-    }
+    const picked = pickDomain(projDomains);
+    validated.push({
+      projectId: b.projectId,
+      domainId: picked.domainId,
+      level: picked.level,
+      preferenceRank: rank,
+      notes: null,
+    });
   }
 
   return { ok: true, bids: validated };

--- a/dali-api/app/projects/routes/projects.staffing.tsx
+++ b/dali-api/app/projects/routes/projects.staffing.tsx
@@ -130,8 +130,16 @@ export async function loader({ request }: Route.LoaderArgs) {
       where: { staffingCycleId: cycle.id, status: "Proposed" },
       select: { userId: true, projectId: true, domainId: true, level: true },
     }),
+    // Columns are the projects that actually RUN in the selected term
+    // (ProjectTerm), not every non-archived project — otherwise the board lists
+    // projects from other terms with empty "0 assigned" columns. Projects with
+    // bids/assignments in this cycle are unioned in below so a project being
+    // staffed never vanishes for a missing ProjectTerm row.
     prisma.project.findMany({
-      where: { status: { not: "Archived" } },
+      where: {
+        status: { not: "Archived" },
+        projectTerms: { some: { termId: selectedTerm.id } },
+      },
       orderBy: [{ status: "asc" }, { name: "asc" }],
       select: { id: true, name: true, status: true },
     }),
@@ -145,6 +153,30 @@ export async function loader({ request }: Route.LoaderArgs) {
       select: { projectId: true, domainId: true, slots: true },
     }),
   ]);
+
+  // Union in any non-archived project that's actually being staffed this cycle
+  // (a bid, assignment, or role request) but lacks a ProjectTerm row for the
+  // term — without it that project would lose its column mid-cycle. Normal
+  // projects already came through the term-scoped query above; this only adds
+  // the strays, so the board still drops projects from other terms.
+  const columnProjectIds = new Set(projects.map((p) => p.id));
+  const stagedProjectIds = Array.from(
+    new Set([
+      ...preferences.map((p) => p.projectId),
+      ...assignmentRows.map((a) => a.projectId),
+      ...roleRequests.map((r) => r.projectId),
+    ]),
+  ).filter((id) => !columnProjectIds.has(id));
+  if (stagedProjectIds.length > 0) {
+    const strays = await prisma.project.findMany({
+      where: { id: { in: stagedProjectIds }, status: { not: "Archived" } },
+      select: { id: true, name: true, status: true },
+    });
+    projects.push(...strays);
+    projects.sort(
+      (a, b) => a.status.localeCompare(b.status) || a.name.localeCompare(b.name),
+    );
+  }
 
   const prefsByUser = new Map<string, Preference[]>();
   for (const p of preferences) {


### PR DESCRIPTION
A project bid now resolves to exactly one StaffingPreference per ranked project instead of one-per-declared-domain, and is never dropped:

- Eligibility no longer gates a bid. A bid on a project the member has no eligibility overlap with still resolves (previously it either expanded into every project domain at P1, or — after a later change — vanished).
- A bid on a project that declares no ProjectDomain rows (e.g. Make101, Deserto) still resolves; it falls back to the member's own highest-level eligibility domain, then to an empty domain so the card always shows.
- The single row's domain is chosen by: member-eligible project domain (highest level) → project's first declared domain (P1) → member's own highest domain → empty. The board places a bid by project, not domain; the domain only labels the card and keys the row.

Also scope the staffing board's project columns to the selected term (ProjectTerm), unioning in any project actually being staffed that cycle, so the board stops listing every non-archived project from other terms.

Tests updated for the one-row-per-bid model.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/733"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782765356&installation_id=133523038&pr_number=733&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F733&signature=1763f38b505fb46b2aca32c97640dc7321755f9f679d396c041643ccb08b320d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->