### PR TITLE
Unify nav: drop per-page Back links, polish tab back/forward arrows

### DIFF
--- a/dali-api/app/components/TabWorkspace.tsx
+++ b/dali-api/app/components/TabWorkspace.tsx
@@ -1274,46 +1274,47 @@ export function TabWorkspace({ initialTabs, apiRef, onActiveUrlChange }: TabWork
               {(() => {
                 const canBack = !!activeTab && activeTab.backStack.length > 0
                 const canFwd = !!activeTab && activeTab.forwardStack.length > 0
+                if (!canBack && !canFwd) return null
                 return (
                   <div className="flex items-stretch border-r border-border">
-                    <button
-                      type="button"
-                      disabled={!canBack}
-                      onClick={(e) => {
-                        e.stopPropagation()
-                        goBack(pane.id)
-                      }}
-                      onContextMenu={(e) => {
-                        if (!canBack) return
-                        e.preventDefault()
-                        e.stopPropagation()
-                        setHistoryMenu({ paneId: pane.id, side: 'back', x: e.clientX, y: e.clientY })
-                      }}
-                      title="Back (right-click for history)"
-                      aria-label="Back"
-                      className="px-2 text-muted-foreground/70 hover:text-foreground hover:bg-muted disabled:opacity-30 disabled:hover:bg-transparent disabled:cursor-default"
-                    >
-                      <ChevronLeft className="w-4 h-4" />
-                    </button>
-                    <button
-                      type="button"
-                      disabled={!canFwd}
-                      onClick={(e) => {
-                        e.stopPropagation()
-                        goForward(pane.id)
-                      }}
-                      onContextMenu={(e) => {
-                        if (!canFwd) return
-                        e.preventDefault()
-                        e.stopPropagation()
-                        setHistoryMenu({ paneId: pane.id, side: 'forward', x: e.clientX, y: e.clientY })
-                      }}
-                      title="Forward (right-click for history)"
-                      aria-label="Forward"
-                      className="px-2 text-muted-foreground/70 hover:text-foreground hover:bg-muted disabled:opacity-30 disabled:hover:bg-transparent disabled:cursor-default"
-                    >
-                      <ChevronRight className="w-4 h-4" />
-                    </button>
+                    {canBack && (
+                      <button
+                        type="button"
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          goBack(pane.id)
+                        }}
+                        onContextMenu={(e) => {
+                          e.preventDefault()
+                          e.stopPropagation()
+                          setHistoryMenu({ paneId: pane.id, side: 'back', x: e.clientX, y: e.clientY })
+                        }}
+                        title="Back (right-click for history)"
+                        aria-label="Back"
+                        className="px-2.5 text-muted-foreground hover:text-foreground hover:bg-muted"
+                      >
+                        <ChevronLeft className="w-[18px] h-[18px]" />
+                      </button>
+                    )}
+                    {canFwd && (
+                      <button
+                        type="button"
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          goForward(pane.id)
+                        }}
+                        onContextMenu={(e) => {
+                          e.preventDefault()
+                          e.stopPropagation()
+                          setHistoryMenu({ paneId: pane.id, side: 'forward', x: e.clientX, y: e.clientY })
+                        }}
+                        title="Forward (right-click for history)"
+                        aria-label="Forward"
+                        className="px-2.5 text-muted-foreground hover:text-foreground hover:bg-muted"
+                      >
+                        <ChevronRight className="w-[18px] h-[18px]" />
+                      </button>
+                    )}
                   </div>
                 )
               })()}

