### PR TITLE
Fix duplicate Final decisions when finalizing in domain-lead view (#766)

### DIFF
--- a/dali-api/app/hiring/lib/__tests__/api.decisions.lineage.test.ts
+++ b/dali-api/app/hiring/lib/__tests__/api.decisions.lineage.test.ts
@@ -21,6 +21,7 @@ const mockPrisma = prisma as unknown as {
   gmailIntegration: { findFirst: ReturnType<typeof vi.fn> };
   decision: {
     findUnique: ReturnType<typeof vi.fn>;
+    findFirst: ReturnType<typeof vi.fn>;
     create: ReturnType<typeof vi.fn>;
     findMany: ReturnType<typeof vi.fn>;
   };
@@ -43,7 +44,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   (mockPrisma as any).dALIMember = { findUnique: vi.fn() };
   (mockPrisma as any).gmailIntegration = { findFirst: vi.fn() };
-  (mockPrisma as any).decision = { findUnique: vi.fn(), create: vi.fn(), findMany: vi.fn() };
+  (mockPrisma as any).decision = { findUnique: vi.fn(), findFirst: vi.fn(), create: vi.fn(), findMany: vi.fn() };
   (mockPrisma as any).domainApplication = { findUnique: vi.fn() };
   (mockPrisma as any).cycleDecisionEmail = { findUnique: vi.fn() };
   (mockPrisma as any).user = { findUnique: vi.fn() };
@@ -67,6 +68,7 @@ describe("Decision lineage (parentDecisionId)", () => {
       waitlistRank: null,
       domainApplication: { application: { applicationCycleId: "cycle-1" } },
     });
+    mockPrisma.decision.findFirst.mockResolvedValue(null); // no existing Final
     mockPrisma.decision.create.mockResolvedValue({ id: FINAL_ID });
 
     const req = new Request("http://localhost/api/decisions/dec-draft/finalize", { method: "POST" });
@@ -80,6 +82,28 @@ describe("Decision lineage (parentDecisionId)", () => {
     // DALIMember.id. The test mock's `member` is the DALIMember row; the
     // actual stored value is the authenticated user.
     expect(arg.data.madeById).toBe(USER_ID);
+  });
+
+  it("finalize: 409s without creating a duplicate when a Final already exists", async () => {
+    vi.mocked(isCore).mockResolvedValue(true);
+    vi.mocked(isDomainLead).mockResolvedValue(false);
+    mockPrisma.decision.findUnique.mockResolvedValue({
+      id: DRAFT_ID,
+      stage: "Draft",
+      type: "Accepted",
+      domainApplicationId: "da-1",
+      notes: null,
+      waitlistRank: null,
+      domainApplication: { application: { applicationCycleId: "cycle-1" } },
+    });
+    // A Final of this type already exists (e.g. a double-click after the first
+    // finalize landed) → the guard short-circuits before creating a second.
+    mockPrisma.decision.findFirst.mockResolvedValue({ id: FINAL_ID });
+
+    const req = new Request("http://localhost/api/decisions/dec-draft/finalize", { method: "POST" });
+    const res = await finalizeAction({ request: req, params: { id: DRAFT_ID }, context: {} } as any);
+    expect(res.status).toBe(409);
+    expect(mockPrisma.decision.create).not.toHaveBeenCalled();
   });
 
   it("release: links the new Released record to its Final predecessor", async () => {

--- a/dali-api/app/hiring/routes/api.decisions.$id.finalize.ts
+++ b/dali-api/app/hiring/routes/api.decisions.$id.finalize.ts
@@ -5,6 +5,10 @@ import { isCore, isDomainLead } from "~/lib/roles";
 import { logAuditEvent } from "~/lib/audit";
 import { requireApiSignedOrForbidden } from "~/hiring/lib/confidentiality";
 
+// Thrown inside the finalize transaction when a Final/Released decision already
+// exists, to bail out without creating a duplicate. Caught + mapped to a 409.
+class AlreadyFinalizedError extends Error {}
+
 export async function action({ request, params }: Route.ActionArgs) {
   const auth = await requireAuth(request);
   if (!auth.ok) return auth.response;
@@ -41,17 +45,47 @@ export async function action({ request, params }: Route.ActionArgs) {
   );
   if (gate) return gate;
 
-  const finalized = await prisma.decision.create({
-    data: {
-      domainApplicationId: decision.domainApplicationId,
-      type: decision.type,
-      stage: "Final",
-      madeById: auth.user.sub,
-      notes: decision.notes,
-      waitlistRank: decision.waitlistRank,
-      parentDecisionId: decision.id,
-    },
-  });
+  // Decision is append-only, so finalizing creates a new Final row. Guard
+  // against producing duplicates when this draft is finalized more than once
+  // (e.g. a double-click before the UI revalidates, or two concurrent requests):
+  // if a Final/Released decision of this type already exists for the
+  // domainApplication, there's nothing to finalize. The check + create run in a
+  // transaction so two simultaneous requests can't both pass the check.
+  let finalized;
+  try {
+    finalized = await prisma.$transaction(async (tx) => {
+      const existing = await tx.decision.findFirst({
+        where: {
+          domainApplicationId: decision.domainApplicationId,
+          type: decision.type,
+          stage: { in: ["Final", "Released"] },
+        },
+        select: { id: true },
+      });
+      if (existing) {
+        throw new AlreadyFinalizedError();
+      }
+      return tx.decision.create({
+        data: {
+          domainApplicationId: decision.domainApplicationId,
+          type: decision.type,
+          stage: "Final",
+          madeById: auth.user.sub,
+          notes: decision.notes,
+          waitlistRank: decision.waitlistRank,
+          parentDecisionId: decision.id,
+        },
+      });
+    });
+  } catch (err) {
+    if (err instanceof AlreadyFinalizedError) {
+      return Response.json(
+        { error: "This decision has already been finalized." },
+        { status: 409 },
+      );
+    }
+    throw err;
+  }
 
   await logAuditEvent({
     action: "decision.finalize",

--- a/dali-api/app/hiring/routes/domain-lead.tsx
+++ b/dali-api/app/hiring/routes/domain-lead.tsx
@@ -2141,6 +2141,27 @@ function ApplicationsTable({ apps, draftDecisions, cycleReviewersForDomain, cycl
   const isUnderReview = currentStatus === "UnderReview";
   const [searchParams, setSearchParams] = useSearchParams();
   const revalidator = useRevalidator();
+  // Which draft is currently being finalized — disables its Finalize button so a
+  // double-click can't POST twice (the append-only Decision model would otherwise
+  // create duplicate Final rows before the revalidate lands).
+  const [finalizingId, setFinalizingId] = useState<string | null>(null);
+  const handleFinalize = async (draftId: string) => {
+    if (finalizingId) return;
+    setFinalizingId(draftId);
+    try {
+      const res = await fetch(`/api/hiring/decisions/${draftId}/finalize`, {
+        method: "POST",
+        credentials: "include",
+      });
+      if (!res.ok && res.status !== 409) {
+        const body = await res.json().catch(() => null);
+        alert(body?.error ?? "Failed to finalize. Please try again.");
+      }
+    } finally {
+      setFinalizingId(null);
+      revalidator.revalidate();
+    }
+  };
   const filter: "all" | "finalize" = searchParams.get("app_filter") === "finalize" ? "finalize" : "all";
   const query = searchParams.get("q") ?? "";
   // Default sort is "none" — preserves the loader's order (newest application
@@ -2447,13 +2468,11 @@ function ApplicationsTable({ apps, draftDecisions, cycleReviewersForDomain, cycl
                   <div className="flex flex-wrap items-center justify-end gap-2">
                   {isUnderReview && draftToFinalize ? (
                     <button
-                      onClick={async () => {
-                        await fetch(`/api/hiring/decisions/${draftToFinalize.id}/finalize`, { method: "POST", credentials: "include" });
-                        revalidator.revalidate();
-                      }}
-                      className="px-2 py-1 text-xs font-medium rounded bg-accent-coral hover:bg-accent-coral/90 text-white transition"
+                      onClick={() => handleFinalize(draftToFinalize.id)}
+                      disabled={finalizingId === draftToFinalize.id}
+                      className="px-2 py-1 text-xs font-medium rounded bg-accent-coral hover:bg-accent-coral/90 text-white transition disabled:opacity-50 disabled:cursor-not-allowed"
                     >
-                      Finalize
+                      {finalizingId === draftToFinalize.id ? "Finalizing…" : "Finalize"}
                     </button>
                   ) : (
                     <span className="text-xs text-muted-foreground/60">—</span>
@@ -2542,13 +2561,11 @@ function ApplicationsTable({ apps, draftDecisions, cycleReviewersForDomain, cycl
               {isUnderReview && draftToFinalize && (
                 <div className="flex flex-wrap items-center gap-2">
                   <button
-                    onClick={async () => {
-                      await fetch(`/api/hiring/decisions/${draftToFinalize.id}/finalize`, { method: "POST", credentials: "include" });
-                      revalidator.revalidate();
-                    }}
-                    className="px-2 py-1 text-xs font-medium rounded bg-accent-coral hover:bg-accent-coral/90 text-white transition"
+                    onClick={() => handleFinalize(draftToFinalize.id)}
+                    disabled={finalizingId === draftToFinalize.id}
+                    className="px-2 py-1 text-xs font-medium rounded bg-accent-coral hover:bg-accent-coral/90 text-white transition disabled:opacity-50 disabled:cursor-not-allowed"
                   >
-                    Finalize
+                    {finalizingId === draftToFinalize.id ? "Finalizing…" : "Finalize"}
                   </button>
                 </div>
               )}


### PR DESCRIPTION
Finalizing a Draft decision creates a new Final row (Decision is append-only), but the endpoint had no guard against finalizing the same draft twice. A double-click on the domain-lead Finalize button (before the UI revalidated) — or two concurrent requests — each passed the stage==="Draft" check and each created a Final row, so the applicant appeared multiple times in the cycle's finalized list.

Server: wrap the finalize in a transaction that first checks for an existing Final/Released decision of the same type for the domainApplication and 409s instead of creating a duplicate. The check+create in one transaction closes the concurrent-request race too.

Client: disable the Finalize button while its request is in flight (both the desktop table and mobile list variants) and surface non-409 errors, so a double-click can't fire two requests.

Test: add a case asserting finalize 409s and creates nothing when a Final already exists.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/767"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783125538&installation_id=133523038&pr_number=767&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F767&signature=3b8c122b2db391b26d425a437d138a4bd0209e80fde65f5d9a4307278f8bcac4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->