### PR TITLE
Remove divider between acceptance message and onboarding block

### DIFF
--- a/dali-api/app/members/lib/welcome.server.ts
+++ b/dali-api/app/members/lib/welcome.server.ts
@@ -124,7 +124,6 @@ export function onboardingEmailHtml(
   }
 
   return `
-    <hr style="border:none;border-top:1px solid #e5e7eb;margin:24px 0;"/>
     ${accountBlock}
     <p>Once you're in, finish setting up by completing your member profile and onboarding steps.</p>
     ${slackLine}


### PR DESCRIPTION
## What

Removes the `<hr>` divider at the top of the onboarding block in `onboardingEmailHtml`.

The onboarding block (account credentials + login link + Slack line + logo) is appended to the **Accepted** decision email. The leading horizontal rule put a visible line between the acceptance copy ("Congratulations — you've been accepted…") and the "log in with your new credentials" section, making one message look like two. Dropping it lets them read as a single continuous email.

## Testing

- `npx vitest run app/members/__tests__/onboarding-email.test.ts`: 5/5 pass (no test referenced the divider).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/761"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783054216&installation_id=133523038&pr_number=761&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F761&signature=6a0e34d3d1d44bd7bb44e844d20c298dd13da8ee77c35f398e9dec479cb0b970"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->