### PR TITLE
Staffing finalize: implement "Create Gmail accounts" project provisioning

### DIFF
--- a/dali-api/app/lib/__tests__/google-workspace.test.ts
+++ b/dali-api/app/lib/__tests__/google-workspace.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { deriveProjectEmails, deriveDaliEmail } from "~/lib/google-workspace";
+
+// These run against the default WORKSPACE_DOMAIN ("dali.dartmouth.edu") since
+// GOOGLE_WORKSPACE_DOMAIN is unset in the test env.
+const DOMAIN = "dali.dartmouth.edu";
+
+describe("deriveProjectEmails", () => {
+  it("slugifies the project name into user + -team group emails", () => {
+    expect(deriveProjectEmails("Project Alpha")).toEqual({
+      userEmail: `project-alpha@${DOMAIN}`,
+      groupEmail: `project-alpha-team@${DOMAIN}`,
+    });
+  });
+
+  it("collapses punctuation and runs of non-alphanumerics to single hyphens", () => {
+    expect(deriveProjectEmails("DALI  OS / 2.0!")).toEqual({
+      userEmail: `dali-os-2-0@${DOMAIN}`,
+      groupEmail: `dali-os-2-0-team@${DOMAIN}`,
+    });
+  });
+
+  it("trims leading/trailing hyphens produced by edge punctuation", () => {
+    expect(deriveProjectEmails("  -Hello-  ")).toEqual({
+      userEmail: `hello@${DOMAIN}`,
+      groupEmail: `hello-team@${DOMAIN}`,
+    });
+  });
+
+  it("falls back to 'project' for an empty/punctuation-only name", () => {
+    expect(deriveProjectEmails("!!!")).toEqual({
+      userEmail: `project@${DOMAIN}`,
+      groupEmail: `project-team@${DOMAIN}`,
+    });
+  });
+});
+
+describe("deriveDaliEmail", () => {
+  it("builds first.last with punctuation stripped (unchanged behavior)", () => {
+    expect(deriveDaliEmail("Ada", "O'Brien")).toBe(`ada.obrien@${DOMAIN}`);
+  });
+});

--- a/dali-api/app/lib/google-workspace.ts
+++ b/dali-api/app/lib/google-workspace.ts
@@ -17,7 +17,12 @@ import { JWT } from "google-auth-library";
 
 const DIRECTORY_USERS_URL =
   "https://admin.googleapis.com/admin/directory/v1/users";
-const SCOPES = ["https://www.googleapis.com/auth/admin.directory.user"];
+const DIRECTORY_GROUPS_URL =
+  "https://admin.googleapis.com/admin/directory/v1/groups";
+const SCOPES = [
+  "https://www.googleapis.com/auth/admin.directory.user",
+  "https://www.googleapis.com/auth/admin.directory.group",
+];
 
 export const WORKSPACE_DOMAIN =
   process.env.GOOGLE_WORKSPACE_DOMAIN ?? "dali.dartmouth.edu";
@@ -48,6 +53,25 @@ export function deriveDaliEmail(firstName: string, lastName: string): string {
   const last = norm(lastName);
   const local = last ? `${first}.${last}` : first;
   return `${local}@${WORKSPACE_DOMAIN}`;
+}
+
+// Project name -> { userEmail, groupEmail } under <domain>. The local part is a
+// hyphen-slug of the name (e.g. "Project Alpha!" -> "project-alpha"); the group
+// appends "-team". Empty/punctuation-only names fall back to "project".
+export function deriveProjectEmails(projectName: string): {
+  userEmail: string;
+  groupEmail: string;
+} {
+  const slug =
+    projectName
+      .toLowerCase()
+      .normalize("NFKD")
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "") || "project";
+  return {
+    userEmail: `${slug}@${WORKSPACE_DOMAIN}`,
+    groupEmail: `${slug}-team@${WORKSPACE_DOMAIN}`,
+  };
 }
 
 // 16 url-safe random chars — a throwaway initial password (the account is set
