### PR TITLE
Fix time-dependent set-close-date test

### DIFF
--- a/dali-api/app/hiring/routes/__tests__/lead.intern-to-full-cycle.$id.test.ts
+++ b/dali-api/app/hiring/routes/__tests__/lead.intern-to-full-cycle.$id.test.ts
@@ -55,15 +55,17 @@ describe("lead.intern-to-full-cycle.$id action — set-close-date", () => {
   });
 
   it("stores the picked date as 11:59:59 PM ET (EDT) as a UTC instant", async () => {
-    await callAction({ intent: "set-close-date", closeDate: "2026-06-01" });
+    // Use a far-future date so the route's "past close date" guard doesn't trip
+    // and pull in prisma.applicationCycleStatusUpdate.findFirst.
+    await callAction({ intent: "set-close-date", closeDate: "2099-06-01" });
 
     expect(mockPrisma.applicationCycle.update).toHaveBeenCalledTimes(1);
     const updateArgs = mockPrisma.applicationCycle.update.mock.calls[0][0];
     expect(updateArgs.where).toEqual({ id: CYCLE_ID });
     const stored = updateArgs.data.closeDate as Date;
     expect(stored).toBeInstanceOf(Date);
-    // 2026-06-01 23:59:59 EDT (UTC-4) === 2026-06-02 03:59:59 UTC.
-    expect(stored.toISOString()).toBe("2026-06-02T03:59:59.000Z");
+    // 2099-06-01 23:59:59 EDT (UTC-4) === 2099-06-02 03:59:59 UTC.
+    expect(stored.toISOString()).toBe("2099-06-02T03:59:59.000Z");
   });
 
   it("clears the close date when the picker is empty", async () => {


### PR DESCRIPTION
## Summary
- Fix the failing `set-close-date` test in `lead.intern-to-full-cycle.$id.test.ts` on `dev`.
- The test posted `closeDate: "2026-06-01"`, which is now in the past. That trips the route's past-date guard at `lead.intern-to-full-cycle.$id.tsx:158-170`, which calls `prisma.applicationCycleStatusUpdate.findFirst` — a model the test never mocked — and throws `TypeError: Cannot read properties of undefined (reading 'findFirst')`.
- Bumped the input to `2099-06-01` (and the expected UTC ISO to `2099-06-02T03:59:59.000Z`) so the guard is skipped and the test exercises only what it claims to: the EDT → UTC conversion.

## Test plan
- [x] `npx vitest run app/hiring/routes/__tests__/lead.intern-to-full-cycle.\$id.test.ts` — 3/3 pass locally
- [ ] CI `Test dali-api` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/752"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783009666&installation_id=133523038&pr_number=752&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F752&signature=9916b3333ae91a18df5596dfe402a4768541684e38d2d7398eacad2c375c5ded"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->