### PR TITLE
MCP: tier 1+2 — notification actions, meeting cancel, groups, project workspace tools

### DIFF
--- a/dali-api/app/lib/__mocks__/db.ts
+++ b/dali-api/app/lib/__mocks__/db.ts
@@ -72,11 +72,34 @@ export const prisma = {
   },
   notification: {
     findMany: vi.fn().mockResolvedValue([]),
+    findUnique: vi.fn(),
     count: vi.fn().mockResolvedValue(0),
     create: vi.fn(),
     createMany: vi.fn(),
     update: vi.fn(),
     updateMany: vi.fn(),
+  },
+  projectAssignment: {
+    findMany: vi.fn().mockResolvedValue([]),
+    findFirst: vi.fn(),
+  },
+  project: {
+    findUnique: vi.fn(),
+    findMany: vi.fn().mockResolvedValue([]),
+  },
+  sprint: {
+    findMany: vi.fn().mockResolvedValue([]),
+    findFirst: vi.fn(),
+  },
+  epic: {
+    findFirst: vi.fn(),
+  },
+  task: {
+    findMany: vi.fn().mockResolvedValue([]),
+    findUnique: vi.fn(),
+    update: vi.fn(),
+    aggregate: vi.fn(),
+    groupBy: vi.fn().mockResolvedValue([]),
   },
   scheduledMeeting: {
     findMany: vi.fn().mockResolvedValue([]),

--- a/dali-api/app/lib/audit.ts
+++ b/dali-api/app/lib/audit.ts
@@ -38,6 +38,8 @@ export const AUDIT_ACTIONS = [
   "email.extension_notice",
   "confidentiality.sign",
   "mcp.tool_called",
+  "mcp.resource_read",
+  "mcp.prompt_rendered",
 ] as const;
 
 export type AuditAction = (typeof AUDIT_ACTIONS)[number];

--- a/dali-api/app/mcp/prompts/__tests__/prompts.test.ts
+++ b/dali-api/app/mcp/prompts/__tests__/prompts.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { WEEKLY_DIGEST_PROMPT } from "~/mcp/prompts/weekly-digest";
+import { MEETING_PREP_PROMPT } from "~/mcp/prompts/meeting-prep";
+import { PROJECT_STATUS_PROMPT } from "~/mcp/prompts/project-status";
+
+describe("mcp prompts", () => {
+  it("weekly-digest is argument-free and references the read tools by name", () => {
+    expect(WEEKLY_DIGEST_PROMPT.arguments).toEqual([]);
+    const [msg] = WEEKLY_DIGEST_PROMPT.build({});
+    expect(msg.role).toBe("user");
+    expect(msg.content.type).toBe("text");
+    expect(msg.content.text).toContain("list_my_tasks");
+    expect(msg.content.text).toContain("list_my_upcoming_meetings");
+    expect(msg.content.text).toContain("list_my_notifications");
+  });
+
+  it("meeting-prep declares a required meetingHint and inlines it", () => {
+    const [hint] = MEETING_PREP_PROMPT.arguments;
+    expect(hint.name).toBe("meetingHint");
+    expect(hint.required).toBe(true);
+    const [msg] = MEETING_PREP_PROMPT.build({ meetingHint: "Standup with Pat" });
+    expect(msg.content.text).toContain('"Standup with Pat"');
+    expect(msg.content.text).toContain("get_member_profile");
+  });
+
+  it("project-status accepts optional audience hint and shapes the prompt accordingly", () => {
+    const required = PROJECT_STATUS_PROMPT.arguments.find((a) => a.required);
+    expect(required?.name).toBe("projectHint");
+    const optional = PROJECT_STATUS_PROMPT.arguments.find((a) => !a.required);
+    expect(optional?.name).toBe("audience");
+
+    const withAudience = PROJECT_STATUS_PROMPT.build({
+      projectHint: "Alpha",
+      audience: "partner",
+    });
+    expect(withAudience[0].content.text).toContain("partner");
+
+    const withoutAudience = PROJECT_STATUS_PROMPT.build({ projectHint: "Alpha" });
+    expect(withoutAudience[0].content.text).toContain("Audience unspecified");
+  });
+});

--- a/dali-api/app/mcp/prompts/meeting-prep.ts
+++ b/dali-api/app/mcp/prompts/meeting-prep.ts
@@ -1,0 +1,49 @@
+// MCP prompt `meeting-prep` — pre-meeting briefing. Caller provides a meeting
+// title fragment or full title to identify the target; the model finds it in
+// the upcoming-meetings list, then enriches attendees and produces an agenda.
+
+import type { PromptDefinition } from "./types";
+
+export const MEETING_PREP_PROMPT: PromptDefinition = {
+  name: "meeting-prep",
+  description:
+    "Draft an agenda + talking points for an upcoming meeting using attendee profiles and shared task context.",
+  arguments: [
+    {
+      name: "meetingHint",
+      description:
+        "A fragment of the meeting title or the participant name. Used to disambiguate against the upcoming-meetings list.",
+      required: true,
+    },
+  ],
+  build(args) {
+    const hint = (args.meetingHint ?? "").trim();
+    return [
+      {
+        role: "user",
+        content: {
+          type: "text",
+          text: [
+            `Help me prepare for an upcoming DALI OS meeting. The user described it as: "${hint}".`,
+            "",
+            "Steps (use the dalios MCP tools):",
+            "",
+            "1. Call `list_my_upcoming_meetings` with `daysAhead: 14`. Find the meeting that best matches the user's description. If you can't pick a single one, ask the user to clarify before continuing.",
+            "2. For each participantUserId on that meeting, call `get_member_profile` to pull their role/domains. Skip the caller themselves.",
+            "3. If the meeting title hints at a project (e.g. a project name), call `list_my_projects` to find a matching id, then `get_project_overview` for that project so you have current sprint/epic context.",
+            "",
+            "Then write the briefing as markdown with these sections:",
+            "",
+            "- **Meeting** — title, time, duration, location/link if any.",
+            "- **Attendees** — one bullet per person: name, role, relevant domains.",
+            "- **Context** — 2–3 bullets on the project/topic if you found one.",
+            "- **Suggested agenda** — 3–5 numbered items. Be specific, not generic.",
+            "- **Questions worth raising** — 2–3 short questions.",
+            "",
+            "Keep the briefing scannable — bullets over paragraphs. Stop and ask if any step returns nothing useful.",
+          ].join("\n"),
+        },
+      },
+    ];
+  },
+};

--- a/dali-api/app/mcp/prompts/project-status.ts
+++ b/dali-api/app/mcp/prompts/project-status.ts
@@ -1,0 +1,63 @@
+// MCP prompt `project-status` — draft a project status update using
+// `get_project_overview` + `list_my_tasks` (scoped to the project). The caller
+// can either pass a `projectId` directly or hint at the project by name and
+// the model resolves it via `list_my_projects`.
+
+import type { PromptDefinition } from "./types";
+
+export const PROJECT_STATUS_PROMPT: PromptDefinition = {
+  name: "project-status",
+  description:
+    "Draft a project status report (progress, risks, next steps) using current sprint, epic, and task data.",
+  arguments: [
+    {
+      name: "projectHint",
+      description:
+        "Either a Project.id or a fragment of the project name. The model resolves it against `list_my_projects` if not an id.",
+      required: true,
+    },
+    {
+      name: "audience",
+      description:
+        "Optional audience hint, e.g. 'partner', 'core', 'mentor'. Shapes the tone and detail level.",
+      required: false,
+    },
+  ],
+  build(args) {
+    const hint = (args.projectHint ?? "").trim();
+    const audience = (args.audience ?? "").trim();
+    const audienceLine = audience
+      ? `Audience for this update: ${audience}. Match the tone accordingly (e.g. partner = less jargon, mentor = focus on member growth, core = operational).`
+      : "Audience unspecified — write neutrally; ask the user who it's for if a tone choice matters.";
+
+    return [
+      {
+        role: "user",
+        content: {
+          type: "text",
+          text: [
+            `Draft a status update for the DALI project the user described as: "${hint}".`,
+            "",
+            audienceLine,
+            "",
+            "Steps (use the dalios MCP tools):",
+            "",
+            "1. If the hint looks like an id (cuid-shaped), use it directly. Otherwise call `list_my_projects` and pick the best name match. Confirm with the user if ambiguous.",
+            "2. Call `get_project_overview` with the resolved projectId.",
+            "3. Call `list_my_tasks` with that projectId AND `status: ['Todo','InProgress','InReview','Done']` to see recently-finished work alongside open work.",
+            "",
+            "Then write the update as markdown with these sections:",
+            "",
+            "- **Headline** — one sentence summary.",
+            "- **This sprint** — what shipped, what's in progress (use the Done + InReview tasks).",
+            "- **Up next** — top 3 Todo items.",
+            "- **Risks / blockers** — items overdue or stuck. Be honest; if there are none, say so.",
+            "- **Asks** — anything the audience can help with.",
+            "",
+            "Keep it under 200 words. Don't invent metrics that aren't in the tool output.",
+          ].join("\n"),
+        },
+      },
+    ];
+  },
+};

--- a/dali-api/app/mcp/prompts/types.ts
+++ b/dali-api/app/mcp/prompts/types.ts
@@ -1,0 +1,23 @@
+// Shared prompt envelope. MCP `prompts/list` advertises argument metadata;
+// `prompts/get` returns a message array the client seeds the conversation
+// with. We keep prompts as plain pure functions: `build(args) → Message[]`,
+// no I/O at prompt-render time. Each prompt is a *recipe* — it instructs the
+// model to call our existing MCP tools and synthesize the result.
+
+export type PromptArgumentSpec = {
+  name: string;
+  description: string;
+  required: boolean;
+};
+
+export type PromptMessage = {
+  role: "user" | "assistant";
+  content: { type: "text"; text: string };
+};
+
+export type PromptDefinition = {
+  name: string;
+  description: string;
+  arguments: PromptArgumentSpec[];
+  build(args: Record<string, string>): PromptMessage[];
+};

--- a/dali-api/app/mcp/prompts/weekly-digest.ts
+++ b/dali-api/app/mcp/prompts/weekly-digest.ts
@@ -1,0 +1,39 @@
+// MCP prompt `weekly-digest` — produces a "what should I focus on this week"
+// briefing for the caller. The prompt instructs the model to call the
+// existing read tools (`list_my_notifications`, `list_my_upcoming_meetings`,
+// `list_my_tasks`) and synthesize, so all data is fetched live.
+
+import type { PromptDefinition } from "./types";
+
+export const WEEKLY_DIGEST_PROMPT: PromptDefinition = {
+  name: "weekly-digest",
+  description:
+    "Synthesize a personal weekly briefing: priority tasks, upcoming meetings, unread announcements.",
+  arguments: [],
+  build() {
+    return [
+      {
+        role: "user",
+        content: {
+          type: "text",
+          text: [
+            "Generate a weekly DALI OS digest for me. Use the dalios MCP tools:",
+            "",
+            "1. Call `list_my_tasks` (no args — defaults to my open work).",
+            "2. Call `list_my_upcoming_meetings` with `daysAhead: 7`.",
+            "3. Call `list_my_notifications` with `onlyUnread: true`.",
+            "",
+            "Then write a short briefing with these sections:",
+            "",
+            "- **This week's focus** — at most 5 tasks, picked by due date and priority. Note overdue items explicitly.",
+            "- **Meetings** — chronological list, one line each: time, title, who else is there (use `get_member_profile` if a name would help).",
+            "- **Unread inbox** — group by kind (announcements vs. invites vs. other); summarize each in one line.",
+            "- **Suggested next action** — a single concrete thing to do right now.",
+            "",
+            "Keep the whole digest under ~250 words. If a section is empty, say so in one short sentence instead of fabricating items.",
+          ].join("\n"),
+        },
+      },
+    ];
+  },
+};

--- a/dali-api/app/mcp/resources/__tests__/announcements-active.test.ts
+++ b/dali-api/app/mcp/resources/__tests__/announcements-active.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("~/lib/db");
+
+import { prisma } from "~/lib/db";
+import {
+  readAnnouncementsActiveResource,
+  ANNOUNCEMENTS_ACTIVE_RESOURCE,
+} from "~/mcp/resources/announcements-active";
+
+const mockPrisma = prisma as unknown as {
+  notification: { findMany: ReturnType<typeof vi.fn> };
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("dali://announcements/active", () => {
+  it("requires the mcp:read scope", () => {
+    expect(ANNOUNCEMENTS_ACTIVE_RESOURCE.requiredScope).toBe("mcp:read");
+  });
+
+  it("renders markdown for each unread SystemAnnouncement", async () => {
+    mockPrisma.notification.findMany.mockResolvedValue([
+      {
+        id: "n1",
+        title: "Lab dinner Friday",
+        body: "RSVP by Wed.",
+        link: "/forms/fill/abc",
+        dueAt: new Date("2026-06-05T22:00:00Z"),
+        createdAt: new Date("2026-06-01T15:00:00Z"),
+        createdBy: { firstName: "Pat", lastName: "Smith" },
+      },
+    ]);
+    const text = await readAnnouncementsActiveResource("u1");
+    expect(text).toContain("## Lab dinner Friday");
+    expect(text).toContain("RSVP by Wed.");
+    expect(text).toContain("by Pat Smith");
+    expect(text).toContain("Due 2026-06-05T22:00:00.000Z");
+    expect(text).toContain("[Open](/forms/fill/abc)");
+
+    expect(mockPrisma.notification.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          recipientUserId: "u1",
+          readAt: null,
+          kind: "SystemAnnouncement",
+        }),
+      }),
+    );
+  });
+
+  it("returns a friendly placeholder when there are none", async () => {
+    mockPrisma.notification.findMany.mockResolvedValue([]);
+    const text = await readAnnouncementsActiveResource("u1");
+    expect(text).toBe("_No active announcements._");
+  });
+});

