### PR TITLE
PresenceBar: tighten hover-card trigger to the avatar only

### DIFF
--- a/dali-api/app/components/collab/PresenceBar.tsx
+++ b/dali-api/app/components/collab/PresenceBar.tsx
@@ -1,7 +1,11 @@
-import { useMemo } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { Link } from "react-router";
 import { usePresence, type Peer } from "./PresenceProvider";
 import { initialsFromName } from "./util";
+
+// Short grace period so moving the cursor from the chip across the gap to the
+// hover card doesn't briefly drop hover state and dismiss the card.
+const HOVER_CLOSE_DELAY_MS = 120;
 
 interface PresenceBarProps {
   className?: string;
@@ -122,16 +126,44 @@ function PresenceChip({
       ? "cursor-pointer hover:z-10 hover:scale-110"
       : "cursor-default";
 
+  // The hover card is driven by explicit pointer state on the chip and the
+  // card so the trigger zone is exactly the avatar (not the bounding box of
+  // any wrapper), and so moving the cursor onto the card keeps it open. CSS
+  // group-hover wrapped both the trigger and the absolutely-positioned card,
+  // which made the trigger zone hard to reason about and let stray hover
+  // events near the chip obscure adjacent buttons.
+  const [open, setOpen] = useState(false);
+  const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const cancelClose = useCallback(() => {
+    if (closeTimer.current) {
+      clearTimeout(closeTimer.current);
+      closeTimer.current = null;
+    }
+  }, []);
+  const show = useCallback(() => {
+    cancelClose();
+    setOpen(true);
+  }, [cancelClose]);
+  const hideSoon = useCallback(() => {
+    cancelClose();
+    closeTimer.current = setTimeout(() => setOpen(false), HOVER_CLOSE_DELAY_MS);
+  }, [cancelClose]);
+
   const chipInner = (
     <span
       className={`relative inline-flex items-center justify-center w-6 h-6 rounded-full overflow-hidden ring-2 ring-white transition-transform ${interactiveClass} ${idleClass}`}
+      onPointerEnter={show}
+      onPointerLeave={hideSoon}
+      onFocus={show}
+      onBlur={hideSoon}
     >
       <ChipAvatar peer={peer} />
     </span>
   );
 
   return (
-    <div className="relative group">
+    <div className="relative">
       {linkable ? (
         <Link
           to={`/members/${peer.userId}`}
@@ -151,7 +183,14 @@ function PresenceChip({
       ) : (
         chipInner
       )}
-      <HoverCard peer={peer} followable={followable} onFollow={onFollow} />
+      <HoverCard
+        peer={peer}
+        followable={followable}
+        onFollow={onFollow}
+        open={open}
+        onPointerEnter={show}
+        onPointerLeave={hideSoon}
+      />
     </div>
   );
 }
@@ -160,20 +199,34 @@ function HoverCard({
   peer,
   followable,
   onFollow,
+  open,
+  onPointerEnter,
+  onPointerLeave,
 }: {
   peer: Peer;
   followable: boolean;
   onFollow: (clientId: number) => void;
+  open: boolean;
+  onPointerEnter: () => void;
+  onPointerLeave: () => void;
 }) {
   const meTag = peer.isMe ? " (you)" : "";
   const idleTag = peer.idle ? " · idle" : "";
 
+  // Unmount when closed so the invisible card doesn't intercept clicks on
+  // anything below it (the prior implementation kept pointer-events-auto on
+  // the inner div even at opacity-0, which could absorb a click meant for
+  // a button the card was covering).
+  if (!open) return null;
+
   return (
     <div
       role="tooltip"
-      className="pointer-events-none absolute left-1/2 top-full z-20 mt-2 -translate-x-1/2 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity"
+      className="absolute left-1/2 top-full z-20 mt-2 -translate-x-1/2 transition-opacity"
+      onPointerEnter={onPointerEnter}
+      onPointerLeave={onPointerLeave}
     >
-      <div className="pointer-events-auto min-w-[12rem] max-w-[16rem] rounded-md border border-border bg-popover text-popover-foreground shadow-lg p-2.5 text-left">
+      <div className="min-w-[12rem] max-w-[16rem] rounded-md border border-border bg-popover text-popover-foreground shadow-lg p-2.5 text-left">
         <div className="flex items-center gap-2">
           <div className="w-8 h-8 shrink-0 rounded-full overflow-hidden">
             <ChipAvatar peer={peer} />


### PR DESCRIPTION
## Summary
- The presence hover card popped up when the cursor was anywhere near a chip — including over buttons next to the chip — because the trigger was a wrapping `group` element and the (invisible) card kept `pointer-events-auto` at `opacity-0`.
- Switch to explicit pointer state on the avatar and card so the trigger zone is exactly the 24×24 avatar, and unmount the card when closed so it can't intercept clicks underneath.
- Preserve "hovering the card keeps it open" via shared handlers + a 120 ms close grace period that bridges the 8 px gap from chip to card.

## Test plan
- [ ] Hover an avatar — card appears.
- [ ] Move cursor onto the card — card stays open (works because the card has the same pointer handlers and a 120 ms grace period bridges the gap).
- [ ] Move cursor off the card → it disappears after ~120 ms.
- [ ] Hover near a button adjacent to a chip — the card no longer appears (trigger zone is just the avatar).
- [ ] Click a button under where the card would render — click registers (card unmounts when closed instead of capturing pointer events).
- [ ] Keyboard focus the chip — card appears (focus handlers preserved); tab away — it closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/770"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783129895&installation_id=133523038&pr_number=770&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F770&signature=92900c3affdd8e440e0cf58a8371e6ce01be102dc946c86a4c6ee6dd40972b6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->