### PR TITLE
Alumni: sidebar variant + route guards

### DIFF
--- a/dali-api/app/components/Layout.tsx
+++ b/dali-api/app/components/Layout.tsx
@@ -45,6 +45,11 @@ interface LayoutProps {
   isCore?: boolean
   isAdmin?: boolean
   isDomainLead?: boolean
+  // Drives the alumni sidebar variant: Home + Members + Calendar are hidden
+  // and most areas (Hiring, Projects, Partners, Education, Internal
+  // Processes, Operations) collapse out of the nav. The loader also
+  // hard-redirects alumni who deep-link past the UI.
+  isAlumni?: boolean
   canViewForms?: boolean
   canViewStaffing?: boolean
   isInterviewer?: boolean
@@ -55,7 +60,11 @@ const EXPANDED_AREAS_KEY = 'dali:sidebar:expanded-areas'
 
 type AreaKey = 'hiring' | 'projects' | 'members' | 'partners' | 'education' | 'internal-processes' | 'admin-console'
 
-export function Layout({ user, photoUrl, isCore = false, isAdmin = false, isDomainLead = false, canViewForms = false, canViewStaffing = false, isInterviewer = false }: LayoutProps) {
+export function Layout({ user, photoUrl, isCore = false, isAdmin = false, isDomainLead = false, isAlumni = false, canViewForms = false, canViewStaffing = false, isInterviewer = false }: LayoutProps) {
+  // Admin / Core overlap with isAlumni is rare (former member rehired as
+  // staff, etc.) but if it happens we honor active authority — the alumni
+  // variant only fires for a "pure" alumnus with no current role.
+  const alumniOnly = isAlumni && !isAdmin && !isCore
   const location = useLocation()
   const { revalidate } = useRevalidator()
   // Held in a ref so the message listener (mounted once) always calls the
@@ -484,7 +493,7 @@ export function Layout({ user, photoUrl, isCore = false, isAdmin = false, isDoma
       label: 'Hiring',
       to: '/hiring/reviewer',
       icon: Briefcase,
-      show: hasHiringAccess,
+      show: hasHiringAccess && !alumniOnly,
       active: activeAreaKey === 'hiring',
       sections: hiringSections,
     },
@@ -493,7 +502,7 @@ export function Layout({ user, photoUrl, isCore = false, isAdmin = false, isDoma
       label: 'Projects',
       to: '/projects/list',
       icon: FolderKanban,
-      show: true,
+      show: !alumniOnly,
       active: activeAreaKey === 'projects',
       sections: projectsSections,
     },
@@ -511,7 +520,7 @@ export function Layout({ user, photoUrl, isCore = false, isAdmin = false, isDoma
       label: 'Partners',
       to: '/partners',
       icon: Handshake,
-      show: true,
+      show: !alumniOnly,
       active: activeAreaKey === 'partners',
       sections: partnersSections,
     },
@@ -520,7 +529,7 @@ export function Layout({ user, photoUrl, isCore = false, isAdmin = false, isDoma
       label: 'Education',
       to: '/education',
       icon: GraduationCap,
-      show: true,
+      show: !alumniOnly,
       active: activeAreaKey === 'education',
       sections: educationSections,
     },
@@ -529,7 +538,7 @@ export function Layout({ user, photoUrl, isCore = false, isAdmin = false, isDoma
       label: 'Internal Processes',
       to: '/internal-processes/transfer',
       icon: Workflow,
-      show: true,
+      show: !alumniOnly,
       active: activeAreaKey === 'internal-processes',
       sections: internalProcessesSections,
     },
@@ -710,7 +719,7 @@ export function Layout({ user, photoUrl, isCore = false, isAdmin = false, isDoma
             </>
           )
         })()}
-        {(() => {
+        {!alumniOnly && (() => {
           const calendarActive = path.startsWith('/calendar')
           return (
             <button

--- a/dali-api/app/lib/__tests__/roles.test.ts
+++ b/dali-api/app/lib/__tests__/roles.test.ts
@@ -349,6 +349,48 @@ describe("getUserRoles — isAlumni field", () => {
     const roles = await getUserRoles("u");
     expect(roles.isAlumni).toBe(false);
   });
+
+  it("flips isLabMember to false for an alumnus with a DALIMember row", async () => {
+    // Past member: DALIMember row still exists, but they've graduated.
+    // Route guards key off isLabMember, so this must go false.
+    setRoleFlags({ member: true });
+    setUser({ dartmouthAffiliation: "ALUMNI" });
+    const roles = await getUserRoles("u");
+    expect(roles.isAlumni).toBe(true);
+    expect(roles.isLabMember).toBe(false);
+  });
+
+  it("keeps isLabMember true for an active member who is not alumni", async () => {
+    setRoleFlags({ member: true });
+    setUser({ classYear: null });
+    const roles = await getUserRoles("u");
+    expect(roles.isLabMember).toBe(true);
+  });
+
+  it("zeros out lingering role flags for pure alumni", async () => {
+    // A member who was a past-term instructor + domain-lead has graduated.
+    // Those *Assignment rows persist (we don't delete history), but neither
+    // flag should still grant authority post-grad.
+    setRoleFlags({ member: true, instructor: true, domainLead: true });
+    setUser({ dartmouthAffiliation: "ALUMNI" });
+    const roles = await getUserRoles("u");
+    expect(roles.isAlumni).toBe(true);
+    expect(roles.isInstructor).toBe(false);
+    expect(roles.isDomainLead).toBe(false);
+    expect(roles.canViewForms).toBe(false);
+  });
+
+  it("preserves Admin authority for an alumnus who is also an Admin", async () => {
+    // A former member rehired as full-time staff: AdminMembership row exists,
+    // classYear math says alumni. Admin authority wins.
+    setRoleFlags({ member: true, admin: true });
+    setUser({ dartmouthAffiliation: "ALUMNI" });
+    const roles = await getUserRoles("u");
+    expect(roles.isAlumni).toBe(true);
+    expect(roles.isAdmin).toBe(true);
+    expect(roles.isCore).toBe(true); // Admin is a superset of Core
+    expect(roles.isLabMember).toBe(true); // not a "pure" alumnus
+  });
 });
 
 // ───────────────────────────────────────────────────────────────────────────

--- a/dali-api/app/lib/roles.ts
+++ b/dali-api/app/lib/roles.ts
@@ -67,15 +67,28 @@ export async function getUserRoles(userId: string): Promise<UserRoles> {
   const isCoreVal = core !== null;
   const isInstructorVal = instructor !== null;
 
+  // Alumni lose lab-member access on derivation; the DALIMember row stays
+  // (we don't delete history) but `isLabMember` is the door used by route
+  // guards, and a pure alumnus should not pass it.
+  //
+  // Admin/Core resolve from independent tables, so a former member who is
+  // also flagged Admin (env-var or AdminMembership) or current-term Core
+  // keeps active authority — derivation only suppresses access for a "pure"
+  // alumnus with no current role. Domain-lead and instructor flags persist
+  // any-term and shouldn't grant authority post-grad; zero them out here.
+  const isAlumniVal = alumni;
+  const pureAlumni = isAlumniVal && !isAdminVal && !isCoreVal;
+
   return {
-    isLabMember: member !== null,
+    isLabMember: member !== null && !pureAlumni,
     // Admins are a superset of Core for access purposes.
     isCore: isAdminVal || isCoreVal,
     isAdmin: isAdminVal,
-    isDomainLead: domainLead !== null,
-    isInstructor: isInstructorVal,
-    isAlumni: alumni,
-    canViewForms: isAdminVal || isCoreVal || isInstructorVal,
+    isDomainLead: !pureAlumni && domainLead !== null,
+    isInstructor: !pureAlumni && isInstructorVal,
+    isAlumni: isAlumniVal,
+    canViewForms:
+      !pureAlumni && (isAdminVal || isCoreVal || isInstructorVal),
     canViewStaffing: isAdminVal || isCoreVal,
   };
 }

--- a/dali-api/app/members/routes/members.tsx
+++ b/dali-api/app/members/routes/members.tsx
@@ -35,6 +35,36 @@ type MemberRow = {
   domainRoles: { domainName: string; level: string }[];
 };
 
+type MemberStatus = "active" | "alumni";
+
+function parseStatus(raw: string | null): MemberStatus {
+  return raw === "alumni" ? "alumni" : "active";
+}
+
+// SQL predicate for the alumni directory: anyone Dartmouth-IDM officially
+// marks ALUMNI, anyone with an explicit graduatedAt in the past, or anyone
+// whose classYear's standard grad date has passed. Mirrors the safe subset
+// of the per-user isAlumni() derivation that can be expressed in a single
+// Prisma `where` clause (skips the assignment-count fallback — directory
+// inclusion is forgiving by design).
+function alumniWhereClause(now: Date) {
+  // Dartmouth Commencement is mid-June. Class of 2026 starts appearing in
+  // the alumni list on 2026-06-15.
+  const month = now.getMonth(); // 0-indexed
+  const day = now.getDate();
+  const postCommencement = month > 5 || (month === 5 && day >= 15);
+  const cohortCutoff = postCommencement
+    ? now.getFullYear()
+    : now.getFullYear() - 1;
+  return {
+    OR: [
+      { dartmouthAffiliation: "ALUMNI" },
+      { graduatedAt: { lt: now } },
+      { classYear: { lte: cohortCutoff } },
+    ],
+  };
+}
+
 export async function loader({ request }: Route.LoaderArgs) {
   const auth = await requireAuth(request);
   if (!auth.ok) return redirect("/login");
@@ -42,10 +72,14 @@ export async function loader({ request }: Route.LoaderArgs) {
 
   const { terms, selected, termId, isAll } = await resolveTermFilter(request);
 
+  const url = new URL(request.url);
+  const status = parseStatus(url.searchParams.get("status"));
+
   // "Active in a term" = the member held a Core role OR a project assignment
   // that term. "All terms" drops the constraint and shows every member.
+  // Only applies to the Active view — Alumni ignores the term filter.
   const activeInTerm =
-    isAll || !termId
+    status === "alumni" || isAll || !termId
       ? {}
       : {
           OR: [
@@ -62,7 +96,6 @@ export async function loader({ request }: Route.LoaderArgs) {
     orderBy: { displayName: "asc" },
     select: { id: true, displayName: true },
   });
-  const url = new URL(request.url);
   const domainParam = url.searchParams.get("domain") ?? "";
   const domainId = domains.some((d) => d.id === domainParam)
     ? domainParam
@@ -74,9 +107,23 @@ export async function loader({ request }: Route.LoaderArgs) {
   // Lab members are Users with a DALIMember row attached. Roles derive from
   // AdminMembership + CoreAssignment per the Phase 2 identity model — see
   // app/admin-console/routes/api.members.ts for the canonical shape.
+  // Alumni view layers an additional predicate on top of the same base set:
+  // a DALIMember row is required (we don't surface non-members in the
+  // directory), but the term-active filter is dropped and the alumni
+  // predicate is applied.
+  const alumniCondition =
+    status === "alumni" ? alumniWhereClause(new Date()) : {};
   const users = await prisma.user.findMany({
-    where: { daliMember: { isNot: null }, ...activeInTerm, ...inDomain },
-    orderBy: [{ lastName: "asc" }, { firstName: "asc" }],
+    where: {
+      daliMember: { isNot: null },
+      ...activeInTerm,
+      ...inDomain,
+      ...alumniCondition,
+    },
+    orderBy:
+      status === "alumni"
+        ? [{ classYear: "desc" }, { lastName: "asc" }, { firstName: "asc" }]
+        : [{ lastName: "asc" }, { firstName: "asc" }],
     select: {
       id: true,
       firstName: true,
@@ -124,6 +171,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     domains,
     selectedDomain: domainId,
     canEdit,
+    status,
   };
 }
 
@@ -243,7 +291,7 @@ export async function action({ request }: Route.ActionArgs) {
 }
 
 export default function MembersList() {
-  const { rows, terms, selectedTerm, domains, selectedDomain, canEdit } =
+  const { rows, terms, selectedTerm, domains, selectedDomain, canEdit, status } =
     useLoaderData<typeof loader>();
   const actionData = useActionData<typeof action>();
   const [creating, setCreating] = useState(false);
@@ -336,19 +384,30 @@ export default function MembersList() {
         </Form>
       )}
 
+      <StatusTabs status={status} />
+
       <div className="flex items-center gap-3 flex-wrap">
         <input
           type="search"
           value={query}
           onChange={(e) => setQuery(e.target.value)}
-          placeholder="Search by name or email"
+          placeholder={status === "alumni" ? "Search alumni by name or email" : "Search by name or email"}
           className="flex-1 min-w-[200px] max-w-sm px-3 py-2 text-sm border border-border rounded-md bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-accent-coral/30"
         />
-        <TermFilter terms={terms} selected={selectedTerm} />
+        {status === "active" && (
+          <TermFilter terms={terms} selected={selectedTerm} />
+        )}
         <DomainFilter domains={domains} selected={selectedDomain} />
         <ViewToggle value={view} onChange={setView} />
         <span className="text-xs text-muted-foreground ml-auto">
-          {filtered.length} {filtered.length === 1 ? "member" : "members"}
+          {filtered.length}{" "}
+          {status === "alumni"
+            ? filtered.length === 1
+              ? "alum"
+              : "alumni"
+            : filtered.length === 1
+              ? "member"
+              : "members"}
           {query && filtered.length !== rows.length ? ` of ${rows.length}` : ""}
         </span>
       </div>
@@ -356,11 +415,15 @@ export default function MembersList() {
       {filtered.length === 0 ? (
         <div className="px-4 py-8 text-center text-sm text-muted-foreground">
           {query
-            ? "No members match this search."
-            : "No members match these filters."}
+            ? status === "alumni"
+              ? "No alumni match this search."
+              : "No members match this search."
+            : status === "alumni"
+              ? "No alumni match these filters."
+              : "No members match these filters."}
         </div>
       ) : view === "list" ? (
-        <MembersTable rows={filtered} />
+        <MembersTable rows={filtered} status={status} />
       ) : (
         <MembersCards rows={filtered} />
       )}
@@ -401,6 +464,46 @@ function CreateField({
   );
 }
 
+// Active ↔ Alumni segmented tab. Drives the loader via `?status=`. Switching
+// to Alumni drops the `?term=` filter (term doesn't apply post-grad) and
+// scopes the list to graduated members.
+function StatusTabs({ status }: { status: MemberStatus }) {
+  const [searchParams, setSearchParams] = useSearchParams();
+  function set(next: MemberStatus) {
+    const params = new URLSearchParams(searchParams);
+    if (next === "alumni") {
+      params.set("status", "alumni");
+      params.delete("term"); // term filter doesn't apply to alumni
+    } else {
+      params.delete("status");
+    }
+    setSearchParams(params);
+  }
+  const tabs: { key: MemberStatus; label: string }[] = [
+    { key: "active", label: "Active" },
+    { key: "alumni", label: "Alumni" },
+  ];
+  return (
+    <div className="inline-flex items-center gap-1 border border-border rounded-md p-1 bg-muted/30 w-fit">
+      {tabs.map((t) => (
+        <button
+          key={t.key}
+          type="button"
+          onClick={() => set(t.key)}
+          aria-pressed={status === t.key}
+          className={`px-3 py-1 text-xs font-medium rounded-sm transition-colors ${
+            status === t.key
+              ? "bg-background text-foreground shadow-sm"
+              : "text-muted-foreground hover:text-foreground"
+          }`}
+        >
+          {t.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
 // Domain dropdown for the members directory. Like TermFilter, it drives the
 // loader via a search param (`?domain=`) and preserves the other params so it
 // composes with the term filter. "" is the "All domains" choice.
@@ -434,8 +537,17 @@ function DomainFilter({
   );
 }
 
-function MembersTable({ rows }: { rows: MemberRow[] }) {
+function MembersTable({
+  rows,
+  status,
+}: {
+  rows: MemberRow[];
+  status: MemberStatus;
+}) {
   const navigate = useNavigate();
+  // Alumni view swaps the Roles column for a Class column — Roles are
+  // largely historical for alumni and class year is the more useful axis.
+  const showClass = status === "alumni";
   return (
     <div className="overflow-x-auto">
       <table className="w-full text-sm min-w-[640px]">
@@ -443,7 +555,9 @@ function MembersTable({ rows }: { rows: MemberRow[] }) {
           <tr>
             <th className="text-left font-medium px-4 py-2">Name</th>
             <th className="text-left font-medium px-4 py-2">Email</th>
-            <th className="text-left font-medium px-4 py-2">Roles</th>
+            <th className="text-left font-medium px-4 py-2">
+              {showClass ? "Class" : "Roles"}
+            </th>
           </tr>
         </thead>
         <tbody>
@@ -462,10 +576,20 @@ function MembersTable({ rows }: { rows: MemberRow[] }) {
               </td>
               <td className="px-4 py-2 text-muted-foreground">{m.email ?? "—"}</td>
               <td className="px-4 py-2">
-                <RolePills
-                  coreTitles={m.coreTitles}
-                  domainRoles={m.domainRoles}
-                />
+                {showClass ? (
+                  m.classYear ? (
+                    <span className="text-muted-foreground">
+                      Class of {m.classYear}
+                    </span>
+                  ) : (
+                    <span className="text-muted-foreground">—</span>
+                  )
+                ) : (
+                  <RolePills
+                    coreTitles={m.coreTitles}
+                    domainRoles={m.domainRoles}
+                  />
+                )}
               </td>
             </tr>
           ))}

--- a/dali-api/app/routes/layout.tsx
+++ b/dali-api/app/routes/layout.tsx
@@ -10,6 +10,29 @@ import { resolvePhotoUrl } from '~/lib/photo'
 import { recordPageView } from '~/lib/analytics'
 import type { Route } from './+types/layout'
 
+// Routes alumni cannot access. Path is matched as a prefix; alumni hitting
+// any of these get redirected home. Keep the home dashboard, /members
+// (directory + own profile editor), and any future /profile route reachable.
+const ALUMNI_DENIED_PREFIXES = [
+  '/projects',
+  '/calendar',
+  '/mentorship',
+  '/hiring',
+  '/core',
+  '/admin-console',
+  '/staffing',
+  '/forms',
+  '/internal-processes',
+  '/partners',
+  '/education',
+]
+
+function isAlumniDeniedPath(pathname: string): boolean {
+  return ALUMNI_DENIED_PREFIXES.some(
+    (p) => pathname === p || pathname.startsWith(`${p}/`),
+  )
+}
+
 export async function loader({ request }: Route.LoaderArgs) {
   const auth = await requireAuth(request)
   if (!auth.ok) return redirect('/login')
@@ -19,9 +42,19 @@ export async function loader({ request }: Route.LoaderArgs) {
     isCore: core,
     isAdmin: admin,
     isDomainLead: domainLead,
+    isAlumni: alumni,
     canViewForms,
     canViewStaffing,
   } = await getUserRoles(auth.user.sub)
+
+  // Alumni route gate. Admins/Core resolve before isLabMember, so a former
+  // member who is also flagged Admin still passes — we only deny pure
+  // alumni. The sidebar is also gated in the Layout component; this loader
+  // check is the source of truth (defends against deep-linking past the UI).
+  if (alumni && !admin && !core) {
+    const url = new URL(request.url)
+    if (isAlumniDeniedPath(url.pathname)) return redirect('/')
+  }
 
   let isInterviewer = false
   if (isLabMember) {
@@ -55,11 +88,11 @@ export async function loader({ request }: Route.LoaderArgs) {
     sessionId: auth.sessionId,
   })
 
-  return { user: auth.user, photoUrl, isCore: core, isAdmin: admin, isDomainLead: domainLead, canViewForms, canViewStaffing, isInterviewer, isEmbedded }
+  return { user: auth.user, photoUrl, isCore: core, isAdmin: admin, isDomainLead: domainLead, isAlumni: alumni, canViewForms, canViewStaffing, isInterviewer, isEmbedded }
 }
 
 export default function AppLayoutRoute() {
-  const { user, photoUrl, isCore, isAdmin, isDomainLead, canViewForms, canViewStaffing, isInterviewer, isEmbedded } = useLoaderData<typeof loader>()
+  const { user, photoUrl, isCore, isAdmin, isDomainLead, isAlumni, canViewForms, canViewStaffing, isInterviewer, isEmbedded } = useLoaderData<typeof loader>()
   const [searchParams] = useSearchParams()
   const location = useLocation()
   const navigate = useNavigate()
@@ -199,7 +232,7 @@ export default function AppLayoutRoute() {
 
   return (
     <>
-      <Layout user={user} photoUrl={photoUrl} isCore={isCore} isAdmin={isAdmin} isDomainLead={isDomainLead} canViewForms={canViewForms} canViewStaffing={canViewStaffing} isInterviewer={isInterviewer} />
+      <Layout user={user} photoUrl={photoUrl} isCore={isCore} isAdmin={isAdmin} isDomainLead={isDomainLead} isAlumni={isAlumni} canViewForms={canViewForms} canViewStaffing={canViewStaffing} isInterviewer={isInterviewer} />
       <LaunchWelcome firstName={user.firstName || user.email.split('@')[0]} />
     </>
   )


### PR DESCRIPTION
## Summary

PR 3 of the alumni-accounts track. Wires PR #739's derivation logic into the user-visible shell. A pure alumnus (`isAlumni && !isAdmin && !isCore`) sees a stripped sidebar and gets a hard server-side redirect home if they deep-link past the UI.

Stacked on `alumni-roles-derivation` (#739); will retarget to `dev` once #737 → #739 → this lands.

- **`getUserRoles`** zeros out lingering role flags for pure alumni:
  - `isLabMember` flips to false (DALIMember row stays — history isn't deleted)
  - `isInstructor`, `isDomainLead`, `canViewForms` drop (any-term tables would otherwise grant authority post-grad)
  - `isAdmin`, `isCore` resolve from independent tables — a former member rehired as staff keeps full authority
- **`layout.tsx` loader** maintains an `ALUMNI_DENIED_PREFIXES` list (Projects, Calendar, Mentorship, Hiring, Core, Admin Console, Staffing, Forms, Internal Processes, Partners, Education) and redirects pure alumni to `/` when they hit any of them. `/members` stays reachable for directory browse + own-profile editing.
- **`Layout.tsx`** takes a new `isAlumni` prop and computes `alumniOnly` — hides the Calendar entry and the Hiring / Projects / Partners / Education / Internal Processes areas.

## What alumni see after this PR

Sidebar: **Home**, **Forms** (only if they happen to also be Core/Admin), **Members**, **Operations** (only if Admin/Core). Pure alumni: Home + Members.

Deep-linking `/hiring/reviewer` or `/projects/list` redirects to `/`.

## Test plan

- [x] `npm test` — 1,059 tests pass (+4 new); only pre-existing `pdfkit` suite failure
- [x] `npm run typecheck` — zero errors in any touched file
- [x] New tests cover: `isLabMember` flip for alumni, `isLabMember` preservation for active members, lingering instructor/domain-lead flags zeroed for pure alumni, Admin authority preserved through alumni status
- [ ] After merge: manual smoke — log in as a member, confirm sidebar is unchanged; flip a test user's `dartmouthAffiliation` to `ALUMNI` and confirm the redirect + reduced sidebar
- [ ] After merge: confirm the home dashboard renders gracefully for alumni (per memory: home widgets are designed to collapse role-gated cards)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/740"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782920430&installation_id=133523038&pr_number=740&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F740&signature=f4506987be727a5befa2f9e44607eb40e446fa04b316b1e2a611c5bb6f82d53d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->