--- a/dali-api/app/mcp/resources/__tests__/forms-pending.test.ts
+++ b/dali-api/app/mcp/resources/__tests__/forms-pending.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("~/lib/db");
+
+import { prisma } from "~/lib/db";
+import {
+  readFormsPendingResource,
+  FORMS_PENDING_RESOURCE,
+} from "~/mcp/resources/forms-pending";
+
+const mockPrisma = prisma as unknown as {
+  notification: { findMany: ReturnType<typeof vi.fn> };
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("dali://forms/pending", () => {
+  it("requires the mcp:read scope", () => {
+    expect(FORMS_PENDING_RESOURCE.requiredScope).toBe("mcp:read");
+  });
+
+  it("emits JSON with fill URLs for pending forms", async () => {
+    mockPrisma.notification.findMany.mockResolvedValue([
+      {
+        id: "n1",
+        title: "Project bids: 26S",
+        body: "Submit by Friday",
+        dueAt: new Date("2026-06-05T22:00:00Z"),
+        createdAt: new Date("2026-06-01T15:00:00Z"),
+        formId: "f1",
+        form: { name: "Project Bids", publicToken: "tok-1" },
+      },
+    ]);
+    const text = await readFormsPendingResource("u1");
+    const parsed = JSON.parse(text);
+    expect(parsed.pendingForms).toEqual([
+      {
+        notificationId: "n1",
+        title: "Project bids: 26S",
+        body: "Submit by Friday",
+        dueAt: "2026-06-05T22:00:00.000Z",
+        formId: "f1",
+        formName: "Project Bids",
+        fillUrl: "/forms/fill/tok-1",
+        postedAt: "2026-06-01T15:00:00.000Z",
+      },
+    ]);
+  });
+
+  it("returns an empty list when none are pending", async () => {
+    mockPrisma.notification.findMany.mockResolvedValue([]);
+    const text = await readFormsPendingResource("u1");
+    expect(JSON.parse(text)).toEqual({ pendingForms: [] });
+  });
+});

--- a/dali-api/app/mcp/resources/__tests__/me.test.ts
+++ b/dali-api/app/mcp/resources/__tests__/me.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect, vi } from "vitest";
+
+// me.ts transitively imports ~/lib/db (via get-member-profile). Hoist the mock
+// so vitest doesn't try to load the real Prisma client — its generated module
+// isn't on disk during CI's `npm test` step.
+vi.mock("~/lib/db");
+
+import { ME_RESOURCE } from "~/mcp/resources/me";
+
+describe("dali://me", () => {
+  it("requires the mcp:read scope", () => {
+    expect(ME_RESOURCE.requiredScope).toBe("mcp:read");
+  });
+
+  it("advertises a JSON mime type and a stable URI", () => {
+    expect(ME_RESOURCE.uri).toBe("dali://me");
+    expect(ME_RESOURCE.mimeType).toBe("application/json");
+  });
+});

--- a/dali-api/app/mcp/resources/announcements-active.ts
+++ b/dali-api/app/mcp/resources/announcements-active.ts
@@ -1,0 +1,64 @@
+// MCP resource `dali://announcements/active` — the caller's unread
+// SystemAnnouncement notifications, rendered as markdown so clients (e.g.
+// Claude Desktop) display them inline. "Active" = unread + the underlying
+// scheduled-meeting (if any) is not Cancelled, mirroring the inbox filter in
+// `listMyNotifications`. Requires the `mcp:read` scope.
+
+import { prisma } from "~/lib/db";
+
+export const ANNOUNCEMENTS_ACTIVE_RESOURCE = {
+  uri: "dali://announcements/active",
+  name: "Active announcements",
+  description:
+    "Lab announcements the authenticated member has not yet read, newest first. Markdown.",
+  mimeType: "text/markdown",
+  requiredScope: "mcp:read" as const,
+};
+
+export async function readAnnouncementsActiveResource(callerId: string) {
+  const rows = await prisma.notification.findMany({
+    where: {
+      recipientUserId: callerId,
+      readAt: null,
+      kind: "SystemAnnouncement",
+    },
+    orderBy: { createdAt: "desc" },
+    take: 50,
+    select: {
+      id: true,
+      title: true,
+      body: true,
+      link: true,
+      dueAt: true,
+      createdAt: true,
+      createdBy: { select: { firstName: true, lastName: true } },
+    },
+  });
+
+  if (rows.length === 0) {
+    return "_No active announcements._";
+  }
+
+  const sections = rows.map((row) => {
+    const author = row.createdBy
+      ? `${row.createdBy.firstName} ${row.createdBy.lastName}`.trim()
+      : null;
+    const meta = [
+      `Posted ${row.createdAt.toISOString()}`,
+      author ? `by ${author}` : null,
+      row.dueAt ? `Due ${row.dueAt.toISOString()}` : null,
+    ]
+      .filter(Boolean)
+      .join(" · ");
+    return [
+      `## ${row.title}`,
+      `_${meta}_`,
+      row.body ?? "",
+      row.link ? `[Open](${row.link})` : "",
+    ]
+      .filter((s) => s.length > 0)
+      .join("\n\n");
+  });
+
+  return sections.join("\n\n---\n\n");
+}

--- a/dali-api/app/mcp/resources/forms-pending.ts
+++ b/dali-api/app/mcp/resources/forms-pending.ts
@@ -1,0 +1,65 @@
+// MCP resource `dali://forms/pending` — published forms attached to one of the
+// caller's unread notifications. Mirrors the form-handling in `listOpenTasks`
+// (`~/lib/tasks.ts`): a notification with `form.published && form.publicToken`
+// links the recipient to the authed fill page, which is what marks the
+// notification read on submit. We expose the title, dueAt, and the fill URL.
+// Requires the `mcp:read` scope.
+
+import { prisma } from "~/lib/db";
+
+export const FORMS_PENDING_RESOURCE = {
+  uri: "dali://forms/pending",
+  name: "Pending forms",
+  description:
+    "Published forms the authenticated member has been asked to fill (still unread/unsubmitted), with their fill URLs. JSON.",
+  mimeType: "application/json",
+  requiredScope: "mcp:read" as const,
+};
+
+type PendingFormOut = {
+  notificationId: string;
+  title: string;
+  body: string | null;
+  dueAt: string | null;
+  formId: string;
+  formName: string;
+  fillUrl: string;
+  postedAt: string;
+};
+
+export async function readFormsPendingResource(callerId: string) {
+  const rows = await prisma.notification.findMany({
+    where: {
+      recipientUserId: callerId,
+      readAt: null,
+      formId: { not: null },
+      form: { published: true, publicToken: { not: null } },
+    },
+    orderBy: { createdAt: "desc" },
+    take: 50,
+    select: {
+      id: true,
+      title: true,
+      body: true,
+      dueAt: true,
+      createdAt: true,
+      formId: true,
+      form: { select: { name: true, publicToken: true } },
+    },
+  });
+
+  const items: PendingFormOut[] = rows
+    .filter((r) => r.form?.publicToken && r.formId)
+    .map((r) => ({
+      notificationId: r.id,
+      title: r.title,
+      body: r.body,
+      dueAt: r.dueAt?.toISOString() ?? null,
+      formId: r.formId!,
+      formName: r.form!.name,
+      fillUrl: `/forms/fill/${r.form!.publicToken}`,
+      postedAt: r.createdAt.toISOString(),
+    }));
+
+  return JSON.stringify({ pendingForms: items }, null, 2);
+}

--- a/dali-api/app/mcp/resources/me.ts
+++ b/dali-api/app/mcp/resources/me.ts
@@ -1,0 +1,20 @@
+// MCP resource `dali://me` — the caller's full profile + tier as JSON. Wraps
+// `runGetMemberProfile` so a client can auto-attach the caller's identity to a
+// conversation instead of forcing the model to call `whoami` first. Requires
+// the `mcp:read` scope.
+
+import { runGetMemberProfile } from "~/mcp/tools/get-member-profile";
+
+export const ME_RESOURCE = {
+  uri: "dali://me",
+  name: "Me",
+  description:
+    "The authenticated DALI OS member's full profile, roles, and current-term domain eligibilities. JSON.",
+  mimeType: "application/json",
+  requiredScope: "mcp:read" as const,
+};
+
+export async function readMeResource(callerId: string) {
+  const profile = await runGetMemberProfile(callerId, { memberId: callerId });
+  return JSON.stringify(profile, null, 2);
+}

