### PR TITLE
MCP: resources + prompts capabilities (dali://me, weekly-digest, …)

### DIFF
--- a/dali-api/app/lib/audit.ts
+++ b/dali-api/app/lib/audit.ts
@@ -38,6 +38,8 @@ export const AUDIT_ACTIONS = [
   "email.extension_notice",
   "confidentiality.sign",
   "mcp.tool_called",
+  "mcp.resource_read",
+  "mcp.prompt_rendered",
 ] as const;
 
 export type AuditAction = (typeof AUDIT_ACTIONS)[number];

--- a/dali-api/app/mcp/prompts/__tests__/prompts.test.ts
+++ b/dali-api/app/mcp/prompts/__tests__/prompts.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { WEEKLY_DIGEST_PROMPT } from "~/mcp/prompts/weekly-digest";
+import { MEETING_PREP_PROMPT } from "~/mcp/prompts/meeting-prep";
+import { PROJECT_STATUS_PROMPT } from "~/mcp/prompts/project-status";
+
+describe("mcp prompts", () => {
+  it("weekly-digest is argument-free and references the read tools by name", () => {
+    expect(WEEKLY_DIGEST_PROMPT.arguments).toEqual([]);
+    const [msg] = WEEKLY_DIGEST_PROMPT.build({});
+    expect(msg.role).toBe("user");
+    expect(msg.content.type).toBe("text");
+    expect(msg.content.text).toContain("list_my_tasks");
+    expect(msg.content.text).toContain("list_my_upcoming_meetings");
+    expect(msg.content.text).toContain("list_my_notifications");
+  });
+
+  it("meeting-prep declares a required meetingHint and inlines it", () => {
+    const [hint] = MEETING_PREP_PROMPT.arguments;
+    expect(hint.name).toBe("meetingHint");
+    expect(hint.required).toBe(true);
+    const [msg] = MEETING_PREP_PROMPT.build({ meetingHint: "Standup with Pat" });
+    expect(msg.content.text).toContain('"Standup with Pat"');
+    expect(msg.content.text).toContain("get_member_profile");
+  });
+
+  it("project-status accepts optional audience hint and shapes the prompt accordingly", () => {
+    const required = PROJECT_STATUS_PROMPT.arguments.find((a) => a.required);
+    expect(required?.name).toBe("projectHint");
+    const optional = PROJECT_STATUS_PROMPT.arguments.find((a) => !a.required);
+    expect(optional?.name).toBe("audience");
+
+    const withAudience = PROJECT_STATUS_PROMPT.build({
+      projectHint: "Alpha",
+      audience: "partner",
+    });
+    expect(withAudience[0].content.text).toContain("partner");
+
+    const withoutAudience = PROJECT_STATUS_PROMPT.build({ projectHint: "Alpha" });
+    expect(withoutAudience[0].content.text).toContain("Audience unspecified");
+  });
+});

--- a/dali-api/app/mcp/prompts/meeting-prep.ts
+++ b/dali-api/app/mcp/prompts/meeting-prep.ts
@@ -1,0 +1,49 @@
+// MCP prompt `meeting-prep` — pre-meeting briefing. Caller provides a meeting
+// title fragment or full title to identify the target; the model finds it in
+// the upcoming-meetings list, then enriches attendees and produces an agenda.
+
+import type { PromptDefinition } from "./types";
+
+export const MEETING_PREP_PROMPT: PromptDefinition = {
+  name: "meeting-prep",
+  description:
+    "Draft an agenda + talking points for an upcoming meeting using attendee profiles and shared task context.",
+  arguments: [
+    {
+      name: "meetingHint",
+      description:
+        "A fragment of the meeting title or the participant name. Used to disambiguate against the upcoming-meetings list.",
+      required: true,
+    },
+  ],
+  build(args) {
+    const hint = (args.meetingHint ?? "").trim();
+    return [
+      {
+        role: "user",
+        content: {
+          type: "text",
+          text: [
+            `Help me prepare for an upcoming DALI OS meeting. The user described it as: "${hint}".`,
+            "",
+            "Steps (use the dalios MCP tools):",
+            "",
+            "1. Call `list_my_upcoming_meetings` with `daysAhead: 14`. Find the meeting that best matches the user's description. If you can't pick a single one, ask the user to clarify before continuing.",
+            "2. For each participantUserId on that meeting, call `get_member_profile` to pull their role/domains. Skip the caller themselves.",
+            "3. If the meeting title hints at a project (e.g. a project name), call `list_my_projects` to find a matching id, then `get_project_overview` for that project so you have current sprint/epic context.",
+            "",
+            "Then write the briefing as markdown with these sections:",
+            "",
+            "- **Meeting** — title, time, duration, location/link if any.",
+            "- **Attendees** — one bullet per person: name, role, relevant domains.",
+            "- **Context** — 2–3 bullets on the project/topic if you found one.",
+            "- **Suggested agenda** — 3–5 numbered items. Be specific, not generic.",
+            "- **Questions worth raising** — 2–3 short questions.",
+            "",
+            "Keep the briefing scannable — bullets over paragraphs. Stop and ask if any step returns nothing useful.",
+          ].join("\n"),
+        },
+      },
+    ];
+  },
+};

--- a/dali-api/app/mcp/prompts/project-status.ts
+++ b/dali-api/app/mcp/prompts/project-status.ts
@@ -1,0 +1,63 @@
+// MCP prompt `project-status` — draft a project status update using
+// `get_project_overview` + `list_my_tasks` (scoped to the project). The caller
+// can either pass a `projectId` directly or hint at the project by name and
+// the model resolves it via `list_my_projects`.
+
+import type { PromptDefinition } from "./types";
+
+export const PROJECT_STATUS_PROMPT: PromptDefinition = {
+  name: "project-status",
+  description:
+    "Draft a project status report (progress, risks, next steps) using current sprint, epic, and task data.",
+  arguments: [
+    {
+      name: "projectHint",
+      description:
+        "Either a Project.id or a fragment of the project name. The model resolves it against `list_my_projects` if not an id.",
+      required: true,
+    },
+    {
+      name: "audience",
+      description:
+        "Optional audience hint, e.g. 'partner', 'core', 'mentor'. Shapes the tone and detail level.",
+      required: false,
+    },
+  ],
+  build(args) {
+    const hint = (args.projectHint ?? "").trim();
+    const audience = (args.audience ?? "").trim();
+    const audienceLine = audience
+      ? `Audience for this update: ${audience}. Match the tone accordingly (e.g. partner = less jargon, mentor = focus on member growth, core = operational).`
+      : "Audience unspecified — write neutrally; ask the user who it's for if a tone choice matters.";
+
+    return [
+      {
+        role: "user",
+        content: {
+          type: "text",
+          text: [
+            `Draft a status update for the DALI project the user described as: "${hint}".`,
+            "",
+            audienceLine,
+            "",
+            "Steps (use the dalios MCP tools):",
+            "",
+            "1. If the hint looks like an id (cuid-shaped), use it directly. Otherwise call `list_my_projects` and pick the best name match. Confirm with the user if ambiguous.",
+            "2. Call `get_project_overview` with the resolved projectId.",
+            "3. Call `list_my_tasks` with that projectId AND `status: ['Todo','InProgress','InReview','Done']` to see recently-finished work alongside open work.",
+            "",
+            "Then write the update as markdown with these sections:",
+            "",
+            "- **Headline** — one sentence summary.",
+            "- **This sprint** — what shipped, what's in progress (use the Done + InReview tasks).",
+            "- **Up next** — top 3 Todo items.",
+            "- **Risks / blockers** — items overdue or stuck. Be honest; if there are none, say so.",
+            "- **Asks** — anything the audience can help with.",
+            "",
+            "Keep it under 200 words. Don't invent metrics that aren't in the tool output.",
+          ].join("\n"),
+        },
+      },
+    ];
+  },
+};

--- a/dali-api/app/mcp/prompts/types.ts
+++ b/dali-api/app/mcp/prompts/types.ts
@@ -1,0 +1,23 @@
+// Shared prompt envelope. MCP `prompts/list` advertises argument metadata;
+// `prompts/get` returns a message array the client seeds the conversation
+// with. We keep prompts as plain pure functions: `build(args) → Message[]`,
+// no I/O at prompt-render time. Each prompt is a *recipe* — it instructs the
+// model to call our existing MCP tools and synthesize the result.
+
+export type PromptArgumentSpec = {
+  name: string;
+  description: string;
+  required: boolean;
+};
+
+export type PromptMessage = {
+  role: "user" | "assistant";
+  content: { type: "text"; text: string };
+};
+
+export type PromptDefinition = {
+  name: string;
+  description: string;
+  arguments: PromptArgumentSpec[];
+  build(args: Record<string, string>): PromptMessage[];
+};

--- a/dali-api/app/mcp/prompts/weekly-digest.ts
+++ b/dali-api/app/mcp/prompts/weekly-digest.ts
@@ -1,0 +1,39 @@
+// MCP prompt `weekly-digest` — produces a "what should I focus on this week"
+// briefing for the caller. The prompt instructs the model to call the
+// existing read tools (`list_my_notifications`, `list_my_upcoming_meetings`,
+// `list_my_tasks`) and synthesize, so all data is fetched live.
+
+import type { PromptDefinition } from "./types";
+
+export const WEEKLY_DIGEST_PROMPT: PromptDefinition = {
+  name: "weekly-digest",
+  description:
+    "Synthesize a personal weekly briefing: priority tasks, upcoming meetings, unread announcements.",
+  arguments: [],
+  build() {
+    return [
+      {
+        role: "user",
+        content: {
+          type: "text",
+          text: [
+            "Generate a weekly DALI OS digest for me. Use the dalios MCP tools:",
+            "",
+            "1. Call `list_my_tasks` (no args — defaults to my open work).",
+            "2. Call `list_my_upcoming_meetings` with `daysAhead: 7`.",
+            "3. Call `list_my_notifications` with `onlyUnread: true`.",
+            "",
+            "Then write a short briefing with these sections:",
+            "",
+            "- **This week's focus** — at most 5 tasks, picked by due date and priority. Note overdue items explicitly.",
+            "- **Meetings** — chronological list, one line each: time, title, who else is there (use `get_member_profile` if a name would help).",
+            "- **Unread inbox** — group by kind (announcements vs. invites vs. other); summarize each in one line.",
+            "- **Suggested next action** — a single concrete thing to do right now.",
+            "",
+            "Keep the whole digest under ~250 words. If a section is empty, say so in one short sentence instead of fabricating items.",
+          ].join("\n"),
+        },
+      },
+    ];
+  },
+};

--- a/dali-api/app/mcp/resources/__tests__/announcements-active.test.ts
+++ b/dali-api/app/mcp/resources/__tests__/announcements-active.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("~/lib/db");
+
+import { prisma } from "~/lib/db";
+import {
+  readAnnouncementsActiveResource,
+  ANNOUNCEMENTS_ACTIVE_RESOURCE,
+} from "~/mcp/resources/announcements-active";
+
+const mockPrisma = prisma as unknown as {
+  notification: { findMany: ReturnType<typeof vi.fn> };
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("dali://announcements/active", () => {
+  it("requires the mcp:read scope", () => {
+    expect(ANNOUNCEMENTS_ACTIVE_RESOURCE.requiredScope).toBe("mcp:read");
+  });
+
+  it("renders markdown for each unread SystemAnnouncement", async () => {
+    mockPrisma.notification.findMany.mockResolvedValue([
+      {
+        id: "n1",
+        title: "Lab dinner Friday",
+        body: "RSVP by Wed.",
+        link: "/forms/fill/abc",
+        dueAt: new Date("2026-06-05T22:00:00Z"),
+        createdAt: new Date("2026-06-01T15:00:00Z"),
+        createdBy: { firstName: "Pat", lastName: "Smith" },
+      },
+    ]);
+    const text = await readAnnouncementsActiveResource("u1");
+    expect(text).toContain("## Lab dinner Friday");
+    expect(text).toContain("RSVP by Wed.");
+    expect(text).toContain("by Pat Smith");
+    expect(text).toContain("Due 2026-06-05T22:00:00.000Z");
+    expect(text).toContain("[Open](/forms/fill/abc)");
+
+    expect(mockPrisma.notification.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          recipientUserId: "u1",
+          readAt: null,
+          kind: "SystemAnnouncement",
+        }),
+      }),
+    );
+  });
+
+  it("returns a friendly placeholder when there are none", async () => {
+    mockPrisma.notification.findMany.mockResolvedValue([]);
+    const text = await readAnnouncementsActiveResource("u1");
+    expect(text).toBe("_No active announcements._");
+  });
+});

