### PR TITLE
Consolidate onboarding email into the Accepted decision email

### DIFF
--- a/dali-api/app/hiring/lib/__tests__/api.decisions.release.test.ts
+++ b/dali-api/app/hiring/lib/__tests__/api.decisions.release.test.ts
@@ -13,7 +13,10 @@ vi.mock("~/members/lib/membership.server", () => ({
   promoteToMember: vi.fn().mockResolvedValue({ created: true }),
 }));
 vi.mock("~/members/lib/welcome.server", () => ({
-  sendWelcome: vi.fn().mockResolvedValue({ notified: true, emailSent: false }),
+  sendWelcome: vi.fn().mockResolvedValue({ notified: true }),
+  onboardingEmailHtml: vi.fn((daliEmail: string | null) =>
+    `<onboarding dali="${daliEmail ?? ""}"/>`,
+  ),
 }));
 vi.mock("~/members/lib/provisioning.server", () => ({
   provisionNewMember: vi.fn().mockResolvedValue({
@@ -150,6 +153,9 @@ describe("POST /api/hiring/decisions/:id/release", () => {
     expect(args.to).toBe("ada@dartmouth.edu");
     expect(args.subject).toBe("Welcome, Ada!");
     expect(args.html).toContain("Hi Ada,");
+    // The onboarding block is appended to the Accepted decision email so the
+    // member gets a single email (no separate welcome message).
+    expect(args.html).toContain("<onboarding");
     expect(args.refreshToken).toBe("gmail-rt");
   });
 
@@ -397,8 +403,9 @@ describe("POST /api/hiring/decisions/:id/release", () => {
     expect(promoteToMember).not.toHaveBeenCalled();
     expect(provisionNewMember).not.toHaveBeenCalled();
     expect(sendWelcome).not.toHaveBeenCalled();
-    // …but the decision email still goes out.
+    // …but the decision email still goes out — without the onboarding block.
     expect(sendEmail).toHaveBeenCalledOnce();
+    expect(vi.mocked(sendEmail).mock.calls[0][0].html).not.toContain("<onboarding");
   });
 
   it("still releases (201) when provisioning throws — failure is isolated", async () => {

--- a/dali-api/app/hiring/routes/api.decisions.$id.release.ts
+++ b/dali-api/app/hiring/routes/api.decisions.$id.release.ts
@@ -8,7 +8,7 @@ import { renderForSlot, decisionSlot } from "~/hiring/lib/email-variables";
 import { logAuditEvent } from "~/lib/audit";
 import { requireApiSignedOrForbidden } from "~/hiring/lib/confidentiality";
 import { promoteToMember } from "~/members/lib/membership.server";
-import { sendWelcome } from "~/members/lib/welcome.server";
+import { sendWelcome, onboardingEmailHtml } from "~/members/lib/welcome.server";
 import { provisionNewMember, type ProvisionResult } from "~/members/lib/provisioning.server";
 import { resolveCandidateEmail, redirectBannerHtml } from "~/lib/candidate-email";
 
@@ -153,9 +153,9 @@ export async function action({ request, params }: Route.ActionArgs) {
       console.error("Failed to provision new member:", err);
     }
 
-    // Welcome the new member: a persistent "finish onboarding" todo + a welcome
-    // email that tells them to log into DALI OS with their new DALI email.
-    // Sent to a reachable address (their Dartmouth email). Best-effort.
+    // Welcome the new member with a persistent "finish onboarding" todo. The
+    // welcome *email* is folded into the Accepted decision email below (single
+    // email per acceptance), so this no longer sends mail. Best-effort.
     try {
       const u = domainApp.application.user;
       const welcomeEmail =
@@ -199,11 +199,19 @@ export async function action({ request, params }: Route.ActionArgs) {
           },
         );
 
+        // For acceptances, append the onboarding block (account details + login
+        // link + logo) so the new member gets a single email instead of a
+        // separate welcome message.
+        const onboarding =
+          decision.type === "Accepted"
+            ? onboardingEmailHtml(provisionResult?.daliEmail ?? null)
+            : "";
+
         await sendEmail({
           refreshToken,
           to,
           subject,
-          html: redirectBannerHtml(redirectedFrom) + html,
+          html: redirectBannerHtml(redirectedFrom) + html + onboarding,
         });
         emailSent = true;
       }

--- a/dali-api/app/members/lib/welcome.server.ts
+++ b/dali-api/app/members/lib/welcome.server.ts
@@ -1,16 +1,16 @@
 import { prisma } from "~/lib/db";
-import { sendEmail } from "~/lib/gmail";
-import { getApplicationsGmailRefreshToken } from "~/lib/gmail-integration";
-import { resolveCandidateEmail, redirectBannerHtml } from "~/lib/candidate-email";
 
 // The onboarding task points here; also used as the dedupe/clear key.
 export const ONBOARDING_LINK = "/onboarding";
 
-// Welcome a newly-promoted member: drop a persistent "finish onboarding" todo
-// notification (links to /onboarding) and send a welcome email. Both are
-// best-effort — a failure here must never block the acceptance/release that
-// triggered it, so callers wrap this in try/catch (and it swallows its own
-// email errors too).
+// Welcome a newly-promoted member by dropping a persistent "finish onboarding"
+// todo notification (links to /onboarding). Best-effort — a failure here must
+// never block the acceptance/release that triggered it, so callers wrap this in
+// try/catch.
+//
+// The onboarding *email* is no longer sent separately: its content is folded
+// into the Accepted decision email at the release call site via
+// `onboardingEmailHtml` below, so an accepted applicant receives a single email.
 //
 // Idempotent: re-running creates another notification only if the member has no
 // open onboarding todo, so a re-release won't spam them.
@@ -32,13 +32,13 @@ export async function clearOnboardingTask(userId: string): Promise<void> {
 export async function sendWelcome(args: {
   userId: string;
   actorId: string;
-  // For the email greeting + the address to send to. Email is skipped when null.
+  // For the email greeting + the address to send to. Kept for call-site parity;
+  // the email itself is now part of the Accepted decision email.
   firstName: string;
   email: string | null;
-  // The member's newly-provisioned @dali.dartmouth.edu login email, if any —
-  // folded into the welcome email so they know which account to log in with.
+  // The member's newly-provisioned @dali.dartmouth.edu login email, if any.
   daliEmail?: string | null;
-}): Promise<{ notified: boolean; emailSent: boolean }> {
+}): Promise<{ notified: boolean }> {
   // The onboarding task links to the /onboarding checklist (the profile form is
   // one step within it). It is a plain todo — NOT form-backed — so submitting
   // the profile form alone doesn't clear it; it stays until onboarding is fully
@@ -69,56 +69,34 @@ export async function sendWelcome(args: {
     notified = true;
   }
 
-  let emailSent = false;
-  try {
-    // In dev/staging this is redirected to a test inbox (with a banner naming
-    // the real intended recipient); in prod it goes to the member.
-    const { to, redirectedFrom } = resolveCandidateEmail(args.email);
-    if (to) {
-      const refreshToken = await getApplicationsGmailRefreshToken();
-      if (refreshToken) {
-        const base = (process.env.FRONTEND_URL ?? "").replace(/\/$/, "");
-        await sendEmail({
-          refreshToken,
-          to,
-          subject: "Welcome to the DALI Lab",
-          html: welcomeHtml(
-            args.firstName,
-            `${base}${ONBOARDING_LINK}`,
-            args.daliEmail ?? null,
-            redirectedFrom,
-          ),
-        });
-        emailSent = true;
-      }
-    }
-  } catch (err) {
-    // Best-effort: a welcome-email failure must not block release.
-    console.error("Failed to send welcome email:", err);
-  }
-
-  return { notified, emailSent };
+  return { notified };
 }
 
-function welcomeHtml(
-  firstName: string,
-  onboardingUrl: string,
-  daliEmail: string | null,
-  // Non-prod only: the real recipient this email was redirected away from.
-  redirectedFrom: string | null,
-): string {
-  const safeName = firstName || "there";
-  const banner = redirectBannerHtml(redirectedFrom);
-  const loginLine = daliEmail
+// Onboarding block appended to the Accepted decision email so a new member gets
+// a single email: the lead-authored acceptance copy, followed by their account
+// details + the link into DALI OS. Includes the DALI logo.
+//
+// daliEmail is the newly-provisioned @dali.dartmouth.edu login address. It may
+// be null when Workspace provisioning hasn't completed yet (e.g. a transient
+// failure) — in that case we say the account is still being set up rather than
+// showing a blank "ready" line, so the member isn't told to log in with an
+// address that doesn't exist.
+export function onboardingEmailHtml(daliEmail: string | null): string {
+  const base = (process.env.FRONTEND_URL ?? "").replace(/\/$/, "");
+  const loginUrl = `${base}/login`;
+  const logoUrl = `${base}/logo-blue.png`;
+
+  const accountLine = daliEmail
     ? `<p>Your DALI account is ready. <strong>Log in to DALI OS with your new DALI email: ${daliEmail}</strong> (you'll be asked to set a password on first login).</p>`
-    : `<p>Your DALI account is ready.</p>`;
+    : `<p>Your DALI account is being set up — you'll receive your DALI login email shortly. In the meantime you can finish the rest of your onboarding below.</p>`;
+
   return `
-    ${banner}
-    <p>Hi ${safeName},</p>
+    <hr style="border:none;border-top:1px solid #e5e7eb;margin:24px 0;"/>
+    <p><img src="${logoUrl}" alt="DALI Lab" width="96" style="display:block;border:0;"/></p>
     <p>Welcome to the DALI Lab!</p>
-    ${loginLine}
+    ${accountLine}
     <p>Once you're in, finish setting up by completing your member profile and onboarding steps.</p>
-    <p><a href="${onboardingUrl}">Complete your onboarding</a></p>
+    <p><a href="${loginUrl}">Log in to DALI OS</a></p>
     <p>— The DALI Lab</p>
   `;
 }


### PR DESCRIPTION
## What

An accepted applicant received **two** emails on release: the cycle's "Accepted" decision email *and* a separate "Welcome to the DALI Lab" message. This consolidates them into a **single email** — the decision email, with the onboarding content appended.

## Why

The separate welcome email was redundant and low-information. Per request, the onboarding details should live in one email that includes a link into the app and the member's newly-created DALI email.

## Changes

- **`welcome.server.ts`**: `sendWelcome` now only creates the persistent "finish onboarding" todo notification (unchanged behavior) — its email-sending is removed. New exported **`onboardingEmailHtml(daliEmail)`** renders the account block: DALI login email, a **Log in to DALI OS** link to `/login`, and the **DALI logo** (`/logo-blue.png`).
- **`api.decisions.$id.release.ts`**: for **Accepted** decisions only, appends `onboardingEmailHtml(provisionResult?.daliEmail)` to the rendered decision email. Non-Accepted decisions are unchanged.
- **Graceful fallback**: when `daliEmail` is null (e.g. Workspace provisioning hasn't completed), the email says the account "is being set up — you'll receive your DALI login email shortly" instead of a blank "account is ready" line.

## Notes

- The onboarding **todo notification** is preserved (still created by `sendWelcome`); only the duplicate *email* is removed.
- Uses the existing `FRONTEND_URL` env var for the login + logo URLs, and the existing dev/staging email-redirect banner still applies.

## Tests

- Updated the release test: the `welcome.server` mock now provides `onboardingEmailHtml`; new assertions confirm the onboarding block is appended on Accepted and absent on non-Accepted decisions.
- Full unit suite green (1048 passed). Typecheck adds no new errors (the pre-existing `scripts/` `tsc` errors are unrelated and present on the base branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/749"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782963916&installation_id=133523038&pr_number=749&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F749&signature=c66207cefc16daf4cf9088112e9f54462204740d7290feee2f33fd0dc6cf50a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->