--- a/dali-api/app/mcp/tools/__tests__/cancel-meeting.test.ts
+++ b/dali-api/app/mcp/tools/__tests__/cancel-meeting.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("~/lib/scheduled-meeting", () => ({
+  cancelScheduledMeeting: vi.fn(),
+}));
+
+import { cancelScheduledMeeting } from "~/lib/scheduled-meeting";
+import {
+  runCancelMeeting,
+  CANCEL_MEETING_TOOL,
+  CancelMeetingError,
+} from "~/mcp/tools/cancel-meeting";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("cancel_meeting", () => {
+  it("requires the mcp:write scope", () => {
+    expect(CANCEL_MEETING_TOOL.requiredScope).toBe("mcp:write");
+  });
+
+  it("returns alreadyCancelled flag on success", async () => {
+    vi.mocked(cancelScheduledMeeting).mockResolvedValue({ ok: true, alreadyCancelled: false });
+    const out = await runCancelMeeting("u1", { meetingId: "m1" });
+    expect(out).toEqual({ ok: true, alreadyCancelled: false });
+    expect(cancelScheduledMeeting).toHaveBeenCalledWith("m1", "u1");
+  });
+
+  it("propagates 403 when caller is not the organizer", async () => {
+    vi.mocked(cancelScheduledMeeting).mockResolvedValue({
+      ok: false,
+      error: "Only the organizer can cancel",
+      status: 403,
+    });
+    await expect(
+      runCancelMeeting("u1", { meetingId: "m1" }),
+    ).rejects.toMatchObject({ name: "CancelMeetingError", status: 403 });
+  });
+
+  it("propagates 404 when meeting is missing", async () => {
+    vi.mocked(cancelScheduledMeeting).mockResolvedValue({
+      ok: false,
+      error: "Not found",
+      status: 404,
+    });
+    await expect(
+      runCancelMeeting("u1", { meetingId: "nope" }),
+    ).rejects.toBeInstanceOf(CancelMeetingError);
+  });
+});

--- a/dali-api/app/mcp/tools/__tests__/get-project-overview.test.ts
+++ b/dali-api/app/mcp/tools/__tests__/get-project-overview.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("~/lib/db");
+vi.mock("~/lib/roles", async (orig) => {
+  const real = await orig<typeof import("~/lib/roles")>();
+  return { ...real, currentTerm: vi.fn() };
+});
+
+import { prisma } from "~/lib/db";
+import { currentTerm } from "~/lib/roles";
+import {
+  runGetProjectOverview,
+  GET_PROJECT_OVERVIEW_TOOL,
+  ProjectNotFoundError,
+} from "~/mcp/tools/get-project-overview";
+
+const mockPrisma = prisma as unknown as {
+  project: { findUnique: ReturnType<typeof vi.fn> };
+  projectAssignment: { findMany: ReturnType<typeof vi.fn> };
+  sprint: { findFirst: ReturnType<typeof vi.fn> };
+  epic: { findFirst: ReturnType<typeof vi.fn> };
+  task: { groupBy: ReturnType<typeof vi.fn> };
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("get_project_overview", () => {
+  it("requires the mcp:read scope", () => {
+    expect(GET_PROJECT_OVERVIEW_TOOL.requiredScope).toBe("mcp:read");
+  });
+
+  it("returns project + current-term roster + active sprint + counts", async () => {
+    vi.mocked(currentTerm).mockResolvedValue({ id: "t1", code: "26S" } as never);
+    mockPrisma.project.findUnique.mockResolvedValue({
+      id: "p1",
+      name: "Alpha",
+      description: "Demo",
+      status: "Active",
+      imageUrl: null,
+      repoUrls: ["https://github.com/dali/alpha"],
+      overviewPageId: "pg-o",
+      prdPageId: null,
+      projectTerms: [
+        { term: { code: "26S", sortKey: 2026.1 } },
+        { term: { code: "26X", sortKey: 2026.2 } },
+      ],
+      partners: [{ partnerOrg: { id: "po1", name: "Acme" } }],
+    });
+    mockPrisma.projectAssignment.findMany.mockResolvedValue([
+      {
+        level: "P3",
+        user: { id: "u1", firstName: "A", lastName: "B" },
+        domain: { id: "d1", displayName: "Dev" },
+      },
+    ]);
+    mockPrisma.sprint.findFirst.mockResolvedValue({
+      id: "s1",
+      name: "Sprint 1",
+      startsAt: new Date("2026-06-01T00:00:00Z"),
+      endsAt: new Date("2026-06-14T00:00:00Z"),
+    });
+    mockPrisma.epic.findFirst.mockResolvedValue({
+      id: "e1",
+      title: "Onboarding",
+      description: null,
+      status: "InProgress",
+    });
+    mockPrisma.task.groupBy.mockResolvedValue([
+      { status: "Todo", _count: { _all: 3 } },
+      { status: "Done", _count: { _all: 5 } },
+    ]);
+
+    const out = await runGetProjectOverview({ projectId: "p1" });
+    expect(out).toMatchObject({
+      id: "p1",
+      name: "Alpha",
+      termCodes: ["26S", "26X"],
+      partners: [{ id: "po1", name: "Acme" }],
+      currentTermRoster: [{ userId: "u1", name: "A B", domain: "Dev", level: "P3" }],
+      activeSprint: { id: "s1", name: "Sprint 1" },
+      currentEpic: { id: "e1", title: "Onboarding", status: "InProgress" },
+      taskCountByStatus: { Todo: 3, InProgress: 0, InReview: 0, Done: 5, Cancelled: 0 },
+    });
+  });
+
+  it("throws when the project is missing", async () => {
+    vi.mocked(currentTerm).mockResolvedValue({ id: "t1", code: "26S" } as never);
+    mockPrisma.project.findUnique.mockResolvedValue(null);
+    await expect(
+      runGetProjectOverview({ projectId: "nope" }),
+    ).rejects.toBeInstanceOf(ProjectNotFoundError);
+  });
+});

--- a/dali-api/app/mcp/tools/__tests__/list-groups.test.ts
+++ b/dali-api/app/mcp/tools/__tests__/list-groups.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("~/lib/groups", () => ({
+  listVisibleGroupsForUser: vi.fn(),
+}));
+
+import { listVisibleGroupsForUser } from "~/lib/groups";
+import { runListGroups, LIST_GROUPS_TOOL } from "~/mcp/tools/list-groups";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+const ACTIVE_GROUP = {
+  id: "g1",
+  name: "Core",
+  type: "Dynamic" as const,
+  dynamicQuery: "core",
+  systemKey: "core",
+  memberIds: ["u1", "u2"],
+  archived: false,
+  archivedAt: null,
+  boundTermIds: [],
+};
+const ARCHIVED_GROUP = {
+  ...ACTIVE_GROUP,
+  id: "g2",
+  name: "Old project group",
+  archived: true,
+  archivedAt: "2025-01-01T00:00:00.000Z",
+};
+
+describe("list_groups", () => {
+  it("requires the mcp:read scope", () => {
+    expect(LIST_GROUPS_TOOL.requiredScope).toBe("mcp:read");
+  });
+
+  it("hides archived groups by default", async () => {
+    vi.mocked(listVisibleGroupsForUser).mockResolvedValue([ACTIVE_GROUP, ARCHIVED_GROUP]);
+    const out = await runListGroups("u1", {});
+    expect(out.groups.map((g) => g.id)).toEqual(["g1"]);
+    expect(out.groups[0]).toMatchObject({
+      id: "g1",
+      name: "Core",
+      type: "Dynamic",
+      memberCount: 2,
+      archived: false,
+    });
+  });
+
+  it("includes archived groups when requested", async () => {
+    vi.mocked(listVisibleGroupsForUser).mockResolvedValue([ACTIVE_GROUP, ARCHIVED_GROUP]);
+    const out = await runListGroups("u1", { includeArchived: true });
+    expect(out.groups.map((g) => g.id)).toEqual(["g1", "g2"]);
+  });
+});

--- a/dali-api/app/mcp/tools/__tests__/list-my-projects.test.ts
+++ b/dali-api/app/mcp/tools/__tests__/list-my-projects.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("~/lib/db");
+vi.mock("~/lib/roles", async (orig) => {
+  const real = await orig<typeof import("~/lib/roles")>();
+  return { ...real, currentTerm: vi.fn() };
+});
+
+import { prisma } from "~/lib/db";
+import { currentTerm } from "~/lib/roles";
+import {
+  runListMyProjects,
+  LIST_MY_PROJECTS_TOOL,
+} from "~/mcp/tools/list-my-projects";
+
+const mockPrisma = prisma as unknown as {
+  projectAssignment: { findMany: ReturnType<typeof vi.fn> };
+  project: { findMany: ReturnType<typeof vi.fn> };
+  sprint: { findMany: ReturnType<typeof vi.fn> };
+  task: { groupBy: ReturnType<typeof vi.fn> };
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("list_my_projects", () => {
+  it("requires the mcp:read scope", () => {
+    expect(LIST_MY_PROJECTS_TOOL.requiredScope).toBe("mcp:read");
+  });
+
+  it("returns empty list when caller has no assignments", async () => {
+    vi.mocked(currentTerm).mockResolvedValue({ id: "t1", code: "26S" } as never);
+    mockPrisma.projectAssignment.findMany.mockResolvedValue([]);
+    const out = await runListMyProjects("u1", {});
+    expect(out).toEqual({ projects: [] });
+  });
+
+  it("enriches assignments with active sprint + open task count", async () => {
+    vi.mocked(currentTerm).mockResolvedValue({ id: "t1", code: "26S" } as never);
+    mockPrisma.projectAssignment.findMany.mockResolvedValue([
+      {
+        projectId: "p1",
+        termId: "t1",
+        level: "P3",
+        term: { code: "26S" },
+        domain: { displayName: "Fullstack Dev" },
+      },
+      {
+        projectId: "p2",
+        termId: "t-old",
+        level: "P2",
+        term: { code: "25F" },
+        domain: { displayName: "Design" },
+      },
+    ]);
+    mockPrisma.project.findMany.mockResolvedValue([
+      { id: "p1", name: "Alpha", status: "Active", imageUrl: null },
+      { id: "p2", name: "Beta", status: "Active", imageUrl: null },
+    ]);
+    mockPrisma.sprint.findMany.mockResolvedValue([
+      {
+        id: "s1",
+        projectId: "p1",
+        name: "Sprint 4",
+        endsAt: new Date("2026-06-15T00:00:00Z"),
+      },
+    ]);
+    mockPrisma.task.groupBy.mockResolvedValue([
+      { projectId: "p1", _count: { _all: 7 } },
+    ]);
+
+    const out = await runListMyProjects("u1", {});
+    expect(out.projects).toHaveLength(2);
+    // Current-term project sorts first.
+    expect(out.projects[0]).toMatchObject({
+      id: "p1",
+      name: "Alpha",
+      currentTermAssignment: { termCode: "26S", domainName: "Fullstack Dev", level: "P3" },
+      activeSprint: { id: "s1", name: "Sprint 4" },
+      openTaskCount: 7,
+    });
+    expect(out.projects[1]).toMatchObject({
+      id: "p2",
+      currentTermAssignment: null,
+      activeSprint: null,
+      openTaskCount: 0,
+    });
+  });
+
+  it("respects currentTermOnly", async () => {
+    vi.mocked(currentTerm).mockResolvedValue({ id: "t1", code: "26S" } as never);
+    mockPrisma.projectAssignment.findMany.mockResolvedValue([]);
+    mockPrisma.project.findMany.mockResolvedValue([]);
+    mockPrisma.sprint.findMany.mockResolvedValue([]);
+    mockPrisma.task.groupBy.mockResolvedValue([]);
+
+    await runListMyProjects("u1", { currentTermOnly: true });
+    expect(mockPrisma.projectAssignment.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ termId: "t1" }) }),
+    );
+  });
+});

