### PR TITLE
Add onboarding profile fields (college/personal info)

### DIFF
--- a/dali-api/app/members/__tests__/profile-form-interpreter.test.ts
+++ b/dali-api/app/members/__tests__/profile-form-interpreter.test.ts
@@ -75,4 +75,59 @@ describe("interpretProfileForm", () => {
     if (!res.ok) return;
     expect(res.update).toEqual({});
   });
+
+  it("maps the new onboarding profile fields", () => {
+    const res = interpretProfileForm({
+      "profile.nameOnFile": "Jonathan Doe",
+      "profile.collegeId": "F00ABCD",
+      "profile.phoneNumber": "+1 555 010 1234",
+      "profile.ethnicity": "Asian",
+      "profile.dietaryRestrictions": "Vegetarian",
+    });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.update).toEqual({
+      nameOnFile: "Jonathan Doe",
+      collegeId: "F00ABCD",
+      phoneNumber: "+1 555 010 1234",
+      ethnicity: "Asian",
+      dietaryRestrictions: "Vegetarian",
+    });
+  });
+
+  it("parses a valid birthday into a UTC-midnight Date", () => {
+    const res = interpretProfileForm({ "profile.birthday": "2004-09-15" });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.update.birthday).toBeInstanceOf(Date);
+    expect(res.update.birthday?.toISOString()).toBe("2004-09-15T00:00:00.000Z");
+  });
+
+  it("rejects a malformed birthday", () => {
+    const res = interpretProfileForm({ "profile.birthday": "Sept 15 2004" });
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error).toMatch(/valid date/);
+  });
+
+  it("rejects an impossible birthday date", () => {
+    const res = interpretProfileForm({ "profile.birthday": "2004-13-40" });
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error).toMatch(/valid date/);
+  });
+
+  it("rejects an impossible-but-shaped birthday (Feb 31)", () => {
+    const res = interpretProfileForm({ "profile.birthday": "2004-02-31" });
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.error).toMatch(/valid date/);
+  });
+
+  it("skips a blank birthday without error", () => {
+    const res = interpretProfileForm({ "profile.birthday": "", "profile.major": "CS" });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.update).toEqual({ major: "CS" });
+  });
 });

--- a/dali-api/app/members/lib/profile-form-interpreter.ts
+++ b/dali-api/app/members/lib/profile-form-interpreter.ts
@@ -22,9 +22,16 @@ const STRING_FIELDS: Record<string, string> = {
   "profile.photoUrl": "photoUrl",
   "profile.githubUsername": "githubUsername",
   "profile.linkedinUrl": "linkedinUrl",
+  // Onboarding profile additions.
+  "profile.nameOnFile": "nameOnFile",
+  "profile.collegeId": "collegeId",
+  "profile.phoneNumber": "phoneNumber",
+  "profile.ethnicity": "ethnicity",
+  "profile.dietaryRestrictions": "dietaryRestrictions",
 };
 
 const CLASS_YEAR_KEY = "profile.classYear";
+const BIRTHDAY_KEY = "profile.birthday";
 
 export type ProfileUpdate = {
   pronouns?: string;
@@ -34,6 +41,12 @@ export type ProfileUpdate = {
   githubUsername?: string;
   linkedinUrl?: string;
   classYear?: number;
+  nameOnFile?: string;
+  collegeId?: string;
+  phoneNumber?: string;
+  ethnicity?: string;
+  dietaryRestrictions?: string;
+  birthday?: Date;
 };
 
 export type ProfileInterpretResult =
@@ -64,6 +77,27 @@ export function interpretProfileForm(
       return { ok: false, error: "Class year must be a 4-digit year." };
     }
     update.classYear = n;
+  }
+
+  // Birthday: accept a YYYY-MM-DD date string. Store at UTC midnight so there's
+  // no timezone drift on a date-only value. Round-trip the parsed components so
+  // impossible dates (e.g. 2004-02-31, which Date silently rolls to Mar 2) are
+  // rejected rather than quietly shifted.
+  const birthdayRaw = asTrimmed(answers[BIRTHDAY_KEY]);
+  if (birthdayRaw !== "") {
+    const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(birthdayRaw);
+    const d = m ? new Date(`${birthdayRaw}T00:00:00.000Z`) : null;
+    const valid =
+      m &&
+      d &&
+      !Number.isNaN(d.getTime()) &&
+      d.getUTCFullYear() === Number(m[1]) &&
+      d.getUTCMonth() + 1 === Number(m[2]) &&
+      d.getUTCDate() === Number(m[3]);
+    if (!valid) {
+      return { ok: false, error: "Birthday must be a valid date (YYYY-MM-DD)." };
+    }
+    update.birthday = d;
   }
 
   return { ok: true, update };

