### PR TITLE
Remove divider between acceptance message and onboarding block (#761)

### DIFF
--- a/dali-api/app/members/lib/welcome.server.ts
+++ b/dali-api/app/members/lib/welcome.server.ts
@@ -124,7 +124,6 @@ export function onboardingEmailHtml(
   }
 
   return `
-    <hr style="border:none;border-top:1px solid #e5e7eb;margin:24px 0;"/>
     ${accountBlock}
     <p>Once you're in, finish setting up by completing your member profile and onboarding steps.</p>
     ${slackLine}


### PR DESCRIPTION
The onboarding block is appended to the Accepted decision email, and the leading <hr> put a visible horizontal rule between the acceptance copy and the "log in with your new credentials" section. Drop it so the two read as one continuous message.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/762"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783054266&installation_id=133523038&pr_number=762&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F762&signature=9700e75c6e8489732db1bd6995351173cd1af1df3e296c42fa0832e7bc1e88fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->