--- a/dali-api/app/mcp/tools/__tests__/list-my-tasks.test.ts
+++ b/dali-api/app/mcp/tools/__tests__/list-my-tasks.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("~/lib/db");
+
+import { prisma } from "~/lib/db";
+import { runListMyTasks, LIST_MY_TASKS_TOOL } from "~/mcp/tools/list-my-tasks";
+
+const mockPrisma = prisma as unknown as {
+  task: { findMany: ReturnType<typeof vi.fn> };
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("list_my_tasks", () => {
+  it("requires the mcp:read scope", () => {
+    expect(LIST_MY_TASKS_TOOL.requiredScope).toBe("mcp:read");
+  });
+
+  it("defaults to open statuses and filters by caller assignment", async () => {
+    mockPrisma.task.findMany.mockResolvedValue([
+      {
+        id: "t1",
+        title: "Wire up auth",
+        status: "InProgress",
+        priority: "High",
+        dueAt: new Date("2026-06-10T00:00:00Z"),
+        createdAt: new Date("2026-06-01T00:00:00Z"),
+        projectId: "p1",
+        project: { name: "Alpha" },
+        sprintId: "s1",
+        sprint: { name: "Sprint 1" },
+        epicId: null,
+        epic: null,
+        domain: { displayName: "Dev" },
+        assignees: [{ userId: "u1" }, { userId: "u2" }],
+      },
+    ]);
+    const out = await runListMyTasks("u1", {});
+    expect(out.tasks).toHaveLength(1);
+    expect(out.tasks[0]).toMatchObject({
+      id: "t1",
+      projectName: "Alpha",
+      sprintName: "Sprint 1",
+      domainName: "Dev",
+      assigneeUserIds: ["u1", "u2"],
+      dueAt: "2026-06-10T00:00:00.000Z",
+    });
+    expect(mockPrisma.task.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          assignees: { some: { userId: "u1" } },
+          status: { in: ["Todo", "InProgress", "InReview"] },
+        }),
+      }),
+    );
+  });
+
+  it("honors explicit status + projectId filters", async () => {
+    mockPrisma.task.findMany.mockResolvedValue([]);
+    await runListMyTasks("u1", { status: ["Done"], projectId: "p1" });
+    expect(mockPrisma.task.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          status: { in: ["Done"] },
+          projectId: "p1",
+        }),
+      }),
+    );
+  });
+});

--- a/dali-api/app/mcp/tools/__tests__/mark-notification-read.test.ts
+++ b/dali-api/app/mcp/tools/__tests__/mark-notification-read.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("~/lib/db");
+
+import { prisma } from "~/lib/db";
+import {
+  runMarkNotificationRead,
+  MARK_NOTIFICATION_READ_TOOL,
+  NotificationNotFoundError,
+  NotificationForbiddenError,
+} from "~/mcp/tools/mark-notification-read";
+
+const mockPrisma = prisma as unknown as {
+  notification: {
+    findUnique: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+  };
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("mark_notification_read", () => {
+  it("requires the mcp:write scope", () => {
+    expect(MARK_NOTIFICATION_READ_TOOL.requiredScope).toBe("mcp:write");
+  });
+
+  it("marks a non-meeting notification read", async () => {
+    mockPrisma.notification.findUnique.mockResolvedValue({
+      recipientUserId: "u1",
+      readAt: null,
+      scheduledMeetingId: null,
+    });
+    mockPrisma.notification.update.mockResolvedValue({});
+    const out = await runMarkNotificationRead("u1", { notificationId: "n1" });
+    expect(out).toEqual({ ok: true, alreadyRead: false });
+    expect(mockPrisma.notification.update).toHaveBeenCalled();
+  });
+
+  it("skips a meeting-invite notification", async () => {
+    mockPrisma.notification.findUnique.mockResolvedValue({
+      recipientUserId: "u1",
+      readAt: null,
+      scheduledMeetingId: "m1",
+    });
+    const out = await runMarkNotificationRead("u1", { notificationId: "n1" });
+    expect(out).toEqual({ ok: true, skipped: "meeting-invite" });
+    expect(mockPrisma.notification.update).not.toHaveBeenCalled();
+  });
+
+  it("is idempotent for already-read", async () => {
+    mockPrisma.notification.findUnique.mockResolvedValue({
+      recipientUserId: "u1",
+      readAt: new Date(),
+      scheduledMeetingId: null,
+    });
+    const out = await runMarkNotificationRead("u1", { notificationId: "n1" });
+    expect(out).toEqual({ ok: true, alreadyRead: true });
+    expect(mockPrisma.notification.update).not.toHaveBeenCalled();
+  });
+
+  it("rejects unknown notification", async () => {
+    mockPrisma.notification.findUnique.mockResolvedValue(null);
+    await expect(
+      runMarkNotificationRead("u1", { notificationId: "nope" }),
+    ).rejects.toBeInstanceOf(NotificationNotFoundError);
+  });
+
+  it("rejects notifications belonging to another user", async () => {
+    mockPrisma.notification.findUnique.mockResolvedValue({
+      recipientUserId: "u2",
+      readAt: null,
+      scheduledMeetingId: null,
+    });
+    await expect(
+      runMarkNotificationRead("u1", { notificationId: "n1" }),
+    ).rejects.toBeInstanceOf(NotificationForbiddenError);
+  });
+});

--- a/dali-api/app/mcp/tools/__tests__/rsvp-to-notification.test.ts
+++ b/dali-api/app/mcp/tools/__tests__/rsvp-to-notification.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("~/lib/db");
+vi.mock("~/lib/google-calendar", () => ({
+  updateGoogleAttendeeRsvp: vi.fn(),
+}));
+
+import { prisma } from "~/lib/db";
+import { updateGoogleAttendeeRsvp } from "~/lib/google-calendar";
+import {
+  runRsvpToNotification,
+  RSVP_TO_NOTIFICATION_TOOL,
+  RsvpError,
+} from "~/mcp/tools/rsvp-to-notification";
+
+const mockPrisma = prisma as unknown as {
+  notification: {
+    findUnique: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+  };
+};
+
+const CALLER = { id: "u1", daliEmail: "u1@dali.dartmouth.edu", dartmouthEmail: null };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("rsvp_to_notification", () => {
+  it("requires the mcp:write scope", () => {
+    expect(RSVP_TO_NOTIFICATION_TOOL.requiredScope).toBe("mcp:write");
+  });
+
+  it("records RSVP and pushes to Google when meeting is on GCal", async () => {
+    mockPrisma.notification.findUnique.mockResolvedValue({
+      id: "n1",
+      recipientUserId: "u1",
+      scheduledMeetingId: "m1",
+      scheduledMeeting: { externalEventId: "ev-1", organizerCalendarLinkId: "cl-1" },
+    });
+    mockPrisma.notification.update.mockResolvedValue({});
+
+    const out = await runRsvpToNotification(CALLER, {
+      notificationId: "n1",
+      response: "accepted",
+    });
+    expect(out).toEqual({ ok: true, gcalError: null });
+    expect(updateGoogleAttendeeRsvp).toHaveBeenCalledWith({
+      linkId: "cl-1",
+      eventId: "ev-1",
+      attendeeEmail: "u1@dali.dartmouth.edu",
+      response: "accepted",
+    });
+    expect(mockPrisma.notification.update).toHaveBeenCalled();
+  });
+
+  it("records the in-app RSVP when Google push fails", async () => {
+    mockPrisma.notification.findUnique.mockResolvedValue({
+      id: "n1",
+      recipientUserId: "u1",
+      scheduledMeetingId: "m1",
+      scheduledMeeting: { externalEventId: "ev-1", organizerCalendarLinkId: "cl-1" },
+    });
+    vi.mocked(updateGoogleAttendeeRsvp).mockRejectedValueOnce(new Error("token expired"));
+    mockPrisma.notification.update.mockResolvedValue({});
+
+    const out = await runRsvpToNotification(CALLER, {
+      notificationId: "n1",
+      response: "declined",
+    });
+    expect(out).toEqual({ ok: true, gcalError: "token expired" });
+    expect(mockPrisma.notification.update).toHaveBeenCalled();
+  });
+
+  it("skips Google push when meeting wasn't pushed", async () => {
+    mockPrisma.notification.findUnique.mockResolvedValue({
+      id: "n1",
+      recipientUserId: "u1",
+      scheduledMeetingId: "m1",
+      scheduledMeeting: { externalEventId: null, organizerCalendarLinkId: null },
+    });
+    mockPrisma.notification.update.mockResolvedValue({});
+
+    const out = await runRsvpToNotification(CALLER, {
+      notificationId: "n1",
+      response: "tentative",
+    });
+    expect(out).toEqual({ ok: true, gcalError: null });
+    expect(updateGoogleAttendeeRsvp).not.toHaveBeenCalled();
+  });
+
+  it("rejects notifications not tied to a meeting", async () => {
+    mockPrisma.notification.findUnique.mockResolvedValue({
+      id: "n1",
+      recipientUserId: "u1",
+      scheduledMeetingId: null,
+      scheduledMeeting: null,
+    });
+    await expect(
+      runRsvpToNotification(CALLER, { notificationId: "n1", response: "accepted" }),
+    ).rejects.toBeInstanceOf(RsvpError);
+  });
+
+  it("rejects notifications belonging to other users", async () => {
+    mockPrisma.notification.findUnique.mockResolvedValue({
+      id: "n1",
+      recipientUserId: "u2",
+      scheduledMeetingId: "m1",
+      scheduledMeeting: { externalEventId: null, organizerCalendarLinkId: null },
+    });
+    await expect(
+      runRsvpToNotification(CALLER, { notificationId: "n1", response: "accepted" }),
+    ).rejects.toThrowError("Forbidden");
+  });
+});

--- a/dali-api/app/mcp/tools/__tests__/update-task-status.test.ts
+++ b/dali-api/app/mcp/tools/__tests__/update-task-status.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("~/lib/db");
+vi.mock("~/lib/roles", async (orig) => {
+  const real = await orig<typeof import("~/lib/roles")>();
+  return { ...real, isCore: vi.fn() };
+});
+
+import { prisma } from "~/lib/db";
+import { isCore } from "~/lib/roles";
+import {
+  runUpdateTaskStatus,
+  UPDATE_TASK_STATUS_TOOL,
+  UpdateTaskStatusError,
+} from "~/mcp/tools/update-task-status";
+
+const mockPrisma = prisma as unknown as {
+  task: {
+    findUnique: ReturnType<typeof vi.fn>;
+    aggregate: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+  };
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("update_task_status", () => {
+  it("requires the mcp:write scope", () => {
+    expect(UPDATE_TASK_STATUS_TOOL.requiredScope).toBe("mcp:write");
+  });
+
+  it("rejects unknown statuses", async () => {
+    await expect(
+      runUpdateTaskStatus("u1", { taskId: "t1", status: "Reopened" }),
+    ).rejects.toBeInstanceOf(UpdateTaskStatusError);
+  });
+
+  it("rejects when task is missing", async () => {
+    mockPrisma.task.findUnique.mockResolvedValue(null);
+    await expect(
+      runUpdateTaskStatus("u1", { taskId: "nope", status: "Done" }),
+    ).rejects.toThrowError("Task not found");
+  });
+
+  it("allows an assignee to move their own task", async () => {
+    mockPrisma.task.findUnique.mockResolvedValue({
+      id: "t1",
+      status: "Todo",
+      projectId: "p1",
+      assignees: [{ userId: "u1" }],
+    });
+    mockPrisma.task.aggregate.mockResolvedValue({ _max: { position: 4 } });
+    mockPrisma.task.update.mockResolvedValue({});
+    const out = await runUpdateTaskStatus("u1", { taskId: "t1", status: "Done" });
+    expect(out).toMatchObject({ ok: true, previousStatus: "Todo", newStatus: "Done" });
+    expect(mockPrisma.task.update).toHaveBeenCalledWith({
+      where: { id: "t1" },
+      data: { status: "Done", position: 5 },
+    });
+    // Core should NOT be consulted when the caller is already an assignee.
+    expect(isCore).not.toHaveBeenCalled();
+  });
+
+  it("allows Core to move someone else's task", async () => {
+    mockPrisma.task.findUnique.mockResolvedValue({
+      id: "t1",
+      status: "Todo",
+      projectId: "p1",
+      assignees: [{ userId: "u-other" }],
+    });
+    vi.mocked(isCore).mockResolvedValue(true);
+    mockPrisma.task.aggregate.mockResolvedValue({ _max: { position: null } });
+    mockPrisma.task.update.mockResolvedValue({});
+    const out = await runUpdateTaskStatus("u1", { taskId: "t1", status: "InReview" });
+    expect(out.newStatus).toBe("InReview");
+    expect(mockPrisma.task.update).toHaveBeenCalledWith({
+      where: { id: "t1" },
+      data: { status: "InReview", position: 0 },
+    });
+  });
+
+  it("forbids non-assignee non-Core movers", async () => {
+    mockPrisma.task.findUnique.mockResolvedValue({
+      id: "t1",
+      status: "Todo",
+      projectId: "p1",
+      assignees: [{ userId: "u-other" }],
+    });
+    vi.mocked(isCore).mockResolvedValue(false);
+    await expect(
+      runUpdateTaskStatus("u1", { taskId: "t1", status: "Done" }),
+    ).rejects.toMatchObject({ name: "UpdateTaskStatusError", status: 403 });
+  });
+});

--- a/dali-api/app/mcp/tools/cancel-meeting.ts
+++ b/dali-api/app/mcp/tools/cancel-meeting.ts
@@ -1,0 +1,41 @@
+// MCP `cancel_meeting` — cancel a ScheduledMeeting the caller organizes.
+// Wraps the same `cancelScheduledMeeting` helper used by
+// `api.scheduled-meetings.$id.cancel.ts`: organizer-only, idempotent, flips
+// status to Cancelled (which pulls the invite from every recipient's
+// inbox/tasks). Requires the `mcp:write` scope.
+
+import { cancelScheduledMeeting } from "~/lib/scheduled-meeting";
+
+export const CANCEL_MEETING_TOOL = {
+  name: "cancel_meeting",
+  description:
+    "Cancel a meeting the authenticated member organizes. Only the organizer may cancel. Idempotent — cancelling an already-cancelled meeting returns alreadyCancelled=true.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      meetingId: {
+        type: "string",
+        minLength: 1,
+        description: "ScheduledMeeting.id, as returned by `list_my_upcoming_meetings` or `schedule_meeting`.",
+      },
+    },
+    required: ["meetingId"],
+    additionalProperties: false,
+  },
+  requiredScope: "mcp:write" as const,
+};
+
+type Input = { meetingId: string };
+
+export class CancelMeetingError extends Error {
+  constructor(message: string, public status: number) {
+    super(message);
+    this.name = "CancelMeetingError";
+  }
+}
+
+export async function runCancelMeeting(callerId: string, input: Input) {
+  const result = await cancelScheduledMeeting(input.meetingId, callerId);
+  if (!result.ok) throw new CancelMeetingError(result.error, result.status);
+  return { ok: true, alreadyCancelled: result.alreadyCancelled };
+}

