### PR TITLE
Onboarding email: drop divider, add 26F event notice + Sean Noh sign-off

### DIFF
--- a/dali-api/app/members/lib/welcome.server.ts
+++ b/dali-api/app/members/lib/welcome.server.ts
@@ -124,7 +124,6 @@ export function onboardingEmailHtml(
   }
 
   return `
-    <hr style="border:none;border-top:1px solid #e5e7eb;margin:24px 0;"/>
     ${accountBlock}
     <p>Once you're in, finish setting up by completing your member profile and onboarding steps.</p>
     ${slackLine}

--- a/dali-api/app/members/lib/welcome.server.ts
+++ b/dali-api/app/members/lib/welcome.server.ts
@@ -127,7 +127,9 @@ export function onboardingEmailHtml(
     ${accountBlock}
     <p>Once you're in, finish setting up by completing your member profile and onboarding steps.</p>
     ${slackLine}
-    <p>— The DALI Lab</p>
+    <p>We also have a special event planned for all day Sunday, September 13th. This is a required event. If there is any concern with this requirement, please reach out.</p>
+    <p>We are very excited to welcome you to DALI soon and look forward to an incredible 26F together. Please reach out with any questions.</p>
+    <p>Best,<br/>Sean Noh and DALI Hiring</p>
     <p><img src="${logoUrl}" alt="DALI Lab" width="96" style="display:block;border:0;"/></p>
   `;
 }


### PR DESCRIPTION
## What

Copy + layout changes to the onboarding block appended to the **Accepted** decision email (`onboardingEmailHtml`):

1. **Remove the `<hr>` divider** between the acceptance message and the onboarding/credentials block, so the acceptance email reads as one continuous message instead of two.
2. **Add the 26F event notice**: "We also have a special event planned for all day Sunday, September 13th. This is a required event. If there is any concern with this requirement, please reach out."
3. **Add the welcome/26F closing**: "We are very excited to welcome you to DALI soon and look forward to an incredible 26F together. Please reach out with any questions."
4. **Replace the sign-off** "— The DALI Lab" with "Best, Sean Noh and DALI Hiring".

## Resulting email (onboarding block)

```
[acceptance template — "Hi {{firstName}}, congrats … {{domain}}"]
As your first onboarding step, log in to DALI OS with your new credentials:
  DALI email: …
  Password: … (you'll be asked to set a password on first login).
Once you're in, finish setting up by completing your member profile and onboarding steps.
We use Slack day-to-day at DALI Studios — a teammate will add you to the workspace shortly.
We also have a special event planned for all day Sunday, September 13th. …
We are very excited to welcome you to DALI soon … an incredible 26F together. …
Best,
Sean Noh and DALI Hiring
[DALI Lab logo]
```

## Testing

- `npm test app/members/__tests__/onboarding-email.test.ts`: 5/5 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/763"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783055617&installation_id=133523038&pr_number=763&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F763&signature=91b12f752922a2b50f53e44f1783acf70205a1b1e75d89a312741f7a90ea75fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->