--- a/dali-api/prisma/migrations/20260602000000_user_onboarding_profile_fields/migration.sql
+++ b/dali-api/prisma/migrations/20260602000000_user_onboarding_profile_fields/migration.sql
@@ -1,0 +1,8 @@
+-- Additional profile fields collected on the New Member Profile (onboarding)
+-- form. All nullable, so no backfill is needed for existing users.
+ALTER TABLE "User" ADD COLUMN "nameOnFile" TEXT;
+ALTER TABLE "User" ADD COLUMN "collegeId" TEXT;
+ALTER TABLE "User" ADD COLUMN "phoneNumber" TEXT;
+ALTER TABLE "User" ADD COLUMN "birthday" TIMESTAMP(3);
+ALTER TABLE "User" ADD COLUMN "ethnicity" TEXT;
+ALTER TABLE "User" ADD COLUMN "dietaryRestrictions" TEXT;

--- a/dali-api/prisma/schema.prisma
+++ b/dali-api/prisma/schema.prisma
@@ -63,6 +63,19 @@ model User {
   githubUsername String?
   personalSite String?
 
+  // ─── Onboarding profile fields (collected on the New Member Profile form) ──
+  // Name as it appears on file with the College, when different from the
+  // first/last above (e.g. a legal name). Optional — blank means "same".
+  nameOnFile          String?
+  // The student's college ID number (the number on their ID card), not a FK.
+  collegeId           String?
+  phoneNumber         String?
+  birthday            DateTime?
+  // Free-text demographic; collected optionally (includes a "Prefer not to
+  // say" choice on the form). Stored as the selected label.
+  ethnicity           String?
+  dietaryRestrictions String?
+
   // ─── Relations: existing ──────────────────────────────────────────────────
   daliMember                    DALIMember?
   applicationCycleStatusUpdates ApplicationCycleStatusUpdate[]

--- a/dali-api/prisma/seeds/accepted-applicants.ts
+++ b/dali-api/prisma/seeds/accepted-applicants.ts
@@ -41,6 +41,47 @@ const PROFILE_QUESTIONS = [
   { key: "profile.hometown", type: "text", required: false, data: { label: "Hometown" } },
   { key: "profile.githubUsername", type: "text", required: false, data: { label: "GitHub username" } },
   { key: "profile.linkedinUrl", type: "text", required: false, data: { label: "LinkedIn URL" } },
+  // College / personal info collected at onboarding. College email is omitted
+  // intentionally — it's already on file (dartmouthEmail) from the application.
+  {
+    key: "profile.nameOnFile",
+    type: "text",
+    required: false,
+    data: { label: "Name on file with the College (if different from above)" },
+  },
+  { key: "profile.collegeId", type: "text", required: true, data: { label: "College ID number" } },
+  { key: "profile.phoneNumber", type: "text", required: true, data: { label: "Phone number" } },
+  {
+    key: "profile.birthday",
+    type: "text",
+    required: true,
+    data: { label: "Birthday (YYYY-MM-DD)" },
+  },
+  {
+    key: "profile.ethnicity",
+    type: "select",
+    required: false,
+    data: {
+      label: "Ethnicity",
+      options: [
+        "American Indian or Alaska Native",
+        "Asian",
+        "Black or African American",
+        "Hispanic or Latino",
+        "Native Hawaiian or Other Pacific Islander",
+        "White",
+        "Two or more races",
+        "Prefer not to say",
+        "Other",
+      ],
+    },
+  },
+  {
+    key: "profile.dietaryRestrictions",
+    type: "text",
+    required: true,
+    data: { label: "Dietary restrictions (write \"none\" if none)" },
+  },
 ];
 
 // Welcoming subtitle shown under the form heading (stored as a ProseMirror doc


### PR DESCRIPTION
## What

Adds six fields to the **New Member Profile** (onboarding) form: name on file with the College (if different), college ID, phone number, birthday, ethnicity, and dietary restrictions.

## Why

Requested for member onboarding. College email is **intentionally omitted** — it's already captured from the application (`dartmouthEmail`).

## Changes

- **Schema + migration** (`20260602000000_user_onboarding_profile_fields`): six new **nullable** `User` columns — `nameOnFile`, `collegeId`, `phoneNumber`, `birthday` (DateTime), `ethnicity`, `dietaryRestrictions`. All additive; no backfill.
- **`profile-form-interpreter.ts`**: maps the new `profile.*` keys to columns; parses `birthday` from `YYYY-MM-DD` into a UTC-midnight `Date` with **calendar validation** (rejects impossible dates like `2004-02-31`, which `Date` would otherwise silently roll to Mar 2).
- **`accepted-applicants.ts` seed**: adds the six questions. Ethnicity is a `select` with US Census categories incl. "Prefer not to say". **Optional:** name-on-file, ethnicity. **Required:** college ID, phone, birthday, dietary. The seed already versions the form, so the latest version (what onboarding renders) picks up the new questions on next run.
- **Tests**: field mapping + birthday parse/validation (valid, malformed, impossible, blank).

## Notes

- Birthday uses a `text` question with a `YYYY-MM-DD` label rather than a new `date` question type, to keep the change contained to onboarding (the Forms renderer has no date type; adding one would touch the renderer + validation across the whole Forms feature). Can follow up with a real date picker if desired.
- Migration is additive/nullable, so `migration-check` should pass cleanly (no data loss).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/757"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783030448&installation_id=133523038&pr_number=757&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F757&signature=f848165e15ed99d0ac0381ce819f6a85f4e2699102d35cef188613a86e520d50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->