--- a/dali-api/app/mcp/tools/get-project-overview.ts
+++ b/dali-api/app/mcp/tools/get-project-overview.ts
@@ -1,0 +1,146 @@
+// MCP `get_project_overview` — read-only drill-down on a Project. Returns the
+// project's identity fields, current-term roster, active sprint, current
+// epic (if any), and task-status counts. Read access mirrors the project
+// detail page: any authenticated DALI OS member can load it. Requires the
+// `mcp:read` scope.
+
+import { prisma } from "~/lib/db";
+import { currentTerm } from "~/lib/roles";
+
+export const GET_PROJECT_OVERVIEW_TOOL = {
+  name: "get_project_overview",
+  description:
+    "Get a Project's overview: status, current-term roster, active sprint, current epic, task counts by status. Read-only.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      projectId: {
+        type: "string",
+        minLength: 1,
+        description: "Project.id, as returned by `list_my_projects`.",
+      },
+    },
+    required: ["projectId"],
+    additionalProperties: false,
+  },
+  requiredScope: "mcp:read" as const,
+};
+
+type Input = { projectId: string };
+
+export class ProjectNotFoundError extends Error {
+  constructor(id: string) {
+    super(`Project ${id} not found`);
+    this.name = "ProjectNotFoundError";
+  }
+}
+
+export async function runGetProjectOverview(input: Input) {
+  const term = await currentTerm();
+  const termId = term?.id ?? null;
+
+  const project = await prisma.project.findUnique({
+    where: { id: input.projectId },
+    select: {
+      id: true,
+      name: true,
+      description: true,
+      status: true,
+      imageUrl: true,
+      repoUrls: true,
+      overviewPageId: true,
+      prdPageId: true,
+      projectTerms: {
+        select: { term: { select: { code: true, sortKey: true } } },
+      },
+      partners: {
+        select: { partnerOrg: { select: { id: true, name: true } } },
+      },
+    },
+  });
+  if (!project) throw new ProjectNotFoundError(input.projectId);
+
+  const [currentAssignments, activeSprint, openEpic, taskCounts] = await Promise.all([
+    termId
+      ? prisma.projectAssignment.findMany({
+          where: { projectId: input.projectId, termId },
+          select: {
+            level: true,
+            user: { select: { id: true, firstName: true, lastName: true } },
+            domain: { select: { id: true, displayName: true } },
+          },
+        })
+      : Promise.resolve([]),
+    prisma.sprint.findFirst({
+      where: { projectId: input.projectId, status: "Active" },
+      orderBy: { startsAt: "desc" },
+      select: { id: true, name: true, startsAt: true, endsAt: true },
+    }),
+    prisma.epic.findFirst({
+      where: {
+        projectId: input.projectId,
+        status: { in: ["Open", "InProgress"] },
+      },
+      orderBy: { position: "asc" },
+      select: { id: true, title: true, description: true, status: true },
+    }),
+    prisma.task.groupBy({
+      by: ["status"],
+      where: { projectId: input.projectId },
+      _count: { _all: true },
+    }),
+  ]);
+
+  const taskCountByStatus: Record<string, number> = {
+    Todo: 0,
+    InProgress: 0,
+    InReview: 0,
+    Done: 0,
+    Cancelled: 0,
+  };
+  for (const row of taskCounts) taskCountByStatus[row.status] = row._count._all;
+
+  const termCodes = project.projectTerms
+    .map((pt) => pt.term)
+    .sort((a, b) => a.sortKey - b.sortKey)
+    .map((t) => t.code);
+
+  return {
+    id: project.id,
+    name: project.name,
+    description: project.description,
+    status: project.status,
+    imageUrl: project.imageUrl,
+    repoUrls: project.repoUrls,
+    overviewPageId: project.overviewPageId,
+    prdPageId: project.prdPageId,
+    termCodes,
+    partners: project.partners.map((p) => ({
+      id: p.partnerOrg.id,
+      name: p.partnerOrg.name,
+    })),
+    currentTermRoster: currentAssignments.map((a) => ({
+      userId: a.user.id,
+      name: `${a.user.firstName} ${a.user.lastName}`.trim(),
+      domain: a.domain.displayName,
+      level: a.level,
+    })),
+    activeSprint: activeSprint
+      ? {
+          id: activeSprint.id,
+          name: activeSprint.name,
+          startsAt: activeSprint.startsAt.toISOString(),
+          endsAt: activeSprint.endsAt.toISOString(),
+        }
+      : null,
+    currentEpic: openEpic
+      ? {
+          id: openEpic.id,
+          title: openEpic.title,
+          description: openEpic.description,
+          status: openEpic.status,
+        }
+      : null,
+    taskCountByStatus,
+  };
+}

--- a/dali-api/app/mcp/tools/list-groups.ts
+++ b/dali-api/app/mcp/tools/list-groups.ts
@@ -1,0 +1,43 @@
+// MCP `list_groups` — lab groups visible to the authenticated member.
+// Static groups they're a member of and Dynamic groups whose resolved
+// membership includes them. Use a returned `id` (member.id) elsewhere, or use
+// `memberIds` to bulk-resolve a group. Requires the `mcp:read` scope.
+
+import { listVisibleGroupsForUser } from "~/lib/groups";
+
+export const LIST_GROUPS_TOOL = {
+  name: "list_groups",
+  description:
+    "List lab groups the authenticated DALI OS member belongs to. Returns each group's id, name, type (Static/Dynamic), and member userIds. Useful for resolving a group into a participant list before calling `schedule_meeting`.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      includeArchived: {
+        type: "boolean",
+        description:
+          "If true, also return groups whose bound terms have ended or that were manually archived (default false).",
+      },
+    },
+    additionalProperties: false,
+  },
+  requiredScope: "mcp:read" as const,
+};
+
+type Input = { includeArchived?: boolean };
+
+export async function runListGroups(callerId: string, input: Input) {
+  const includeArchived = input.includeArchived ?? false;
+  const visible = await listVisibleGroupsForUser(callerId);
+  const groups = visible
+    .filter((g) => includeArchived || !g.archived)
+    .map((g) => ({
+      id: g.id,
+      name: g.name,
+      type: g.type,
+      systemKey: g.systemKey,
+      memberIds: g.memberIds,
+      memberCount: g.memberIds.length,
+      archived: g.archived,
+    }));
+  return { groups };
+}