@@ -89,8 +113,24 @@ export async function provisionWorkspaceAccount(args: {
   }
 
   const email = deriveDaliEmail(args.firstName, args.lastName);
-  const password = tempPassword();
+  return createDirectoryUser({
+    email,
+    givenName: args.firstName,
+    familyName: args.lastName || args.firstName,
+    recoveryEmail: args.recoveryEmail,
+  });
+}
 
+// Shared Directory API user-create. Idempotent: a 409 (already exists) is
+// reported as { created: false } success. The caller is responsible for the
+// configured-gate; this assumes it's already checked.
+async function createDirectoryUser(args: {
+  email: string;
+  givenName: string;
+  familyName: string;
+  recoveryEmail?: string | null;
+}): Promise<WorkspaceResult> {
+  const password = tempPassword();
   try {
     const token = await getAccessToken();
     const res = await fetch(DIRECTORY_USERS_URL, {
@@ -100,8 +140,8 @@ export async function provisionWorkspaceAccount(args: {
         "Content-Type": "application/json",
       },
       body: JSON.stringify({
-        primaryEmail: email,
-        name: { givenName: args.firstName, familyName: args.lastName || args.firstName },
+        primaryEmail: args.email,
+        name: { givenName: args.givenName, familyName: args.familyName },
         password,
         changePasswordAtNextLogin: true,
         ...(args.recoveryEmail ? { recoveryEmail: args.recoveryEmail } : {}),
@@ -110,13 +150,118 @@ export async function provisionWorkspaceAccount(args: {
 
     if (res.status === 409) {
       // Already exists — fine.
-      return { status: "ok", email, created: false };
+      return { status: "ok", email: args.email, created: false };
     }
     if (!res.ok) {
       const body = await res.text();
       return { status: "error", message: `Directory API ${res.status}: ${body.slice(0, 300)}` };
     }
-    return { status: "ok", email, created: true, tempPassword: password };
+    return { status: "ok", email: args.email, created: true, tempPassword: password };
+  } catch (err) {
+    return {
+      status: "error",
+      message: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+// Create a project-owned Workspace user at an EXPLICIT email (e.g.
+// "project-alpha@dali.dartmouth.edu"). Unlike a member account, the name is the
+// project name (givenName), and there's no recovery email. Idempotent via 409.
+export async function provisionProjectUser(args: {
+  email: string;
+  projectName: string;
+}): Promise<WorkspaceResult> {
+  if (!workspaceConfigured()) {
+    return {
+      status: "skipped",
+      message: "Google Workspace provisioning is not configured.",
+    };
+  }
+  return createDirectoryUser({
+    email: args.email,
+    givenName: args.projectName,
+    // Directory API requires a non-empty familyName; reuse the project name.
+    familyName: args.projectName,
+  });
+}
+
+export type GroupResult =
+  | { status: "ok"; email: string; created: boolean }
+  | { status: "skipped"; message: string }
+  | { status: "error"; message: string };
+
+// Get-or-create a Workspace group at an explicit email. Idempotent: a 409 is
+// reported as { created: false }. The group name defaults to `name` (the
+// project name + " Team") so it's recognizable in the Admin console.
+export async function ensureWorkspaceGroup(args: {
+  email: string;
+  name: string;
+}): Promise<GroupResult> {
+  if (!workspaceConfigured()) {
+    return {
+      status: "skipped",
+      message: "Google Workspace provisioning is not configured.",
+    };
+  }
+  try {
+    const token = await getAccessToken();
+    const res = await fetch(DIRECTORY_GROUPS_URL, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ email: args.email, name: args.name }),
+    });
+    if (res.status === 409) {
+      return { status: "ok", email: args.email, created: false };
+    }
+    if (!res.ok) {
+      const body = await res.text();
+      return { status: "error", message: `Directory API ${res.status}: ${body.slice(0, 300)}` };
+    }
+    return { status: "ok", email: args.email, created: true };
+  } catch (err) {
+    return {
+      status: "error",
+      message: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+export type GroupMemberResult =
+  | { status: "ok"; added: boolean }
+  | { status: "error"; message: string };
+
+// Add a member (by email) to a group. Idempotent: a 409 (already a member) is
+// reported as { added: false } success. A 404 surfaces as an error (the group
+// or member email doesn't resolve) so the caller can report it.
+export async function addGroupMember(args: {
+  groupEmail: string;
+  memberEmail: string;
+}): Promise<GroupMemberResult> {
+  try {
+    const token = await getAccessToken();
+    const res = await fetch(
+      `${DIRECTORY_GROUPS_URL}/${encodeURIComponent(args.groupEmail)}/members`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ email: args.memberEmail, role: "MEMBER" }),
+      },
+    );
+    if (res.status === 409) {
+      return { status: "ok", added: false };
+    }
+    if (!res.ok) {
+      const body = await res.text();
+      return { status: "error", message: `Directory API ${res.status}: ${body.slice(0, 200)}` };
+    }
+    return { status: "ok", added: true };
   } catch (err) {
     return {
       status: "error",

--- a/dali-api/app/projects/components/FinalizeModal.tsx
+++ b/dali-api/app/projects/components/FinalizeModal.tsx
@@ -38,8 +38,9 @@ const AUTOMATIONS: {
   {
     id: "gmail",
     label: "Create Gmail accounts",
-    description: "Provision project Google Workspace accounts.",
-    configured: false,
+    description:
+      "Provision the project's Google Workspace account and -team group, and add the confirmed roster to the group.",
+    configured: true,
   },
 ];
 

--- a/dali-api/app/projects/routes/api.staffing.finalize.ts
+++ b/dali-api/app/projects/routes/api.staffing.finalize.ts
@@ -5,6 +5,13 @@ import { canManageStaffing } from "~/lib/roles";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { postMessage, ensureChannel, inviteUsersToChannel } from "~/slack/lib/slack-client";
 import { ensureTeam, addTeamMember } from "~/slack/lib/github-app";
+import {
+  workspaceConfigured,
+  deriveProjectEmails,
+  provisionProjectUser,
+  ensureWorkspaceGroup,
+  addGroupMember,
+} from "~/lib/google-workspace";
 import { logAuditEvent } from "~/lib/audit";
 
 // POST /api/staffing/finalize
@@ -20,7 +27,12 @@ import { logAuditEvent } from "~/lib/audit";
 //                  the project, id cached on Project.slackChannelId), invite
 //                  the confirmed roster (by synced slackUserId), and post a team
 //                  announcement (members + domain/level, plus repos).
-//   - gmail:       STUB — no Google Admin SDK wired up yet.
+//   - gmail:       provision the project's Google Workspace identity — a USER
+//                  account (<slug>@dali.dartmouth.edu, cached on
+//                  Project.calendarEmail) and a GROUP (<slug>-team@…, cached on
+//                  Project.teamGroupEmail) whose members are the confirmed
+//                  roster's DALI emails. Env-gated; reports "skipped" when the
+//                  Admin SDK isn't configured.
 //   - github:      get-or-create the project's GITHUB_ORG team (from
 //                  Project.githubTeamSlug) and add the confirmed roster.
 
@@ -84,7 +96,15 @@ export async function action({ request }: Route.ActionArgs) {
   }
   const project = await prisma.project.findUnique({
     where: { id: body.projectId },
-    select: { id: true, name: true, githubTeamSlug: true, slackChannelId: true, repoUrls: true },
+    select: {
+      id: true,
+      name: true,
+      githubTeamSlug: true,
+      slackChannelId: true,
+      repoUrls: true,
+      calendarEmail: true,
+      teamGroupEmail: true,
+    },
   });
   if (!project) {
     return withCors(request, Response.json({ error: "Project not found" }, { status: 404 }));
@@ -238,12 +258,121 @@ export async function action({ request }: Route.ActionArgs) {
     }
   }
 
-  // ── gmail (stub) ───────────────────────────────────────────────────────────
+  // ── gmail ──────────────────────────────────────────────────────────────────
+  // Provision the project's Google Workspace identity:
+  //   1. USER  <slug>@dali.dartmouth.edu  — get-or-created, cached on
+  //      Project.calendarEmail (reused as the project's calendar owner). If the
+  //      project already has a calendarEmail set, that exact address is used.
+  //   2. GROUP <slug>-team@dali.dartmouth.edu — get-or-created, cached on
+  //      Project.teamGroupEmail, with the confirmed roster's DALI emails added
+  //      as members. A roster member without a daliEmail is skipped + reported.
+  // Re-runnable: every Directory API call treats "already exists" (409) as
+  // success and we never remove members.
   if (selected.has("gmail")) {
-    results.gmail = {
-      status: "skipped",
-      message: "Google Workspace account provisioning is not configured.",
-    };
+    if (!workspaceConfigured()) {
+      results.gmail = {
+        status: "skipped",
+        message: "Google Workspace provisioning is not configured.",
+      };
+    } else {
+      try {
+        // Use the project's existing addresses when set; otherwise derive from
+        // the project name and backfill so later runs reuse the same identity.
+        const derived = deriveProjectEmails(project.name);
+        const userEmail = project.calendarEmail?.trim() || derived.userEmail;
+        const groupEmail = project.teamGroupEmail?.trim() || derived.groupEmail;
+
+        const parts: string[] = [];
+
+        // 1. User account.
+        const user = await provisionProjectUser({
+          email: userEmail,
+          projectName: project.name,
+        });
+        if (user.status === "error") {
+          results.gmail = { status: "error", message: `User: ${user.message}` };
+        } else {
+          parts.push(
+            user.status === "ok"
+              ? `${user.created ? "created" : "found"} user ${user.email}`
+              : `user ${user.message}`,
+          );
+          if (user.status === "ok" && !project.calendarEmail) {
+            await prisma.project.update({
+              where: { id: project.id },
+              data: { calendarEmail: user.email },
+            });
+          }
+
+          // 2. Group.
+          const group = await ensureWorkspaceGroup({
+            email: groupEmail,
+            name: `${project.name} Team`,
+          });
+          if (group.status === "error") {
+            results.gmail = { status: "error", message: `Group: ${group.message}` };
+          } else {
+            parts.push(
+              group.status === "ok"
+                ? `${group.created ? "created" : "found"} group ${group.email}`
+                : `group ${group.message}`,
+            );
+            if (group.status === "ok" && !project.teamGroupEmail) {
+              await prisma.project.update({
+                where: { id: project.id },
+                data: { teamGroupEmail: group.email },
+              });
+            }
+
+            // 3. Add the confirmed roster's DALI emails to the group.
+            if (group.status === "ok") {
+              const roster = await prisma.staffingAssignment.findMany({
+                where: {
+                  staffingCycleId: cycle.id,
+                  projectId: project.id,
+                  status: "Confirmed",
+                },
+                select: {
+                  user: { select: { firstName: true, lastName: true, daliEmail: true } },
+                },
+              });
+              const emails = new Set<string>();
+              const missing: string[] = [];
+              for (const r of roster) {
+                const e = r.user.daliEmail?.trim();
+                if (e) emails.add(e);
+                else missing.push(`${r.user.firstName} ${r.user.lastName}`);
+              }
+
+              let added = 0;
+              let already = 0;
+              const memberErrors: string[] = [];
+              for (const email of emails) {
+                const m = await addGroupMember({ groupEmail: group.email, memberEmail: email });
+                if (m.status === "error") memberErrors.push(`${email}: ${m.message}`);
+                else if (m.added) added++;
+                else already++;
+              }
+
+              parts.push(`added ${added} member${added === 1 ? "" : "s"}`);
+              if (already > 0) parts.push(`${already} already in group`);
+              if (missing.length > 0) {
+                parts.push(`skipped ${missing.length} with no DALI email (${missing.join(", ")})`);
+              }
+              results.gmail = {
+                status: memberErrors.length > 0 ? "error" : "ok",
+                message:
+                  memberErrors.length > 0
+                    ? `${parts.join("; ")}; errors: ${memberErrors.join("; ")}`
+                    : `${parts.join("; ")}.`,
+              };
+            }
+          }
+        }
+      } catch (err) {
+        results.gmail = { status: "error", message: errMsg(err) };
+      }
+    }
   }
 
   // ── github ───────────────────────────────────────────────────────────────

--- a/dali-api/docs/ONBOARDING_PROVISIONING.md
+++ b/dali-api/docs/ONBOARDING_PROVISIONING.md
@@ -51,7 +51,9 @@ this exists yet — here's the one-time setup:
 2. Enable the **Admin SDK API** for that project.
 3. In the **Google Workspace Admin console** → Security → API controls →
    **Domain-wide delegation**, add the service account's **client ID** with the
-   scope: `https://www.googleapis.com/auth/admin.directory.user`.
+   scopes: `https://www.googleapis.com/auth/admin.directory.user`,
+   `https://www.googleapis.com/auth/admin.directory.group` (the group scope is
+   needed for the staffing "Create Gmail accounts" project automation below).
 4. Pick a **Workspace super-admin** account for the service account to
    impersonate (delegation requires acting *as* an admin).
 5. Set these env vars (Fly secrets in dev/staging/prod):
@@ -70,6 +72,28 @@ Until configured, this step reports `skipped`.
 
 Code: `app/lib/google-workspace.ts` (uses `google-auth-library`, already a
 dependency — no `googleapis` needed).
+
+---
+
+## Project Workspace identity (staffing "Create Gmail accounts")
+
+Separately from per-member provisioning, the staffing **Finalize** modal's
+**Create Gmail accounts** automation
+(`app/projects/routes/api.staffing.finalize.ts`) provisions a project's own
+Workspace identity for the confirmed roster:
+
+1. A **user** account `<slug>@dali.dartmouth.edu` (slug = the hyphenated project
+   name). Cached on `Project.calendarEmail` — if that's already set (the
+   project's calendar owner), that exact address is reused instead of deriving.
+2. A **group** `<slug>-team@dali.dartmouth.edu`. Cached on
+   `Project.teamGroupEmail`, with each confirmed roster member's
+   `User.daliEmail` added as a `MEMBER`.
+
+Uses the **same** service-account env as member provisioning above, plus the
+`admin.directory.group` delegation scope. Re-runnable: every Directory API call
+treats "already exists" (409) as success and members are never removed. Roster
+members without a `daliEmail` are skipped and named in the result. Until the env
+is configured, the step reports `skipped`.
 
 ---
 

--- a/dali-api/prisma/migrations/20260603120000_project_team_group_email/migration.sql
+++ b/dali-api/prisma/migrations/20260603120000_project_team_group_email/migration.sql
@@ -1,0 +1,6 @@
+-- Project-team Google Workspace GROUP address (e.g.
+-- "projectalpha-team@dali.dartmouth.edu"). Get-or-created by the staffing
+-- "Create Gmail accounts" finalize automation, which also adds the confirmed
+-- roster as group members. Null until that automation first runs. Nullable,
+-- additive — no backfill, no data loss.
+ALTER TABLE "Project" ADD COLUMN "teamGroupEmail" TEXT;

--- a/dali-api/prisma/schema.prisma
+++ b/dali-api/prisma/schema.prisma
@@ -1842,8 +1842,16 @@ model Project {
   description   String?
   // Project-owned Google Workspace identity (e.g.,
   // "projectalpha@dali.dartmouth.edu"). Calendar events for this project
-  // are owned by this identity, not the organizer's personal calendar.
+  // are owned by this identity, not the organizer's personal calendar. Also
+  // the user account provisioned by the staffing "Create Gmail accounts"
+  // finalize automation (backfilled there if unset).
   calendarEmail String?
+
+  // Project-team Google Workspace GROUP address (e.g.,
+  // "projectalpha-team@dali.dartmouth.edu"). Get-or-created by the staffing
+  // "Create Gmail accounts" finalize automation, which also adds the confirmed
+  // roster as group members. Null until that automation first runs.
+  teamGroupEmail String?
   // Expected span length: how many terms the project is *planned* to run, as
   // a target. Independent of the actual ProjectTerm set — a project may have
   // fewer terms added than expected (still being scheduled) or more. Drives


### PR DESCRIPTION
## What

Implements the **Create Gmail accounts** automation in the staffing **Finalize** modal — previously a "Not configured" stub. On finalize it provisions the project's Google Workspace identity for the confirmed roster:

1. **User account** — `<slug>@dali.dartmouth.edu` (slug = hyphenated project name). Cached on `Project.calendarEmail`; if that's already set (the project's calendar owner), the existing address is reused instead of re-deriving.
2. **Group** — `<slug>-team@dali.dartmouth.edu`, cached on the new `Project.teamGroupEmail` column. Each confirmed roster member's `User.daliEmail` is added as a `MEMBER`.

This matches the request: a `projectname@…` *user* plus a `projectname-team@…` *group* containing the people staffed on that project.

## How

- **`app/lib/google-workspace.ts`** — extends the existing Admin SDK Directory client (already used for member `@dali.dartmouth.edu` accounts via `google-auth-library` + service account + domain-wide delegation). Refactors user-create into a shared `createDirectoryUser`, and adds:
  - `deriveProjectEmails(name)` → `{ userEmail, groupEmail }`
  - `provisionProjectUser({ email, projectName })` — create user at an explicit email
  - `ensureWorkspaceGroup({ email, name })` and `addGroupMember({ groupEmail, memberEmail })`
  - adds the `admin.directory.group` scope
- **`app/projects/routes/api.staffing.finalize.ts`** — replaces the gmail stub with the real flow (user → group → add roster), reporting a per-step message.
- **`FinalizeModal.tsx`** — flips the gmail automation to `configured: true` and updates its description.
- **Schema/migration** — adds nullable `Project.teamGroupEmail` (additive, no backfill, no data loss).
- **Docs** — `ONBOARDING_PROVISIONING.md` gains a "Project Workspace identity" section + the group scope.
- **Test** — unit tests for `deriveProjectEmails` slugification edge cases.

## Idempotency & safety

- Every Directory API call treats **409 (already exists)** as success; members are **never removed** → safe to re-run, consistent with the Slack/GitHub steps.
- **Env-gated**: reports `skipped` when the Workspace service account isn't configured — ships safely with the integration off.
- Roster members **without a `daliEmail`** are skipped and named in the result message.

## Test plan

- [x] `npm test` — `app/lib` + `app/projects` suites: 360 passing (incl. new `google-workspace.test.ts`).
- [x] `npm run typecheck` — no errors in `app/` (pre-existing `scripts/` errors are unrelated).
- [ ] Live Workspace provisioning requires the `GOOGLE_WORKSPACE_*` service-account env (+ new group scope) — reports `skipped` until configured, so behavior is unchanged in environments without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/769"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783129031&installation_id=133523038&pr_number=769&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F769&signature=61c7f231ebd8d910a4af6b1cfad92cfb4a135ab9adc124565f9d6598aafe2a6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->