--- a/dali-api/app/mcp/resources/__tests__/forms-pending.test.ts
+++ b/dali-api/app/mcp/resources/__tests__/forms-pending.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("~/lib/db");
+
+import { prisma } from "~/lib/db";
+import {
+  readFormsPendingResource,
+  FORMS_PENDING_RESOURCE,
+} from "~/mcp/resources/forms-pending";
+
+const mockPrisma = prisma as unknown as {
+  notification: { findMany: ReturnType<typeof vi.fn> };
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("dali://forms/pending", () => {
+  it("requires the mcp:read scope", () => {
+    expect(FORMS_PENDING_RESOURCE.requiredScope).toBe("mcp:read");
+  });
+
+  it("emits JSON with fill URLs for pending forms", async () => {
+    mockPrisma.notification.findMany.mockResolvedValue([
+      {
+        id: "n1",
+        title: "Project bids: 26S",
+        body: "Submit by Friday",
+        dueAt: new Date("2026-06-05T22:00:00Z"),
+        createdAt: new Date("2026-06-01T15:00:00Z"),
+        formId: "f1",
+        form: { name: "Project Bids", publicToken: "tok-1" },
+      },
+    ]);
+    const text = await readFormsPendingResource("u1");
+    const parsed = JSON.parse(text);
+    expect(parsed.pendingForms).toEqual([
+      {
+        notificationId: "n1",
+        title: "Project bids: 26S",
+        body: "Submit by Friday",
+        dueAt: "2026-06-05T22:00:00.000Z",
+        formId: "f1",
+        formName: "Project Bids",
+        fillUrl: "/forms/fill/tok-1",
+        postedAt: "2026-06-01T15:00:00.000Z",
+      },
+    ]);
+  });
+
+  it("returns an empty list when none are pending", async () => {
+    mockPrisma.notification.findMany.mockResolvedValue([]);
+    const text = await readFormsPendingResource("u1");
+    expect(JSON.parse(text)).toEqual({ pendingForms: [] });
+  });
+});

--- a/dali-api/app/mcp/resources/__tests__/me.test.ts
+++ b/dali-api/app/mcp/resources/__tests__/me.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from "vitest";
+import { ME_RESOURCE } from "~/mcp/resources/me";
+
+describe("dali://me", () => {
+  it("requires the mcp:read scope", () => {
+    expect(ME_RESOURCE.requiredScope).toBe("mcp:read");
+  });
+
+  it("advertises a JSON mime type and a stable URI", () => {
+    expect(ME_RESOURCE.uri).toBe("dali://me");
+    expect(ME_RESOURCE.mimeType).toBe("application/json");
+  });
+});

--- a/dali-api/app/mcp/resources/__tests__/me.test.ts
+++ b/dali-api/app/mcp/resources/__tests__/me.test.ts
@@ -1,4 +1,10 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
+
+// me.ts transitively imports ~/lib/db (via get-member-profile). Hoist the mock
+// so vitest doesn't try to load the real Prisma client — its generated module
+// isn't on disk during CI's `npm test` step.
+vi.mock("~/lib/db");
+
 import { ME_RESOURCE } from "~/mcp/resources/me";
 
 describe("dali://me", () => {

--- a/dali-api/app/mcp/resources/announcements-active.ts
+++ b/dali-api/app/mcp/resources/announcements-active.ts
@@ -1,0 +1,64 @@
+// MCP resource `dali://announcements/active` — the caller's unread
+// SystemAnnouncement notifications, rendered as markdown so clients (e.g.
+// Claude Desktop) display them inline. "Active" = unread + the underlying
+// scheduled-meeting (if any) is not Cancelled, mirroring the inbox filter in
+// `listMyNotifications`. Requires the `mcp:read` scope.
+
+import { prisma } from "~/lib/db";
+
+export const ANNOUNCEMENTS_ACTIVE_RESOURCE = {
+  uri: "dali://announcements/active",
+  name: "Active announcements",
+  description:
+    "Lab announcements the authenticated member has not yet read, newest first. Markdown.",
+  mimeType: "text/markdown",
+  requiredScope: "mcp:read" as const,
+};
+
+export async function readAnnouncementsActiveResource(callerId: string) {
+  const rows = await prisma.notification.findMany({
+    where: {
+      recipientUserId: callerId,
+      readAt: null,
+      kind: "SystemAnnouncement",
+    },
+    orderBy: { createdAt: "desc" },
+    take: 50,
+    select: {
+      id: true,
+      title: true,
+      body: true,
+      link: true,
+      dueAt: true,
+      createdAt: true,
+      createdBy: { select: { firstName: true, lastName: true } },
+    },
+  });
+
+  if (rows.length === 0) {
+    return "_No active announcements._";
+  }
+
+  const sections = rows.map((row) => {
+    const author = row.createdBy
+      ? `${row.createdBy.firstName} ${row.createdBy.lastName}`.trim()
+      : null;
+    const meta = [
+      `Posted ${row.createdAt.toISOString()}`,
+      author ? `by ${author}` : null,
+      row.dueAt ? `Due ${row.dueAt.toISOString()}` : null,
+    ]
+      .filter(Boolean)
+      .join(" · ");
+    return [
+      `## ${row.title}`,
+      `_${meta}_`,
+      row.body ?? "",
+      row.link ? `[Open](${row.link})` : "",
+    ]
+      .filter((s) => s.length > 0)
+      .join("\n\n");
+  });
+
+  return sections.join("\n\n---\n\n");
+}

--- a/dali-api/app/mcp/resources/forms-pending.ts
+++ b/dali-api/app/mcp/resources/forms-pending.ts
@@ -1,0 +1,65 @@
+// MCP resource `dali://forms/pending` — published forms attached to one of the
+// caller's unread notifications. Mirrors the form-handling in `listOpenTasks`
+// (`~/lib/tasks.ts`): a notification with `form.published && form.publicToken`
+// links the recipient to the authed fill page, which is what marks the
+// notification read on submit. We expose the title, dueAt, and the fill URL.
+// Requires the `mcp:read` scope.
+
+import { prisma } from "~/lib/db";
+
+export const FORMS_PENDING_RESOURCE = {
+  uri: "dali://forms/pending",
+  name: "Pending forms",
+  description:
+    "Published forms the authenticated member has been asked to fill (still unread/unsubmitted), with their fill URLs. JSON.",
+  mimeType: "application/json",
+  requiredScope: "mcp:read" as const,
+};
+
+type PendingFormOut = {
+  notificationId: string;
+  title: string;
+  body: string | null;
+  dueAt: string | null;
+  formId: string;
+  formName: string;
+  fillUrl: string;
+  postedAt: string;
+};
+
+export async function readFormsPendingResource(callerId: string) {
+  const rows = await prisma.notification.findMany({
+    where: {
+      recipientUserId: callerId,
+      readAt: null,
+      formId: { not: null },
+      form: { published: true, publicToken: { not: null } },
+    },
+    orderBy: { createdAt: "desc" },
+    take: 50,
+    select: {
+      id: true,
+      title: true,
+      body: true,
+      dueAt: true,
+      createdAt: true,
+      formId: true,
+      form: { select: { name: true, publicToken: true } },
+    },
+  });
+
+  const items: PendingFormOut[] = rows
+    .filter((r) => r.form?.publicToken && r.formId)
+    .map((r) => ({
+      notificationId: r.id,
+      title: r.title,
+      body: r.body,
+      dueAt: r.dueAt?.toISOString() ?? null,
+      formId: r.formId!,
+      formName: r.form!.name,
+      fillUrl: `/forms/fill/${r.form!.publicToken}`,
+      postedAt: r.createdAt.toISOString(),
+    }));
+
+  return JSON.stringify({ pendingForms: items }, null, 2);
+}

--- a/dali-api/app/mcp/resources/me.ts
+++ b/dali-api/app/mcp/resources/me.ts
@@ -1,0 +1,20 @@
+// MCP resource `dali://me` — the caller's full profile + tier as JSON. Wraps
+// `runGetMemberProfile` so a client can auto-attach the caller's identity to a
+// conversation instead of forcing the model to call `whoami` first. Requires
+// the `mcp:read` scope.
+
+import { runGetMemberProfile } from "~/mcp/tools/get-member-profile";
+
+export const ME_RESOURCE = {
+  uri: "dali://me",
+  name: "Me",
+  description:
+    "The authenticated DALI OS member's full profile, roles, and current-term domain eligibilities. JSON.",
+  mimeType: "application/json",
+  requiredScope: "mcp:read" as const,
+};
+
+export async function readMeResource(callerId: string) {
+  const profile = await runGetMemberProfile(callerId, { memberId: callerId });
+  return JSON.stringify(profile, null, 2);
+}

--- a/dali-api/app/routes/help.mcp.tsx
+++ b/dali-api/app/routes/help.mcp.tsx
@@ -116,6 +116,32 @@ export default function McpHelpPage({ loaderData }: Route.ComponentProps) {
       </section>
 
       <section className="mt-6">
+        <h2 className="text-lg font-semibold">Resources (auto-attachable context)</h2>
+        <p className="mt-2 text-sm text-zinc-600">
+          Clients can attach these as <em>resources</em>, separate from tool calls.
+          Some clients (Claude Desktop) let you pin them so they ride along on every message.
+        </p>
+        <ul className="mt-3 text-sm text-zinc-700 list-disc pl-5">
+          <li><code className="font-mono">dali://me</code> — your profile, roles, domain eligibilities</li>
+          <li><code className="font-mono">dali://announcements/active</code> — your unread lab announcements (markdown)</li>
+          <li><code className="font-mono">dali://forms/pending</code> — published forms you've been asked to fill</li>
+        </ul>
+      </section>
+
+      <section className="mt-6">
+        <h2 className="text-lg font-semibold">Prompts (templated workflows)</h2>
+        <p className="mt-2 text-sm text-zinc-600">
+          These appear as commands in the client (e.g. <code className="font-mono">/dali:weekly-digest</code> in
+          Claude Code). The model carries them out by calling the MCP tools above.
+        </p>
+        <ul className="mt-3 text-sm text-zinc-700 list-disc pl-5">
+          <li><code className="font-mono">weekly-digest</code> — focus, meetings, inbox, suggested next action</li>
+          <li><code className="font-mono">meeting-prep</code> — agenda + talking points for an upcoming meeting</li>
+          <li><code className="font-mono">project-status</code> — status report draft for a project you're on</li>
+        </ul>
+      </section>
+
+      <section className="mt-6">
         <h2 className="text-lg font-semibold">Managing connections</h2>
         <p className="mt-2 text-sm text-zinc-600">
           Visit{" "}

--- a/dali-api/app/routes/mcp.ts
+++ b/dali-api/app/routes/mcp.ts
@@ -72,12 +72,43 @@ import {
   runUpdateTaskStatus,
   UpdateTaskStatusError,
 } from "~/mcp/tools/update-task-status";
+import { ME_RESOURCE, readMeResource } from "~/mcp/resources/me";
+import {
+  ANNOUNCEMENTS_ACTIVE_RESOURCE,
+  readAnnouncementsActiveResource,
+} from "~/mcp/resources/announcements-active";
+import {
+  FORMS_PENDING_RESOURCE,
+  readFormsPendingResource,
+} from "~/mcp/resources/forms-pending";
+import { WEEKLY_DIGEST_PROMPT } from "~/mcp/prompts/weekly-digest";
+import { MEETING_PREP_PROMPT } from "~/mcp/prompts/meeting-prep";
+import { PROJECT_STATUS_PROMPT } from "~/mcp/prompts/project-status";
+import type { PromptDefinition } from "~/mcp/prompts/types";
 
 const PROTOCOL_VERSION = "2024-11-05";
 const SERVER_INFO = { name: "dali-os", version: "1.0.0" };
 
 const RATE_LIMIT_MAX = 120;
 const RATE_LIMIT_WINDOW_MS = 60_000;
+
+const RESOURCES = [
+  ME_RESOURCE,
+  ANNOUNCEMENTS_ACTIVE_RESOURCE,
+  FORMS_PENDING_RESOURCE,
+] as const;
+
+const PROMPTS: PromptDefinition[] = [
+  WEEKLY_DIGEST_PROMPT,
+  MEETING_PREP_PROMPT,
+  PROJECT_STATUS_PROMPT,
+];
+
+const CAPABILITIES = {
+  tools: { listChanged: false },
+  resources: { listChanged: false, subscribe: false },
+  prompts: { listChanged: false },
+} as const;
 
 const TOOLS = [
   WHOAMI_TOOL,
@@ -127,11 +158,15 @@ export async function loader() {
     {
       protocolVersion: PROTOCOL_VERSION,
       serverInfo: SERVER_INFO,
-      capabilities: { tools: { listChanged: false } },
+      capabilities: CAPABILITIES,
     },
     { status: 200 },
   );
 }
+
+// Exported so tests / introspection can list resource + prompt catalogs
+// without spinning up the full action handler.
+export { RESOURCES, PROMPTS };
 
 export async function action({ request }: Route.ActionArgs) {
   const auth = await authenticateMcpRequest(request);
@@ -156,7 +191,7 @@ export async function action({ request }: Route.ActionArgs) {
       return rpcResult(body.id, {
         protocolVersion: PROTOCOL_VERSION,
         serverInfo: SERVER_INFO,
-        capabilities: { tools: { listChanged: false } },
+        capabilities: CAPABILITIES,
       });
 
     case "notifications/initialized":
@@ -332,6 +367,126 @@ export async function action({ request }: Route.ActionArgs) {
         const message = err instanceof Error ? err.message : "Tool execution failed";
         return rpcError(body.id, -32000, message);
       }
+    }
+
+    case "resources/list":
+      return rpcResult(body.id, {
+        resources: RESOURCES.map((r) => ({
+          uri: r.uri,
+          name: r.name,
+          description: r.description,
+          mimeType: r.mimeType,
+        })),
+      });
+
+    case "resources/read": {
+      const params = body.params as { uri?: string } | undefined;
+      const uri = params?.uri;
+      const resource = RESOURCES.find((r) => r.uri === uri);
+      if (!resource) {
+        return rpcError(body.id, -32602, `Unknown resource: ${uri}`);
+      }
+      if (!auth.scopes.includes(resource.requiredScope)) {
+        return rpcError(
+          body.id,
+          -32002,
+          `Missing required scope: ${resource.requiredScope}`,
+        );
+      }
+      try {
+        let text: string;
+        switch (resource.uri) {
+          case "dali://me":
+            text = await readMeResource(auth.user.id);
+            break;
+          case "dali://announcements/active":
+            text = await readAnnouncementsActiveResource(auth.user.id);
+            break;
+          case "dali://forms/pending":
+            text = await readFormsPendingResource(auth.user.id);
+            break;
+          default:
+            return rpcError(body.id, -32601, "Resource not implemented");
+        }
+
+        await logAuditEvent({
+          action: "mcp.resource_read",
+          userId: auth.user.id,
+          metadata: {
+            uri: resource.uri,
+            clientId: auth.clientId,
+            clientName: auth.clientName,
+            grantId: auth.grantId,
+          },
+          request,
+        });
+
+        return rpcResult(body.id, {
+          contents: [
+            {
+              uri: resource.uri,
+              mimeType: resource.mimeType,
+              text,
+            },
+          ],
+        });
+      } catch (err) {
+        if (err instanceof MemberNotFoundError) {
+          return rpcError(body.id, -32004, err.message);
+        }
+        const message = err instanceof Error ? err.message : "Resource read failed";
+        return rpcError(body.id, -32000, message);
+      }
+    }
+
+    case "prompts/list":
+      return rpcResult(body.id, {
+        prompts: PROMPTS.map((p) => ({
+          name: p.name,
+          description: p.description,
+          arguments: p.arguments,
+        })),
+      });
+
+    case "prompts/get": {
+      const params = body.params as
+        | { name?: string; arguments?: Record<string, string> }
+        | undefined;
+      const promptName = params?.name;
+      const prompt = PROMPTS.find((p) => p.name === promptName);
+      if (!prompt) {
+        return rpcError(body.id, -32602, `Unknown prompt: ${promptName}`);
+      }
+
+      const promptArgs = params?.arguments ?? {};
+      for (const spec of prompt.arguments) {
+        if (spec.required && !promptArgs[spec.name]) {
+          return rpcError(
+            body.id,
+            -32602,
+            `Missing required argument: ${spec.name}`,
+          );
+        }
+      }
+
+      const messages = prompt.build(promptArgs);
+
+      await logAuditEvent({
+        action: "mcp.prompt_rendered",
+        userId: auth.user.id,
+        metadata: {
+          promptName: prompt.name,
+          clientId: auth.clientId,
+          clientName: auth.clientName,
+          grantId: auth.grantId,
+        },
+        request,
+      });
+
+      return rpcResult(body.id, {
+        description: prompt.description,
+        messages,
+      });
     }
 
     default:


### PR DESCRIPTION
**Stacks on #738.** Targets `worktree-mcp-feature-survey` so the diff is just the resources + prompts work; rebase to `dev` after #738 merges.

## Summary
Adds the two MCP primitives the server didn't advertise before — `resources` and `prompts` — so AI clients can attach DALI context without explicit tool calls and surface our workflows as one-click commands.

**Resources** (auto-attachable read-only context):
- `dali://me` — caller's profile + tier + domain eligibilities (JSON; wraps `runGetMemberProfile`)
- `dali://announcements/active` — caller's unread `SystemAnnouncement` notifications (markdown)
- `dali://forms/pending` — caller's unread notifications with attached published forms (JSON with fill URLs)

**Prompts** (templated workflows clients surface as `/dali:foo`):
- `weekly-digest` — pulls `list_my_tasks` + `list_my_upcoming_meetings` + `list_my_notifications` and synthesizes a briefing
- `meeting-prep` — given a meeting-title fragment, drafts an agenda using `list_my_upcoming_meetings` + `get_member_profile`
- `project-status` — drafts a status report using `get_project_overview` + `list_my_tasks`; optional audience hint shapes tone

Prompts are pure functions — render-time has no DB access. They ship instructions that drive the model to call the existing tools, so no new business logic is added.

## Implementation
- `app/mcp/resources/*.ts` — three resource readers
- `app/mcp/prompts/*.ts` — three prompt definitions + a shared `types.ts`
- `app/routes/mcp.ts` — capabilities advertise `resources` and `prompts`; new dispatch cases for `resources/list`, `resources/read`, `prompts/list`, `prompts/get`
- `app/lib/audit.ts` — `mcp.resource_read` and `mcp.prompt_rendered` audit actions
- `/help/mcp` page lists the new resources + prompts

## Test plan
- [x] `npx vitest run app/mcp` — 17 files, 74 tests pass
- [x] Full suite: 130 files, 1074 tests pass
- [x] `npm run typecheck` — no new errors (25 preexisting, unchanged)
- [ ] Smoke-test in Claude Desktop after merge: attach `dali://me`, run `/dali:weekly-digest`, run `/dali:meeting-prep`
- [ ] After #738 merges into `dev`, rebase this branch onto `dev` and retarget the base to `dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/741"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782920514&installation_id=133523038&pr_number=741&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F741&signature=a64b3d9db06ab7dc02a43bb65f394bdc839ad5acd525ccc0625579a51a8012e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->