--- a/dali-api/app/mcp/tools/list-my-projects.ts
+++ b/dali-api/app/mcp/tools/list-my-projects.ts
@@ -1,0 +1,135 @@
+// MCP `list_my_projects` — every Project the authenticated member is staffed
+// on (any term, like `isProjectMember`), enriched with current-term context:
+// their role on the project this term, the active sprint, open task count.
+// Requires the `mcp:read` scope.
+
+import { prisma } from "~/lib/db";
+import { currentTerm } from "~/lib/roles";
+
+export const LIST_MY_PROJECTS_TOOL = {
+  name: "list_my_projects",
+  description:
+    "List projects the authenticated DALI OS member is staffed on. Past-term assignments stay visible (matches in-app access). Each row includes the current-term role/domain (if assigned this term), the active sprint, and open task count.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      currentTermOnly: {
+        type: "boolean",
+        description:
+          "If true, only return projects the member is staffed on for the current term (default false — past assignments included, matching project workspace access).",
+      },
+    },
+    additionalProperties: false,
+  },
+  requiredScope: "mcp:read" as const,
+};
+
+type Input = { currentTermOnly?: boolean };
+
+type MyProjectOut = {
+  id: string;
+  name: string;
+  status: "Active" | "Paused" | "Archived";
+  imageUrl: string | null;
+  currentTermAssignment: {
+    termCode: string;
+    domainName: string;
+    level: string;
+  } | null;
+  activeSprint: { id: string; name: string; endsAt: string } | null;
+  openTaskCount: number;
+};
+
+export async function runListMyProjects(callerId: string, input: Input) {
+  const term = await currentTerm();
+  const termId = term?.id ?? null;
+
+  const assignments = await prisma.projectAssignment.findMany({
+    where: {
+      userId: callerId,
+      ...(input.currentTermOnly && termId ? { termId } : {}),
+    },
+    select: {
+      projectId: true,
+      termId: true,
+      level: true,
+      term: { select: { code: true } },
+      domain: { select: { displayName: true } },
+    },
+  });
+
+  const projectIds = Array.from(new Set(assignments.map((a) => a.projectId)));
+  if (projectIds.length === 0) return { projects: [] as MyProjectOut[] };
+
+  const [projects, activeSprints, openTaskCounts] = await Promise.all([
+    prisma.project.findMany({
+      where: { id: { in: projectIds } },
+      select: { id: true, name: true, status: true, imageUrl: true },
+    }),
+    prisma.sprint.findMany({
+      where: { projectId: { in: projectIds }, status: "Active" },
+      orderBy: { startsAt: "desc" },
+      select: { id: true, projectId: true, name: true, endsAt: true },
+    }),
+    prisma.task.groupBy({
+      by: ["projectId"],
+      where: {
+        projectId: { in: projectIds },
+        status: { notIn: ["Done", "Cancelled"] },
+      },
+      _count: { _all: true },
+    }),
+  ]);
+
+  // First active sprint per project (groupBy not directly applicable here).
+  const activeSprintByProject = new Map<string, { id: string; name: string; endsAt: Date }>();
+  for (const s of activeSprints) {
+    if (!activeSprintByProject.has(s.projectId)) {
+      activeSprintByProject.set(s.projectId, { id: s.id, name: s.name, endsAt: s.endsAt });
+    }
+  }
+  const openTaskByProject = new Map<string, number>();
+  for (const row of openTaskCounts) openTaskByProject.set(row.projectId, row._count._all);
+
+  // Pick the current-term assignment per project if one exists.
+  const currentTermByProject = new Map<
+    string,
+    { termCode: string; domainName: string; level: string }
+  >();
+  if (termId) {
+    for (const a of assignments) {
+      if (a.termId === termId && !currentTermByProject.has(a.projectId)) {
+        currentTermByProject.set(a.projectId, {
+          termCode: a.term.code,
+          domainName: a.domain.displayName,
+          level: a.level,
+        });
+      }
+    }
+  }
+
+  const out: MyProjectOut[] = projects.map((p) => {
+    const sprint = activeSprintByProject.get(p.id);
+    return {
+      id: p.id,
+      name: p.name,
+      status: p.status,
+      imageUrl: p.imageUrl,
+      currentTermAssignment: currentTermByProject.get(p.id) ?? null,
+      activeSprint: sprint
+        ? { id: sprint.id, name: sprint.name, endsAt: sprint.endsAt.toISOString() }
+        : null,
+      openTaskCount: openTaskByProject.get(p.id) ?? 0,
+    };
+  });
+
+  // Sort: current-term assignments first, then by name.
+  out.sort((a, b) => {
+    const aCurrent = a.currentTermAssignment ? 0 : 1;
+    const bCurrent = b.currentTermAssignment ? 0 : 1;
+    if (aCurrent !== bCurrent) return aCurrent - bCurrent;
+    return a.name.localeCompare(b.name);
+  });
+
+  return { projects: out };
+}

--- a/dali-api/app/mcp/tools/list-my-tasks.ts
+++ b/dali-api/app/mcp/tools/list-my-tasks.ts
@@ -1,0 +1,107 @@
+// MCP `list_my_tasks` — every project Task the authenticated member is
+// assigned to, with sprint/epic/project context. By default hides Done and
+// Cancelled. Filter by status, project, or sprint. Requires the `mcp:read`
+// scope.
+
+import { prisma } from "~/lib/db";
+import { TASK_STATUSES, type TaskStatus } from "~/projects/lib/task-board";
+
+export const LIST_MY_TASKS_TOOL = {
+  name: "list_my_tasks",
+  description:
+    "List project tasks the authenticated DALI OS member is assigned to. Defaults to open work (excludes Done and Cancelled). Filter by status, projectId, or sprintId.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      status: {
+        type: "array",
+        items: {
+          type: "string",
+          enum: TASK_STATUSES as unknown as string[],
+        },
+        maxItems: TASK_STATUSES.length,
+        description:
+          "Restrict to these task statuses. Default ['Todo','InProgress','InReview'] — pass explicit list to include Done/Cancelled.",
+      },
+      projectId: {
+        type: "string",
+        minLength: 1,
+        description: "Restrict to a single project.",
+      },
+      sprintId: {
+        type: "string",
+        minLength: 1,
+        description: "Restrict to a single sprint (use a sprintId from `get_project_overview`).",
+      },
+      limit: {
+        type: "integer",
+        minimum: 1,
+        maximum: 100,
+        description: "Maximum tasks to return (default 50, max 100).",
+      },
+    },
+    additionalProperties: false,
+  },
+  requiredScope: "mcp:read" as const,
+};
+
+type Input = {
+  status?: TaskStatus[];
+  projectId?: string;
+  sprintId?: string;
+  limit?: number;
+};
+
+const DEFAULT_OPEN_STATUSES: TaskStatus[] = ["Todo", "InProgress", "InReview"];
+
+export async function runListMyTasks(callerId: string, input: Input) {
+  const limit = Math.max(1, Math.min(input.limit ?? 50, 100));
+  const statuses =
+    input.status && input.status.length > 0 ? input.status : DEFAULT_OPEN_STATUSES;
+
+  const rows = await prisma.task.findMany({
+    where: {
+      assignees: { some: { userId: callerId } },
+      status: { in: statuses },
+      ...(input.projectId ? { projectId: input.projectId } : {}),
+      ...(input.sprintId ? { sprintId: input.sprintId } : {}),
+    },
+    orderBy: [{ dueAt: "asc" }, { priority: "desc" }, { createdAt: "desc" }],
+    take: limit,
+    select: {
+      id: true,
+      title: true,
+      status: true,
+      priority: true,
+      dueAt: true,
+      createdAt: true,
+      projectId: true,
+      project: { select: { name: true } },
+      sprintId: true,
+      sprint: { select: { name: true } },
+      epicId: true,
+      epic: { select: { title: true } },
+      domain: { select: { displayName: true } },
+      assignees: { select: { userId: true } },
+    },
+  });
+
+  return {
+    tasks: rows.map((t) => ({
+      id: t.id,
+      title: t.title,
+      status: t.status,
+      priority: t.priority,
+      dueAt: t.dueAt?.toISOString() ?? null,
+      createdAt: t.createdAt.toISOString(),
+      projectId: t.projectId,
+      projectName: t.project.name,
+      sprintId: t.sprintId,
+      sprintName: t.sprint?.name ?? null,
+      epicId: t.epicId,
+      epicTitle: t.epic?.title ?? null,
+      domainName: t.domain?.displayName ?? null,
+      assigneeUserIds: t.assignees.map((a) => a.userId),
+    })),
+  };
+}

--- a/dali-api/app/mcp/tools/mark-notification-read.ts
+++ b/dali-api/app/mcp/tools/mark-notification-read.ts
@@ -1,0 +1,68 @@
+// MCP `mark_notification_read` — clear a notification from the caller's
+// inbox/tasks. Mirrors `api.notifications.$id.read.ts`: a meeting-invite
+// notification stays a todo until the recipient RSVPs (so plain "read" is a
+// no-op for those), matching the in-app behavior. Requires the `mcp:write`
+// scope.
+
+import { prisma } from "~/lib/db";
+
+export const MARK_NOTIFICATION_READ_TOOL = {
+  name: "mark_notification_read",
+  description:
+    "Mark one of the authenticated member's notifications as read. Meeting invites are not cleared by this — use `rsvp_to_notification` for those.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      notificationId: {
+        type: "string",
+        minLength: 1,
+        description: "Notification.id, as returned by `list_my_notifications`.",
+      },
+    },
+    required: ["notificationId"],
+    additionalProperties: false,
+  },
+  requiredScope: "mcp:write" as const,
+};
+
+type Input = { notificationId: string };
+
+export class NotificationNotFoundError extends Error {
+  constructor(id: string) {
+    super(`Notification ${id} not found`);
+    this.name = "NotificationNotFoundError";
+  }
+}
+
+export class NotificationForbiddenError extends Error {
+  constructor() {
+    super("Notification belongs to another user");
+    this.name = "NotificationForbiddenError";
+  }
+}
+
+export type MarkNotificationReadResult =
+  | { ok: true; alreadyRead: boolean; skipped?: undefined }
+  | { ok: true; alreadyRead?: undefined; skipped: "meeting-invite" };
+
+export async function runMarkNotificationRead(
+  callerId: string,
+  input: Input,
+): Promise<MarkNotificationReadResult> {
+  const existing = await prisma.notification.findUnique({
+    where: { id: input.notificationId },
+    select: { recipientUserId: true, readAt: true, scheduledMeetingId: true },
+  });
+  if (!existing) throw new NotificationNotFoundError(input.notificationId);
+  if (existing.recipientUserId !== callerId) throw new NotificationForbiddenError();
+
+  // Mirror api.notifications.$id.read.ts: meeting invites only clear via RSVP.
+  if (existing.scheduledMeetingId) return { ok: true, skipped: "meeting-invite" };
+
+  if (existing.readAt) return { ok: true, alreadyRead: true };
+  await prisma.notification.update({
+    where: { id: input.notificationId },
+    data: { readAt: new Date() },
+  });
+  return { ok: true, alreadyRead: false };
+}

--- a/dali-api/app/mcp/tools/rsvp-to-notification.ts
+++ b/dali-api/app/mcp/tools/rsvp-to-notification.ts
@@ -1,0 +1,99 @@
+// MCP `rsvp_to_notification` — accept / decline / tentatively-accept a
+// MeetingInvite notification. Mirrors `api.notifications.$id.rsvp.ts`,
+// including the best-effort Google Calendar attendee response push. Requires
+// the `mcp:write` scope.
+
+import { prisma } from "~/lib/db";
+import { updateGoogleAttendeeRsvp } from "~/lib/google-calendar";
+
+export const RSVP_TO_NOTIFICATION_TOOL = {
+  name: "rsvp_to_notification",
+  description:
+    "Respond to a meeting-invite notification (accepted/declined/tentative). Records the RSVP, marks the notification read, and best-effort pushes the response to Google Calendar when the meeting was pushed there.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      notificationId: {
+        type: "string",
+        minLength: 1,
+        description: "Notification.id of a MeetingInvite, from `list_my_notifications`.",
+      },
+      response: {
+        type: "string",
+        enum: ["accepted", "declined", "tentative"],
+        description: "The RSVP response to record.",
+      },
+    },
+    required: ["notificationId", "response"],
+    additionalProperties: false,
+  },
+  requiredScope: "mcp:write" as const,
+};
+
+type Input = { notificationId: string; response: "accepted" | "declined" | "tentative" };
+
+const RSVP_TO_ENUM = {
+  accepted: "Accepted",
+  declined: "Declined",
+  tentative: "Tentative",
+} as const;
+
+export class RsvpError extends Error {
+  constructor(message: string, public status: number) {
+    super(message);
+    this.name = "RsvpError";
+  }
+}
+
+export async function runRsvpToNotification(
+  caller: { id: string; daliEmail: string | null; dartmouthEmail: string | null },
+  input: Input,
+) {
+  const notif = await prisma.notification.findUnique({
+    where: { id: input.notificationId },
+    select: {
+      id: true,
+      recipientUserId: true,
+      scheduledMeetingId: true,
+      scheduledMeeting: {
+        select: { externalEventId: true, organizerCalendarLinkId: true },
+      },
+    },
+  });
+  if (!notif) throw new RsvpError("Notification not found", 404);
+  if (notif.recipientUserId !== caller.id) throw new RsvpError("Forbidden", 403);
+  if (!notif.scheduledMeetingId) {
+    throw new RsvpError("Notification has no associated meeting", 400);
+  }
+
+  const attendeeEmail = caller.daliEmail ?? caller.dartmouthEmail;
+
+  let gcalError: string | null = null;
+  if (
+    notif.scheduledMeeting?.externalEventId &&
+    notif.scheduledMeeting.organizerCalendarLinkId &&
+    attendeeEmail
+  ) {
+    try {
+      await updateGoogleAttendeeRsvp({
+        linkId: notif.scheduledMeeting.organizerCalendarLinkId,
+        eventId: notif.scheduledMeeting.externalEventId,
+        attendeeEmail,
+        response: input.response,
+      });
+    } catch (err) {
+      gcalError = err instanceof Error ? err.message : "Google RSVP push failed";
+    }
+  }
+
+  await prisma.notification.update({
+    where: { id: input.notificationId },
+    data: {
+      rsvp: RSVP_TO_ENUM[input.response],
+      rsvpAt: new Date(),
+      readAt: new Date(),
+    },
+  });
+
+  return { ok: true, gcalError };
+}