--- a/dali-api/app/forms/components/FormDetail.tsx
+++ b/dali-api/app/forms/components/FormDetail.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect, useRef } from "react";
-import { Link, useLoaderData, useFetcher } from "react-router";
+import { useLoaderData, useFetcher } from "react-router";
 import {
-  ArrowLeft,
   Plus,
   Pencil,
   FileText,
@@ -52,7 +51,7 @@ function formatDateShort(iso: string) {
 //                         (save-version) and clears the draft. Frozen versions
 //                         are read-only and are what publishing serves.
 export function FormDetail() {
-  const { form, terms, backTo } = useLoaderData<typeof loader>();
+  const { form, terms } = useLoaderData<typeof loader>();
   // A dedicated fetcher for saves so the builder's buttons can reflect
   // request state ("Saving…"/"Saved ✓"). The submitted intent tells us which
   // button is in flight; fetcher.state + a brief post-success window drive the
@@ -192,12 +191,6 @@ export function FormDetail() {
   return (
     <div className="space-y-6">
       <div>
-        <Link
-          to={backTo}
-          className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground/80 mb-4"
-        >
-          <ArrowLeft className="w-4 h-4 mr-1" /> Back to Forms
-        </Link>
         <div className="flex justify-between items-start">
           <div>
             <h1 className="text-2xl font-bold text-foreground">{form.name}</h1>

--- a/dali-api/app/forms/routes/forms.edit.$formId.tsx
+++ b/dali-api/app/forms/routes/forms.edit.$formId.tsx
@@ -24,11 +24,9 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     orderBy: { sortKey: "desc" },
     select: { id: true, code: true },
   });
-  // Return the user to the form's folder (or top level) on "Back".
   return {
     form,
     terms,
-    backTo: form.folderId ? `/forms/${form.folderId}` : "/forms",
   };
 }
 

--- a/dali-api/app/hiring/components/ChallengeDetail.tsx
+++ b/dali-api/app/hiring/components/ChallengeDetail.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from 'react'
-import { Link, useLoaderData, useSubmit, useSearchParams, useNavigation, Form } from 'react-router'
-import { ArrowLeft, Plus, FileText, Clock, UserIcon, Eye } from 'lucide-react'
+import { useLoaderData, useSubmit, useSearchParams, useNavigation, Form } from 'react-router'
+import { Plus, FileText, Clock, UserIcon, Eye } from 'lucide-react'
 import { FormBuilderTab } from '~/hiring/components/ChallengeBuilder'
 import { RichTextViewer, isEmptyDoc } from '~/components/RichTextViewer'
 import { ChallengePreviewModal } from '~/hiring/components/ChallengePreviewModal'
@@ -111,12 +111,6 @@ export function ChallengeDetail() {
   return (
     <div className="space-y-6">
       <div>
-        <Link
-          to="/hiring/library?tab=challenges"
-          className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground/80 mb-4"
-        >
-          <ArrowLeft className="w-4 h-4 mr-1" /> Back to Library
-        </Link>
         <div className="flex justify-between items-start">
           <div>
             <h1 className="text-2xl font-bold text-foreground">{challenge.name}</h1>

--- a/dali-api/app/hiring/components/ConfidentialityAgreementDetail.tsx
+++ b/dali-api/app/hiring/components/ConfidentialityAgreementDetail.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
-import { Link, Form, useLoaderData } from "react-router";
-import { ArrowLeft, Plus, Clock, UserIcon, Pencil } from "lucide-react";
+import { Form, useLoaderData } from "react-router";
+import { Plus, Clock, UserIcon, Pencil } from "lucide-react";
 import type { loader } from "~/hiring/routes/confidentiality-agreements.$id";
 import { RichTextEditor } from "~/components/RichTextEditor";
 import { RichTextViewer, isEmptyDoc } from "~/components/RichTextViewer";
@@ -51,16 +51,6 @@ export function ConfidentialityAgreementDetail() {
 
   return (
     <div className="space-y-6 max-w-5xl mx-auto">
-      <div>
-        <Link
-          to="/hiring/library?tab=agreements"
-          className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground"
-        >
-          <ArrowLeft className="w-4 h-4 mr-1" />
-          Back to Library
-        </Link>
-      </div>
-
       <div className="flex items-start justify-between gap-4">
         <div className="min-w-0">
           {isRenaming ? (

--- a/dali-api/app/hiring/components/EmailTemplateDetail.tsx
+++ b/dali-api/app/hiring/components/EmailTemplateDetail.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo } from 'react'
-import { Link, Form, useLoaderData } from 'react-router'
-import { ArrowLeft, Plus, Clock, UserIcon, Pencil, AlertTriangle } from 'lucide-react'
+import { Form, useLoaderData } from 'react-router'
+import { Plus, Clock, UserIcon, Pencil, AlertTriangle } from 'lucide-react'
 import type { loader } from '~/hiring/routes/email-templates.$id'
 import {
   ALL_TEMPLATE_VARIABLES,
@@ -87,13 +87,6 @@ export function EmailTemplateDetail() {
 
   return (
     <div className="space-y-6 max-w-5xl mx-auto">
-      <div>
-        <Link to="/hiring/emails" className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground">
-          <ArrowLeft className="w-4 h-4 mr-1" />
-          Back to email templates
-        </Link>
-      </div>
-
       <div className="flex items-start justify-between gap-4">
         <div className="min-w-0">
           {isRenaming ? (

--- a/dali-api/app/hiring/components/RubricDetail.tsx
+++ b/dali-api/app/hiring/components/RubricDetail.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react'
-import { Link, Form, useLoaderData } from 'react-router'
+import { Form, useLoaderData } from 'react-router'
 import {
-  ArrowLeft,
   Plus,
   Clock,
   UserIcon,
@@ -69,12 +68,6 @@ export function RubricDetail() {
   return (
     <div className="space-y-6">
       <div>
-        <Link
-          to="/hiring/library?tab=rubrics"
-          className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground/80 mb-4"
-        >
-          <ArrowLeft className="w-4 h-4 mr-1" /> Back to Library
-        </Link>
         <div className="flex justify-between items-start">
           <div>
             <h1 className="text-2xl font-bold text-foreground">{rubric.name}</h1>

--- a/dali-api/app/hiring/routes/applications.$domainApplicationId.tsx
+++ b/dali-api/app/hiring/routes/applications.$domainApplicationId.tsx
@@ -1,5 +1,5 @@
 import { Link, redirect, useLoaderData, useSearchParams } from "react-router";
-import { ArrowLeft, Calendar, MapPin, Users } from "lucide-react";
+import { Calendar, MapPin, Users } from "lucide-react";
 import type { Route } from "./+types/applications.$domainApplicationId";
 import { prisma } from "~/lib/db";
 import { requireAuth } from "~/lib/auth";
@@ -457,13 +457,7 @@ export default function ApplicationReadOnlyDetail() {
   return (
     <div className="space-y-6 pb-12">
       <div>
-        <Link
-          to="/hiring/applications"
-          className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground/80"
-        >
-          <ArrowLeft className="w-4 h-4 mr-1" /> Back to Applications
-        </Link>
-        <h1 className="text-2xl font-bold text-foreground mt-2">
+        <h1 className="text-2xl font-bold text-foreground">
           {data.applicantName}
         </h1>
         <p className="mt-1 text-muted-foreground">

--- a/dali-api/app/hiring/routes/cycles.$cycleId.confidentiality.tsx
+++ b/dali-api/app/hiring/routes/cycles.$cycleId.confidentiality.tsx
@@ -129,7 +129,7 @@ export default function CycleConfidentialityPage() {
           to="/"
           className="inline-block text-sm font-medium text-blue-600 hover:text-blue-700"
         >
-          ← Back to home
+          Open home
         </Link>
       </div>
     );

--- a/dali-api/app/hiring/routes/domain-lead.application.$id.tsx
+++ b/dali-api/app/hiring/routes/domain-lead.application.$id.tsx
@@ -1,11 +1,11 @@
 import { useState } from "react";
-import { Link, redirect, useLoaderData } from "react-router";
+import { redirect, useLoaderData } from "react-router";
 import type { Route } from "./+types/domain-lead.application.$id";
 import { prisma } from "~/lib/db";
 import { requireAuth } from "~/lib/auth";
 import { requirePageSignedOrRedirect } from "~/hiring/lib/confidentiality";
 import { presignAnswers } from "~/hiring/lib/presign";
-import { ArrowLeft, ChevronDown } from "lucide-react";
+import { ChevronDown } from "lucide-react";
 import { ApplicationViewer } from "~/hiring/components/ApplicationViewer";
 import { ReviewSummary } from "~/hiring/components/ReviewSummary";
 import { buildCriteriaLabelMap } from "~/hiring/lib/rubric-criteria";
@@ -276,13 +276,7 @@ export default function DomainLeadApplicationView() {
       {/* Header */}
       <div className="flex items-start justify-between gap-4">
         <div>
-          <Link
-            to="/hiring/domain-lead"
-            className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground/80"
-          >
-            <ArrowLeft className="w-4 h-4 mr-1" /> Back to Dashboard
-          </Link>
-          <h1 className="text-2xl font-bold text-foreground mt-2">
+          <h1 className="text-2xl font-bold text-foreground">
             {application.user.firstName} {application.user.lastName}
           </h1>
           <p className="mt-1 text-muted-foreground">

--- a/dali-api/app/hiring/routes/domain-lead.delibs.$id.tsx
+++ b/dali-api/app/hiring/routes/domain-lead.delibs.$id.tsx
@@ -6,7 +6,7 @@ import { requireAuth } from "~/lib/auth";
 import { parseSessionCookie } from "~/lib/cookies";
 import { isDomainLead } from "~/lib/roles";
 import { requirePageSignedOrRedirect } from "~/hiring/lib/confidentiality";
-import { ArrowLeft, GripVertical, X, Check } from "lucide-react";
+import { GripVertical, X, Check } from "lucide-react";
 import { INITIAL_COLUMNS, FINAL_COLUMNS, buildColumnOrder } from "~/hiring/lib/delibs";
 import { inReviewPipelineFilter } from "~/hiring/lib/application-pipeline-filter";
 import { ApplicantContextModal } from "~/hiring/components/delibs/ApplicantContextModal";
@@ -296,12 +296,6 @@ export default function DelibsKanban() {
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <button
-            onClick={() => navigate("/hiring/domain-lead")}
-            className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground/80 mb-2"
-          >
-            <ArrowLeft className="w-4 h-4 mr-1" /> Back to Dashboard
-          </button>
           <h1 className="text-2xl font-bold text-foreground">
             {session.type === "Initial" ? "Initial" : "Final"} Deliberations —{" "}
             {session.domain.name}

--- a/dali-api/app/hiring/routes/interviewer.interview.$interviewId.tsx
+++ b/dali-api/app/hiring/routes/interviewer.interview.$interviewId.tsx
@@ -1,8 +1,7 @@
 import React, { useState, useCallback } from 'react'
-import { Link, useLoaderData } from 'react-router'
+import { useLoaderData } from 'react-router'
 import { redirect } from 'react-router'
 import {
-  ArrowLeft,
   Clock,
   Check,
   Video,
@@ -329,15 +328,7 @@ export default function InterviewDetailPage() {
       subtitle={presenceSubtitle}
     >
     <div className="space-y-8 max-w-6xl mx-auto">
-      {/* Back button + presence avatars inline */}
-      <div className="flex items-center justify-between">
-        <Link
-          to="/hiring/reviewer"
-          className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground/80"
-        >
-          <ArrowLeft className="w-4 h-4 mr-1" />
-          Back to Dashboard
-        </Link>
+      <div className="flex items-center justify-end">
         <PresenceBar />
       </div>
 

--- a/dali-api/app/hiring/routes/reviewer.application.$id.tsx
+++ b/dali-api/app/hiring/routes/reviewer.application.$id.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from 'react'
-import { Link, redirect, useLoaderData, useSubmit } from 'react-router'
-import { ArrowLeft, HelpCircle, X, Check } from 'lucide-react'
+import { redirect, useLoaderData, useSubmit } from 'react-router'
+import { HelpCircle, X, Check } from 'lucide-react'
 import { prisma } from '~/lib/db'
 import { requireAuth } from "~/lib/auth";
 import { hasCycleAccess } from '~/lib/roles'
@@ -376,10 +376,7 @@ export default function ReviewerApplicationReview() {
     >
     <div className="space-y-6 pb-12 relative">
       <div>
-        <div className="flex items-center justify-between mb-4">
-          <Link to="/hiring/reviewer" className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground/80">
-            <ArrowLeft className="w-4 h-4 mr-1" /> Back to Dashboard
-          </Link>
+        <div className="flex items-center justify-end mb-4">
           <PresenceBar />
         </div>
         <div className="flex justify-between items-end">

--- a/dali-api/app/members/routes/members.$id.tsx
+++ b/dali-api/app/members/routes/members.$id.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { Form, Link, redirect, useActionData, useFetcher, useLoaderData, useNavigation, useSubmit } from "react-router";
+import { Form, redirect, useActionData, useFetcher, useLoaderData, useNavigation, useSubmit } from "react-router";
 import type { Route } from "./+types/members.$id";
 import { prisma } from "~/lib/db";
 import { requireAuth } from "~/lib/auth";
@@ -257,10 +257,7 @@ export default function MemberDetail() {
 
   const page = (
     <div className="flex flex-col gap-4">
-      <div className="flex items-center justify-between gap-3">
-        <Link to="/members" className="text-sm text-muted-foreground hover:text-foreground">
-          ← Back to members
-        </Link>
+      <div className="flex items-center justify-end gap-3">
         <PresenceBar />
       </div>
 

--- a/dali-api/app/partners/routes/partners.applications.$id.tsx
+++ b/dali-api/app/partners/routes/partners.applications.$id.tsx
@@ -294,13 +294,7 @@ export default function PartnerApplicationDetail() {
 
   return (
     <div className="flex flex-col gap-4">
-      <div className="flex items-center justify-between">
-        <Link
-          to="/partners/applications"
-          className="text-sm text-muted-foreground hover:text-foreground"
-        >
-          ← Back to applications
-        </Link>
+      <div className="flex items-center justify-end">
         <EditModeToggle
           canEdit={canEditPerm}
           editMode={editMode}

--- a/dali-api/app/projects/routes/projects.$id.tsx
+++ b/dali-api/app/projects/routes/projects.$id.tsx
@@ -721,13 +721,7 @@ export default function ProjectDetail() {
 
   const page = (
     <div className="flex flex-col gap-4">
-      <div className="flex items-center justify-between gap-3">
-        <Link
-          to="/projects/list"
-          className="text-sm text-muted-foreground hover:text-foreground"
-        >
-          ← Back to projects
-        </Link>
+      <div className="flex items-center justify-end gap-3">
         <PresenceBar />
       </div>
 

--- a/dali-api/app/projects/routes/projects.intent-to-work.$userId.tsx
+++ b/dali-api/app/projects/routes/projects.intent-to-work.$userId.tsx
@@ -1,11 +1,11 @@
-import { Link, redirect, useLoaderData } from "react-router";
+import { redirect, useLoaderData } from "react-router";
 import type { Route } from "./+types/projects.intent-to-work.$userId";
 import { requireAuth } from "~/lib/auth";
 import { canViewStaffing, currentTerm } from "~/lib/roles";
 import { prisma } from "~/lib/db";
 import { ensureStaffingCycle } from "../lib/staffing-cycle";
 import { getSlotBinding } from "../lib/form-slots";
-import { ALL_TERMS, resolveTermFilter } from "~/lib/terms";
+import { resolveTermFilter } from "~/lib/terms";
 import { buildSubmissionView } from "../lib/submission-view.server";
 
 const SLOT = "intent-to-work" as const;
@@ -61,11 +61,6 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     // can see they're not currently surfaced in the board table.
     fields: row.detailFields,
     cycleName: cycle.name,
-    // Preserve the viewed term on the way back, so the list reopens on the
-    // same term instead of resetting to the current one.
-    backTo: `/projects/intent-to-work?term=${encodeURIComponent(
-      isAll ? ALL_TERMS : term.id,
-    )}`,
   };
 }
 
@@ -74,13 +69,7 @@ export default function IntentSubmissionDetail() {
   return (
     <div className="flex flex-col gap-6">
       <div>
-        <Link
-          to={data.backTo}
-          className="text-sm text-accent-coral hover:underline"
-        >
-          ← Back to Intent to Work
-        </Link>
-        <h1 className="font-heading text-2xl font-bold text-foreground mt-2">
+        <h1 className="font-heading text-2xl font-bold text-foreground">
           {data.record.name}
         </h1>
         <p className="text-sm text-muted-foreground">{data.cycleName}</p>

--- a/dali-api/app/projects/routes/projects.level-up.$userId.tsx
+++ b/dali-api/app/projects/routes/projects.level-up.$userId.tsx
@@ -1,4 +1,4 @@
-import { Link, redirect, useLoaderData } from "react-router";
+import { redirect, useLoaderData } from "react-router";
 import type { Route } from "./+types/projects.level-up.$userId";
 import { requireAuth } from "~/lib/auth";
 import { canViewStaffing, currentTerm } from "~/lib/roles";
@@ -64,13 +64,7 @@ export default function LevelUpSubmissionDetail() {
   return (
     <div className="flex flex-col gap-6">
       <div>
-        <Link
-          to="/projects/level-up"
-          className="text-sm text-accent-coral hover:underline"
-        >
-          ← Back to Level Up
-        </Link>
-        <h1 className="font-heading text-2xl font-bold text-foreground mt-2">
+        <h1 className="font-heading text-2xl font-bold text-foreground">
           {data.record.name}
         </h1>
         <p className="text-sm text-muted-foreground">{data.cycleName}</p>

--- a/dali-api/app/projects/routes/projects.project-bids.$userId.tsx
+++ b/dali-api/app/projects/routes/projects.project-bids.$userId.tsx
@@ -1,11 +1,11 @@
-import { Link, redirect, useLoaderData } from "react-router";
+import { redirect, useLoaderData } from "react-router";
 import type { Route } from "./+types/projects.project-bids.$userId";
 import { requireAuth } from "~/lib/auth";
 import { canViewStaffing, currentTerm } from "~/lib/roles";
 import { prisma } from "~/lib/db";
 import { ensureStaffingCycle } from "../lib/staffing-cycle";
 import { getSlotBinding } from "../lib/form-slots";
-import { ALL_TERMS, resolveTermFilter } from "~/lib/terms";
+import { resolveTermFilter } from "~/lib/terms";
 import { buildSubmissionView } from "../lib/submission-view.server";
 
 const SLOT = "project-bids" as const;
@@ -64,11 +64,6 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     // can see they're not currently surfaced in the board table.
     fields: row.detailFields,
     cycleName: cycle.name,
-    // Preserve the viewed term on the way back, so the list reopens on the
-    // same term instead of resetting to the current one.
-    backTo: `/projects/project-bids?term=${encodeURIComponent(
-      isAll ? ALL_TERMS : term.id,
-    )}`,
   };
 }
 
@@ -77,13 +72,7 @@ export default function ProjectBidSubmissionDetail() {
   return (
     <div className="flex flex-col gap-6">
       <div>
-        <Link
-          to={data.backTo}
-          className="text-sm text-accent-coral hover:underline"
-        >
-          ← Back to Project Bids
-        </Link>
-        <h1 className="font-heading text-2xl font-bold text-foreground mt-2">
+        <h1 className="font-heading text-2xl font-bold text-foreground">
           {data.record.name}
         </h1>
         <p className="text-sm text-muted-foreground">{data.cycleName}</p>

--- a/dali-api/app/routes/documents.$pageId.tsx
+++ b/dali-api/app/routes/documents.$pageId.tsx
@@ -1,4 +1,4 @@
-import { Link, redirect, useLoaderData } from "react-router";
+import { redirect, useLoaderData } from "react-router";
 import type { Route } from "./+types/documents.$pageId";
 import { prisma } from "~/lib/db";
 import { requireAuth } from "~/lib/auth";
@@ -35,15 +35,6 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 
   const canEdit = await isCore(auth.user.sub);
 
-  // Parent project for the back link — only present for Project pages.
-  const project =
-    page.workspaceType === "Project" && page.workspaceId
-      ? await prisma.project.findUnique({
-          where: { id: page.workspaceId },
-          select: { id: true, name: true },
-        })
-      : null;
-
   const allTags = await prisma.docTag.findMany({
     where: { archivedAt: null },
     orderBy: { label: "asc" },
@@ -60,7 +51,6 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     title: page.title,
     tags: page.tags.map((t) => t.tag).sort((a, b) => a.label.localeCompare(b.label)),
     allTags,
-    project,
     canEdit,
     collabToken,
     userName: presenceUser?.name ?? fallbackName,
@@ -76,7 +66,6 @@ export default function DocumentPage() {
     title,
     tags,
     allTags,
-    project,
     canEdit,
     collabToken,
     userName,
@@ -87,15 +76,6 @@ export default function DocumentPage() {
 
   return (
     <div className="flex flex-col gap-4">
-      {project && (
-        <Link
-          to={`/projects/${project.id}`}
-          className="text-sm text-muted-foreground hover:text-foreground"
-        >
-          ← Back to {project.name}
-        </Link>
-      )}
-
       <DocumentEditor
         pageId={pageId}
         initialTitle={title}

--- a/dali-api/app/routes/documents.file.$fileId.tsx
+++ b/dali-api/app/routes/documents.file.$fileId.tsx
@@ -1,4 +1,4 @@
-import { Link, redirect, useLoaderData } from "react-router";
+import { redirect, useLoaderData } from "react-router";
 import { Download } from "lucide-react";
 import type { Route } from "./+types/documents.file.$fileId";
 import { prisma } from "~/lib/db";
@@ -28,7 +28,6 @@ export async function loader({ request, params }: Route.LoaderArgs) {
       projectId: true,
       currentVersionId: true,
       archivedAt: true,
-      project: { select: { id: true, name: true } },
       tags: { select: { tag: { select: { id: true, label: true, slug: true, color: true } } } },
       versions: {
         orderBy: { createdAt: "desc" },
@@ -73,7 +72,6 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   return {
     fileId: file.id,
     title: file.title,
-    project: file.project,
     tags: file.tags.map((t) => t.tag).sort((a, b) => a.label.localeCompare(b.label)),
     allTags,
     versions,
@@ -83,18 +81,11 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 }
 
 export default function FilePage() {
-  const { fileId, title, project, tags, allTags, versions, canEdit, currentUserId } =
+  const { fileId, title, tags, allTags, versions, canEdit, currentUserId } =
     useLoaderData() as Exclude<Awaited<ReturnType<typeof loader>>, Response>;
 
   return (
     <div className="flex flex-col gap-4">
-      <Link
-        to={project ? `/projects/${project.id}` : "/projects/list"}
-        className="text-sm text-muted-foreground hover:text-foreground"
-      >
-        ← {project ? `Back to ${project.name}` : "Back to projects"}
-      </Link>
-
       <div className="grid grid-cols-1 lg:grid-cols-[1fr_320px] gap-6">
         <div className="min-w-0">
           <h1 className="font-heading text-3xl font-bold text-foreground">{title}</h1>

--- a/dali-api/app/routes/intern-to-full.tsx
+++ b/dali-api/app/routes/intern-to-full.tsx
@@ -307,7 +307,7 @@ function Message({ title, children }: { title: string; children: React.ReactNode
       <h2 className="font-heading text-xl font-bold text-dark-blue mb-2">{title}</h2>
       <p className="text-sm text-muted-foreground">{children}</p>
       <Link to="/" className="mt-6 inline-block text-sm text-accent-coral hover:underline">
-        ← Back to home
+        Open home
       </Link>
     </div>
   );


### PR DESCRIPTION
## Summary

Two competing back models — page-rendered "← Back to X" links and the tab bar's back/forward arrows — pulled in different directions and meant different things depending on the page. Standardize on the tab back arrow (per-tab history, persisted, works everywhere) and remove the 18 ad-hoc page-level Back links.

### Removed page-level Back links (18 sites)

Each was a hardcoded `<Link to="/parent">` that duplicated and conflicted with the tab back arrow.

- `projects.$id.tsx`, `projects.level-up.$userId.tsx`, `projects.intent-to-work.$userId.tsx`, `projects.project-bids.$userId.tsx`
- `partners.applications.$id.tsx`
- `members.$id.tsx`
- `documents.$pageId.tsx`, `documents.file.$fileId.tsx`
- `applications.$domainApplicationId.tsx`, `domain-lead.application.$id.tsx`, `domain-lead.delibs.$id.tsx`, `reviewer.application.$id.tsx`, `interviewer.interview.$interviewId.tsx`
- `EmailTemplateDetail.tsx`, `ChallengeDetail.tsx`, `RubricDetail.tsx`, `ConfidentialityAgreementDetail.tsx`
- `FormDetail.tsx`

Dead loader fields (`backTo`, parent `project` joins) and unused `ArrowLeft`/`Link` imports cleaned up alongside.

### Empty-state escape hatches reframed (2 sites)

`cycles.$cycleId.confidentiality.tsx` and `intern-to-full.tsx` keep their link to `/` since they're terminal empty-state branches with no other escape, but the label changes from "← Back to home" to "Open home" — a CTA, not history navigation.

### TabWorkspace polish (`TabWorkspace.tsx:1278`)

The tab bar's back/forward arrows were functionally complete but visually nearly invisible (70% of muted-foreground on muted-bg, dimmed to 30% when disabled). Now:
- Hidden entirely when their stacks are empty (was: dimmed to 30%)
- Default contrast bumped to full muted-foreground
- Slightly larger hit target (`px-2.5`, `w-[18px] h-[18px]`)

### Out of scope (kept)

- Applicant portal (`portal.*`, `ApplicantErrorBoundary`) — different layout, no tab workspace, Back is the only nav
- `LaunchWelcome.tsx` — modal, not navigation

## Test plan

- [ ] Open a hiring application detail tab → confirm tab back arrow returns to list; no duplicate page-level "Back" link
- [ ] Open a project, then open a document tab from it → confirm document tab has no "Back to {project}" link; tab back arrow works
- [ ] Open a member detail, navigate to another member → tab back arrow returns to previous member
- [ ] Land on `/hiring/cycles/{id}/confidentiality` with no signed agreement → "Open home" link reads as a CTA, not back
- [ ] Open a fresh tab (no history) → back/forward arrows are absent (not dimmed)
- [ ] Navigate within a tab → back arrow appears, returns to prior URL
- [ ] No regression in split-pane, drag-reorder, Cmd+[ / Cmd+] keyboard nav

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/743"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782921043&installation_id=133523038&pr_number=743&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F743&signature=d35a7c3482608a826e10b606b4d7bbe678d3d4982a07a5041477f5386baceb6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->