### PR TITLE
Surface Finalize controls for post-interview decisions

### DIFF
--- a/dali-api/app/hiring/routes/domain-lead.tsx
+++ b/dali-api/app/hiring/routes/domain-lead.tsx
@@ -647,9 +647,23 @@ function StatPill({ label, value, color = "text-foreground" }: { label: string; 
   );
 }
 
+// Find the most-recent Draft decision that hasn't been superseded by a Final
+// or Released sibling of the same type. Mirrors the per-row finalize lookup in
+// `ApplicationsTable` so the Interviews section uses the same definition of
+// "needs finalization".
+function findFinalizableDraft(decisions: any[]) {
+  return decisions.find((d: any) => {
+    if (d.stage !== "Draft") return false;
+    return !decisions.some(
+      (other: any) => other.type === d.type && (other.stage === "Final" || other.stage === "Released")
+    );
+  });
+}
+
 export default function DomainLeadDashboard() {
   const data = useLoaderData<typeof loader>() as any;
   const navigate = useNavigate();
+  const revalidator = useRevalidator();
   const domainData = data?.domainData ?? [];
 
   if (domainData.length === 0) {
@@ -1018,6 +1032,35 @@ export default function DomainLeadDashboard() {
                     const interviewersWithAvailability = (interviewers ?? []).filter((i: any) => i.availabilityHours > 0);
                     const noAvailability = invited.length > 0 && interviewersWithAvailability.length === 0;
 
+                    // Post-interview applicants whose Final-delibs Draft hasn't
+                    // been promoted to Final yet. Their `inferredStatus` is
+                    // still `PostInterviewPending` (which keys off the latest
+                    // *Released* decision), so they live in this section rather
+                    // than Reviews — but the finalize UI on `ApplicationsTable`
+                    // never reached them. Surface the action here instead.
+                    const finalizableByDaId = new Map<string, any>();
+                    for (const app of invited) {
+                      const da = app.domainApplications?.[0];
+                      if (!da) continue;
+                      const draft = findFinalizableDraft(da.decisions ?? []);
+                      if (draft) finalizableByDaId.set(da.id, draft);
+                    }
+                    const finalizableCount = finalizableByDaId.size;
+                    const canFinalize = currentStatus === "UnderReview";
+                    const finalizeOne = async (daId: string | undefined) => {
+                      if (!daId) return;
+                      const draft = finalizableByDaId.get(daId);
+                      if (!draft) return;
+                      await fetch(`/api/hiring/decisions/${draft.id}/finalize`, { method: "POST", credentials: "include" });
+                      revalidator.revalidate();
+                    };
+                    const finalizeAll = async () => {
+                      for (const draft of finalizableByDaId.values()) {
+                        await fetch(`/api/hiring/decisions/${draft.id}/finalize`, { method: "POST", credentials: "include" });
+                      }
+                      revalidator.revalidate();
+                    };
+
                     return hasAnyInterviewActivity ? (
                       <Section
                         title="Interviews"
@@ -1036,6 +1079,28 @@ export default function DomainLeadDashboard() {
                             <div className="flex items-center gap-2 text-sm text-yellow-800 bg-yellow-50 border border-yellow-200 rounded-lg px-4 py-3">
                               <Clock className="w-4 h-4 flex-shrink-0" />
                               <span>No interviewers have set their availability yet. Applicants can't book interviews until interviewers submit availability blocks.</span>
+                            </div>
+                          )}
+
+                          {/* Post-interview finalize banner — appears once Final
+                              delibs have been closed and produced Draft decisions
+                              on these applicants. */}
+                          {canFinalize && finalizableCount > 0 && (
+                            <div className="flex flex-col sm:flex-row sm:items-center gap-3 bg-accent-coral/5 border border-accent-coral/30 rounded-lg px-4 py-3">
+                              <div className="text-sm flex-1">
+                                <span className="font-medium text-foreground">
+                                  {finalizableCount} post-interview decision{finalizableCount === 1 ? "" : "s"} ready to finalize
+                                </span>
+                                <span className="text-muted-foreground">
+                                  {" "}— drafts from final delibs. Finalizing locks them in for the hiring lead to release.
+                                </span>
+                              </div>
+                              <button
+                                onClick={finalizeAll}
+                                className="flex-shrink-0 px-3 py-1.5 text-xs font-medium rounded-lg bg-accent-coral hover:bg-accent-coral/90 text-white transition self-start sm:self-auto"
+                              >
+                                Finalize All ({finalizableCount})
+                              </button>
                             </div>
                           )}
 
@@ -1139,9 +1204,19 @@ export default function DomainLeadDashboard() {
                                             )}
                                           </td>
                                           <td className="px-6 py-4">
-                                            <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-bold ${statusPill(row)}`}>
-                                              {row.status}
-                                            </span>
+                                            <div className="flex items-center gap-2">
+                                              <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-bold ${statusPill(row)}`}>
+                                                {row.status}
+                                              </span>
+                                              {canFinalize && row.daId && finalizableByDaId.has(row.daId) && (
+                                                <button
+                                                  onClick={(e) => { e.stopPropagation(); finalizeOne(row.daId); }}
+                                                  className="px-2 py-0.5 text-xs font-medium rounded bg-accent-coral hover:bg-accent-coral/90 text-white transition"
+                                                >
+                                                  Finalize
+                                                </button>
+                                              )}
+                                            </div>
                                           </td>
                                           <td className="px-6 py-4 text-muted-foreground text-xs">{row.inDomain}</td>
                                           <td className="px-6 py-4 text-muted-foreground text-xs">{row.crossDomain}</td>
@@ -1159,9 +1234,19 @@ export default function DomainLeadDashboard() {
                                     >
                                       <div className="flex items-start justify-between gap-2">
                                         <div className="font-medium text-foreground min-w-0 truncate">{row.name}</div>
-                                        <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-bold flex-shrink-0 ${statusPill(row)}`}>
-                                          {row.status}
-                                        </span>
+                                        <div className="flex items-center gap-2 flex-shrink-0">
+                                          <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-bold ${statusPill(row)}`}>
+                                            {row.status}
+                                          </span>
+                                          {canFinalize && row.daId && finalizableByDaId.has(row.daId) && (
+                                            <button
+                                              onClick={(e) => { e.stopPropagation(); finalizeOne(row.daId); }}
+                                              className="px-2 py-0.5 text-xs font-medium rounded bg-accent-coral hover:bg-accent-coral/90 text-white transition"
+                                            >
+                                              Finalize
+                                            </button>
+                                          )}
+                                        </div>
                                       </div>
                                       {row.booked && (
                                         <>


### PR DESCRIPTION
## Summary

After Final delibs close, the Draft `Accepted` / `Waitlisted` / `Rejected` decisions were stranded with no UI path to finalize:

- Final-delibs close writes Draft decisions (`api.delibs.$id.ts:106-117`).
- Those applicants' `inferredStatus` is computed from the latest **Released** decision, which is still `InvitedToInterview` from initial delibs — so they stay `PostInterviewPending` (`domain-application-status.ts:101-134`).
- The domain‑lead page filters apps into Reviews (`status !== PostInterviewPending`) and Interviews (`status === PostInterviewPending`). The Finalize UI in `ApplicationsTable` only lives in Reviews, so post‑interview Drafts were never reachable.

This PR adds finalize controls directly to the Interviews section:

- **"Finalize All (N)" banner** above the rows table when any Completed‑interview applicant has an un‑finalized Draft from Final delibs.
- **Per‑row Finalize button** inline with the Status pill (desktop + mobile).
- Both gate on `currentStatus === "UnderReview"` to match the existing pattern in `ApplicationsTable`.
- Reuses the existing `POST /api/hiring/decisions/:id/finalize` endpoint — no API or schema changes.

After finalize, the rest of the flow is already wired: the hiring lead's `/lead/cycle/:id?tab=decisions` page picks up new `stage="Final"` decisions automatically and surfaces Release All / per‑row release with the per‑cycle email‑template binding gate.

## Test plan

- [ ] Close Final delibs for a Standard cycle; confirm the "Finalize All (N)" banner appears in the Interviews section with the correct count.
- [ ] Click "Finalize All" — verify the banner disappears, the per-row Finalize buttons clear, and the matching decisions land in `/lead/cycle/:id?tab=decisions` as ready-to-release.
- [ ] Click per-row Finalize on a single Completed interview row — verify it finalizes only that one and the row click still navigates to the application page (no event bubbling).
- [ ] Move cycle to `Completed` status — verify the banner and per-row Finalize buttons disappear.
- [ ] On mobile width, verify the Finalize button renders alongside the Status pill in the card view.
- [ ] InternToFull cycle (no interviews) — verify the Reviews section's existing "Needs Finalization" still works and the Interviews section remains hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/753"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783020355&installation_id=133523038&pr_number=753&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F753&signature=2ba4b769b99a38c68855b807f181b60ccf10b11f42d05a0b28e0e68b097f43fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->