### PR TITLE
Staffing: one bid row per project + scrollable columns; release-acceptance tests

### DIFF
--- a/dali-api/.env.example
+++ b/dali-api/.env.example
@@ -10,9 +10,40 @@ GOOGLE_REDIRECT_URI=http://localhost:5173/auth/google/callback
 # dartmouth sso url
 CAS_BASE_URL="https://login.dartmouth.edu/cas"
 
+# Gmail send-as address for outbound app email (hiring decision emails, member
+# welcome emails). The actual OAuth refresh token lives in a GmailIntegration
+# DB row created via the one-time /admin/authorize-gmail flow — without that row
+# all email sending is skipped (no error). This is just the from/send-as match.
+GMAIL_USER="applications@dali.dartmouth.edu"
+
+# Onboarding/welcome + acceptance emails: in non-prod (DALI_APP_ENV != prod)
+# every candidate email is redirected to this single test inbox, with a banner
+# naming who it WOULD have gone to in prod. Defaults to sophie.park if unset.
+# ONBOARDING_EMAIL_OVERRIDE="sophie.park@dali.dartmouth.edu"
+
+# Google Workspace account provisioning (Admin SDK Directory API). When an
+# applicant is accepted, creates their @dali.dartmouth.edu account. Needs a
+# Google service account with DOMAIN-WIDE DELEGATION authorized for the
+# admin.directory.user scope, impersonating a Workspace super-admin. All three
+# must be set or the step is skipped. See docs/ONBOARDING_PROVISIONING.md.
+# ⚠️ Creates REAL accounts even from local dev — only set when you mean it.
+GOOGLE_WORKSPACE_SA_EMAIL=""
+# Full PEM; literal \n is unescaped at runtime.
+GOOGLE_WORKSPACE_SA_PRIVATE_KEY=""
+GOOGLE_WORKSPACE_ADMIN_EMAIL=""
+# Optional; defaults to dali.dartmouth.edu.
+# GOOGLE_WORKSPACE_DOMAIN="dali.dartmouth.edu"
+
 # frontend and api urls
 FRONTEND_URL="http://localhost:5173"
 API_BASE_URL="http://localhost:3001"
+
+# Deployment environment. Auto-derived from FLY_APP_NAME in deployed envs
+# (dali-api-prod → prod, dali-api-staging → staging, else dev). Set explicitly
+# to override locally. Candidate-facing emails (acceptance + welcome) only go to
+# the real applicant when this is "prod"; otherwise they're redirected to the
+# test inbox below.
+# DALI_APP_ENV="dev"
 
 # AWS S3 — direct-to-S3 uploads (application files, profile photos). Required
 # for the presign endpoints in app/lib/s3.ts; uploads fail without them.
@@ -45,9 +76,17 @@ DALI_GENERAL_CALENDAR_ICS=""
 # /api/slack/events returns 503 when SLACK_SIGNING_SECRET is missing.
 SLACK_SIGNING_SECRET=""
 SLACK_BOT_TOKEN=""
-# Channel ID the staffing "finalize" automation posts the confirmed roster to
-# (e.g. "C0123ABC"). When empty, the Slack step is skipped (reported as such).
-STAFFING_SLACK_CHANNEL=""
+# A newly-accepted member is invited into the workspace's #general channel on
+# acceptance (the channel is resolved by name — no env var needed). The staffing
+# "finalize" automation instead creates/uses each project's OWN channel (named
+# after the project) for the team announcement + invites.
+#
+# Inviting a new member's email to the workspace uses admin.users.invite, which
+# needs an ADMIN-scoped token (admin.users:write) on a Business+/Enterprise Grid
+# workspace — distinct from SLACK_BOT_TOKEN. Both must be set or the invite is
+# skipped.
+SLACK_ADMIN_TOKEN=""
+SLACK_TEAM_ID=""
 
 # GitHub App used to file issues from Slack bug reports, and (when the App has
 # org "Members: write") to provision project teams from staffing finalize.

--- a/dali-api/app/components/LaunchWelcome.tsx
+++ b/dali-api/app/components/LaunchWelcome.tsx
@@ -103,7 +103,12 @@ function findByExactText(text: string) {
   return findInSidebar((btn) => (btn.textContent || "").trim() === text);
 }
 