--- a/dali-api/app/mcp/tools/update-task-status.ts
+++ b/dali-api/app/mcp/tools/update-task-status.ts
@@ -1,0 +1,94 @@
+// MCP `update_task_status` — move a project Task to a different status. Lands
+// the task at the end of the target column (same "append" semantics as the
+// drag-to-end of board).
+//
+// Permission: the web board endpoint (`api.tasks.$id.move.ts`) gates moves to
+// Core only. For MCP we additionally allow a task's own assignees to update
+// status — the "list my tasks, mark mine done" flow is the primary value
+// here. Anyone else (incl. non-Core members not assigned to the task) is
+// rejected. Requires the `mcp:write` scope.
+
+import { prisma } from "~/lib/db";
+import { isCore } from "~/lib/roles";
+import {
+  TASK_STATUSES,
+  type TaskStatus,
+  isTaskStatus,
+} from "~/projects/lib/task-board";
+
+export const UPDATE_TASK_STATUS_TOOL = {
+  name: "update_task_status",
+  description:
+    "Move a project task to a different status column (e.g. mark a task Done). Allowed for the task's assignees and for Core members.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      taskId: {
+        type: "string",
+        minLength: 1,
+        description: "Task.id, as returned by `list_my_tasks`.",
+      },
+      status: {
+        type: "string",
+        enum: TASK_STATUSES as unknown as string[],
+        description: "Target status column.",
+      },
+    },
+    required: ["taskId", "status"],
+    additionalProperties: false,
+  },
+  requiredScope: "mcp:write" as const,
+};
+
+type Input = { taskId: string; status: string };
+
+export class UpdateTaskStatusError extends Error {
+  constructor(message: string, public status: number) {
+    super(message);
+    this.name = "UpdateTaskStatusError";
+  }
+}
+
+export async function runUpdateTaskStatus(callerId: string, input: Input) {
+  if (!isTaskStatus(input.status)) {
+    throw new UpdateTaskStatusError("Invalid status", 400);
+  }
+  const newStatus: TaskStatus = input.status;
+
+  const task = await prisma.task.findUnique({
+    where: { id: input.taskId },
+    select: {
+      id: true,
+      status: true,
+      projectId: true,
+      assignees: { select: { userId: true } },
+    },
+  });
+  if (!task) throw new UpdateTaskStatusError("Task not found", 404);
+
+  const isAssignee = task.assignees.some((a) => a.userId === callerId);
+  const callerIsCore = isAssignee ? false : await isCore(callerId);
+  if (!isAssignee && !callerIsCore) {
+    throw new UpdateTaskStatusError("Forbidden", 403);
+  }
+
+  // Append to the end of the target column (same project, same status). Mirrors
+  // the web `nextPositionInColumn` helper without round-tripping the whole board.
+  const maxInCol = await prisma.task.aggregate({
+    where: { projectId: task.projectId, status: newStatus },
+    _max: { position: true },
+  });
+  const nextPosition = (maxInCol._max.position ?? -1) + 1;
+
+  await prisma.task.update({
+    where: { id: input.taskId },
+    data: { status: newStatus, position: nextPosition },
+  });
+
+  return {
+    ok: true,
+    taskId: input.taskId,
+    previousStatus: task.status,
+    newStatus,
+  };
+}