-const STEPS: TourStep[] = [
+// The tour steps. A member who hasn't linked a Google Calendar gets an extra
+// "connect your calendar" step (moved here out of the onboarding checklist);
+// once linked it drops off. Built as a function so the calendar step is
+// conditional on the current user.
+function buildSteps(opts: { hasCalendarLink: boolean }): TourStep[] {
+  const steps: TourStep[] = [
   {
     icon: <FolderKanban className="w-4 h-4" />,
     eyebrow: "Projects",
@@ -213,7 +218,30 @@ const STEPS: TourStep[] = [
       },
     },
   },
-];
+  ];
+
+  // Offer calendar connect only when the member hasn't linked one yet.
+  if (!opts.hasCalendarLink) {
+    steps.push({
+      icon: <CalendarPlus className="w-4 h-4" />,
+      eyebrow: "Connect your calendar",
+      cta: (
+        <>
+          Connect your <strong>Google Calendar</strong> so the lab can see your
+          availability for scheduling.
+        </>
+      ),
+      action: {
+        label: "Connect Google Calendar",
+        onClick: () => {
+          window.location.href = "/oauth/calendar/google/start";
+        },
+      },
+    });
+  }
+
+  return steps;
+}
 
 function readPhase(): Phase {
   try {
@@ -225,12 +253,12 @@ function readPhase(): Phase {
   return "modal";
 }
 
-function readStep(): number {
+function readStep(maxStep: number): number {
   try {
     const raw = window.localStorage.getItem(STEP_KEY);
     if (raw === null) return 0;
     const n = parseInt(raw, 10);
-    return Number.isFinite(n) ? Math.max(0, Math.min(STEPS.length, n)) : 0;
+    return Number.isFinite(n) ? Math.max(0, Math.min(maxStep, n)) : 0;
   } catch {
     return 0;
   }
@@ -316,7 +344,21 @@ function Spotlight({ target }: { target: HTMLElement }) {
   );
 }
 
-export function LaunchWelcome({ firstName }: { firstName: string }) {
+export function LaunchWelcome({
+  firstName,
+  hasCalendarLink = true,
+  // Server says this member just onboarded and hasn't done the tour yet — show
+  // it once, overriding any browser-localStorage "seen" flag (the tour is now
+  // tracked per USER on the server).
+  shouldShowTour = false,
+}: {
+  firstName: string;
+  hasCalendarLink?: boolean;
+  shouldShowTour?: boolean;
+}) {
+  // Steps are stable for a given user within a session; the calendar step is
+  // included only when they haven't linked a calendar yet.
+  const steps = useRef(buildSteps({ hasCalendarLink })).current;
   const [phase, setPhase] = useState<Phase>("done");
   const [step, setStep] = useState(0);
   const [arrived, setArrived] = useState(false);
@@ -326,8 +368,33 @@ export function LaunchWelcome({ firstName }: { firstName: string }) {
   const titleId = useId();
 
   useEffect(() => {
+    // Server-driven auto-show wins over the browser's localStorage flag: a
+    // freshly-onboarded member sees the tour even in a browser where someone
+    // else dismissed it before.
+    if (shouldShowTour) {
+      setPhase("modal");
+      setStep(0);
+      return;
+    }
     setPhase(readPhase());
-    setStep(readStep());
+    setStep(readStep(steps.length));
+  }, [steps.length, shouldShowTour]);
+
+  // Manual re-run: a "Start tour" button (next to the DALI OS logo) dispatches
+  // this event. Re-runs the tour regardless of past completion.
+  useEffect(() => {
+    function onStart() {
+      try {
+        window.localStorage.removeItem(DONE_KEY);
+      } catch {
+        // ignore
+      }
+      setStep(0);
+      setArrived(false);
+      setPhase("modal");
+    }
+    window.addEventListener("dali:start-tour", onStart);
+    return () => window.removeEventListener("dali:start-tour", onStart);
   }, []);
 
   // Re-resolve the highlight target whenever the active step changes.
@@ -341,8 +408,8 @@ export function LaunchWelcome({ firstName }: { firstName: string }) {
   // element flips the step to "arrived" the same way a URL change would.
   useEffect(() => {
     if (phase !== "card") return;
-    if (step >= STEPS.length) return;
-    const s = STEPS[step];
+    if (step >= steps.length) return;
+    const s = steps[step];
     const find = s.findTarget;
     if (!find || arrived) {
       setSidebarTarget(null);
@@ -380,11 +447,11 @@ export function LaunchWelcome({ firstName }: { firstName: string }) {
       setNextTarget(null);
       return;
     }
-    if (step >= STEPS.length) {
+    if (step >= steps.length) {
       setNextTarget(null);
       return;
     }
-    const s = STEPS[step];
+    const s = steps[step];
     const shouldPulse = s.findTarget ? arrived : true;
     setNextTarget(shouldPulse ? nextButtonRef.current : null);
   }, [phase, step, arrived]);
@@ -396,8 +463,8 @@ export function LaunchWelcome({ firstName }: { firstName: string }) {
     (url: string) => {
       if (phase !== "card") return;
       if (arrived) return;
-      if (step >= STEPS.length) return;
-      const match = STEPS[step].matches;
+      if (step >= steps.length) return;
+      const match = steps[step].matches;
       if (!match) return; // info-only step — URL changes don't advance it
       try {
         const path = new URL(url, window.location.origin).pathname;
@@ -446,6 +513,11 @@ export function LaunchWelcome({ firstName }: { firstName: string }) {
     } catch {
       // ignore
     }
+    // Persist completion per-user so the tour isn't auto-shown again (the
+    // localStorage flag above is just a same-browser fast path). Best-effort.
+    void fetch("/api/tour/complete", { method: "POST", credentials: "include" }).catch(
+      () => {},
+    );
     setPhase("done");
   }
 
@@ -503,8 +575,8 @@ export function LaunchWelcome({ firstName }: { firstName: string }) {
     );
   }
 
-  const isFinal = step >= STEPS.length;
-  const current = isFinal ? null : STEPS[step];
+  const isFinal = step >= steps.length;
+  const current = isFinal ? null : steps[step];
 
   return (
     <>
@@ -574,7 +646,7 @@ export function LaunchWelcome({ firstName }: { firstName: string }) {
           </div>
 
           <div className="flex items-center gap-1.5" aria-hidden="true">
-            {STEPS.map((_, i) => (
+            {steps.map((_, i) => (
               <span
                 key={i}
                 className={

--- a/dali-api/app/components/Layout.tsx
+++ b/dali-api/app/components/Layout.tsx
@@ -48,6 +48,7 @@ interface LayoutProps {
   canViewForms?: boolean
   canViewStaffing?: boolean
   isInterviewer?: boolean
+  hasHiringAccess?: boolean
 }
 
 const SIDEBAR_COLLAPSED_KEY = 'dali:sidebar:collapsed'
@@ -55,7 +56,7 @@ const EXPANDED_AREAS_KEY = 'dali:sidebar:expanded-areas'
 
 type AreaKey = 'hiring' | 'projects' | 'members' | 'partners' | 'education' | 'internal-processes' | 'admin-console'
 
-export function Layout({ user, photoUrl, isCore = false, isAdmin = false, isDomainLead = false, canViewForms = false, canViewStaffing = false, isInterviewer = false }: LayoutProps) {
+export function Layout({ user, photoUrl, isCore = false, isAdmin = false, isDomainLead = false, canViewForms = false, canViewStaffing = false, isInterviewer = false, hasHiringAccess = false }: LayoutProps) {
   const location = useLocation()
   const { revalidate } = useRevalidator()
   // Held in a ref so the message listener (mounted once) always calls the
@@ -261,19 +262,18 @@ export function Layout({ user, photoUrl, isCore = false, isAdmin = false, isDoma
       label: 'Reviews',
       to: '/hiring/reviewer',
       icon: MessageSquare,
-      show: true,
+      show: hasHiringAccess,
       active: path.startsWith('/hiring/reviewer') || path.startsWith('/hiring/interviewer/interview'),
       sub: null,
     },
     {
-      // Database view of all submissions for a cycle. Core sees every
-      // domain; reviewers see only their assigned domains. The route
-      // itself handles users with no access (empty state), so the tab is
-      // shown to everyone like Reviews.
+      // Database view of all submissions for a cycle. Core sees every domain;
+      // reviewers see only their assigned domains. Gated with the rest of
+      // Hiring so non-hiring members never see it (or its empty reviewer state).
       label: 'Applications',
       to: '/hiring/applications',
       icon: FileText,
-      show: true,
+      show: hasHiringAccess,
       active: path.startsWith('/hiring/applications'),
       sub: null,
     },
@@ -477,7 +477,6 @@ export function Layout({ user, photoUrl, isCore = false, isAdmin = false, isDoma
     },
   ].filter((s) => s.show)
 
-  const hasHiringAccess = true
   const areas = [
     {
       key: 'hiring' as AreaKey,
@@ -576,15 +575,26 @@ export function Layout({ user, photoUrl, isCore = false, isAdmin = false, isDoma
           )}
         </button>
         {!collapsed && (
-          <button
-            type="button"
-            onClick={toggleCollapsed}
-            className="hidden md:flex p-1.5 text-white/40 hover:text-white/80 hover:bg-white/5 rounded-md transition flex-shrink-0"
-            aria-label="Collapse sidebar"
-            title="Collapse sidebar"
-          >
-            <ChevronLeft className="w-4 h-4" />
-          </button>
+          <div className="flex items-center gap-1 flex-shrink-0">
+            <button
+              type="button"
+              onClick={() => window.dispatchEvent(new Event('dali:start-tour'))}
+              className="hidden md:flex p-1.5 text-white/40 hover:text-white/80 hover:bg-white/5 rounded-md transition"
+              aria-label="Start tour"
+              title="Take the tour"
+            >
+              <HelpCircle className="w-4 h-4" />
+            </button>
+            <button
+              type="button"
+              onClick={toggleCollapsed}
+              className="hidden md:flex p-1.5 text-white/40 hover:text-white/80 hover:bg-white/5 rounded-md transition"
+              aria-label="Collapse sidebar"
+              title="Collapse sidebar"
+            >
+              <ChevronLeft className="w-4 h-4" />
+            </button>
+          </div>
         )}
       </div>
       {collapsed && (

--- a/dali-api/app/forms/components/MemberFormFillView.tsx
+++ b/dali-api/app/forms/components/MemberFormFillView.tsx
@@ -1,0 +1,159 @@
+import { useState } from "react";
+import { ChallengeQuestionField } from "~/hiring/components/ChallengeQuestionField";
+import { RichTextViewer, isEmptyDoc } from "~/components/RichTextViewer";
+import type { Question } from "~/types";
+
+// The shared authenticated form-fill UI. Rendered both by /forms/fill/:token
+// and inline by /onboarding (so onboarding has no cross-URL redirect — the tab
+// URL matches its content in the embedded workspace). The caller passes the
+// already-loaded form data (from loadPublicForm) + its token; submission posts
+// to /api/forms/fill/:token, same as before.
+
+export type MemberFormData = {
+  name: string;
+  description: unknown;
+  versionId: string;
+  questions: Question[];
+  token: string;
+};
+
+export function MemberFormFillView({
+  data,
+  // Optional: rendered on the "Submitted" screen instead of the default copy.
+  doneContent,
+}: {
+  data: MemberFormData;
+  doneContent?: React.ReactNode;
+}) {
+  const [answers, setAnswers] = useState<Record<string, string>>({});
+  const [state, setState] = useState<"idle" | "submitting" | "done">("idle");
+  const [error, setError] = useState<string | null>(null);
+  const questions = data.questions;
+
+  function set(key: string, v: string) {
+    setAnswers((a) => ({ ...a, [key]: v }));
+  }
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    for (const q of questions) {
+      if (!q.required || q.type === "file") continue;
+      if (!answers[q.key]?.trim()) {
+        setError(`"${q.data.label}" is required.`);
+        return;
+      }
+    }
+    setState("submitting");
+    try {
+      const res = await fetch(`/api/forms/fill/${data.token}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ versionId: data.versionId, answers }),
+      });
+      const out = (await res.json().catch(() => ({}))) as { error?: string };
+      if (!res.ok) {
+        setError(out.error ?? `Submission failed (${res.status}).`);
+        setState("idle");
+        return;
+      }
+      setState("done");
+    } catch {
+      setError("Network error — please try again.");
+      setState("idle");
+    }
+  }
+
+  if (state === "done") {
+    return (
+      <div className="text-center py-10">
+        {doneContent ?? (
+          <>
+            <h1 className="font-heading text-xl font-bold text-dark-blue">
+              Submitted
+            </h1>
+            <p className="text-sm text-muted-foreground mt-2">
+              Your response to “{data.name}” has been recorded.
+            </p>
+          </>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <h1 className="font-heading text-2xl font-bold text-dark-blue">
+        {data.name}
+      </h1>
+      {data.description && !isEmptyDoc(data.description) && (
+        <div className="mt-2 text-sm text-muted-foreground">
+          <RichTextViewer content={data.description} />
+        </div>
+      )}
+
+      {error && (
+        <div className="mt-4 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+          {error}
+        </div>
+      )}
+
+      <form onSubmit={submit} className="mt-6 flex flex-col gap-5">
+        {questions.map((q) => (
+          <div key={q.key}>
+            <label className="block text-sm font-medium text-dark-blue mb-1">
+              {q.data.label}
+              {q.required && <span className="text-destructive"> *</span>}
+            </label>
+            {q.data.description && (
+              <p className="text-xs text-muted-foreground mb-1.5">
+                {q.data.description}
+              </p>
+            )}
+            {q.type === "file" ? (
+              <div className="text-xs text-muted-foreground italic border border-dashed border-border rounded-md px-3 py-2">
+                File uploads aren’t available here.
+              </div>
+            ) : (
+              <ChallengeQuestionField
+                question={q}
+                value={answers[q.key] ?? ""}
+                onChange={(v) => set(q.key, v)}
+              />
+            )}
+          </div>
+        ))}
+
+        <button
+          type="submit"
+          disabled={state === "submitting"}
+          className="self-start px-4 py-2 text-sm font-medium rounded-lg bg-accent-coral text-white hover:bg-accent-coral/90 disabled:opacity-60 transition-colors"
+        >
+          {state === "submitting" ? "Submitting…" : "Submit"}
+        </button>
+      </form>
+    </>
+  );
+}
+
+// The branded card chrome both routes wrap the form in.
+export function MemberFormShell({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="min-h-screen bg-section-bg p-4 sm:p-8 pt-10 sm:pt-16">
+      <div className="mx-auto max-w-2xl bg-card border border-border rounded-xl p-6 sm:p-8">
+        <div className="flex items-center gap-2 mb-6">
+          <div className="w-7 h-7 bg-accent-coral rounded-md flex items-center justify-center">
+            <span className="text-white font-bold text-base leading-none font-heading">
+              D
+            </span>
+          </div>
+          <span className="font-heading text-sm font-bold text-dark-blue">
+            DALI OS
+          </span>
+        </div>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/dali-api/app/forms/lib/public-form.ts
+++ b/dali-api/app/forms/lib/public-form.ts
@@ -18,6 +18,13 @@ import {
   type ColumnMapping,
 } from "~/projects/lib/slot-roles";
 import { pickStaffingBinding, type Slot } from "~/projects/lib/form-slots";
+import {
+  interpretProfileForm,
+  NEW_MEMBER_PROFILE_FORM_NAME,
+  type ProfileUpdate,
+} from "~/members/lib/profile-form-interpreter";
+import { clearOnboardingTask } from "~/members/lib/welcome.server";
+import { syncSlackUserId } from "~/members/lib/slack-sync.server";
 
 export type PublicForm = {
   formId: string;
@@ -167,6 +174,7 @@ export async function submitMemberForm(args: {
     where: { publicToken: args.token },
     select: {
       id: true,
+      name: true,
       published: true,
       versions: {
         where: { id: args.versionId },
@@ -226,6 +234,19 @@ export async function submitMemberForm(args: {
   );
 
   if (!staffingBinding) {
+    // The onboarding "New Member Profile" form IS the onboarding step: it writes
+    // its answers onto the member's User profile fields (see profile-form-
+    // interpreter) AND completes onboarding (stamps DALIMember.onboardedAt +
+    // clears the persistent onboarding task). Everything else (Slack, calendar)
+    // happens in earlier provisioning / the later party tour.
+    const isProfileForm = form.name === NEW_MEMBER_PROFILE_FORM_NAME;
+    let profileUpdate: ProfileUpdate | null = null;
+    if (isProfileForm) {
+      const interpreted = interpretProfileForm(args.answers);
+      if (!interpreted.ok) return { error: interpreted.error, status: 400 };
+      profileUpdate = interpreted.update;
+    }
+
     // Ordinary member submission — record it, attributed to the member, and
     // close any "todo" notification that pointed them at this form so the
     // Home banner / Tasks count clears.
@@ -238,8 +259,25 @@ export async function submitMemberForm(args: {
           answers: args.answers as object,
         },
       });
+      if (profileUpdate && Object.keys(profileUpdate).length > 0) {
+        await tx.user.update({ where: { id: args.userId }, data: profileUpdate });
+      }
+      if (isProfileForm) {
+        // Submitting the profile form finishes onboarding.
+        await tx.dALIMember.updateMany({
+          where: { userId: args.userId, onboardedAt: null },
+          data: { onboardedAt: new Date() },
+        });
+      }
       await closeFormTodos(tx, args.userId, form.id);
     });
+    if (isProfileForm) {
+      await clearOnboardingTask(args.userId);
+      // Onboarding Slack-account sync: by now the member may have joined Slack
+      // (e.g. via the welcome invite), so try to resolve + store their Slack
+      // user id for future per-project channel invites. Best-effort.
+      await syncSlackUserId(args.userId).catch(() => {});
+    }
     return { ok: true };
   }
 

--- a/dali-api/app/hiring/lib/__tests__/api.decisions.release.test.ts
+++ b/dali-api/app/hiring/lib/__tests__/api.decisions.release.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
 
 vi.mock("~/lib/db");
 vi.mock("~/lib/auth", () => ({
@@ -6,11 +6,30 @@ vi.mock("~/lib/auth", () => ({
 }));
 vi.mock("~/lib/roles");
 vi.mock("~/lib/gmail");
+// Acceptance side-effects (promote/welcome/provision) are exercised by their
+// own unit tests; stub them here so this suite stays focused on the decision
+// email + released-row behavior.
+vi.mock("~/members/lib/membership.server", () => ({
+  promoteToMember: vi.fn().mockResolvedValue({ created: true }),
+}));
+vi.mock("~/members/lib/welcome.server", () => ({
+  sendWelcome: vi.fn().mockResolvedValue({ notified: true, emailSent: false }),
+}));
+vi.mock("~/members/lib/provisioning.server", () => ({
+  provisionNewMember: vi.fn().mockResolvedValue({
+    github: { status: "skipped", message: "" },
+    slack: { status: "skipped", message: "" },
+    gmail: { status: "skipped", message: "" },
+  }),
+}));
 
 import { prisma } from "~/lib/db";
 import { requireAuth } from "~/lib/auth";
 import { isCore } from "~/lib/roles";
 import { sendEmail } from "~/lib/gmail";
+import { promoteToMember } from "~/members/lib/membership.server";
+import { sendWelcome } from "~/members/lib/welcome.server";
+import { provisionNewMember } from "~/members/lib/provisioning.server";
 import { action } from "~/hiring/routes/api.decisions.$id.release";
 
 const mockPrisma = prisma as unknown as {
@@ -77,6 +96,10 @@ function setupApplicantContext(opts: { domainName?: string | null } = {}) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // Candidate emails redirect to a test inbox outside prod; these tests assert
+  // the real-recipient + template behavior, so pin the env to prod. The
+  // dev-redirect path is asserted in its own test below.
+  process.env.DALI_APP_ENV = "prod";
   (mockPrisma as any).dALIMember = { findUnique: vi.fn() };
   (mockPrisma as any).decision = { findUnique: vi.fn(), create: vi.fn() };
   (mockPrisma as any).domainApplication = { findUnique: vi.fn() };
@@ -84,6 +107,10 @@ beforeEach(() => {
   (mockPrisma as any).user = { findUnique: vi.fn() };
   (mockPrisma as any).gmailIntegration = { findFirst: vi.fn() };
   vi.mocked(sendEmail).mockResolvedValue(undefined as any);
+});
+
+afterAll(() => {
+  delete process.env.DALI_APP_ENV;
 });
 
 function makeRequest() {
@@ -267,6 +294,131 @@ describe("POST /api/hiring/decisions/:id/release", () => {
     const res = await action({ request: makeRequest(), params: { id: DECISION_ID }, context: {} } as any);
     expect(res.status).toBe(201);
     expect(errSpy).toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+
+  it("in non-prod, redirects the decision email to the test inbox with a banner naming the real recipient", async () => {
+    process.env.DALI_APP_ENV = "dev";
+    setupAuth();
+    setupFinalDecision("Accepted");
+    setupApplicantContext();
+    mockPrisma.cycleDecisionEmail.findUnique.mockResolvedValue({
+      applicationCycleId: CYCLE_ID,
+      decisionType: "Accepted",
+      emailTemplateVersionId: "etv-1",
+      emailTemplateVersion: { id: "etv-1", subject: "Welcome!", body: "Hi {{firstName}}" },
+    });
+
+    const res = await action({ request: makeRequest(), params: { id: DECISION_ID }, context: {} } as any);
+    expect(res.status).toBe(201);
+    const args = vi.mocked(sendEmail).mock.calls[0][0];
+    // Redirected away from the candidate to the test inbox…
+    expect(args.to).not.toBe("ada@dartmouth.edu");
+    // …and the body names who it would have gone to in prod.
+    expect(args.html).toContain("ada@dartmouth.edu");
+    expect(args.html).toContain("Test environment");
+  });
+
+  it("on Accepted, promotes to member, provisions, and sends welcome — all for the applicant", async () => {
+    setupAuth();
+    setupFinalDecision("Accepted");
+    setupApplicantContext();
+    mockPrisma.cycleDecisionEmail.findUnique.mockResolvedValue({
+      applicationCycleId: CYCLE_ID,
+      decisionType: "Accepted",
+      emailTemplateVersionId: "etv-1",
+      emailTemplateVersion: { id: "etv-1", subject: "Welcome!", body: "Hi {{firstName}}" },
+    });
+
+    const res = await action({ request: makeRequest(), params: { id: DECISION_ID }, context: {} } as any);
+    expect(res.status).toBe(201);
+
+    // Promotes the APPLICANT (not the acting lead) into the target domain at P1.
+    expect(promoteToMember).toHaveBeenCalledOnce();
+    expect(vi.mocked(promoteToMember).mock.calls[0][0]).toMatchObject({
+      userId: "applicant-user-id",
+      domainId: "dom-1",
+      level: "P1",
+      actorId: USER_ID,
+    });
+
+    // Provisions external accounts for the applicant in the target domain.
+    expect(provisionNewMember).toHaveBeenCalledOnce();
+    expect(vi.mocked(provisionNewMember).mock.calls[0][0]).toMatchObject({
+      userId: "applicant-user-id",
+      domainId: "dom-1",
+    });
+
+    // Welcomes the applicant at a reachable address.
+    expect(sendWelcome).toHaveBeenCalledOnce();
+    expect(vi.mocked(sendWelcome).mock.calls[0][0]).toMatchObject({
+      userId: "applicant-user-id",
+      email: "ada@dartmouth.edu",
+    });
+  });
+
+  it("folds the provisioned daliEmail into the welcome call", async () => {
+    setupAuth();
+    setupFinalDecision("Accepted");
+    setupApplicantContext();
+    vi.mocked(provisionNewMember).mockResolvedValueOnce({
+      daliEmail: "ada.lovelace@dali.dartmouth.edu",
+      github: { status: "skipped", message: "" },
+      slack: { status: "skipped", message: "" },
+      gmail: { status: "skipped", message: "" },
+    } as any);
+    mockPrisma.cycleDecisionEmail.findUnique.mockResolvedValue({
+      applicationCycleId: CYCLE_ID,
+      decisionType: "Accepted",
+      emailTemplateVersionId: "etv-1",
+      emailTemplateVersion: { id: "etv-1", subject: "Welcome!", body: "Hi {{firstName}}" },
+    });
+
+    const res = await action({ request: makeRequest(), params: { id: DECISION_ID }, context: {} } as any);
+    expect(res.status).toBe(201);
+    expect(vi.mocked(sendWelcome).mock.calls[0][0].daliEmail).toBe(
+      "ada.lovelace@dali.dartmouth.edu",
+    );
+  });
+
+  it("does NOT promote / provision / welcome for non-Accepted decisions", async () => {
+    setupAuth();
+    setupFinalDecision("Rejected");
+    setupApplicantContext();
+    mockPrisma.cycleDecisionEmail.findUnique.mockResolvedValue({
+      applicationCycleId: CYCLE_ID,
+      decisionType: "Rejected",
+      emailTemplateVersionId: "etv-rej",
+      emailTemplateVersion: { id: "etv-rej", subject: "x", body: "y" },
+    });
+
+    const res = await action({ request: makeRequest(), params: { id: DECISION_ID }, context: {} } as any);
+    expect(res.status).toBe(201);
+    expect(promoteToMember).not.toHaveBeenCalled();
+    expect(provisionNewMember).not.toHaveBeenCalled();
+    expect(sendWelcome).not.toHaveBeenCalled();
+    // …but the decision email still goes out.
+    expect(sendEmail).toHaveBeenCalledOnce();
+  });
+
+  it("still releases (201) when provisioning throws — failure is isolated", async () => {
+    setupAuth();
+    setupFinalDecision("Accepted");
+    setupApplicantContext();
+    vi.mocked(provisionNewMember).mockRejectedValueOnce(new Error("workspace 500"));
+    mockPrisma.cycleDecisionEmail.findUnique.mockResolvedValue({
+      applicationCycleId: CYCLE_ID,
+      decisionType: "Accepted",
+      emailTemplateVersionId: "etv-1",
+      emailTemplateVersion: { id: "etv-1", subject: "Welcome!", body: "Hi {{firstName}}" },
+    });
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const res = await action({ request: makeRequest(), params: { id: DECISION_ID }, context: {} } as any);
+    expect(res.status).toBe(201);
+    // promotion ran before provisioning; welcome still runs after the catch.
+    expect(promoteToMember).toHaveBeenCalledOnce();
+    expect(sendWelcome).toHaveBeenCalledOnce();
     errSpy.mockRestore();
   });
 });

--- a/dali-api/app/hiring/routes/api.decisions.$id.release.ts
+++ b/dali-api/app/hiring/routes/api.decisions.$id.release.ts
@@ -7,6 +7,10 @@ import { getApplicationsGmailRefreshToken } from "~/lib/gmail-integration";
 import { renderForSlot, decisionSlot } from "~/hiring/lib/email-variables";
 import { logAuditEvent } from "~/lib/audit";
 import { requireApiSignedOrForbidden } from "~/hiring/lib/confidentiality";
+import { promoteToMember } from "~/members/lib/membership.server";
+import { sendWelcome } from "~/members/lib/welcome.server";
+import { provisionNewMember, type ProvisionResult } from "~/members/lib/provisioning.server";
+import { resolveCandidateEmail, redirectBannerHtml } from "~/lib/candidate-email";
 
 export async function action({ request, params }: Route.ActionArgs) {
   const auth = await requireAuth(request);
@@ -117,45 +121,72 @@ export async function action({ request, params }: Route.ActionArgs) {
     },
   });
 
-  // ── InternToFull conversion side-effect ──────────────────────────────────
-  // When an InternToFull applicant is accepted, grant them DomainEligibility
-  // in the target domain at P1 so subsequent staffing flows pick them up.
-  // Their intern DomainEligibility is left intact; it naturally lapses when
-  // their intern term ends. Idempotent: upserts on the (userId, domainId)
-  // unique constraint so a re-release doesn't change anything.
-  let internConversionApplied = false;
-  if (
-    decision.type === "Accepted" &&
-    domainApp.application.applicationCycle.cycleType === "InternToFull"
-  ) {
-    await prisma.domainEligibility.upsert({
-      where: {
-        userId_domainId: {
-          userId: domainApp.application.userId,
-          domainId: targetDomain.id,
-        },
-      },
-      update: {},
-      create: {
+  // ── Acceptance side-effect: promote to member + grant eligibility ─────────
+  // When ANY applicant is accepted (Standard or InternToFull), make them a lab
+  // member and grant DomainEligibility in the target domain at P1 so staffing
+  // flows pick them up. Previously only InternToFull granted eligibility and
+  // nobody was auto-promoted to a member. Idempotent: promoteToMember upserts
+  // the DALIMember row and eligibility, so a re-release changes nothing. A
+  // brand-new member's onboardedAt stays null → the layout gate routes them
+  // through /onboarding on first login.
+  let memberPromoted = false;
+  let welcomeNotified = false;
+  let provisionResult: ProvisionResult | null = null;
+  if (decision.type === "Accepted") {
+    const { created } = await promoteToMember({
+      userId: domainApp.application.userId,
+      domainId: targetDomain.id,
+      level: "P1",
+      actorId: auth.user.sub,
+    });
+    memberPromoted = created;
+
+    // Provision FIRST — this creates the @dali.dartmouth.edu account and the
+    // Slack invite. The welcome email then references the new DALI email.
+    // Best-effort: each step is isolated; failures are recorded, not thrown.
+    try {
+      provisionResult = await provisionNewMember({
         userId: domainApp.application.userId,
         domainId: targetDomain.id,
-        level: "P1",
-        promotedBy: auth.user.sub,
-      },
-    });
-    internConversionApplied = true;
+      });
+    } catch (err) {
+      console.error("Failed to provision new member:", err);
+    }
+
+    // Welcome the new member: a persistent "finish onboarding" todo + a welcome
+    // email that tells them to log into DALI OS with their new DALI email.
+    // Sent to a reachable address (their Dartmouth email). Best-effort.
+    try {
+      const u = domainApp.application.user;
+      const welcomeEmail =
+        u?.dartmouthEmail ?? (u?.netId ? `${u.netId}@dartmouth.edu` : null);
+      const { notified } = await sendWelcome({
+        userId: domainApp.application.userId,
+        actorId: auth.user.sub,
+        firstName: u?.firstName ?? "",
+        email: welcomeEmail,
+        daliEmail: provisionResult?.daliEmail ?? null,
+      });
+      welcomeNotified = notified;
+    } catch (err) {
+      console.error("Failed to send welcome:", err);
+    }
   }
 
   // ── Send notification email via per-cycle binding ────────────────────────────
   let emailSent = false;
   try {
     const user = domainApp.application.user;
-    const email =
+    const intendedEmail =
       user?.dartmouthEmail ??
       (user?.netId ? `${user.netId}@dartmouth.edu` : null);
     const domainName = targetDomain.displayName ?? targetDomain.name ?? "";
 
-    if (email && user) {
+    // dev/staging: redirect to the test inbox with a banner naming the real
+    // candidate; prod: send to the candidate.
+    const { to, redirectedFrom } = resolveCandidateEmail(intendedEmail);
+
+    if (to && user) {
       const refreshToken = await getApplicationsGmailRefreshToken();
 
       if (refreshToken) {
@@ -170,9 +201,9 @@ export async function action({ request, params }: Route.ActionArgs) {
 
         await sendEmail({
           refreshToken,
-          to: email,
+          to,
           subject,
-          html,
+          html: redirectBannerHtml(redirectedFrom) + html,
         });
         emailSent = true;
       }
@@ -192,7 +223,9 @@ export async function action({ request, params }: Route.ActionArgs) {
       domainApplicationId: decision.domainApplicationId,
       type: released.type,
       emailSent,
-      internConversionApplied,
+      memberPromoted,
+      welcomeNotified,
+      provisioning: provisionResult,
     },
     request,
   });

--- a/dali-api/app/hiring/routes/applications.tsx
+++ b/dali-api/app/hiring/routes/applications.tsx
@@ -21,7 +21,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   if (!auth.ok) return redirect("/login");
   if (auth.user.type === "applicant") return redirect("/portal");
 
-  const { isCore } = await getUserRoles(auth.user.sub);
+  const { isCore, isAdmin, isDomainLead } = await getUserRoles(auth.user.sub);
 
   // Reviewer assignments across all cycles — used both to decide which cycles
   // a reviewer can see and to scope domains within the selected cycle.
@@ -29,6 +29,18 @@ export async function loader({ request }: Route.LoaderArgs) {
     where: { userId: auth.user.sub },
     select: { applicationCycleId: true, domainId: true },
   });
+
+  // Hard gate: a user with no hiring role at all (not Core/Admin/DomainLead and
+  // a reviewer/interviewer on no cycle) has no business here — send them home
+  // rather than showing the "you aren't a reviewer" empty state. (The sidebar
+  // already hides Hiring for them; this stops direct navigation too.)
+  if (!isCore && !isAdmin && !isDomainLead && reviewerRows.length === 0) {
+    const interviewer = await prisma.cycleInterviewer.findFirst({
+      where: { userId: auth.user.sub },
+      select: { id: true },
+    });
+    if (!interviewer) return redirect("/");
+  }
 
   // Cycle dropdown: Core sees every cycle; a reviewer sees only the cycles
   // they're assigned on.

--- a/dali-api/app/lib/candidate-email.ts
+++ b/dali-api/app/lib/candidate-email.ts
@@ -1,0 +1,34 @@
+import { getAppEnv } from "~/lib/app-env";
+
+// Candidate-facing emails (decision + welcome) must never reach real applicants
+// from dev/staging. This centralizes the redirect: in prod the email goes to the
+// intended recipient; otherwise it goes to a single test inbox, and callers add
+// a banner naming who it WOULD have gone to in prod.
+
+export const TEST_INBOX =
+  process.env.ONBOARDING_EMAIL_OVERRIDE ?? "sophie.park@dali.dartmouth.edu";
+
+export type ResolvedRecipient = {
+  // Where the email is actually sent.
+  to: string | null;
+  // In non-prod, the real intended recipient (for the banner); null in prod.
+  redirectedFrom: string | null;
+};
+
+// Resolve the actual send target for a candidate email.
+export function resolveCandidateEmail(intended: string | null): ResolvedRecipient {
+  if (getAppEnv() === "prod") {
+    return { to: intended, redirectedFrom: null };
+  }
+  return { to: TEST_INBOX, redirectedFrom: intended };
+}
+
+// A small HTML banner shown on redirected (non-prod) emails naming the real
+// recipient. Empty string in prod (redirectedFrom is null there).
+export function redirectBannerHtml(redirectedFrom: string | null): string {
+  if (redirectedFrom === null) return "";
+  return `<div style="background:#fff3cd;border:1px solid #ffe69c;padding:8px 12px;border-radius:6px;margin-bottom:12px;font-size:13px;color:#664d03;">
+    ⚠️ <strong>Test environment.</strong> In production this email would have been sent to:
+    <strong>${redirectedFrom || "(no address on file)"}</strong>
+  </div>`;
+}

--- a/dali-api/app/lib/google-workspace.ts
+++ b/dali-api/app/lib/google-workspace.ts
@@ -1,0 +1,126 @@
+import { JWT } from "google-auth-library";
+
+// Google Workspace account provisioning via the Admin SDK Directory API. Used
+// to create a member's @dali.dartmouth.edu account when they're accepted.
+//
+// Auth model: a Google Cloud SERVICE ACCOUNT with DOMAIN-WIDE DELEGATION,
+// impersonating a Workspace super-admin (GOOGLE_WORKSPACE_ADMIN_EMAIL) for the
+// admin.directory.user scope. This is the only way to call the Directory API
+// for a Workspace domain. See dali-api/docs/ONBOARDING_PROVISIONING.md for the
+// one-time setup (service account, delegation, env vars).
+//
+// We call the REST endpoint directly with a JWT access token (google-auth-
+// library is already a dependency; googleapis is not, and we avoid adding it).
+// Everything is gated on the env being present — when unconfigured the caller
+// gets { status: "skipped" } and nothing happens, mirroring the staffing-
+// finalize stub precedent.
+
+const DIRECTORY_USERS_URL =
+  "https://admin.googleapis.com/admin/directory/v1/users";
+const SCOPES = ["https://www.googleapis.com/auth/admin.directory.user"];
+
+export const WORKSPACE_DOMAIN =
+  process.env.GOOGLE_WORKSPACE_DOMAIN ?? "dali.dartmouth.edu";
+
+export type WorkspaceResult =
+  | { status: "ok"; email: string; created: boolean; tempPassword?: string }
+  | { status: "skipped"; message: string }
+  | { status: "error"; message: string };
+
+// Whether the Workspace integration is configured. Cheap; no network.
+export function workspaceConfigured(): boolean {
+  return !!(
+    process.env.GOOGLE_WORKSPACE_SA_EMAIL &&
+    process.env.GOOGLE_WORKSPACE_SA_PRIVATE_KEY &&
+    process.env.GOOGLE_WORKSPACE_ADMIN_EMAIL
+  );
+}
+
+// firstName + lastName -> first.last@<domain>, lowercased, punctuation stripped.
+export function deriveDaliEmail(firstName: string, lastName: string): string {
+  const norm = (s: string) =>
+    s
+      .toLowerCase()
+      .normalize("NFKD")
+      .replace(/[^a-z0-9]+/g, "")
+      .trim();
+  const first = norm(firstName) || "member";
+  const last = norm(lastName);
+  const local = last ? `${first}.${last}` : first;
+  return `${local}@${WORKSPACE_DOMAIN}`;
+}
+
+// 16 url-safe random chars — a throwaway initial password (the account is set
+// to force a password change on first login).
+function tempPassword(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(12));
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+async function getAccessToken(): Promise<string> {
+  // SA private key often arrives with escaped newlines from env; restore them.
+  const key = process.env.GOOGLE_WORKSPACE_SA_PRIVATE_KEY!.replace(/\\n/g, "\n");
+  const jwt = new JWT({
+    email: process.env.GOOGLE_WORKSPACE_SA_EMAIL!,
+    key,
+    scopes: SCOPES,
+    // Domain-wide delegation: act as this Workspace admin.
+    subject: process.env.GOOGLE_WORKSPACE_ADMIN_EMAIL!,
+  });
+  const { access_token } = await jwt.authorize();
+  if (!access_token) throw new Error("No access token from service account.");
+  return access_token;
+}
+
+// Create the member's Workspace account. Idempotent-ish: if the account
+// already exists (409), we treat it as success (created: false). Returns the
+// resolved email so callers can store it / put it in the welcome message.
+export async function provisionWorkspaceAccount(args: {
+  firstName: string;
+  lastName: string;
+  // Optional recovery email (e.g. their Dartmouth address).
+  recoveryEmail?: string | null;
+}): Promise<WorkspaceResult> {
+  if (!workspaceConfigured()) {
+    return {
+      status: "skipped",
+      message: "Google Workspace provisioning is not configured.",
+    };
+  }
+
+  const email = deriveDaliEmail(args.firstName, args.lastName);
+  const password = tempPassword();
+
+  try {
+    const token = await getAccessToken();
+    const res = await fetch(DIRECTORY_USERS_URL, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        primaryEmail: email,
+        name: { givenName: args.firstName, familyName: args.lastName || args.firstName },
+        password,
+        changePasswordAtNextLogin: true,
+        ...(args.recoveryEmail ? { recoveryEmail: args.recoveryEmail } : {}),
+      }),
+    });
+
+    if (res.status === 409) {
+      // Already exists — fine.
+      return { status: "ok", email, created: false };
+    }
+    if (!res.ok) {
+      const body = await res.text();
+      return { status: "error", message: `Directory API ${res.status}: ${body.slice(0, 300)}` };
+    }
+    return { status: "ok", email, created: true, tempPassword: password };
+  } catch (err) {
+    return {
+      status: "error",
+      message: err instanceof Error ? err.message : String(err),
+    };
+  }
+}

--- a/dali-api/app/lib/tasks.ts
+++ b/dali-api/app/lib/tasks.ts
@@ -2,6 +2,7 @@ import type { Prisma } from "~/generated/prisma/client";
 import { prisma } from "~/lib/db";
 import { getActiveCycle } from "~/hiring/lib/cycles";
 import { isInternToFullEligible } from "~/hiring/lib/intern-eligibility";
+import { ONBOARDING_LINK } from "~/members/lib/welcome.server";
 
 // A "task" (todo) is any unread notification — every NotificationKind counts.
 // The Tasks sidebar, Home attention banner, and sidebar count all read this
@@ -166,10 +167,14 @@ export async function listOpenTasks(userId: string): Promise<Task[]> {
         ? `/forms/fill/${n.form.publicToken}`
         : null;
 
-    // A self-clearing action — RSVP (meeting invite) or an attached form —
-    // marks the task read on its own, so no Confirm button. A bare link
-    // doesn't count: opening it isn't the same as being done.
-    const hasAction = !!n.scheduledMeetingId || !!formLink;
+    // A self-clearing action — RSVP (meeting invite), an attached form, or the
+    // onboarding task — marks the task read on its own, so no Confirm button. A
+    // bare link doesn't count: opening it isn't the same as being done. The
+    // onboarding task clears only when the member completes the profile form
+    // (see submitMemberForm), so it must NOT offer a manual Confirm.
+    const isOnboarding =
+      n.kind === "SystemAnnouncement" && n.link === ONBOARDING_LINK;
+    const hasAction = !!n.scheduledMeetingId || !!formLink || isOnboarding;
 
     return {
       id: n.id,

--- a/dali-api/app/members/__tests__/membership.server.test.ts
+++ b/dali-api/app/members/__tests__/membership.server.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("~/lib/db");
+// promoteToMember delegates eligibility to addOrUpdateEligibility — stub it so
+// this test stays focused on the membership upsert behavior.
+vi.mock("~/admin-console/lib/eligibility.server", () => ({
+  addOrUpdateEligibility: vi.fn().mockResolvedValue({ id: "e1" }),
+}));
+
+import { prisma } from "~/lib/db";
+import { promoteToMember } from "~/members/lib/membership.server";
+import { addOrUpdateEligibility } from "~/admin-console/lib/eligibility.server";
+
+const mockPrisma = prisma as unknown as {
+  dALIMember: {
+    findUnique: ReturnType<typeof vi.fn>;
+    create: ReturnType<typeof vi.fn>;
+  };
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (mockPrisma as any).dALIMember = {
+    findUnique: vi.fn(),
+    create: vi.fn().mockResolvedValue({ id: "m1" }),
+  };
+});
+
+describe("promoteToMember", () => {
+  it("creates a DALIMember when none exists", async () => {
+    mockPrisma.dALIMember.findUnique.mockResolvedValue(null);
+    const res = await promoteToMember({ userId: "u1", actorId: "actor" });
+    expect(mockPrisma.dALIMember.create).toHaveBeenCalledWith({
+      data: { userId: "u1" },
+    });
+    expect(res.created).toBe(true);
+  });
+
+  it("is idempotent — no create when the member already exists", async () => {
+    mockPrisma.dALIMember.findUnique.mockResolvedValue({ id: "m1" });
+    const res = await promoteToMember({ userId: "u1", actorId: "actor" });
+    expect(mockPrisma.dALIMember.create).not.toHaveBeenCalled();
+    expect(res.created).toBe(false);
+  });
+
+  it("grants eligibility when a domain + level are given", async () => {
+    mockPrisma.dALIMember.findUnique.mockResolvedValue(null);
+    await promoteToMember({
+      userId: "u1",
+      domainId: "d1",
+      level: "P1",
+      actorId: "actor",
+    });
+    expect(addOrUpdateEligibility).toHaveBeenCalledWith({
+      userId: "u1",
+      domainId: "d1",
+      level: "P1",
+      actorId: "actor",
+    });
+  });
+
+  it("skips eligibility when no domain/level given", async () => {
+    mockPrisma.dALIMember.findUnique.mockResolvedValue({ id: "m1" });
+    await promoteToMember({ userId: "u1", actorId: "actor" });
+    expect(addOrUpdateEligibility).not.toHaveBeenCalled();
+  });
+});

--- a/dali-api/app/members/__tests__/profile-form-interpreter.test.ts
+++ b/dali-api/app/members/__tests__/profile-form-interpreter.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { interpretProfileForm } from "~/members/lib/profile-form-interpreter";
+
+describe("interpretProfileForm", () => {
+  it("maps known profile keys onto User fields", () => {
+    const res = interpretProfileForm({
+      "profile.pronouns": "they/them",
+      "profile.major": "Computer Science",
+      "profile.hometown": "Hanover, NH",
+      "profile.githubUsername": "octocat",
+      "profile.linkedinUrl": "https://linkedin.com/in/x",
+      "profile.photoUrl": "https://x.dev/me.jpg",
+    });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.update).toEqual({
+      pronouns: "they/them",
+      major: "Computer Science",
+      hometown: "Hanover, NH",
+      githubUsername: "octocat",
+      linkedinUrl: "https://linkedin.com/in/x",
+      photoUrl: "https://x.dev/me.jpg",
+    });
+  });
+
+  it("ignores profile.personalSite (field removed)", () => {
+    const res = interpretProfileForm({
+      "profile.major": "Math",
+      "profile.personalSite": "https://x.dev",
+    });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.update).toEqual({ major: "Math" });
+  });
+
+  it("parses a valid class year", () => {
+    const res = interpretProfileForm({ "profile.classYear": "2027" });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.update).toEqual({ classYear: 2027 });
+  });
+
+  it("rejects a non-4-digit class year", () => {
+    const res = interpretProfileForm({ "profile.classYear": "27" });
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error).toMatch(/4-digit/);
+  });
+
+  it("skips blank answers so existing fields aren't wiped", () => {
+    const res = interpretProfileForm({
+      "profile.pronouns": "   ",
+      "profile.major": "",
+      "profile.hometown": "Boston",
+    });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.update).toEqual({ hometown: "Boston" });
+  });
+
+  it("ignores unknown keys", () => {
+    const res = interpretProfileForm({
+      "profile.major": "Math",
+      "q-random": "whatever",
+      somethingElse: "x",
+    });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.update).toEqual({ major: "Math" });
+  });
+
+  it("returns an empty update for no relevant answers", () => {
+    const res = interpretProfileForm({ "q-1": "a", "q-2": "b" });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.update).toEqual({});
+  });
+});

--- a/dali-api/app/members/__tests__/slack-sync.server.test.ts
+++ b/dali-api/app/members/__tests__/slack-sync.server.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("~/lib/db");
+vi.mock("~/slack/lib/slack-client", () => ({
+  lookupSlackUserByEmail: vi.fn(),
+}));
+
+import { prisma } from "~/lib/db";
+import { lookupSlackUserByEmail } from "~/slack/lib/slack-client";
+import { syncSlackUserId } from "~/members/lib/slack-sync.server";
+
+const mockPrisma = prisma as unknown as {
+  user: { findUnique: ReturnType<typeof vi.fn>; update: ReturnType<typeof vi.fn> };
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (mockPrisma as any).user = { findUnique: vi.fn(), update: vi.fn().mockResolvedValue({}) };
+});
+
+describe("syncSlackUserId", () => {
+  it("no-ops when slackUserId is already set", async () => {
+    mockPrisma.user.findUnique.mockResolvedValue({ slackUserId: "U1", daliEmail: "a@x" });
+    const res = await syncSlackUserId("u1");
+    expect(res).toEqual({ status: "ok", slackUserId: "U1" });
+    expect(lookupSlackUserByEmail).not.toHaveBeenCalled();
+    expect(mockPrisma.user.update).not.toHaveBeenCalled();
+  });
+
+  it("resolves + stores the slack id from the dali email", async () => {
+    mockPrisma.user.findUnique.mockResolvedValue({
+      slackUserId: null,
+      daliEmail: "riley@dali.dartmouth.edu",
+      dartmouthEmail: null,
+      personalEmail: null,
+    });
+    vi.mocked(lookupSlackUserByEmail).mockResolvedValue("U9");
+    const res = await syncSlackUserId("u1");
+    expect(lookupSlackUserByEmail).toHaveBeenCalledWith("riley@dali.dartmouth.edu");
+    expect(mockPrisma.user.update).toHaveBeenCalledWith({
+      where: { id: "u1" },
+      data: { slackUserId: "U9" },
+    });
+    expect(res).toEqual({ status: "ok", slackUserId: "U9" });
+  });
+
+  it("falls back to the dartmouth email when dali has no match", async () => {
+    mockPrisma.user.findUnique.mockResolvedValue({
+      slackUserId: null,
+      daliEmail: "riley@dali.dartmouth.edu",
+      dartmouthEmail: "riley@dartmouth.edu",
+      personalEmail: null,
+    });
+    vi.mocked(lookupSlackUserByEmail)
+      .mockResolvedValueOnce(null) // dali — no match
+      .mockResolvedValueOnce("U7"); // dartmouth — match
+    const res = await syncSlackUserId("u1");
+    expect(lookupSlackUserByEmail).toHaveBeenCalledTimes(2);
+    expect(res).toEqual({ status: "ok", slackUserId: "U7" });
+  });
+
+  it("skips when no email resolves to a Slack account", async () => {
+    mockPrisma.user.findUnique.mockResolvedValue({
+      slackUserId: null,
+      daliEmail: "riley@dali.dartmouth.edu",
+      dartmouthEmail: null,
+      personalEmail: null,
+    });
+    vi.mocked(lookupSlackUserByEmail).mockResolvedValue(null);
+    const res = await syncSlackUserId("u1");
+    expect(res).toEqual({ status: "skipped", slackUserId: null });
+    expect(mockPrisma.user.update).not.toHaveBeenCalled();
+  });
+});

--- a/dali-api/app/members/lib/membership.server.ts
+++ b/dali-api/app/members/lib/membership.server.ts
@@ -1,0 +1,40 @@
+import { prisma } from "~/lib/db";
+import { addOrUpdateEligibility } from "~/admin-console/lib/eligibility.server";
+import type { Level } from "~/admin-console/lib/eligibility";
+
+// Promote an existing User to a lab member (DALIMember marker row), optionally
+// granting domain eligibility. Used by:
+//   - the /members directory action (manual add/promote)
+//   - the accepted-applicant release flow (auto-promote on Accepted)
+//
+// Idempotent: re-promoting an existing member is a no-op for membership, and
+// the eligibility grant goes through addOrUpdateEligibility's upsert. A
+// brand-new member's DALIMember starts with a null onboardedAt so the layout
+// gate sends them through /onboarding; an already-onboarded member keeps theirs.
+export async function promoteToMember(args: {
+  userId: string;
+  // When set, grant DomainEligibility at this level in this domain.
+  domainId?: string;
+  level?: Level;
+  // Who triggered the promotion (stamped on the eligibility grant).
+  actorId: string;
+}): Promise<{ created: boolean }> {
+  const existing = await prisma.dALIMember.findUnique({
+    where: { userId: args.userId },
+    select: { id: true },
+  });
+  if (!existing) {
+    await prisma.dALIMember.create({ data: { userId: args.userId } });
+  }
+
+  if (args.domainId && args.level) {
+    await addOrUpdateEligibility({
+      userId: args.userId,
+      domainId: args.domainId,
+      level: args.level,
+      actorId: args.actorId,
+    });
+  }
+
+  return { created: !existing };
+}

--- a/dali-api/app/members/lib/profile-form-interpreter.ts
+++ b/dali-api/app/members/lib/profile-form-interpreter.ts
@@ -1,0 +1,70 @@
+// Maps a "New Member Profile" form submission's answers onto User profile
+// fields. Used by the onboarding flow: an accepted applicant gets a form-backed
+// welcome notification whose form collects their personal info; on submit we
+// interpret the answers into a User update. Pure (no DB/HTTP) so it's fully
+// unit-testable, mirroring projects/lib/bid-form-interpreter.ts.
+//
+// The onboarding form's questions use well-known KEYS (stable across label
+// edits) that map 1:1 to User columns. Unknown keys are ignored; blank answers
+// are skipped (left unchanged on the user) rather than nulling existing data.
+
+// The form is identified by this exact name (created/published once via the
+// /forms builder). submitMemberForm matches on it to apply this interpreter.
+// This name is ALSO the heading the new member sees on the fill page, so it's
+// written as a welcome rather than an internal label.
+export const NEW_MEMBER_PROFILE_FORM_NAME = "Welcome to DALI! 👋";
+
+// Question key -> User string field. The onboarding form must use these keys.
+const STRING_FIELDS: Record<string, string> = {
+  "profile.pronouns": "pronouns",
+  "profile.major": "major",
+  "profile.hometown": "hometown",
+  "profile.photoUrl": "photoUrl",
+  "profile.githubUsername": "githubUsername",
+  "profile.linkedinUrl": "linkedinUrl",
+};
+
+const CLASS_YEAR_KEY = "profile.classYear";
+
+export type ProfileUpdate = {
+  pronouns?: string;
+  major?: string;
+  hometown?: string;
+  photoUrl?: string;
+  githubUsername?: string;
+  linkedinUrl?: string;
+  classYear?: number;
+};
+
+export type ProfileInterpretResult =
+  | { ok: true; update: ProfileUpdate }
+  | { ok: false; error: string };
+
+function asTrimmed(v: unknown): string {
+  return typeof v === "string" ? v.trim() : "";
+}
+
+// Build a User-update partial from the answers. Only non-blank answers are
+// written, so submitting a sparse form never wipes fields the member already
+// has. classYear is validated as a 4-digit year (mirrors members.$id.tsx).
+export function interpretProfileForm(
+  answers: Record<string, unknown>,
+): ProfileInterpretResult {
+  const update: ProfileUpdate = {};
+
+  for (const [key, field] of Object.entries(STRING_FIELDS)) {
+    const value = asTrimmed(answers[key]);
+    if (value !== "") (update as Record<string, unknown>)[field] = value;
+  }
+
+  const classYearRaw = asTrimmed(answers[CLASS_YEAR_KEY]);
+  if (classYearRaw !== "") {
+    const n = Number(classYearRaw);
+    if (!Number.isInteger(n) || n < 1900 || n > 2100) {
+      return { ok: false, error: "Class year must be a 4-digit year." };
+    }
+    update.classYear = n;
+  }
+
+  return { ok: true, update };
+}

--- a/dali-api/app/members/lib/provisioning.server.ts
+++ b/dali-api/app/members/lib/provisioning.server.ts
@@ -1,0 +1,146 @@
+import { prisma } from "~/lib/db";
+import { ensureTeam, addTeamMember } from "~/slack/lib/github-app";
+import { inviteToWorkspace } from "~/slack/lib/slack-client";
+import { provisionWorkspaceAccount, type WorkspaceResult } from "~/lib/google-workspace";
+import { syncSlackUserId } from "~/members/lib/slack-sync.server";
+
+// Best-effort external provisioning for a newly-accepted member. Each step is
+// isolated and idempotent; a failure in one never blocks the others or the
+// acceptance that triggered it. Returns a per-integration status summary the
+// caller records on the audit event.
+//
+// Order matters: the Workspace account (the member's @dali.dartmouth.edu email)
+// is created FIRST, because the Slack invite and the welcome email both target
+// that address. Steps that need it are skipped if Workspace isn't configured.
+//
+// Steps:
+//   - workspace: create the @dali.dartmouth.edu Google account (Admin SDK).
+//   - slack:     invite that email to the workspace (admin token) + announce.
+//   - github:    add the member's GitHub handle to their domain's org team.
+
+type StepStatus = { status: "ok" | "skipped" | "error"; message: string };
+export type ProvisionResult = {
+  workspace: StepStatus;
+  slack: StepStatus;
+  github: StepStatus;
+  // The provisioned DALI email, when Workspace ran — so callers (welcome email)
+  // can tell the member which address to log in with.
+  daliEmail: string | null;
+};
+
+function errMsg(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}
+
+// Org team slug for a domain. Domains don't carry a githubTeamSlug column (only
+// Projects do), so derive a stable slug from the domain's code/name.
+function domainTeamSlug(domain: { code?: string | null; name: string }): string {
+  const base = (domain.code ?? domain.name).toLowerCase();
+  return base.replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+}
+
+function toStep(w: WorkspaceResult): StepStatus {
+  if (w.status === "ok") {
+    return { status: "ok", message: `${w.created ? "Created" : "Exists"}: ${w.email}` };
+  }
+  return { status: w.status, message: w.message };
+}
+
+export async function provisionNewMember(args: {
+  userId: string;
+  domainId: string;
+}): Promise<ProvisionResult> {
+  const user = await prisma.user.findUnique({
+    where: { id: args.userId },
+    select: {
+      firstName: true,
+      lastName: true,
+      githubUsername: true,
+      daliEmail: true,
+      dartmouthEmail: true,
+    },
+  });
+  const domain = await prisma.domain.findUnique({
+    where: { id: args.domainId },
+    select: { name: true, displayName: true, code: true },
+  });
+
+  const result: ProvisionResult = {
+    workspace: { status: "skipped", message: "" },
+    slack: { status: "skipped", message: "" },
+    github: { status: "skipped", message: "" },
+    daliEmail: user?.daliEmail ?? null,
+  };
+
+  // ── workspace: create the @dali.dartmouth.edu account ───────────────────
+  let daliEmail = user?.daliEmail ?? null;
+  if (user) {
+    const w = await provisionWorkspaceAccount({
+      firstName: user.firstName,
+      lastName: user.lastName,
+      recoveryEmail: user.dartmouthEmail,
+    });
+    result.workspace = toStep(w);
+    if (w.status === "ok") {
+      daliEmail = w.email;
+      result.daliEmail = w.email;
+      // Persist the new DALI email onto the User so login + future flows use it.
+      if (!user.daliEmail || user.daliEmail !== w.email) {
+        try {
+          await prisma.user.update({
+            where: { id: args.userId },
+            data: { daliEmail: w.email },
+          });
+        } catch {
+          // A unique-collision here shouldn't fail provisioning; leave as-is.
+        }
+      }
+    }
+  }
+
+  // ── slack: invite the new member to the workspace + sync slackUserId ─────
+  // On acceptance the member isn't staffed onto any project yet, so we just
+  // invite them into the workspace — they land in #general (resolved by name in
+  // inviteToWorkspace) — and sync their Slack id. The per-project welcome
+  // announcement happens later, on staffing finalize, in each project's own
+  // channel — there's no lab-wide announcement here.
+  try {
+    const parts: string[] = [];
+    if (daliEmail) {
+      // No channel passed → inviteToWorkspace defaults to #general.
+      const inv = await inviteToWorkspace(daliEmail, []);
+      parts.push(`invite: ${inv.message}`);
+    } else {
+      parts.push("invite: skipped (no DALI email)");
+    }
+    // Resolve + store the member's Slack user id so per-project channel invites
+    // (staffing finalize) can add them by id later.
+    const sync = await syncSlackUserId(args.userId);
+    parts.push(`slack id: ${sync.status}`);
+    result.slack = { status: "ok", message: parts.join("; ") };
+  } catch (err) {
+    result.slack = { status: "error", message: errMsg(err) };
+  }
+
+  // ── github: add member to their domain's org team ───────────────────────
+  if (!process.env.GITHUB_ORG) {
+    result.github = { status: "skipped", message: "GITHUB_ORG not set." };
+  } else if (!user?.githubUsername?.trim()) {
+    result.github = { status: "skipped", message: "Member has no GitHub username yet." };
+  } else if (!domain) {
+    result.github = { status: "skipped", message: "Domain not found." };
+  } else {
+    try {
+      const team = await ensureTeam(domainTeamSlug(domain));
+      await addTeamMember(team.slug, user.githubUsername.trim());
+      result.github = {
+        status: "ok",
+        message: `Added ${user.githubUsername.trim()} to team "${team.slug}".`,
+      };
+    } catch (err) {
+      result.github = { status: "error", message: errMsg(err) };
+    }
+  }
+
+  return result;
+}

--- a/dali-api/app/members/lib/slack-sync.server.ts
+++ b/dali-api/app/members/lib/slack-sync.server.ts
@@ -1,0 +1,45 @@
+import { prisma } from "~/lib/db";
+import { lookupSlackUserByEmail } from "~/slack/lib/slack-client";
+
+// Resolve and persist a member's Slack user id from their email, so later
+// channel invites (staffing finalize) can add them by id. Tries their DALI
+// email first, then Dartmouth/personal. Best-effort + idempotent: leaves
+// slackUserId untouched if no Slack account matches or it's already set.
+//
+// Called as an onboarding/provisioning step. The lookup needs the bot token's
+// users:read.email scope; without it (or no Slack account) we simply no-op.
+export async function syncSlackUserId(
+  userId: string,
+): Promise<{ status: "ok" | "skipped"; slackUserId: string | null }> {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: {
+      slackUserId: true,
+      daliEmail: true,
+      dartmouthEmail: true,
+      personalEmail: true,
+    },
+  });
+  if (!user) return { status: "skipped", slackUserId: null };
+  if (user.slackUserId) {
+    return { status: "ok", slackUserId: user.slackUserId };
+  }
+
+  const emails = [user.daliEmail, user.dartmouthEmail, user.personalEmail].filter(
+    (e): e is string => !!e,
+  );
+  for (const email of emails) {
+    const slackId = await lookupSlackUserByEmail(email);
+    if (slackId) {
+      try {
+        await prisma.user.update({ where: { id: userId }, data: { slackUserId: slackId } });
+      } catch {
+        // Unique collision (another user already mapped to this slack id) —
+        // leave as-is rather than failing the onboarding step.
+        return { status: "skipped", slackUserId: null };
+      }
+      return { status: "ok", slackUserId: slackId };
+    }
+  }
+  return { status: "skipped", slackUserId: null };
+}

--- a/dali-api/app/members/lib/welcome.server.ts
+++ b/dali-api/app/members/lib/welcome.server.ts
@@ -1,0 +1,124 @@
+import { prisma } from "~/lib/db";
+import { sendEmail } from "~/lib/gmail";
+import { getApplicationsGmailRefreshToken } from "~/lib/gmail-integration";
+import { resolveCandidateEmail, redirectBannerHtml } from "~/lib/candidate-email";
+
+// The onboarding task points here; also used as the dedupe/clear key.
+export const ONBOARDING_LINK = "/onboarding";
+
+// Welcome a newly-promoted member: drop a persistent "finish onboarding" todo
+// notification (links to /onboarding) and send a welcome email. Both are
+// best-effort — a failure here must never block the acceptance/release that
+// triggered it, so callers wrap this in try/catch (and it swallows its own
+// email errors too).
+//
+// Idempotent: re-running creates another notification only if the member has no
+// open onboarding todo, so a re-release won't spam them.
+
+// Mark a member's onboarding task read so it drops out of their task list. Call
+// this when onboarding is finished (onboardedAt set). Idempotent.
+export async function clearOnboardingTask(userId: string): Promise<void> {
+  await prisma.notification.updateMany({
+    where: {
+      recipientUserId: userId,
+      kind: "SystemAnnouncement",
+      link: ONBOARDING_LINK,
+      readAt: null,
+    },
+    data: { readAt: new Date() },
+  });
+}
+
+export async function sendWelcome(args: {
+  userId: string;
+  actorId: string;
+  // For the email greeting + the address to send to. Email is skipped when null.
+  firstName: string;
+  email: string | null;
+  // The member's newly-provisioned @dali.dartmouth.edu login email, if any —
+  // folded into the welcome email so they know which account to log in with.
+  daliEmail?: string | null;
+}): Promise<{ notified: boolean; emailSent: boolean }> {
+  // The onboarding task links to the /onboarding checklist (the profile form is
+  // one step within it). It is a plain todo — NOT form-backed — so submitting
+  // the profile form alone doesn't clear it; it stays until onboarding is fully
+  // finished (clearOnboardingTask, called when onboardedAt is set).
+  let notified = false;
+  // Don't re-notify on a re-release: only create if there's no existing
+  // onboarding todo for this member.
+  const existing = await prisma.notification.findFirst({
+    where: {
+      recipientUserId: args.userId,
+      kind: "SystemAnnouncement",
+      link: ONBOARDING_LINK,
+    },
+    select: { id: true },
+  });
+  if (!existing) {
+    await prisma.notification.create({
+      data: {
+        recipientUserId: args.userId,
+        createdByUserId: args.actorId,
+        kind: "SystemAnnouncement",
+        title: "Welcome to DALI — finish onboarding",
+        body: "Complete a few quick steps to finish setting up your account.",
+        isTodo: true,
+        link: ONBOARDING_LINK,
+      },
+    });
+    notified = true;
+  }
+
+  let emailSent = false;
+  try {
+    // In dev/staging this is redirected to a test inbox (with a banner naming
+    // the real intended recipient); in prod it goes to the member.
+    const { to, redirectedFrom } = resolveCandidateEmail(args.email);
+    if (to) {
+      const refreshToken = await getApplicationsGmailRefreshToken();
+      if (refreshToken) {
+        const base = (process.env.FRONTEND_URL ?? "").replace(/\/$/, "");
+        await sendEmail({
+          refreshToken,
+          to,
+          subject: "Welcome to the DALI Lab",
+          html: welcomeHtml(
+            args.firstName,
+            `${base}${ONBOARDING_LINK}`,
+            args.daliEmail ?? null,
+            redirectedFrom,
+          ),
+        });
+        emailSent = true;
+      }
+    }
+  } catch (err) {
+    // Best-effort: a welcome-email failure must not block release.
+    console.error("Failed to send welcome email:", err);
+  }
+
+  return { notified, emailSent };
+}
+
+function welcomeHtml(
+  firstName: string,
+  onboardingUrl: string,
+  daliEmail: string | null,
+  // Non-prod only: the real recipient this email was redirected away from.
+  redirectedFrom: string | null,
+): string {
+  const safeName = firstName || "there";
+  const banner = redirectBannerHtml(redirectedFrom);
+  const loginLine = daliEmail
+    ? `<p>Your DALI account is ready. <strong>Log in to DALI OS with your new DALI email: ${daliEmail}</strong> (you'll be asked to set a password on first login).</p>`
+    : `<p>Your DALI account is ready.</p>`;
+  return `
+    ${banner}
+    <p>Hi ${safeName},</p>
+    <p>Welcome to the DALI Lab!</p>
+    ${loginLine}
+    <p>Once you're in, finish setting up by completing your member profile and onboarding steps.</p>
+    <p><a href="${onboardingUrl}">Complete your onboarding</a></p>
+    <p>— The DALI Lab</p>
+  `;
+}

--- a/dali-api/app/members/routes/members.tsx
+++ b/dali-api/app/members/routes/members.tsx
@@ -13,6 +13,7 @@ import { requireAuth } from "~/lib/auth";
 import { isCore } from "~/lib/roles";
 import { requestOpenTabIfEmbedded } from "~/components/workspace-link";
 import { prisma } from "~/lib/db";
+import { promoteToMember } from "~/members/lib/membership.server";
 import { initialsFromName } from "~/lib/display";
 import { resolvePhotoUrl } from "~/lib/photo";
 import { ViewToggle, useViewPreference } from "~/components/ViewToggle";
@@ -214,9 +215,7 @@ export async function action({ request }: Route.ActionArgs) {
   if (existing) {
     // The User already exists — promote them to a lab member rather than
     // erroring out, then send the editor to their profile.
-    if (!existing.daliMember) {
-      await prisma.dALIMember.create({ data: { userId: existing.id } });
-    }
+    await promoteToMember({ userId: existing.id, actorId: auth.user.sub });
     return redirect(`/members/${existing.id}`);
   }
 

--- a/dali-api/app/projects/components/BidModal.tsx
+++ b/dali-api/app/projects/components/BidModal.tsx
@@ -23,6 +23,15 @@ const LEVEL_LABEL: Record<Level, string> = {
   P3: "P3 · Mentor",
 };
 
+// One project's bid, collapsed across the StaffingPreference rows it expanded
+// into: best rank, the distinct domain·level combos, and the first note found.
+type ProjectBid = {
+  projectId: string;
+  rank: number;
+  notes: string | null;
+  combos: { domainId: string; level: Level }[];
+};
+
 export function BidModal({
   open,
   onClose,
@@ -33,7 +42,27 @@ export function BidModal({
   domainNames,
   currentProjectId,
 }: BidModalProps) {
-  const sorted = [...preferences].sort((a, b) => a.preferenceRank - b.preferenceRank);
+  // A single bid expands server-side into one StaffingPreference row per
+  // (domain, level) the project + member resolve to, so the same project can
+  // appear in several rows. Collapse to one row per project — best (lowest)
+  // rank wins the heading, and each domain·level combo shows as a chip.
+  const byProject = new Map<string, ProjectBid>();
+  for (const p of preferences) {
+    const existing = byProject.get(p.projectId);
+    if (existing) {
+      existing.rank = Math.min(existing.rank, p.preferenceRank);
+      existing.combos.push({ domainId: p.domainId, level: p.level });
+      if (!existing.notes && p.notes) existing.notes = p.notes;
+    } else {
+      byProject.set(p.projectId, {
+        projectId: p.projectId,
+        rank: p.preferenceRank,
+        notes: p.notes,
+        combos: [{ domainId: p.domainId, level: p.level }],
+      });
+    }
+  }
+  const sorted = [...byProject.values()].sort((a, b) => a.rank - b.rank);
   return (
     <Modal
       open={open}
@@ -76,7 +105,7 @@ export function BidModal({
                   const isCurrent = p.projectId === currentProjectId;
                   return (
                     <li
-                      key={`${p.projectId}:${p.domainId}`}
+                      key={p.projectId}
                       className={`border rounded-md p-3 ${
                         isCurrent
                           ? "border-accent-coral bg-accent-coral/5"
@@ -85,11 +114,18 @@ export function BidModal({
                     >
                       <div className="flex items-baseline justify-between gap-2 flex-wrap">
                         <span className="font-semibold text-foreground">
-                          #{p.preferenceRank} · {projectNames[p.projectId] ?? p.projectId}
+                          #{p.rank} · {projectNames[p.projectId] ?? p.projectId}
                         </span>
-                        <span className="text-xs text-muted-foreground">
-                          {domainNames[p.domainId] ?? p.domainId} · {LEVEL_LABEL[p.level]}
-                        </span>
+                      </div>
+                      <div className="flex flex-wrap gap-1 mt-2">
+                        {p.combos.map((c) => (
+                          <span
+                            key={`${c.domainId}:${c.level}`}
+                            className="inline-flex items-center px-1.5 py-0.5 text-[11px] font-medium rounded bg-muted text-foreground"
+                          >
+                            {domainNames[c.domainId] ?? c.domainId} · {LEVEL_LABEL[c.level]}
+                          </span>
+                        ))}
                       </div>
                       {p.notes && (
                         <p className="text-sm text-muted-foreground mt-2 whitespace-pre-wrap">

--- a/dali-api/app/projects/components/StaffingBoard.tsx
+++ b/dali-api/app/projects/components/StaffingBoard.tsx
@@ -280,9 +280,9 @@ function Column({
       ref={setNodeRef}
       className={`flex-shrink-0 w-64 border rounded-lg ${toneClasses[tone]} ${
         isOver ? "ring-2 ring-accent-coral/40" : ""
-      } flex flex-col`}
+      } flex flex-col max-h-[calc(100vh-12rem)]`}
     >
-      <div className="px-3 py-2 border-b border-border">
+      <div className="px-3 py-2 border-b border-border flex-shrink-0">
         <div className="flex items-center gap-1.5">
           <div className="text-sm font-semibold text-foreground truncate flex-1" title={title}>
             {title}
@@ -314,9 +314,15 @@ function Column({
           </div>
         )}
       </div>
-      <div className="flex flex-col gap-2 p-2 min-h-[28rem]">
+      {/* Only the card list scrolls; the header above stays pinned. flex-1 +
+          min-h-0 lets it shrink within the column's max-height so overflow-y
+          kicks in instead of stretching the page. */}
+      <div className="flex flex-col gap-2 p-2 flex-1 min-h-0 overflow-y-auto">
         {cards.length === 0 ? (
-          <div className="text-xs text-muted-foreground italic text-center py-4">Empty</div>
+          // min-h keeps an empty column a usable drop target.
+          <div className="text-xs text-muted-foreground italic text-center py-4 min-h-[12rem]">
+            Empty
+          </div>
         ) : (
           cards.map((card) => (
             <MemberCard

--- a/dali-api/app/projects/routes/api.staffing.finalize.ts
+++ b/dali-api/app/projects/routes/api.staffing.finalize.ts
@@ -3,7 +3,7 @@ import { prisma } from "~/lib/db";
 import { requireAuth } from "~/lib/auth";
 import { canManageStaffing } from "~/lib/roles";
 import { withCors, handlePreflight } from "~/lib/cors";
-import { postMessage } from "~/slack/lib/slack-client";
+import { postMessage, ensureChannel, inviteUsersToChannel } from "~/slack/lib/slack-client";
 import { ensureTeam, addTeamMember } from "~/slack/lib/github-app";
 import { logAuditEvent } from "~/lib/audit";
 
@@ -16,7 +16,10 @@ import { logAuditEvent } from "~/lib/audit";
 // Automations:
 //   - assignments: Proposed StaffingAssignment rows for this project+cycle →
 //     Confirmed, and upsert canonical ProjectAssignment + DomainEligibility.
-//   - slack:       post the confirmed roster to STAFFING_SLACK_CHANNEL.
+//   - slack:       get-or-create the project's own Slack channel (named after
+//                  the project, id cached on Project.slackChannelId), invite
+//                  the confirmed roster (by synced slackUserId), and post a team
+//                  announcement (members + domain/level, plus repos).
 //   - gmail:       STUB — no Google Admin SDK wired up yet.
 //   - github:      get-or-create the project's GITHUB_ORG team (from
 //                  Project.githubTeamSlug) and add the confirmed roster.
@@ -81,7 +84,7 @@ export async function action({ request }: Route.ActionArgs) {
   }
   const project = await prisma.project.findUnique({
     where: { id: body.projectId },
-    select: { id: true, name: true, githubTeamSlug: true },
+    select: { id: true, name: true, githubTeamSlug: true, slackChannelId: true, repoUrls: true },
   });
   if (!project) {
     return withCors(request, Response.json({ error: "Project not found" }, { status: 404 }));
@@ -157,33 +160,78 @@ export async function action({ request }: Route.ActionArgs) {
   }
 
   // ── slack ──────────────────────────────────────────────────────────────────
+  // Per-project channel: get-or-create one named after the project, invite the
+  // confirmed roster (by their synced slackUserId), and post a team
+  // announcement (each member's domain + level, plus the project's repos). The
+  // channel id is reused across runs (stored on Project.slackChannelId).
   if (selected.has("slack")) {
-    const channel = process.env.STAFFING_SLACK_CHANNEL;
-    if (!channel) {
-      results.slack = {
-        status: "skipped",
-        message: "STAFFING_SLACK_CHANNEL not set.",
-      };
+    if (!process.env.SLACK_BOT_TOKEN) {
+      results.slack = { status: "skipped", message: "SLACK_BOT_TOKEN not set." };
     } else {
       try {
-        // Roster reflects confirmed rows regardless of whether the
-        // assignments step ran this invocation.
+        // Confirmed roster with level + slack id, regardless of whether the
+        // assignments step ran this invocation. StaffingAssignment has no domain
+        // RELATION (only domainId), so resolve display names separately.
         const roster = await prisma.staffingAssignment.findMany({
-          where: {
-            staffingCycleId: cycle.id,
-            projectId: project.id,
-            status: "Confirmed",
+          where: { staffingCycleId: cycle.id, projectId: project.id, status: "Confirmed" },
+          select: {
+            level: true,
+            domainId: true,
+            user: { select: { firstName: true, lastName: true, slackUserId: true } },
           },
-          select: { user: { select: { firstName: true, lastName: true } }, level: true },
         });
-        const lines = roster
-          .map((r) => `• ${r.user.firstName} ${r.user.lastName} (${r.level})`)
-          .join("\n");
+        const domainNames = new Map(
+          (
+            await prisma.domain.findMany({
+              where: { id: { in: [...new Set(roster.map((r) => r.domainId))] } },
+              select: { id: true, displayName: true },
+            })
+          ).map((d) => [d.id, d.displayName]),
+        );
+
+        // 1. Resolve the channel: reuse the stored id, else create one from the
+        //    project name and backfill the id for next time.
+        let channelId = project.slackChannelId;
+        let channelNote = "reused channel";
+        if (!channelId) {
+          const ch = await ensureChannel(project.name);
+          channelId = ch.id;
+          channelNote = ch.created ? `created #${ch.name}` : `found #${ch.name}`;
+          await prisma.project.update({
+            where: { id: project.id },
+            data: { slackChannelId: channelId },
+          });
+        }
+
+        // 2. Invite confirmed members who have a synced Slack id.
+        const slackIds = roster
+          .map((r) => r.user.slackUserId)
+          .filter((id): id is string => !!id);
+        const missing = roster.length - slackIds.length;
+        const inv = await inviteUsersToChannel(channelId, slackIds);
+
+        // 3. Announce the team: name — domain (level), plus repos.
+        // Only call out mentors (P3); P1/P2 just show their role/domain without
+        // a level label.
+        const lines = roster.map((r) => {
+          const role = domainNames.get(r.domainId) ?? "?";
+          const suffix = r.level === "P3" ? " (Mentor)" : "";
+          return `• ${r.user.firstName} ${r.user.lastName} — ${role}${suffix}`;
+        });
+        const repoLines = (project.repoUrls ?? []).map((u) => `• ${u}`);
         const text =
-          `*${project.name}* staffed for ${cycle.name}\n` +
-          (roster.length > 0 ? lines : "_No confirmed members yet._");
-        await postMessage(channel, text);
-        results.slack = { status: "ok", message: `Posted roster (${roster.length}) to Slack.` };
+          `*${project.name}* is staffed for ${cycle.name}! :tada:\n\n` +
+          `*Team*\n${lines.length > 0 ? lines.join("\n") : "_No confirmed members yet._"}` +
+          (repoLines.length > 0 ? `\n\n*Repos*\n${repoLines.join("\n")}` : "");
+        await postMessage(channelId, text);
+
+        const parts = [
+          channelNote,
+          `invited ${inv.invited}`,
+          `announced ${roster.length} member(s)`,
+        ];
+        if (missing > 0) parts.push(`${missing} without a synced Slack id`);
+        results.slack = { status: "ok", message: `${parts.join("; ")}.` };
       } catch (err) {
         results.slack = { status: "error", message: errMsg(err) };
       }

--- a/dali-api/app/routes.ts
+++ b/dali-api/app/routes.ts
@@ -5,6 +5,7 @@ export default [
   layout("routes/layout.tsx", [
     index("routes/home.tsx"),
     route("profile", "routes/profile.tsx"),
+    route("onboarding", "routes/onboarding.tsx"),
     route("calendar", "calendar/routes/calendar.tsx"),
 
     // Hiring section
@@ -167,6 +168,7 @@ export default [
   // Groups (admin) and notifications (per-user + admin send)
   route("api/groups", "admin-console/routes/api.groups.ts"),
   route("api/groups/:groupId", "admin-console/routes/api.groups.$groupId.ts"),
+  route("api/tour/complete", "routes/api.tour.complete.ts"),
   route("api/notifications", "routes/api.notifications.ts"),
   route("api/notifications/send", "admin-console/routes/api.notifications.send.ts"),
   route("api/notifications/:id/read", "routes/api.notifications.$id.read.ts"),

--- a/dali-api/app/routes/api.notifications.$id.read.ts
+++ b/dali-api/app/routes/api.notifications.$id.read.ts
@@ -2,6 +2,7 @@ import type { Route } from "./+types/api.notifications.$id.read";
 import { prisma } from "~/lib/db";
 import { requireAuth } from "~/lib/auth";
 import { withCors, handlePreflight } from "~/lib/cors";
+import { ONBOARDING_LINK } from "~/members/lib/welcome.server";
 
 export async function action({ request, params }: Route.ActionArgs) {
   const preflight = handlePreflight(request);
@@ -17,7 +18,13 @@ export async function action({ request, params }: Route.ActionArgs) {
   const id = params.id!;
   const existing = await prisma.notification.findUnique({
     where: { id },
-    select: { recipientUserId: true, readAt: true, scheduledMeetingId: true },
+    select: {
+      recipientUserId: true,
+      readAt: true,
+      scheduledMeetingId: true,
+      kind: true,
+      link: true,
+    },
   });
   if (!existing) {
     return withCors(request, Response.json({ error: "Not found" }, { status: 404 }));
@@ -31,6 +38,13 @@ export async function action({ request, params }: Route.ActionArgs) {
   // must not dismiss it, so it stays a todo until an Accept/Maybe/Decline.
   if (existing.scheduledMeetingId) {
     return withCors(request, Response.json({ ok: true, skipped: "meeting-invite" }));
+  }
+
+  // The onboarding task is the same: opening /onboarding must not dismiss it.
+  // It clears only when onboarding is actually finished (clearOnboardingTask,
+  // from the /onboarding "Finish" action), so it persists across visits.
+  if (existing.kind === "SystemAnnouncement" && existing.link === ONBOARDING_LINK) {
+    return withCors(request, Response.json({ ok: true, skipped: "onboarding" }));
   }
 
   if (existing.readAt) {

--- a/dali-api/app/routes/api.notifications.ts
+++ b/dali-api/app/routes/api.notifications.ts
@@ -4,6 +4,7 @@ import { requireAuth } from "~/lib/auth";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { listOpenTasks } from "~/lib/tasks";
 import { listMyNotifications } from "~/lib/notifications";
+import { ONBOARDING_LINK } from "~/members/lib/welcome.server";
 
 export async function loader({ request }: Route.LoaderArgs) {
   const preflight = handlePreflight(request);
@@ -38,14 +39,15 @@ export async function action({ request }: Route.ActionArgs) {
     return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));
   }
 
-  // POST with no id = "mark all read". Meeting invites are excluded: they
-  // clear only when the recipient RSVPs (Accept/Maybe/Decline), never on a
-  // blanket read.
+  // POST with no id = "mark all read". Excluded: meeting invites (clear only on
+  // RSVP) and the onboarding task (clears only when onboarding is finished), so
+  // neither is dismissed by a blanket read.
   await prisma.notification.updateMany({
     where: {
       recipientUserId: auth.user.sub,
       readAt: null,
       scheduledMeetingId: null,
+      NOT: { kind: "SystemAnnouncement", link: ONBOARDING_LINK },
     },
     data: { readAt: new Date() },
   });

--- a/dali-api/app/routes/api.tour.complete.ts
+++ b/dali-api/app/routes/api.tour.complete.ts
@@ -1,0 +1,21 @@
+import type { Route } from "./+types/api.tour.complete";
+import { prisma } from "~/lib/db";
+import { requireAuth } from "~/lib/auth";
+
+// Mark the launch tour completed for the current member so it isn't auto-shown
+// again (server-driven, per-user). Called when the member finishes or dismisses
+// the tour. Idempotent. A manual "start tour" button can still re-run it later;
+// this only governs the automatic post-onboarding show.
+export async function action({ request }: Route.ActionArgs) {
+  const auth = await requireAuth(request);
+  if (!auth.ok) return Response.json({ error: "Unauthorized" }, { status: 401 });
+  if (request.method !== "POST") {
+    return Response.json({ error: "Method not allowed" }, { status: 405 });
+  }
+
+  await prisma.dALIMember.updateMany({
+    where: { userId: auth.user.sub, tourCompletedAt: null },
+    data: { tourCompletedAt: new Date() },
+  });
+  return Response.json({ ok: true });
+}

--- a/dali-api/app/routes/forms.fill.$token.tsx
+++ b/dali-api/app/routes/forms.fill.$token.tsx
@@ -1,12 +1,12 @@
-import { useState } from "react";
 import { redirect, useLoaderData } from "react-router";
 import type { Route } from "./+types/forms.fill.$token";
 import { requireAuth } from "~/lib/auth";
 import { requireMember } from "~/lib/roles";
 import { loadPublicForm } from "~/forms/lib/public-form";
-import { ChallengeQuestionField } from "~/hiring/components/ChallengeQuestionField";
-import { RichTextViewer, isEmptyDoc } from "~/components/RichTextViewer";
-import type { Question } from "~/types";
+import {
+  MemberFormFillView,
+  MemberFormShell,
+} from "~/forms/components/MemberFormFillView";
 
 export const meta: Route.MetaFunction = ({ data }) => [
   { title: `${(data as { name?: string })?.name ?? "Form"} · DALI OS` },
@@ -35,133 +35,9 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 
 export default function MemberFormFill() {
   const data = useLoaderData<typeof loader>();
-  const [answers, setAnswers] = useState<Record<string, string>>({});
-  const [state, setState] = useState<"idle" | "submitting" | "done">("idle");
-  const [error, setError] = useState<string | null>(null);
-
-  const questions: Question[] = data.questions;
-
-  function set(key: string, v: string) {
-    setAnswers((a) => ({ ...a, [key]: v }));
-  }
-
-  async function submit(e: React.FormEvent) {
-    e.preventDefault();
-    setError(null);
-    for (const q of questions) {
-      if (!q.required || q.type === "file") continue;
-      if (!answers[q.key]?.trim()) {
-        setError(`"${q.data.label}" is required.`);
-        return;
-      }
-    }
-    setState("submitting");
-    try {
-      const res = await fetch(`/api/forms/fill/${data.token}`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        credentials: "include",
-        body: JSON.stringify({ versionId: data.versionId, answers }),
-      });
-      const out = (await res.json().catch(() => ({}))) as { error?: string };
-      if (!res.ok) {
-        setError(out.error ?? `Submission failed (${res.status}).`);
-        setState("idle");
-        return;
-      }
-      setState("done");
-    } catch {
-      setError("Network error — please try again.");
-      setState("idle");
-    }
-  }
-
-  if (state === "done") {
-    return (
-      <Shell>
-        <div className="text-center py-10">
-          <h1 className="font-heading text-xl font-bold text-dark-blue">
-            Submitted
-          </h1>
-          <p className="text-sm text-muted-foreground mt-2">
-            Your response to “{data.name}” has been recorded.
-          </p>
-        </div>
-      </Shell>
-    );
-  }
-
   return (
-    <Shell>
-      <h1 className="font-heading text-2xl font-bold text-dark-blue">
-        {data.name}
-      </h1>
-      {data.description && !isEmptyDoc(data.description) && (
-        <div className="mt-2 text-sm text-muted-foreground">
-          <RichTextViewer content={data.description} />
-        </div>
-      )}
-
-      {error && (
-        <div className="mt-4 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
-          {error}
-        </div>
-      )}
-
-      <form onSubmit={submit} className="mt-6 flex flex-col gap-5">
-        {questions.map((q) => (
-          <div key={q.key}>
-            <label className="block text-sm font-medium text-dark-blue mb-1">
-              {q.data.label}
-              {q.required && <span className="text-destructive"> *</span>}
-            </label>
-            {q.data.description && (
-              <p className="text-xs text-muted-foreground mb-1.5">
-                {q.data.description}
-              </p>
-            )}
-            {q.type === "file" ? (
-              <div className="text-xs text-muted-foreground italic border border-dashed border-border rounded-md px-3 py-2">
-                File uploads aren’t available here.
-              </div>
-            ) : (
-              <ChallengeQuestionField
-                question={q}
-                value={answers[q.key] ?? ""}
-                onChange={(v) => set(q.key, v)}
-              />
-            )}
-          </div>
-        ))}
-
-        <button
-          type="submit"
-          disabled={state === "submitting"}
-          className="self-start px-4 py-2 text-sm font-medium rounded-lg bg-accent-coral text-white hover:bg-accent-coral/90 disabled:opacity-60 transition-colors"
-        >
-          {state === "submitting" ? "Submitting…" : "Submit"}
-        </button>
-      </form>
-    </Shell>
-  );
-}
-
-function Shell({ children }: { children: React.ReactNode }) {
-  return (
-    <div className="min-h-screen bg-section-bg p-4 sm:p-8 pt-10 sm:pt-16">
-      <div className="mx-auto max-w-2xl bg-card border border-border rounded-xl p-6 sm:p-8">
-        <div className="flex items-center gap-2 mb-6">
-          <div className="w-7 h-7 bg-accent-coral rounded-md flex items-center justify-center">
-            <span className="text-white font-bold text-base leading-none font-heading">
-              D
-            </span>
-          </div>
-          <span className="font-heading text-sm font-bold text-dark-blue">
-            DALI OS
-          </span>
-        </div>
-        {children}
-      </div>
-    </div>
+    <MemberFormShell>
+      <MemberFormFillView data={data} />
+    </MemberFormShell>
   );
 }

--- a/dali-api/app/routes/layout.tsx
+++ b/dali-api/app/routes/layout.tsx
@@ -14,6 +14,11 @@ export async function loader({ request }: Route.LoaderArgs) {
   const auth = await requireAuth(request)
   if (!auth.ok) return redirect('/login')
   if (auth.user.type === 'applicant') return redirect('/portal')
+
+  // Onboarding is NOT a hard gate: a new member can use the whole app freely.
+  // Their onboarding lives as a persistent task (the welcome notification) that
+  // links to /onboarding and only clears once they finish. See welcome.server.
+
   const {
     isLabMember,
     isCore: core,
@@ -34,13 +39,43 @@ export async function loader({ request }: Route.LoaderArgs) {
     }
   }
 
+  // Whether to show the Hiring tab at all. Core/Admin/DomainLead always; other
+  // lab members only if they're a reviewer or interviewer on ANY cycle (not
+  // just the active one — a reviewer on a past/future cycle still needs in).
+  let hasHiringAccess = core || admin || domainLead
+  if (!hasHiringAccess && isLabMember) {
+    const [reviewer, interviewer] = await Promise.all([
+      prisma.cycleReviewer.findFirst({ where: { userId: auth.user.sub }, select: { id: true } }),
+      prisma.cycleInterviewer.findFirst({ where: { userId: auth.user.sub }, select: { id: true } }),
+    ])
+    hasHiringAccess = reviewer !== null || interviewer !== null
+  }
+
   // Drives the sidebar footer avatar. The loader runs on every shell
-  // load/revalidation, so this stays in sync after a profile edit.
+  // load/revalidation, so this stays in sync after a profile edit. Also tells
+  // the launch tour whether to offer the "connect your calendar" step.
   const me = await prisma.user.findUnique({
     where: { id: auth.user.sub },
-    select: { photoUrl: true },
+    select: {
+      photoUrl: true,
+      calendarLinks: {
+        where: { provider: "Google", enabled: true },
+        select: { id: true },
+        take: 1,
+      },
+      daliMember: { select: { onboardedAt: true, tourCompletedAt: true } },
+    },
   })
   const photoUrl = await resolvePhotoUrl(me?.photoUrl)
+  const hasCalendarLink = (me?.calendarLinks.length ?? 0) > 0
+
+  // Auto-show the launch tour once per USER (server-driven, not browser
+  // localStorage): a member who has finished onboarding but not yet completed
+  // the tour. Established members were backfilled (tourCompletedAt set), so only
+  // the just-onboarded get it. A manual "start tour" button can re-run it later
+  // regardless of this flag.
+  const shouldShowTour =
+    !!me?.daliMember?.onboardedAt && me.daliMember.tourCompletedAt === null
 
   // Detect iframe context from Sec-Fetch-Dest. Modern browsers (Chrome, Firefox,
   // Safari 16+) set this automatically and it survives server-side redirects,
@@ -55,11 +90,11 @@ export async function loader({ request }: Route.LoaderArgs) {
     sessionId: auth.sessionId,
   })
 
-  return { user: auth.user, photoUrl, isCore: core, isAdmin: admin, isDomainLead: domainLead, canViewForms, canViewStaffing, isInterviewer, isEmbedded }
+  return { user: auth.user, photoUrl, hasCalendarLink, shouldShowTour, isCore: core, isAdmin: admin, isDomainLead: domainLead, canViewForms, canViewStaffing, isInterviewer, hasHiringAccess, isEmbedded }
 }
 
 export default function AppLayoutRoute() {
-  const { user, photoUrl, isCore, isAdmin, isDomainLead, canViewForms, canViewStaffing, isInterviewer, isEmbedded } = useLoaderData<typeof loader>()
+  const { user, photoUrl, hasCalendarLink, shouldShowTour, isCore, isAdmin, isDomainLead, canViewForms, canViewStaffing, isInterviewer, hasHiringAccess, isEmbedded } = useLoaderData<typeof loader>()
   const [searchParams] = useSearchParams()
   const location = useLocation()
   const navigate = useNavigate()
@@ -199,8 +234,8 @@ export default function AppLayoutRoute() {
 
   return (
     <>
-      <Layout user={user} photoUrl={photoUrl} isCore={isCore} isAdmin={isAdmin} isDomainLead={isDomainLead} canViewForms={canViewForms} canViewStaffing={canViewStaffing} isInterviewer={isInterviewer} />
-      <LaunchWelcome firstName={user.firstName || user.email.split('@')[0]} />
+      <Layout user={user} photoUrl={photoUrl} isCore={isCore} isAdmin={isAdmin} isDomainLead={isDomainLead} canViewForms={canViewForms} canViewStaffing={canViewStaffing} isInterviewer={isInterviewer} hasHiringAccess={hasHiringAccess} />
+      <LaunchWelcome firstName={user.firstName || user.email.split('@')[0]} hasCalendarLink={hasCalendarLink} shouldShowTour={shouldShowTour} />
     </>
   )
 }

--- a/dali-api/app/routes/onboarding.tsx
+++ b/dali-api/app/routes/onboarding.tsx
@@ -1,0 +1,72 @@
+// Onboarding IS the "Welcome to DALI! 👋" profile form, rendered INLINE here —
+// no cross-URL redirect, so the embedded workspace tab's URL (/onboarding)
+// matches its content (avoids the tab-identity race that surfaced other pages).
+// Submitting the form writes the member's profile, stamps DALIMember.onboardedAt,
+// and clears the onboarding task (see submitMemberForm in public-form.ts).
+// Everything else happens in earlier provisioning (DALI email, Slack invite) or
+// the later party tour (calendar, app install, MCP). Already-onboarded members
+// or non-members are sent home so the form never shows to established members.
+
+import type { Route } from "./+types/onboarding";
+import { redirect, useLoaderData } from "react-router";
+import { requireAuth } from "~/lib/auth";
+import { prisma } from "~/lib/db";
+import { loadPublicForm } from "~/forms/lib/public-form";
+import {
+  MemberFormFillView,
+  MemberFormShell,
+} from "~/forms/components/MemberFormFillView";
+import { NEW_MEMBER_PROFILE_FORM_NAME } from "~/members/lib/profile-form-interpreter";
+
+export const meta: Route.MetaFunction = () => [{ title: "Welcome · DALI OS" }];
+
+export async function loader({ request }: Route.LoaderArgs) {
+  const auth = await requireAuth(request);
+  if (!auth.ok) return redirect("/login");
+  if (auth.user.type === "applicant") return redirect("/portal");
+
+  const member = await prisma.dALIMember.findUnique({
+    where: { userId: auth.user.sub },
+    select: { onboardedAt: true },
+  });
+  // Only un-onboarded members belong here; everyone else goes home.
+  if (!member || member.onboardedAt !== null) {
+    return redirect("/");
+  }
+
+  // Resolve the onboarding form's token, then load it the same way the fill
+  // route does so we render an identical form inline (no redirect).
+  const profileForm = await prisma.form.findFirst({
+    where: { name: NEW_MEMBER_PROFILE_FORM_NAME, published: true },
+    orderBy: { createdAt: "desc" },
+    select: { publicToken: true },
+  });
+  const form = profileForm?.publicToken
+    ? await loadPublicForm(profileForm.publicToken, auth.user.sub)
+    : null;
+
+  return {
+    form: form ? { ...form, token: profileForm!.publicToken! } : null,
+  };
+}
+
+export default function OnboardingPage({ loaderData }: Route.ComponentProps) {
+  const { form } = useLoaderData<typeof loader>();
+  return (
+    <MemberFormShell>
+      {form ? (
+        <MemberFormFillView data={form} />
+      ) : (
+        <div className="py-10 text-center">
+          <h1 className="font-heading text-xl font-bold text-dark-blue">
+            Welcome to DALI!
+          </h1>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Your onboarding form isn't available yet. Please check back shortly,
+            or ask a lead if this persists.
+          </p>
+        </div>
+      )}
+    </MemberFormShell>
+  );
+}

--- a/dali-api/app/routes/profile.tsx
+++ b/dali-api/app/routes/profile.tsx
@@ -12,6 +12,7 @@ import { prisma } from "~/lib/db";
 import { getUserRoles, currentTerm } from "~/lib/roles";
 import { resolvePhotoUrl } from "~/lib/photo";
 import { userInitials } from "~/lib/display";
+import { NEW_MEMBER_PROFILE_FORM_NAME } from "~/members/lib/profile-form-interpreter";
 import type { Route } from "./+types/profile";
 
 export const meta: Route.MetaFunction = () => [{ title: "Profile · DALI OS" }];
@@ -22,6 +23,33 @@ export async function loader({ request }: Route.LoaderArgs) {
   if (auth.user.type === "applicant") return redirect("/portal");
 
   const userId = auth.user.sub;
+
+  // A member still in onboarding (onboardedAt null) who hasn't filled out the
+  // "New Member Profile" form yet is sent to it before they can view their
+  // profile page. Established members (onboardedAt backfilled by the migration)
+  // are NOT redirected even if they predate this form. Once a member submits
+  // the form, this falls through to the normal read-only profile view.
+  const membership = await prisma.dALIMember.findUnique({
+    where: { userId },
+    select: { onboardedAt: true },
+  });
+  if (membership && membership.onboardedAt === null) {
+    const profileForm = await prisma.form.findFirst({
+      where: { name: NEW_MEMBER_PROFILE_FORM_NAME, published: true },
+      select: { publicToken: true },
+    });
+    if (profileForm?.publicToken) {
+      const submitted = await prisma.formSubmission.count({
+        where: {
+          userId,
+          form: { name: NEW_MEMBER_PROFILE_FORM_NAME },
+        },
+      });
+      if (submitted === 0) {
+        return redirect(`/forms/fill/${profileForm.publicToken}`);
+      }
+    }
+  }
   const [user, roles, term] = await Promise.all([
     prisma.user.findUnique({
       where: { id: userId },

--- a/dali-api/app/slack/lib/slack-client.ts
+++ b/dali-api/app/slack/lib/slack-client.ts
@@ -77,3 +77,135 @@ export async function getPermalink(channel: string, ts: string): Promise<string 
   const res = await client().chat.getPermalink({ channel, message_ts: ts });
   return res.permalink ?? null;
 }
+
+// Invite an email to the Slack workspace. admin.users.invite requires an
+// ADMIN token (admin.users:write scope) on an Enterprise Grid / Business+
+// workspace — distinct from SLACK_BOT_TOKEN. Provide it as SLACK_ADMIN_TOKEN.
+// Gated: returns "skipped" when no admin token / team id is configured rather
+// than throwing, so onboarding works without it.
+export async function inviteToWorkspace(
+  email: string,
+  channelIds: string[],
+): Promise<{ status: "ok" | "skipped" | "error"; message: string }> {
+  const token = process.env.SLACK_ADMIN_TOKEN;
+  const teamId = process.env.SLACK_TEAM_ID;
+  if (!token || !teamId) {
+    return { status: "skipped", message: "SLACK_ADMIN_TOKEN / SLACK_TEAM_ID not set." };
+  }
+  // admin.users.invite requires a channel id. Default to the workspace's
+  // #general channel (resolved by name) when the caller passes none — new
+  // members always land in general on acceptance.
+  let ids = channelIds;
+  if (ids.length === 0) {
+    const general = await findChannelByName("general");
+    if (!general) {
+      return { status: "skipped", message: "Could not resolve #general channel for invite." };
+    }
+    ids = [general.id];
+  }
+  try {
+    const admin = new WebClient(token);
+    await admin.admin.users.invite({
+      team_id: teamId,
+      email,
+      channel_ids: ids as [string, ...string[]],
+    });
+    return { status: "ok", message: `Invited ${email} to Slack.` };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    // already_in_team / already_invited are benign.
+    if (/already_(in_team|invited)/.test(msg)) {
+      return { status: "ok", message: `${email} already in Slack.` };
+    }
+    return { status: "error", message: msg };
+  }
+}
+
+// Resolve a Slack user id from an email via users.lookupByEmail (needs the bot
+// token's users:read.email scope). Returns null when the email isn't a Slack
+// user or the scope/token is missing — callers treat that as "no Slack account
+// yet" rather than an error. Used by the onboarding Slack-account sync.
+export async function lookupSlackUserByEmail(email: string): Promise<string | null> {
+  if (!process.env.SLACK_BOT_TOKEN) return null;
+  try {
+    const res = await client().users.lookupByEmail({ email });
+    return res.user?.id ?? null;
+  } catch {
+    // users_not_found / missing_scope / etc. — no id resolvable.
+    return null;
+  }
+}
+
+// Get-or-create a public channel and return its id + final name. Slack lowercases
+// and sanitizes channel names; we pre-sanitize so the stored name matches. If a
+// channel with that name already exists, Slack returns name_taken — we resolve
+// the existing channel's id instead of failing. Needs channels:manage (create)
+// and channels:read (resolve existing).
+export async function ensureChannel(
+  name: string,
+): Promise<{ id: string; name: string; created: boolean }> {
+  const safe = sanitizeChannelName(name);
+  try {
+    const res = await client().conversations.create({ name: safe });
+    const id = res.channel?.id;
+    if (!id) throw new Error("conversations.create returned no channel id");
+    return { id, name: res.channel?.name ?? safe, created: true };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (/name_taken/.test(msg)) {
+      const existing = await findChannelByName(safe);
+      if (existing) return { ...existing, created: false };
+    }
+    throw err;
+  }
+}
+
+// Invite Slack user ids to a channel. Slack's conversations.invite takes up to
+// ~1000 users per call; we pass them comma-joined. already_in_channel and
+// not_in_channel-type errors for some users are benign and don't fail the rest.
+export async function inviteUsersToChannel(
+  channelId: string,
+  userIds: string[],
+): Promise<{ invited: number; skipped: number }> {
+  const unique = [...new Set(userIds.filter(Boolean))];
+  if (unique.length === 0) return { invited: 0, skipped: 0 };
+  try {
+    await client().conversations.invite({ channel: channelId, users: unique.join(",") });
+    return { invited: unique.length, skipped: 0 };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    // If everyone's already in, that's success; otherwise surface the count.
+    if (/already_in_channel/.test(msg)) return { invited: 0, skipped: unique.length };
+    throw err;
+  }
+}
+
+function sanitizeChannelName(name: string): string {
+  // Slack channel names: lowercase, no spaces/periods, ≤80 chars, hyphens ok.
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80);
+}
+
+async function findChannelByName(
+  name: string,
+): Promise<{ id: string; name: string } | null> {
+  // Page through public channels to find an exact name match. Small workspaces
+  // resolve in one page; we cap at a few pages to bound the call.
+  let cursor: string | undefined;
+  for (let i = 0; i < 10; i++) {
+    const res = await client().conversations.list({
+      exclude_archived: true,
+      types: "public_channel",
+      limit: 1000,
+      cursor,
+    });
+    const match = (res.channels ?? []).find((c) => c.name === name);
+    if (match?.id) return { id: match.id, name: match.name ?? name };
+    cursor = res.response_metadata?.next_cursor || undefined;
+    if (!cursor) break;
+  }
+  return null;
+}

--- a/dali-api/docs/ONBOARDING_PROVISIONING.md
+++ b/dali-api/docs/ONBOARDING_PROVISIONING.md
@@ -1,0 +1,109 @@
+# Onboarding & acceptance provisioning — setup
+
+When a hiring applicant is **accepted** (a Final decision is released), the
+release path (`app/hiring/routes/api.decisions.$id.release.ts`) runs this
+pipeline:
+
+1. **Promote to member** + grant `DomainEligibility` P1 (always).
+2. **Provision** (`app/members/lib/provisioning.server.ts`):
+   - **Google Workspace** — create the member's `@dali.dartmouth.edu` account.
+   - **Slack** — invite that DALI email to the workspace + announce to a channel.
+   - **GitHub** — add the member's GitHub handle to their domain's org team.
+3. **Welcome** (`app/members/lib/welcome.server.ts`):
+   - A persistent **onboarding task** (the New Member Profile form). It clears
+     only when the member submits the form — that submission also stamps
+     `DALIMember.onboardedAt`.
+   - A **welcome email** that tells them to log in with their new DALI email.
+4. After onboarding, the **party tour** (`LaunchWelcome`) offers calendar
+   connect (only if not already linked), app install, MCP, etc.
+
+**Every external step is best-effort and env-gated.** When a step's
+configuration is missing it reports `skipped` and the acceptance still
+succeeds — nothing here blocks a release. So the code ships safely with none of
+the below configured; configure each to turn the real integration on.
+
+---
+
+## Email recipient override (dev/staging)
+
+Welcome/onboarding emails go to the **real candidate only in prod**
+(`getAppEnv() === "prod"`). In dev/staging they're redirected to a test inbox.
+
+| Env var | Default | Notes |
+|---|---|---|
+| `ONBOARDING_EMAIL_OVERRIDE` | `sophie.park@dali.dartmouth.edu` | dev/staging test inbox |
+| `FRONTEND_URL` | — | base URL for the onboarding link in the email |
+
+Email sending also needs the existing **`GmailIntegration`** row (the
+`applications@…` service account) — set up via `/admin/authorize-gmail`. Without
+it, emails are skipped (`emailSent=false`) but everything else proceeds.
+
+---
+
+## Google Workspace account creation — **action required**
+
+Creating an `@dali.dartmouth.edu` account uses the **Admin SDK Directory API**,
+which requires a Google **service account with domain-wide delegation**. None of
+this exists yet — here's the one-time setup:
+
+1. In Google Cloud, create (or reuse) a **service account**. Note its email and
+   create a **JSON key**; you'll use the `client_email` and `private_key`.
+2. Enable the **Admin SDK API** for that project.
+3. In the **Google Workspace Admin console** → Security → API controls →
+   **Domain-wide delegation**, add the service account's **client ID** with the
+   scope: `https://www.googleapis.com/auth/admin.directory.user`.
+4. Pick a **Workspace super-admin** account for the service account to
+   impersonate (delegation requires acting *as* an admin).
+5. Set these env vars (Fly secrets in dev/staging/prod):
+
+| Env var | Example | Notes |
+|---|---|---|
+| `GOOGLE_WORKSPACE_SA_EMAIL` | `prov@…iam.gserviceaccount.com` | service account `client_email` |
+| `GOOGLE_WORKSPACE_SA_PRIVATE_KEY` | `-----BEGIN PRIVATE KEY-----\n…` | the key; literal `\n` is fine, it's unescaped at runtime |
+| `GOOGLE_WORKSPACE_ADMIN_EMAIL` | `admin@dali.dartmouth.edu` | the super-admin to impersonate |
+| `GOOGLE_WORKSPACE_DOMAIN` | `dali.dartmouth.edu` | optional; defaults to this |
+
+Behavior once set: a new member gets `first.last@dali.dartmouth.edu` created with
+a random temp password and **forced password change on first login**; that email
+is stored on `User.daliEmail`. Already-exists (409) is treated as success.
+Until configured, this step reports `skipped`.
+
+Code: `app/lib/google-workspace.ts` (uses `google-auth-library`, already a
+dependency — no `googleapis` needed).
+
+---
+
+## Slack invite — **action required**
+
+`admin.users.invite` requires an **admin-scoped token** (`admin.users:write`) on
+a **Business+ / Enterprise Grid** workspace — distinct from the bot token.
+
+| Env var | Notes |
+|---|---|
+| `SLACK_ADMIN_TOKEN` | admin token with `admin.users:write` |
+| `SLACK_TEAM_ID` | the workspace/team id to invite into |
+| `STAFFING_SLACK_CHANNEL` | channel the new member is invited into + announced to |
+
+Until set, the invite reports `skipped`; the channel announcement still posts if
+`SLACK_BOT_TOKEN` + `STAFFING_SLACK_CHANNEL` are present (existing behavior).
+
+---
+
+## GitHub team — already wired
+
+Reuses the existing GitHub App (`GITHUB_ORG`, `GITHUB_APP_*`). On acceptance the
+member's `User.githubUsername` (collected on the profile form, optional) is added
+to their domain's org team (slug derived from the domain code). Skipped when the
+org isn't set or the member has no GitHub username.
+
+---
+
+## The New Member Profile form
+
+Onboarding *is* this form. It must exist and be **published** with question keys
+matching `app/members/lib/profile-form-interpreter.ts`
+(`profile.pronouns`, `profile.classYear`, `profile.major`, `profile.hometown`,
+`profile.githubUsername`, `profile.linkedinUrl`). The seed
+`prisma/seeds/accepted-applicants.ts` creates/publishes it (and re-versions it on
+drift). In a fresh environment, run that seed once (or build the form in `/forms`
+named exactly **"New Member Profile"** and publish it).

--- a/dali-api/prisma/migrations/20260529000000_dalimember_onboarded_at/migration.sql
+++ b/dali-api/prisma/migrations/20260529000000_dalimember_onboarded_at/migration.sql
@@ -1,0 +1,9 @@
+-- Track first-login onboarding completion on DALIMember. Null = not yet
+-- onboarded; the layout loader redirects such members to /onboarding.
+ALTER TABLE "DALIMember" ADD COLUMN "onboardedAt" TIMESTAMP(3);
+
+-- Backfill existing members so they are NOT forced through onboarding: treat
+-- everyone who is already a member as having onboarded at their join time.
+-- Only members created from now on (e.g. via accepted-applicant promotion)
+-- start with a null onboardedAt and go through the flow.
+UPDATE "DALIMember" SET "onboardedAt" = "createdAt" WHERE "onboardedAt" IS NULL;

--- a/dali-api/prisma/migrations/20260530000000_dalimember_tour_completed_at/migration.sql
+++ b/dali-api/prisma/migrations/20260530000000_dalimember_tour_completed_at/migration.sql
@@ -1,0 +1,12 @@
+-- Track launch-tour completion per member (server-driven, not browser
+-- localStorage). Null = not yet completed → the tour is shown once after
+-- onboarding. Backfill existing members to now() so they don't suddenly get
+-- the tour; only members onboarding from here on will see it.
+ALTER TABLE "DALIMember" ADD COLUMN "tourCompletedAt" TIMESTAMP(3);
+
+-- Only suppress the tour for members who are ALREADY onboarded. Members still
+-- mid-onboarding (onboardedAt IS NULL — e.g. freshly accepted) keep a null
+-- tourCompletedAt so they get the tour after they finish onboarding.
+UPDATE "DALIMember"
+  SET "tourCompletedAt" = "createdAt"
+  WHERE "tourCompletedAt" IS NULL AND "onboardedAt" IS NOT NULL;

--- a/dali-api/prisma/migrations/20260530010000_project_slack_channel/migration.sql
+++ b/dali-api/prisma/migrations/20260530010000_project_slack_channel/migration.sql
@@ -1,0 +1,5 @@
+-- Per-project Slack channel id (e.g. "C0123ABC"). The channel NAME is derived
+-- from the project name; the staffing finalize automation get-or-creates that
+-- channel, backfills this id, then invites confirmed members + posts the team
+-- announcement. Null = the channel step hasn't run yet. Nullable.
+ALTER TABLE "Project" ADD COLUMN "slackChannelId" TEXT;

--- a/dali-api/prisma/schema.prisma
+++ b/dali-api/prisma/schema.prisma
@@ -167,6 +167,18 @@ model DALIMember {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
+  // Null until the member finishes the first-login onboarding flow
+  // (/onboarding). The layout loader redirects members with a null value into
+  // onboarding. Pre-existing members are backfilled to createdAt by the
+  // migration so they're never forced through it.
+  onboardedAt DateTime?
+
+  // Null until the member finishes (or dismisses) the launch tour. The tour is
+  // shown once per USER (server-driven, not browser localStorage) on the first
+  // home visit after onboarding. Pre-existing members are backfilled so they
+  // don't suddenly get the tour.
+  tourCompletedAt DateTime?
+
   userId String @unique
   user   User   @relation(fields: [userId], references: [id])
 }
@@ -1844,6 +1856,13 @@ model Project {
   // teams" finalize automation get-or-creates a team with this slug under
   // GITHUB_ORG and adds the confirmed roster. Null = automation skips.
   githubTeamSlug String?
+
+  // The project's Slack channel id (e.g. "C0123ABC"), used to invite members +
+  // post the team announcement on staffing finalize. The channel NAME is always
+  // derived from the project name (slugified); finalize get-or-creates that
+  // channel and backfills this id so it's reused on later runs. Null until the
+  // first finalize that runs the Slack channel step.
+  slackChannelId String?
 
   overviewPage Page? @relation("ProjectOverview", fields: [overviewPageId], references: [id])
   prdPage      Page? @relation("ProjectPRD", fields: [prdPageId], references: [id])

--- a/dali-api/prisma/seeds/accepted-applicants.ts
+++ b/dali-api/prisma/seeds/accepted-applicants.ts
@@ -1,0 +1,219 @@
+// Seed a few "just accepted" applicants as NEW MEMBERS who still need to
+// onboard, then run the real welcome path (form-backed profile todo + welcome
+// email). This exercises the same helpers the acceptance-release flow uses
+// (promoteToMember + sendWelcome), so the seeded members land in exactly the
+// state a freshly-accepted applicant would: DALIMember with onboardedAt=null,
+// P1 eligibility in a domain, and a "complete your profile" notification.
+//
+// Welcome emails are redirected to a single inbox by welcome.server's
+// ONBOARDING_EMAIL_OVERRIDE (defaults to sophie.park@dali.dartmouth.edu), so
+// running this won't email the seeded fake people.
+//
+// Idempotent: users are upserted by daliEmail; promoteToMember and sendWelcome
+// are themselves idempotent (no duplicate member rows or duplicate welcome
+// notifications on re-run).
+//
+// Usage:
+//   npx tsx --env-file .env prisma/seeds/accepted-applicants.ts
+import { PrismaClient } from "../../app/generated/prisma/client.js";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { promoteToMember } from "../../app/members/lib/membership.server.js";
+import { sendWelcome } from "../../app/members/lib/welcome.server.js";
+import { NEW_MEMBER_PROFILE_FORM_NAME } from "../../app/members/lib/profile-form-interpreter.js";
+
+const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL! });
+const prisma = new PrismaClient({ adapter });
+
+// The onboarding "New Member Profile" form. Its question KEYS must match the
+// interpreter (profile-form-interpreter.ts) so submitting writes User fields.
+const PROFILE_QUESTIONS = [
+  {
+    key: "profile.pronouns",
+    type: "select",
+    required: true,
+    data: {
+      label: "Pronouns",
+      options: ["she/her", "he/him", "they/them", "she/they", "he/they", "Prefer not to say", "Other"],
+    },
+  },
+  { key: "profile.classYear", type: "text", required: true, data: { label: "Class year (e.g. 2027)" } },
+  { key: "profile.major", type: "text", required: true, data: { label: "Major" } },
+  { key: "profile.hometown", type: "text", required: false, data: { label: "Hometown" } },
+  { key: "profile.githubUsername", type: "text", required: false, data: { label: "GitHub username" } },
+  { key: "profile.linkedinUrl", type: "text", required: false, data: { label: "LinkedIn URL" } },
+];
+
+// Welcoming subtitle shown under the form heading (stored as a ProseMirror doc
+// JSON string in FormVersion.intro; rendered by RichTextViewer on the fill
+// page). The heading itself is the form name ("Welcome to DALI! 👋").
+const PROFILE_INTRO = JSON.stringify({
+  type: "doc",
+  content: [
+    {
+      type: "paragraph",
+      content: [
+        {
+          type: "text",
+          text: "We're so glad you're here. Tell us a bit about yourself to finish setting up your account.",
+        },
+      ],
+    },
+  ],
+});
+
+function newPublicToken(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(24));
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+// Create + publish the profile form, keeping its questions in sync with
+// PROFILE_QUESTIONS (idempotent by name). Consumers read the LATEST version, so
+// when the questions change we add a new version; otherwise nothing changes.
+async function ensureProfileForm(createdById: string): Promise<void> {
+  const existing = await prisma.form.findFirst({
+    where: { name: NEW_MEMBER_PROFILE_FORM_NAME },
+    select: {
+      id: true,
+      published: true,
+      publicToken: true,
+      versions: {
+        orderBy: { versionNumber: "desc" },
+        take: 1,
+        select: { versionNumber: true, questions: true, intro: true },
+      },
+    },
+  });
+
+  if (!existing) {
+    await prisma.form.create({
+      data: {
+        name: NEW_MEMBER_PROFILE_FORM_NAME,
+        createdById,
+        published: true,
+        publicToken: newPublicToken(),
+        versions: {
+          create: {
+            versionNumber: 1,
+            questions: PROFILE_QUESTIONS,
+            intro: PROFILE_INTRO,
+            createdById,
+          },
+        },
+      },
+    });
+    return;
+  }
+
+  const latest = existing.versions[0];
+  const drifted =
+    !latest ||
+    JSON.stringify(latest.questions) !== JSON.stringify(PROFILE_QUESTIONS) ||
+    latest.intro !== PROFILE_INTRO;
+  if (drifted) {
+    await prisma.formVersion.create({
+      data: {
+        formId: existing.id,
+        versionNumber: (latest?.versionNumber ?? 0) + 1,
+        questions: PROFILE_QUESTIONS,
+        intro: PROFILE_INTRO,
+        createdById,
+      },
+    });
+  }
+  if (!existing.published || !existing.publicToken) {
+    await prisma.form.update({
+      where: { id: existing.id },
+      data: { published: true, publicToken: existing.publicToken ?? newPublicToken() },
+    });
+  }
+}
+
+// (firstName, lastName, domain code to grant eligibility in)
+const ACCEPTED = [
+  { firstName: "Riley", lastName: "Chen", domainCode: "Fullstack" },
+  { firstName: "Jordan", lastName: "Okafor", domainCode: "UIUX" },
+  { firstName: "Sam", lastName: "Alvarez", domainCode: "PM" },
+];
+
+function emailFor(first: string, last: string): string {
+  return `${first}.${last}.seed@dali.dartmouth.edu`.toLowerCase();
+}
+
+async function main() {
+  // An actor to stamp promotedBy / notification author. Prefer a real admin;
+  // fall back to any user so the FK is valid.
+  const actor =
+    (await prisma.adminMembership.findFirst({ select: { userId: true } }))
+      ?.userId ??
+    (await prisma.user.findFirst({ select: { id: true } }))?.id ??
+    null;
+
+  // Publish the onboarding profile form so the welcome path can attach it.
+  if (actor) {
+    await ensureProfileForm(actor);
+    console.log(`  ✓ "${NEW_MEMBER_PROFILE_FORM_NAME}" form ensured + published`);
+  }
+
+  let seeded = 0;
+  for (const person of ACCEPTED) {
+    const email = emailFor(person.firstName, person.lastName);
+
+    const domain = await prisma.domain.findUnique({
+      where: { code: person.domainCode },
+      select: { id: true, displayName: true },
+    });
+    if (!domain) {
+      console.warn(`  ⊘ domain "${person.domainCode}" not found — run the v0-reference seed first. Skipping ${person.firstName}.`);
+      continue;
+    }
+
+    // Upsert the user (idempotent by daliEmail).
+    const user = await prisma.user.upsert({
+      where: { daliEmail: email },
+      update: { firstName: person.firstName, lastName: person.lastName },
+      create: {
+        firstName: person.firstName,
+        lastName: person.lastName,
+        daliEmail: email,
+      },
+      select: { id: true, firstName: true },
+    });
+
+    // Promote to member + grant P1 eligibility (same as accepted release).
+    // promoteToMember leaves onboardedAt null for a new member, so the layout
+    // gate will route them through /onboarding.
+    await promoteToMember({
+      userId: user.id,
+      domainId: domain.id,
+      level: "P1",
+      actorId: actor ?? user.id,
+    });
+
+    // Run the real welcome path: form-backed profile todo + welcome email
+    // (redirected to the override inbox).
+    const { notified, emailSent } = await sendWelcome({
+      userId: user.id,
+      actorId: actor ?? user.id,
+      firstName: user.firstName,
+      email, // overridden by welcome.server to the test inbox
+    });
+
+    console.log(
+      `  ✓ ${person.firstName} ${person.lastName} — member + ${domain.displayName} P1; ` +
+        `welcome notified=${notified}, emailSent=${emailSent}`,
+    );
+    seeded++;
+  }
+
+  console.log(`\nSeeded ${seeded}/${ACCEPTED.length} accepted applicants (needing onboarding).`);
+  if (seeded > 0) {
+    console.log("Log in as one of them (or check the override inbox) to see the onboarding flow.");
+  }
+}
+
+main()
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());

--- a/dali-api/prisma/seeds/releasable-accepted.ts
+++ b/dali-api/prisma/seeds/releasable-accepted.ts
@@ -1,0 +1,168 @@
+// Seed a few applicants with a FINAL Accepted decision in an existing cycle, so
+// you can exercise the full release → onboarding pipeline from the hiring-lead
+// UI: open the cycle's decisions, click "Release" on one of these, and watch
+// promote → provision → welcome (email goes to sophie.park in dev/staging).
+//
+// Attaches to the "Fall 2026" cycle (cycle-fall-2026), which already has the
+// Accepted email-template binding + a bound confidentiality agreement. We also
+// add the missing confidentiality SIGNATURE for the releasing admin (otherwise
+// release 403s).
+//
+// Idempotent: users upserted by dartmouthEmail; application upserted by the
+// (user, cycle) unique; we only create a Final decision if the applicant has no
+// existing decision yet.
+//
+// Usage:
+//   npx tsx --env-file .env prisma/seeds/releasable-accepted.ts
+import { PrismaClient } from "../../app/generated/prisma/client.js";
+import { PrismaPg } from "@prisma/adapter-pg";
+
+const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL! });
+const prisma = new PrismaClient({ adapter });
+
+const CYCLE_ID = "cycle-fall-2026";
+
+// (first, last, domain code). Dartmouth email is derived; it's only the
+// nominal recipient — in dev/staging the welcome email is redirected to
+// sophie.park by welcome.server.
+const APPLICANTS = [
+  { firstName: "Nadia", lastName: "Brooks", domainCode: "Fullstack" },
+  { firstName: "Theo", lastName: "Nguyen", domainCode: "UIUX" },
+  { firstName: "Priya", lastName: "Raman", domainCode: "PM" },
+];
+
+function netIdFor(first: string, last: string): string {
+  return `${first}.${last}.cand`.toLowerCase();
+}
+
+async function main() {
+  const cycle = await prisma.applicationCycle.findUnique({
+    where: { id: CYCLE_ID },
+    select: { id: true, name: true },
+  });
+  if (!cycle) throw new Error(`Cycle ${CYCLE_ID} not found — run the base seed first.`);
+
+  // The releasing hiring lead: an admin. They must have signed the cycle's
+  // confidentiality agreement or release 403s.
+  const admin = await prisma.adminMembership.findFirst({
+    select: { userId: true, user: { select: { firstName: true } } },
+  });
+  if (!admin) throw new Error("No admin user found to act as releaser.");
+
+  const binding = await prisma.cycleConfidentialityAgreement.findUnique({
+    where: { applicationCycleId: CYCLE_ID },
+    select: { confidentialityAgreementVersionId: true },
+  });
+  if (binding) {
+    const existingSig = await prisma.confidentialityAgreementSignature.findFirst({
+      where: { applicationCycleId: CYCLE_ID, userId: admin.userId },
+      select: { id: true },
+    });
+    if (!existingSig) {
+      await prisma.confidentialityAgreementSignature.create({
+        data: {
+          userId: admin.userId,
+          applicationCycleId: CYCLE_ID,
+          confidentialityAgreementVersionId: binding.confidentialityAgreementVersionId,
+        },
+      });
+      console.log(`  ✓ signed confidentiality for releaser (${admin.user.firstName})`);
+    }
+  }
+
+  let made = 0;
+  for (const a of APPLICANTS) {
+    const domain = await prisma.domain.findUnique({
+      where: { code: a.domainCode },
+      select: { id: true, displayName: true },
+    });
+    if (!domain) {
+      console.warn(`  ⊘ domain "${a.domainCode}" not found — skipping ${a.firstName}.`);
+      continue;
+    }
+
+    const netId = netIdFor(a.firstName, a.lastName);
+    const dartmouthEmail = `${netId}@dartmouth.edu`;
+
+    // Applicant User (no daliEmail yet — that's created at acceptance/provision).
+    const user = await prisma.user.upsert({
+      where: { netId },
+      update: { firstName: a.firstName, lastName: a.lastName, dartmouthEmail },
+      create: { netId, firstName: a.firstName, lastName: a.lastName, dartmouthEmail },
+      select: { id: true },
+    });
+
+    // Application for this cycle (unique on user+cycle).
+    const application = await prisma.application.upsert({
+      where: { userId_applicationCycleId: { userId: user.id, applicationCycleId: CYCLE_ID } },
+      update: {},
+      create: {
+        userId: user.id,
+        applicationCycleId: CYCLE_ID,
+        answers: {},
+        applicationType: "Standard",
+      },
+      select: { id: true },
+    });
+
+    // DomainApplication (domain linked directly so release can resolve it).
+    let domainApp = await prisma.domainApplication.findFirst({
+      where: { applicationId: application.id, domainId: domain.id },
+      select: { id: true },
+    });
+    if (!domainApp) {
+      domainApp = await prisma.domainApplication.create({
+        data: { applicationId: application.id, domainId: domain.id, answers: {}, selected: true },
+        select: { id: true },
+      });
+    }
+
+    // A FINAL Accepted decision, ready for the UI's Release button. Only create
+    // if this domain app has no decision yet (so re-running doesn't pile them up).
+    const existingDecision = await prisma.decision.findFirst({
+      where: { domainApplicationId: domainApp.id },
+      select: { id: true },
+    });
+    if (!existingDecision) {
+      const draft = await prisma.decision.create({
+        data: {
+          domainApplicationId: domainApp.id,
+          type: "Accepted",
+          stage: "Draft",
+          madeById: admin.userId,
+        },
+        select: { id: true },
+      });
+      await prisma.decision.create({
+        data: {
+          domainApplicationId: domainApp.id,
+          type: "Accepted",
+          stage: "Final",
+          madeById: admin.userId,
+          parentDecisionId: draft.id,
+        },
+      });
+      made++;
+      console.log(`  ✓ ${a.firstName} ${a.lastName} — Final Accepted in ${domain.displayName} (releasable)`);
+    } else {
+      console.log(`  = ${a.firstName} ${a.lastName} — already has a decision; left as-is`);
+    }
+  }
+
+  console.log(
+    `\nSeeded ${made} releasable Accepted decision(s) in "${cycle.name}".`,
+  );
+  console.log(
+    "Open the hiring lead view for Fall 2026, find these applicants, and click Release.",
+  );
+  console.log(
+    "In dev/staging the welcome email is redirected to sophie.park@dali.dartmouth.edu.",
+  );
+}
+
+main()
+  .catch((e) => {
+    console.error(e.message ?? e);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());


### PR DESCRIPTION
## Summary

Three staffing/hiring changes that came out of debugging the staffing board:

### 1. BidModal — one row per project
A single bid expands **server-side** into one `StaffingPreference` row per `(domain, level)` the project + member resolve to (see `bid-validation.ts`). The board's member card already reads one-per-project, but the **BidModal** rendered every row, so clicking into a member showed the same project repeated once per domain·level.

Fix: collapse to one row per project — best (lowest) rank wins the heading, and each domain·level combo renders as a chip under it. Display-only; no data or card changes.

### 2. StaffingBoard — scrollable columns, pinned header
A column with many bids stretched the whole page vertically. Now each column is capped to the viewport height (`max-h-[calc(100vh-12rem)]`), the header (`flex-shrink-0`) stays pinned, and only the card list scrolls (`flex-1 min-h-0 overflow-y-auto`). Empty columns keep a 12rem drop target. Horizontal scroll across columns is unchanged.

### 3. Release-acceptance test coverage
The existing suite stubbed `promoteToMember` / `provisionNewMember` / `sendWelcome` but never asserted they fire. Added tests that lock down:
- Accepted → promotes the **applicant** (not the acting lead) at P1 in the target domain, provisions, and welcomes; the provisioned `daliEmail` is folded into the welcome call.
- Non-Accepted (Rejected) → none of those fire, but the decision email still sends.
- Provisioning throwing still returns 201 (failure isolation) and welcome still runs.

## Testing
- `npm test app/hiring/lib/__tests__/api.decisions.release.test.ts` → 13/13 passing.
- Manually exercised the release flow against a local throwaway DB with external integrations neutralized: confirmed member promotion, P1 eligibility, welcome todo, and idempotency on re-release — no emails/accounts created. (Email send to `applications@`/staging-redirect to `systems@` to be verified in staging.)
- BidModal + StaffingBoard are Tailwind/JSX changes; typecheck clean for both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/746"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782933439&installation_id=133523038&pr_number=746&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F746&signature=7f1fca7d36dbb1b227b2f9654d18be10b3bfce85523a297f07bf996a182352f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->