--- a/dali-api/app/routes/help.mcp.tsx
+++ b/dali-api/app/routes/help.mcp.tsx
@@ -89,6 +89,33 @@ export default function McpHelpPage({ loaderData }: Route.ComponentProps) {
       </section>
 
       <section className="mt-6">
+        <h2 className="text-lg font-semibold">What can an assistant do?</h2>
+        <p className="mt-2 text-sm text-zinc-600">
+          DALI OS currently exposes these tools over MCP. Read tools need only{" "}
+          <code className="font-mono">mcp:read</code>; write tools need{" "}
+          <code className="font-mono">mcp:write</code>.
+        </p>
+        <ul className="mt-3 grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-1 text-sm text-zinc-700 list-disc pl-5">
+          <li><code className="font-mono">whoami</code> — identity + role tier</li>
+          <li><code className="font-mono">search_directory</code> — find a member</li>
+          <li><code className="font-mono">get_member_profile</code> — single member</li>
+          <li><code className="font-mono">list_groups</code> — your lab groups</li>
+          <li><code className="font-mono">list_my_notifications</code> — inbox</li>
+          <li><code className="font-mono">mark_notification_read</code> — clear one</li>
+          <li><code className="font-mono">rsvp_to_notification</code> — accept/decline an invite</li>
+          <li><code className="font-mono">list_my_upcoming_meetings</code> — next N days</li>
+          <li><code className="font-mono">list_my_calendar_links</code> — Google calendars</li>
+          <li><code className="font-mono">find_mutual_freebusy</code> — group availability</li>
+          <li><code className="font-mono">schedule_meeting</code> — create one</li>
+          <li><code className="font-mono">cancel_meeting</code> — cancel one you organize</li>
+          <li><code className="font-mono">list_my_projects</code> — projects you're on</li>
+          <li><code className="font-mono">get_project_overview</code> — project detail</li>
+          <li><code className="font-mono">list_my_tasks</code> — your project tasks</li>
+          <li><code className="font-mono">update_task_status</code> — move a task</li>
+        </ul>
+      </section>
+
+      <section className="mt-6">
         <h2 className="text-lg font-semibold">Managing connections</h2>
         <p className="mt-2 text-sm text-zinc-600">
           Visit{" "}

--- a/dali-api/app/routes/help.mcp.tsx
+++ b/dali-api/app/routes/help.mcp.tsx
@@ -116,6 +116,32 @@ export default function McpHelpPage({ loaderData }: Route.ComponentProps) {
       </section>
 
       <section className="mt-6">
+        <h2 className="text-lg font-semibold">Resources (auto-attachable context)</h2>
+        <p className="mt-2 text-sm text-zinc-600">
+          Clients can attach these as <em>resources</em>, separate from tool calls.
+          Some clients (Claude Desktop) let you pin them so they ride along on every message.
+        </p>
+        <ul className="mt-3 text-sm text-zinc-700 list-disc pl-5">
+          <li><code className="font-mono">dali://me</code> — your profile, roles, domain eligibilities</li>
+          <li><code className="font-mono">dali://announcements/active</code> — your unread lab announcements (markdown)</li>
+          <li><code className="font-mono">dali://forms/pending</code> — published forms you've been asked to fill</li>
+        </ul>
+      </section>
+
+      <section className="mt-6">
+        <h2 className="text-lg font-semibold">Prompts (templated workflows)</h2>
+        <p className="mt-2 text-sm text-zinc-600">
+          These appear as commands in the client (e.g. <code className="font-mono">/dali:weekly-digest</code> in
+          Claude Code). The model carries them out by calling the MCP tools above.
+        </p>
+        <ul className="mt-3 text-sm text-zinc-700 list-disc pl-5">
+          <li><code className="font-mono">weekly-digest</code> — focus, meetings, inbox, suggested next action</li>
+          <li><code className="font-mono">meeting-prep</code> — agenda + talking points for an upcoming meeting</li>
+          <li><code className="font-mono">project-status</code> — status report draft for a project you're on</li>
+        </ul>
+      </section>
+
+      <section className="mt-6">
         <h2 className="text-lg font-semibold">Managing connections</h2>
         <p className="mt-2 text-sm text-zinc-600">
           Visit{" "}

--- a/dali-api/app/routes/mcp.ts
+++ b/dali-api/app/routes/mcp.ts
@@ -40,6 +40,38 @@ import {
   LIST_MY_CALENDAR_LINKS_TOOL,
   runListMyCalendarLinks,
 } from "~/mcp/tools/list-my-calendar-links";
+import {
+  MARK_NOTIFICATION_READ_TOOL,
+  runMarkNotificationRead,
+  NotificationNotFoundError,
+  NotificationForbiddenError,
+} from "~/mcp/tools/mark-notification-read";
+import {
+  RSVP_TO_NOTIFICATION_TOOL,
+  runRsvpToNotification,
+  RsvpError,
+} from "~/mcp/tools/rsvp-to-notification";
+import {
+  CANCEL_MEETING_TOOL,
+  runCancelMeeting,
+  CancelMeetingError,
+} from "~/mcp/tools/cancel-meeting";
+import { LIST_GROUPS_TOOL, runListGroups } from "~/mcp/tools/list-groups";
+import {
+  LIST_MY_PROJECTS_TOOL,
+  runListMyProjects,
+} from "~/mcp/tools/list-my-projects";
+import {
+  GET_PROJECT_OVERVIEW_TOOL,
+  runGetProjectOverview,
+  ProjectNotFoundError,
+} from "~/mcp/tools/get-project-overview";
+import { LIST_MY_TASKS_TOOL, runListMyTasks } from "~/mcp/tools/list-my-tasks";
+import {
+  UPDATE_TASK_STATUS_TOOL,
+  runUpdateTaskStatus,
+  UpdateTaskStatusError,
+} from "~/mcp/tools/update-task-status";
 
 const PROTOCOL_VERSION = "2024-11-05";
 const SERVER_INFO = { name: "dali-os", version: "1.0.0" };
@@ -56,6 +88,14 @@ const TOOLS = [
   GET_MEMBER_PROFILE_TOOL,
   SCHEDULE_MEETING_TOOL,
   LIST_MY_CALENDAR_LINKS_TOOL,
+  MARK_NOTIFICATION_READ_TOOL,
+  RSVP_TO_NOTIFICATION_TOOL,
+  CANCEL_MEETING_TOOL,
+  LIST_GROUPS_TOOL,
+  LIST_MY_PROJECTS_TOOL,
+  GET_PROJECT_OVERVIEW_TOOL,
+  LIST_MY_TASKS_TOOL,
+  UPDATE_TASK_STATUS_TOOL,
 ] as const;
 
 type JsonRpcRequest = {
@@ -195,6 +235,53 @@ export async function action({ request }: Route.ActionArgs) {
           case "list_my_calendar_links":
             payload = await runListMyCalendarLinks(auth.user.id);
             break;
+          case "mark_notification_read":
+            payload = await runMarkNotificationRead(
+              auth.user.id,
+              args as Parameters<typeof runMarkNotificationRead>[1],
+            );
+            break;
+          case "rsvp_to_notification":
+            payload = await runRsvpToNotification(
+              auth.user,
+              args as Parameters<typeof runRsvpToNotification>[1],
+            );
+            break;
+          case "cancel_meeting":
+            payload = await runCancelMeeting(
+              auth.user.id,
+              args as Parameters<typeof runCancelMeeting>[1],
+            );
+            break;
+          case "list_groups":
+            payload = await runListGroups(
+              auth.user.id,
+              args as Parameters<typeof runListGroups>[1],
+            );
+            break;
+          case "list_my_projects":
+            payload = await runListMyProjects(
+              auth.user.id,
+              args as Parameters<typeof runListMyProjects>[1],
+            );
+            break;
+          case "get_project_overview":
+            payload = await runGetProjectOverview(
+              args as Parameters<typeof runGetProjectOverview>[0],
+            );
+            break;
+          case "list_my_tasks":
+            payload = await runListMyTasks(
+              auth.user.id,
+              args as Parameters<typeof runListMyTasks>[1],
+            );
+            break;
+          case "update_task_status":
+            payload = await runUpdateTaskStatus(
+              auth.user.id,
+              args as Parameters<typeof runUpdateTaskStatus>[1],
+            );
+            break;
           default:
             return rpcError(body.id, -32601, "Tool not implemented");
         }
@@ -218,6 +305,26 @@ export async function action({ request }: Route.ActionArgs) {
       } catch (err) {
         if (err instanceof MemberNotFoundError) {
           return rpcError(body.id, -32004, err.message);
+        }
+        if (err instanceof ProjectNotFoundError) {
+          return rpcError(body.id, -32004, err.message);
+        }
+        if (err instanceof NotificationNotFoundError) {
+          return rpcError(body.id, -32004, err.message);
+        }
+        if (err instanceof NotificationForbiddenError) {
+          return rpcError(body.id, -32003, err.message);
+        }
+        if (err instanceof RsvpError) {
+          // 403 → forbidden code; everything else maps to invalid params.
+          return rpcError(body.id, err.status === 403 ? -32003 : -32602, err.message);
+        }
+        if (err instanceof CancelMeetingError) {
+          return rpcError(body.id, err.status === 403 ? -32003 : -32004, err.message);
+        }
+        if (err instanceof UpdateTaskStatusError) {
+          const code = err.status === 403 ? -32003 : err.status === 404 ? -32004 : -32602;
+          return rpcError(body.id, code, err.message);
         }
         if (err instanceof ScheduleMeetingError) {
           return rpcError(body.id, -32602, err.message);

--- a/dali-api/app/routes/mcp.ts
+++ b/dali-api/app/routes/mcp.ts
@@ -72,12 +72,43 @@ import {
   runUpdateTaskStatus,
   UpdateTaskStatusError,
 } from "~/mcp/tools/update-task-status";
+import { ME_RESOURCE, readMeResource } from "~/mcp/resources/me";
+import {
+  ANNOUNCEMENTS_ACTIVE_RESOURCE,
+  readAnnouncementsActiveResource,
+} from "~/mcp/resources/announcements-active";
+import {
+  FORMS_PENDING_RESOURCE,
+  readFormsPendingResource,
+} from "~/mcp/resources/forms-pending";
+import { WEEKLY_DIGEST_PROMPT } from "~/mcp/prompts/weekly-digest";
+import { MEETING_PREP_PROMPT } from "~/mcp/prompts/meeting-prep";
+import { PROJECT_STATUS_PROMPT } from "~/mcp/prompts/project-status";
+import type { PromptDefinition } from "~/mcp/prompts/types";
 
 const PROTOCOL_VERSION = "2024-11-05";
 const SERVER_INFO = { name: "dali-os", version: "1.0.0" };
 
 const RATE_LIMIT_MAX = 120;
 const RATE_LIMIT_WINDOW_MS = 60_000;
+
+const RESOURCES = [
+  ME_RESOURCE,
+  ANNOUNCEMENTS_ACTIVE_RESOURCE,
+  FORMS_PENDING_RESOURCE,
+] as const;
+
+const PROMPTS: PromptDefinition[] = [
+  WEEKLY_DIGEST_PROMPT,
+  MEETING_PREP_PROMPT,
+  PROJECT_STATUS_PROMPT,
+];
+
+const CAPABILITIES = {
+  tools: { listChanged: false },
+  resources: { listChanged: false, subscribe: false },
+  prompts: { listChanged: false },
+} as const;
 
 const TOOLS = [
   WHOAMI_TOOL,
@@ -127,11 +158,15 @@ export async function loader() {
     {
       protocolVersion: PROTOCOL_VERSION,
       serverInfo: SERVER_INFO,
-      capabilities: { tools: { listChanged: false } },
+      capabilities: CAPABILITIES,
     },
     { status: 200 },
   );
 }
+
+// Exported so tests / introspection can list resource + prompt catalogs
+// without spinning up the full action handler.
+export { RESOURCES, PROMPTS };
 
 export async function action({ request }: Route.ActionArgs) {
   const auth = await authenticateMcpRequest(request);
@@ -156,7 +191,7 @@ export async function action({ request }: Route.ActionArgs) {
       return rpcResult(body.id, {
         protocolVersion: PROTOCOL_VERSION,
         serverInfo: SERVER_INFO,
-        capabilities: { tools: { listChanged: false } },
+        capabilities: CAPABILITIES,
       });
 
     case "notifications/initialized":
@@ -332,6 +367,126 @@ export async function action({ request }: Route.ActionArgs) {
         const message = err instanceof Error ? err.message : "Tool execution failed";
         return rpcError(body.id, -32000, message);
       }
+    }
+
+    case "resources/list":
+      return rpcResult(body.id, {
+        resources: RESOURCES.map((r) => ({
+          uri: r.uri,
+          name: r.name,
+          description: r.description,
+          mimeType: r.mimeType,
+        })),
+      });
+
+    case "resources/read": {
+      const params = body.params as { uri?: string } | undefined;
+      const uri = params?.uri;
+      const resource = RESOURCES.find((r) => r.uri === uri);
+      if (!resource) {
+        return rpcError(body.id, -32602, `Unknown resource: ${uri}`);
+      }
+      if (!auth.scopes.includes(resource.requiredScope)) {
+        return rpcError(
+          body.id,
+          -32002,
+          `Missing required scope: ${resource.requiredScope}`,
+        );
+      }
+      try {
+        let text: string;
+        switch (resource.uri) {
+          case "dali://me":
+            text = await readMeResource(auth.user.id);
+            break;
+          case "dali://announcements/active":
+            text = await readAnnouncementsActiveResource(auth.user.id);
+            break;
+          case "dali://forms/pending":
+            text = await readFormsPendingResource(auth.user.id);
+            break;
+          default:
+            return rpcError(body.id, -32601, "Resource not implemented");
+        }
+
+        await logAuditEvent({
+          action: "mcp.resource_read",
+          userId: auth.user.id,
+          metadata: {
+            uri: resource.uri,
+            clientId: auth.clientId,
+            clientName: auth.clientName,
+            grantId: auth.grantId,
+          },
+          request,
+        });
+
+        return rpcResult(body.id, {
+          contents: [
+            {
+              uri: resource.uri,
+              mimeType: resource.mimeType,
+              text,
+            },
+          ],
+        });
+      } catch (err) {
+        if (err instanceof MemberNotFoundError) {
+          return rpcError(body.id, -32004, err.message);
+        }
+        const message = err instanceof Error ? err.message : "Resource read failed";
+        return rpcError(body.id, -32000, message);
+      }
+    }
+
+    case "prompts/list":
+      return rpcResult(body.id, {
+        prompts: PROMPTS.map((p) => ({
+          name: p.name,
+          description: p.description,
+          arguments: p.arguments,
+        })),
+      });
+
+    case "prompts/get": {
+      const params = body.params as
+        | { name?: string; arguments?: Record<string, string> }
+        | undefined;
+      const promptName = params?.name;
+      const prompt = PROMPTS.find((p) => p.name === promptName);
+      if (!prompt) {
+        return rpcError(body.id, -32602, `Unknown prompt: ${promptName}`);
+      }
+
+      const promptArgs = params?.arguments ?? {};
+      for (const spec of prompt.arguments) {
+        if (spec.required && !promptArgs[spec.name]) {
+          return rpcError(
+            body.id,
+            -32602,
+            `Missing required argument: ${spec.name}`,
+          );
+        }
+      }
+
+      const messages = prompt.build(promptArgs);
+
+      await logAuditEvent({
+        action: "mcp.prompt_rendered",
+        userId: auth.user.id,
+        metadata: {
+          promptName: prompt.name,
+          clientId: auth.clientId,
+          clientName: auth.clientName,
+          grantId: auth.grantId,
+        },
+        request,
+      });
+
+      return rpcResult(body.id, {
+        description: prompt.description,
+        messages,
+      });
     }
 
     default:


### PR DESCRIPTION
## Summary
Adds 8 MCP tools that close the gaps in the current 8-tool catalog.

**Tier 1 — finish loops the existing tools half-supported**
- `mark_notification_read` — clears a notification (meeting invites still stay until RSVP, matching the in-app rule)
- `rsvp_to_notification` — accept/decline/tentative on a MeetingInvite, best-effort Google Calendar push
- `cancel_meeting` — organizer-only, wraps the existing `cancelScheduledMeeting` helper
- `list_groups` — lab groups the caller belongs to (Static + Dynamic), with member IDs for downstream tools

**Tier 2 — project workspace**
- `list_my_projects` — projects the caller has a ProjectAssignment on, enriched with current-term role/domain, active sprint, open task count
- `get_project_overview` — read-only drill-down: roster, active sprint, current epic, task counts by status
- `list_my_tasks` — caller's project tasks, defaults to open statuses, filters by status/projectId/sprintId
- `update_task_status` — move a task to a different column. **Diverges from the web** (which is Core-only) by also allowing the task's assignees, so the "list my tasks → mark done" MCP flow works for normal members.

Wired into `routes/mcp.ts` (TOOLS array, dispatch switch, error code mapping) and added a tool catalog section to `/help/mcp`. Extended the Vitest prisma mock with project/task/sprint/epic models so the new tools test in isolation following the existing per-tool pattern.

## Test plan
- [x] `npx vitest run app/mcp/tools/__tests__` — 13 files, 63 tests pass
- [x] Full suite: `npx vitest run` — 126 files, 1063 tests pass
- [x] `npm run typecheck` — no new errors (25 preexisting errors in scripts/seeds, unchanged)
- [ ] Smoke-test in Claude Desktop after merge: list/mark notifications, list/move a task, list groups, list/overview a project
- [ ] Confirm `update_task_status` permission change (assignee-allowed) is acceptable — flag if Core-only was deliberate
- [ ] CI: `test.yml`, `build-check.yml`, `migration-check.yml` (no migration changes), `codeql.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/738"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782919682&installation_id=133523038&pr_number=738&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F738&signature=c29305e2cde1100479a4970b88b1ffe6d826c7b898b60125a716cedf1a500ace"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->