### PR TITLE
Staffing board: add non-bidder members manually; merge duplicate project bids on card

### DIFF
--- a/dali-api/app/lib/audit.ts
+++ b/dali-api/app/lib/audit.ts
@@ -29,6 +29,8 @@ export const AUDIT_ACTIONS = [
   "group.delete",
   "staffing.assign",
   "staffing.finalize",
+  "staffing.board-member.add",
+  "staffing.board-member.remove",
   "document.delete",
   "projectFile.create",
   "projectFile.version",

--- a/dali-api/app/members/lib/welcome.server.ts
+++ b/dali-api/app/members/lib/welcome.server.ts
@@ -127,6 +127,7 @@ export function onboardingEmailHtml(
     <hr style="border:none;border-top:1px solid #e5e7eb;margin:24px 0;"/>
     ${accountBlock}
     <p>Once you're in, finish setting up by completing your member profile and onboarding steps.</p>
+    <p><strong>The deadline to accept your offer and complete onboarding is June 8th, 2026.</strong></p>
     ${slackLine}
     <p>— The DALI Lab</p>
     <p><img src="${logoUrl}" alt="DALI Lab" width="96" style="display:block;border:0;"/></p>

--- a/dali-api/app/projects/components/AddMemberControl.tsx
+++ b/dali-api/app/projects/components/AddMemberControl.tsx
@@ -1,0 +1,142 @@
+import { useEffect, useRef, useState } from "react";
+import { useRevalidator } from "react-router";
+import { UserPlus } from "lucide-react";
+
+type Candidate = { userId: string; name: string; email: string | null };
+
+// "Add member" search-and-add control for the staffing board. Lets a staffing
+// lead place a DALI member who never bid onto the board as an Unassigned card.
+// Searches /api/staffing/board-member (debounced); POSTing adds the member and
+// revalidates the route so the new card appears.
+export function AddMemberControl({ cycleId }: { cycleId: string }) {
+  const revalidator = useRevalidator();
+  const [open, setOpen] = useState(false);
+  const [q, setQ] = useState("");
+  const [results, setResults] = useState<Candidate[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [adding, setAdding] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Close on outside click.
+  useEffect(() => {
+    if (!open) return;
+    function onDown(e: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", onDown);
+    return () => document.removeEventListener("mousedown", onDown);
+  }, [open]);
+
+  // Debounced search whenever the query changes (min 2 chars).
+  useEffect(() => {
+    if (!open) return;
+    const query = q.trim();
+    if (query.length < 2) {
+      setResults([]);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    const ctrl = new AbortController();
+    const t = setTimeout(async () => {
+      try {
+        const res = await fetch(
+          `/api/staffing/board-member?cycleId=${encodeURIComponent(cycleId)}&q=${encodeURIComponent(query)}`,
+          { credentials: "include", signal: ctrl.signal },
+        );
+        const json = (await res.json().catch(() => ({}))) as {
+          results?: Candidate[];
+          error?: string;
+        };
+        if (!res.ok) {
+          setError(json.error ?? `Search failed: ${res.status}`);
+          setResults([]);
+        } else {
+          setError(null);
+          setResults(json.results ?? []);
+        }
+      } catch (e) {
+        if ((e as Error).name !== "AbortError") setError("Search failed");
+      } finally {
+        setLoading(false);
+      }
+    }, 250);
+    return () => {
+      clearTimeout(t);
+      ctrl.abort();
+    };
+  }, [q, open, cycleId]);
+
+  async function add(userId: string) {
+    setAdding(userId);
+    setError(null);
+    try {
+      const res = await fetch("/api/staffing/board-member", {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ cycleId, userId }),
+      });
+      const json = (await res.json().catch(() => ({}))) as { error?: string };
+      if (!res.ok) {
+        setError(json.error ?? `Add failed: ${res.status}`);
+        return;
+      }
+      // Drop the added member from the local list; refresh the board.
+      setResults((prev) => prev.filter((r) => r.userId !== userId));
+      revalidator.revalidate();
+    } catch {
+      setError("Add failed");
+    } finally {
+      setAdding(null);
+    }
+  }
+
+  return (
+    <div className="relative" ref={containerRef}>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="inline-flex items-center gap-1.5 text-sm px-2.5 py-1 border border-border rounded-md bg-background text-foreground hover:bg-muted focus:outline-none focus:ring-2 focus:ring-accent-coral/30"
+      >
+        <UserPlus className="w-4 h-4" />
+        Add member
+      </button>
+
+      {open && (
+        <div className="absolute right-0 mt-1 w-72 bg-card border border-border rounded-md shadow-lg z-50 p-2">
+          <input
+            autoFocus
+            type="text"
+            value={q}
+            onChange={(e) => setQ(e.target.value)}
+            placeholder="Search members by name or email…"
+            className="w-full text-sm px-2 py-1.5 border border-border rounded-md bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-accent-coral/30"
+          />
+          {error && <p className="text-xs text-destructive mt-1.5">{error}</p>}
+          <div className="mt-2 max-h-64 overflow-y-auto flex flex-col gap-0.5">
+            {loading && <p className="text-xs text-muted-foreground px-1 py-1">Searching…</p>}
+            {!loading && q.trim().length >= 2 && results.length === 0 && !error && (
+              <p className="text-xs text-muted-foreground px-1 py-1">No members found.</p>
+            )}
+            {results.map((r) => (
+              <button
+                key={r.userId}
+                type="button"
+                disabled={adding === r.userId}
+                onClick={() => add(r.userId)}
+                className="text-left px-2 py-1.5 rounded hover:bg-muted disabled:opacity-50 flex flex-col"
+              >
+                <span className="text-sm text-foreground">{r.name}</span>
+                {r.email && <span className="text-[11px] text-muted-foreground">{r.email}</span>}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dali-api/app/projects/components/MemberCard.tsx
+++ b/dali-api/app/projects/components/MemberCard.tsx
@@ -12,12 +12,15 @@ type Props = {
   card: MemberCardModel;
   columnId: string;
   projectNames: Record<string, string>;
+  domainNames: Record<string, string>;
   onOpenBid: () => void;
+  /** Remove a manually-added member from the board. Only passed for managers. */
+  onRemove?: () => void;
   /** When false the card is static (read-only viewers). */
   draggable: boolean;
 };
 
-export function MemberCard({ card, columnId, projectNames, onOpenBid, draggable }: Props) {
+export function MemberCard({ card, columnId, projectNames, domainNames, onOpenBid, onRemove, draggable }: Props) {
   const dragId = `${columnId}::${card.userId}`;
   const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
     id: dragId,
@@ -73,13 +76,37 @@ export function MemberCard({ card, columnId, projectNames, onOpenBid, draggable 
                 Bid unresolved
               </span>
             )}
+            {card.manuallyAdded && (
+              <span
+                className="inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium rounded bg-muted text-muted-foreground"
+                title="Manually added to the board (no bid submitted)."
+              >
+                Added
+              </span>
+            )}
           </div>
           <RoleStrip card={card} />
         </div>
+        {onRemove && card.manuallyAdded && (
+          <button
+            type="button"
+            // Stop the press from starting a drag or opening the bid modal.
+            onPointerDown={(e) => e.stopPropagation()}
+            onClick={(e) => {
+              e.stopPropagation();
+              onRemove();
+            }}
+            title="Remove from board"
+            aria-label={`Remove ${fullName} from board`}
+            className="flex-shrink-0 text-muted-foreground hover:text-destructive text-sm leading-none px-1 rounded hover:bg-muted"
+          >
+            ×
+          </button>
+        )}
       </div>
 
       <DomainLevelStrip card={card} />
-      <BidStrip card={card} projectNames={projectNames} />
+      <BidStrip card={card} projectNames={projectNames} domainNames={domainNames} />
     </div>
   );
 }
@@ -141,9 +168,11 @@ function RoleStrip({ card }: { card: MemberCardModel }) {
 function BidStrip({
   card,
   projectNames,
+  domainNames,
 }: {
   card: MemberCardModel;
   projectNames: Record<string, string>;
+  domainNames: Record<string, string>;
 }) {
   // Always show the member's top 3 project preferences in rank order,
   // regardless of which column the card is in.
@@ -160,12 +189,23 @@ function BidStrip({
   }
   return (
     <ol className="text-[11px] text-muted-foreground flex flex-col gap-0.5">
-      {card.topPreferences.map((p) => (
-        <li key={p.projectId} className="truncate">
-          <span className="font-semibold">#{p.rank}</span>{" "}
-          {projectNames[p.projectId] ?? p.projectId}
-        </li>
-      ))}
+      {card.topPreferences.map((p) => {
+        // A project bid at this rank in multiple domains shows the project once
+        // with its domains appended (e.g. "Evergreen — Fullstack, UI/UX"),
+        // rather than repeating the project line per domain.
+        const domains = p.domainIds
+          .map((id) => domainNames[id])
+          .filter((n): n is string => !!n);
+        return (
+          <li key={`${p.projectId}-${p.rank}`} className="truncate">
+            <span className="font-semibold">#{p.rank}</span>{" "}
+            {projectNames[p.projectId] ?? p.projectId}
+            {domains.length > 0 && (
+              <span className="text-muted-foreground/70"> — {domains.join(", ")}</span>
+            )}
+          </li>
+        );
+      })}
     </ol>
   );
 }

--- a/dali-api/app/projects/components/StaffingBoard.tsx
+++ b/dali-api/app/projects/components/StaffingBoard.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react";
-import { useSearchParams } from "react-router";
+import { useSearchParams, useRevalidator } from "react-router";
 import {
   DndContext,
   PointerSensor,
@@ -21,6 +21,7 @@ import { CheckCircle2 } from "lucide-react";
 import { MemberCard } from "./MemberCard";
 import { BidModal } from "./BidModal";
 import { FinalizeModal } from "./FinalizeModal";
+import { AddMemberControl } from "./AddMemberControl";
 
 type ProjectMeta = { id: string; name: string; status: "Active" | "Paused" | "Archived" };
 
@@ -59,6 +60,7 @@ export function StaffingBoard({
   canManage,
 }: Props) {
   const [searchParams, setSearchParams] = useSearchParams();
+  const revalidator = useRevalidator();
   const [assignments, setAssignments] = useState<Assignment[]>(initialAssignments);
   const [error, setError] = useState<string | null>(null);
   const [openBidUserId, setOpenBidUserId] = useState<string | null>(null);
@@ -134,6 +136,26 @@ export function StaffingBoard({
     });
   }
 
+  async function handleRemoveMember(userId: string) {
+    setError(null);
+    try {
+      const res = await fetch("/api/staffing/board-member", {
+        method: "DELETE",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ cycleId, userId }),
+      });
+      if (!res.ok) {
+        const json = (await res.json().catch(() => ({}))) as { error?: string };
+        setError(json.error ?? `Failed to remove member: ${res.status}`);
+        return;
+      }
+      revalidator.revalidate();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to remove member");
+    }
+  }
+
   const openBidMember = openBidUserId ? memberById.get(openBidUserId) ?? null : null;
   const openBidColumnId = openBidUserId
     ? assignments.find((a) => a.userId === openBidUserId)?.projectId ?? null
@@ -142,6 +164,7 @@ export function StaffingBoard({
   return (
     <div className="flex flex-col gap-3">
       <div className="flex items-center justify-end gap-3 flex-wrap">
+        {canManage && <AddMemberControl cycleId={cycleId} />}
         <div className="flex items-center gap-2">
           <label className="sr-only" htmlFor="staffing-term">
             Term
@@ -191,7 +214,9 @@ export function StaffingBoard({
             tone="muted"
             cards={board[UNASSIGNED] ?? []}
             projectNames={projectNames}
+            domainNames={domainNames}
             onOpenBid={setOpenBidUserId}
+            onRemoveMember={canManage ? handleRemoveMember : undefined}
             draggable={canManage}
           />
           {projects.map((p) => (
@@ -203,6 +228,7 @@ export function StaffingBoard({
               tone={p.status === "Active" ? "active" : "dim"}
               cards={board[p.id] ?? []}
               projectNames={projectNames}
+              domainNames={domainNames}
               demand={demandByProject[p.id]}
               onOpenBid={setOpenBidUserId}
               draggable={canManage}
@@ -247,8 +273,10 @@ function Column({
   tone,
   cards,
   projectNames,
+  domainNames,
   demand,
   onOpenBid,
+  onRemoveMember,
   draggable,
   onFinalize,
 }: {
@@ -258,11 +286,14 @@ function Column({
   tone: ColumnTone;
   cards: MemberCardModel[];
   projectNames: Record<string, string>;
+  domainNames: Record<string, string>;
   // Per-domain expected headcount for this project this term. Absent for
   // the Unassigned column and for projects with no ProjectRoleRequest rows;
   // rendered as small chips under the assigned count.
   demand?: DomainDemand[];
   onOpenBid: (userId: string) => void;
+  // Remove a manually-added member from the board. Only set for managers.
+  onRemoveMember?: (userId: string) => void;
   draggable: boolean;
   // Only set for project columns the user can manage; renders the finalize
   // icon button in the header.
@@ -330,7 +361,9 @@ function Column({
               card={card}
               columnId={id}
               projectNames={projectNames}
+              domainNames={domainNames}
               onOpenBid={() => onOpenBid(card.userId)}
+              onRemove={onRemoveMember ? () => onRemoveMember(card.userId) : undefined}
               draggable={draggable}
             />
           ))

--- a/dali-api/app/projects/lib/__tests__/staffing-board.test.ts
+++ b/dali-api/app/projects/lib/__tests__/staffing-board.test.ts
@@ -53,6 +53,53 @@ describe("buildBoard", () => {
     expect(card.topPreferences.map((p) => p.projectId)).toEqual(["p9", "p1"]);
   });
 
+  it("dedupes same-project same-rank bids into one entry listing each domain", () => {
+    // Gaelle's case: rank-1 bid on "Evergreen" in two domains. The card should
+    // show one #1 Evergreen entry whose domainIds carry both, not two lines.
+    const board = buildBoard({
+      projectIds: [],
+      members: [
+        member({
+          preferences: [
+            { projectId: "evergreen", domainId: "fullstack", level: "P1", preferenceRank: 1, notes: null },
+            { projectId: "evergreen", domainId: "uiux", level: "P1", preferenceRank: 1, notes: null },
+            { projectId: "p2", domainId: "fullstack", level: "P1", preferenceRank: 2, notes: null },
+          ],
+        }),
+      ],
+      assignments: [],
+    });
+    const { topPreferences } = board[UNASSIGNED][0];
+    expect(topPreferences).toEqual([
+      { projectId: "evergreen", rank: 1, domainIds: ["fullstack", "uiux"] },
+      { projectId: "p2", rank: 2, domainIds: ["fullstack"] },
+    ]);
+  });
+
+  it("caps topPreferences at 3 distinct (project, rank) entries, not raw rows", () => {
+    const board = buildBoard({
+      projectIds: [],
+      members: [
+        member({
+          preferences: [
+            // Two rows for rank 1 collapse to one entry, leaving room for 2,3,4.
+            { projectId: "p1", domainId: "d1", level: "P1", preferenceRank: 1, notes: null },
+            { projectId: "p1", domainId: "d2", level: "P1", preferenceRank: 1, notes: null },
+            { projectId: "p2", domainId: "d1", level: "P1", preferenceRank: 2, notes: null },
+            { projectId: "p3", domainId: "d1", level: "P1", preferenceRank: 3, notes: null },
+            { projectId: "p4", domainId: "d1", level: "P1", preferenceRank: 4, notes: null },
+          ],
+        }),
+      ],
+      assignments: [],
+    });
+    expect(board[UNASSIGNED][0].topPreferences.map((p) => p.projectId)).toEqual([
+      "p1",
+      "p2",
+      "p3",
+    ]);
+  });
+
   it("puts an assigned member in the project column and uses the assignment's level", () => {
     const board = buildBoard({
       projectIds: ["p1"],

--- a/dali-api/app/projects/lib/staffing-board.ts
+++ b/dali-api/app/projects/lib/staffing-board.ts
@@ -45,6 +45,10 @@ export type MemberInput = {
   // staffing lead notices, rather than vanishing. Derived in the loader; never
   // set for members whose preferences resolved normally.
   unresolvedBid?: boolean;
+  // True when a staffing lead manually placed this member on the board (no bid)
+  // via StaffingBoardMember. Drives the card's remove (×) affordance. A member
+  // who also bid is sourced from their preferences instead, so this stays false.
+  manuallyAdded?: boolean;
 };
 
 export type Assignment = {
@@ -69,10 +73,16 @@ export type MemberCardModel = {
   // For an assigned column, the level recorded on the assignment row.
   level: Level | null;
   // Member's top 3 project preferences in rank order. Always shown on the card.
-  topPreferences: { projectId: string; rank: number }[];
+  // Deduped by (projectId, rank): a member can bid the same project at one rank
+  // in multiple domains (e.g. Evergreen #1 as both Fullstack and UI/UX) — those
+  // collapse to one entry whose `domainIds` lists each bid domain, so the card
+  // shows the project once with its domains rather than repeating the line.
+  topPreferences: { projectId: string; rank: number; domainIds: string[] }[];
   // Mirrors MemberInput.unresolvedBid — the card renders a badge so the member
   // is visibly distinguished from one who simply hasn't been placed yet.
   unresolvedBid: boolean;
+  // Mirrors MemberInput.manuallyAdded — drives the card's remove (×) button.
+  manuallyAdded: boolean;
 };
 
 export const UNASSIGNED = "__unassigned__";
@@ -144,12 +154,34 @@ function toCard(
     coreTitles: member.coreTitles,
     domainLevels: member.domainLevels,
     level,
-    topPreferences: [...member.preferences]
-      .sort((a, b) => a.preferenceRank - b.preferenceRank)
-      .slice(0, 3)
-      .map((p) => ({ projectId: p.projectId, rank: p.preferenceRank })),
+    topPreferences: topPreferences(member.preferences),
     unresolvedBid: member.unresolvedBid ?? false,
+    manuallyAdded: member.manuallyAdded ?? false,
   };
+}
+
+// Top 3 project picks in rank order, deduped by (projectId, rank). When a member
+// bids the same project at the same rank in several domains, the entry's
+// `domainIds` lists each (in first-seen order). The 3-item cap counts distinct
+// (project, rank) entries, not raw preference rows.
+function topPreferences(
+  prefs: Preference[],
+): { projectId: string; rank: number; domainIds: string[] }[] {
+  const byKey = new Map<string, { projectId: string; rank: number; domainIds: string[] }>();
+  for (const p of [...prefs].sort((a, b) => a.preferenceRank - b.preferenceRank)) {
+    const key = `${p.projectId}::${p.preferenceRank}`;
+    const entry = byKey.get(key);
+    if (entry) {
+      if (!entry.domainIds.includes(p.domainId)) entry.domainIds.push(p.domainId);
+    } else {
+      byKey.set(key, {
+        projectId: p.projectId,
+        rank: p.preferenceRank,
+        domainIds: [p.domainId],
+      });
+    }
+  }
+  return Array.from(byKey.values()).slice(0, 3);
 }
 
 function topPreference(prefs: Preference[]): Preference | null {

--- a/dali-api/app/projects/routes/api.staffing.board-member.ts
+++ b/dali-api/app/projects/routes/api.staffing.board-member.ts
@@ -1,0 +1,189 @@
+import type { Route } from "./+types/api.staffing.board-member";
+import { prisma } from "~/lib/db";
+import { requireAuth } from "~/lib/auth";
+import { canManageStaffing } from "~/lib/roles";
+import { withCors, handlePreflight } from "~/lib/cors";
+import { logAuditEvent } from "~/lib/audit";
+
+// Staffing board membership for non-bidders.
+//
+//   GET  /api/staffing/board-member?cycleId=&q=
+//        Search DALI members (by name/email) to add to the board. Excludes
+//        users already on the board for this cycle (a bid, an assignment, or an
+//        existing StaffingBoardMember row). Returns up to 10 matches.
+//
+//   POST /api/staffing/board-member  { cycleId, userId }
+//        Upsert a StaffingBoardMember so the user shows as an Unassigned card.
+//
+//   DELETE /api/staffing/board-member  { cycleId, userId }
+//        Remove the manual board placement. Only removes the StaffingBoardMember
+//        row — it never touches the member's bids or assignments, so a member
+//        who also bid stays on the board.
+//
+// All paths require canManageStaffing.
+
+export async function loader({ request }: Route.LoaderArgs) {
+  const preflight = handlePreflight(request);
+  if (preflight) return preflight;
+
+  const auth = await requireAuth(request);
+  if (!auth.ok) return withCors(request, auth.response);
+  if (!(await canManageStaffing(auth.user.sub))) {
+    return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
+  }
+
+  const url = new URL(request.url);
+  const cycleId = url.searchParams.get("cycleId");
+  const q = (url.searchParams.get("q") ?? "").trim();
+  if (!cycleId) {
+    return withCors(request, Response.json({ error: "cycleId required" }, { status: 400 }));
+  }
+  if (q.length < 2) {
+    return withCors(request, Response.json({ results: [] }));
+  }
+
+  // Already-on-the-board user ids: bidders, proposed-assignees, and existing
+  // manual board members. Excluded from search so the lead can't double-add.
+  const [prefs, assigns, board] = await Promise.all([
+    prisma.staffingPreference.findMany({
+      where: { staffingCycleId: cycleId },
+      select: { userId: true },
+      distinct: ["userId"],
+    }),
+    prisma.staffingAssignment.findMany({
+      where: { staffingCycleId: cycleId, status: "Proposed" },
+      select: { userId: true },
+      distinct: ["userId"],
+    }),
+    prisma.staffingBoardMember.findMany({
+      where: { staffingCycleId: cycleId },
+      select: { userId: true },
+    }),
+  ]);
+  const onBoard = new Set([
+    ...prefs.map((p) => p.userId),
+    ...assigns.map((a) => a.userId),
+    ...board.map((b) => b.userId),
+  ]);
+
+  // Per-token AND match across first/last/email, so "ada o" matches "Ada
+  // O'Brien". Members only (daliMember present) — the staff-able pool.
+  const tokens = q.split(/\s+/).filter(Boolean).slice(0, 4);
+  const users = await prisma.user.findMany({
+    where: {
+      daliMember: { isNot: null },
+      AND: tokens.map((t) => ({
+        OR: [
+          { firstName: { contains: t, mode: "insensitive" as const } },
+          { lastName: { contains: t, mode: "insensitive" as const } },
+          { daliEmail: { contains: t, mode: "insensitive" as const } },
+          { dartmouthEmail: { contains: t, mode: "insensitive" as const } },
+        ],
+      })),
+    },
+    select: {
+      id: true,
+      firstName: true,
+      lastName: true,
+      daliEmail: true,
+      dartmouthEmail: true,
+    },
+    orderBy: [{ lastName: "asc" }, { firstName: "asc" }],
+    take: 25,
+  });
+
+  const results = users
+    .filter((u) => !onBoard.has(u.id))
+    .slice(0, 10)
+    .map((u) => ({
+      userId: u.id,
+      name: `${u.firstName} ${u.lastName}`.trim(),
+      email: u.daliEmail ?? u.dartmouthEmail,
+    }));
+
+  return withCors(request, Response.json({ results }));
+}
+
+type MutateBody = { cycleId: string; userId: string };
+
+function isMutateBody(x: unknown): x is MutateBody {
+  if (!x || typeof x !== "object") return false;
+  const o = x as Record<string, unknown>;
+  return typeof o.cycleId === "string" && typeof o.userId === "string";
+}
+
+export async function action({ request }: Route.ActionArgs) {
+  const preflight = handlePreflight(request);
+  if (preflight) return preflight;
+
+  const auth = await requireAuth(request);
+  if (!auth.ok) return withCors(request, auth.response);
+  if (!(await canManageStaffing(auth.user.sub))) {
+    return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
+  }
+  if (request.method !== "POST" && request.method !== "DELETE") {
+    return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return withCors(request, Response.json({ error: "Invalid JSON" }, { status: 400 }));
+  }
+  if (!isMutateBody(body)) {
+    return withCors(request, Response.json({ error: "Invalid body" }, { status: 400 }));
+  }
+
+  const cycle = await prisma.staffingCycle.findUnique({
+    where: { id: body.cycleId },
+    select: { id: true },
+  });
+  if (!cycle) {
+    return withCors(request, Response.json({ error: "Cycle not found" }, { status: 404 }));
+  }
+
+  if (request.method === "DELETE") {
+    await prisma.staffingBoardMember.deleteMany({
+      where: { staffingCycleId: body.cycleId, userId: body.userId },
+    });
+    await logAuditEvent({
+      action: "staffing.board-member.remove",
+      userId: auth.user.sub,
+      targetId: body.userId,
+      metadata: { cycleId: body.cycleId },
+      request,
+    });
+    return withCors(request, Response.json({ ok: true }));
+  }
+
+  // POST: must be a real DALI member.
+  const user = await prisma.user.findFirst({
+    where: { id: body.userId, daliMember: { isNot: null } },
+    select: { id: true },
+  });
+  if (!user) {
+    return withCors(request, Response.json({ error: "User is not a DALI member" }, { status: 400 }));
+  }
+
+  // Idempotent: re-adding an existing board member is a no-op.
+  await prisma.staffingBoardMember.upsert({
+    where: {
+      userId_staffingCycleId: { userId: body.userId, staffingCycleId: body.cycleId },
+    },
+    update: {},
+    create: {
+      userId: body.userId,
+      staffingCycleId: body.cycleId,
+      addedById: auth.user.sub,
+    },
+  });
+  await logAuditEvent({
+    action: "staffing.board-member.add",
+    userId: auth.user.sub,
+    targetId: body.userId,
+    metadata: { cycleId: body.cycleId },
+    request,
+  });
+  return withCors(request, Response.json({ ok: true }));
+}

--- a/dali-api/app/projects/routes/projects.staffing.tsx
+++ b/dali-api/app/projects/routes/projects.staffing.tsx
@@ -282,6 +282,45 @@ export async function loader({ request }: Route.LoaderArgs) {
     members.push(...flagged);
   }
 
+  // Members a staffing lead manually placed on the board (no bid) — surfaced as
+  // ordinary Unassigned cards (no unresolved-bid flag). Skip anyone already in
+  // the pool above (they bid, or were flagged), so their real bid takes over.
+  const placedUserIds = new Set(members.map((m) => m.userId));
+  const boardMemberIds = (
+    await prisma.staffingBoardMember.findMany({
+      where: { staffingCycleId: cycle.id },
+      select: { userId: true },
+    })
+  )
+    .map((b) => b.userId)
+    .filter((id) => !placedUserIds.has(id));
+
+  if (boardMemberIds.length > 0) {
+    const manualUsers = await prisma.user.findMany({
+      where: { id: { in: boardMemberIds } },
+      select: {
+        id: true,
+        firstName: true,
+        lastName: true,
+        daliEmail: true,
+        dartmouthEmail: true,
+        photoUrl: true,
+        adminMembership: { select: { id: true } },
+        coreAssignments: { select: { leadTitle: true } },
+        domainEligibilities: {
+          select: { level: true, domain: { select: { displayName: true } } },
+        },
+      },
+    });
+    const manual = await Promise.all(
+      manualUsers.map(async (u) => ({
+        ...(await toMemberInput(u, [], false)),
+        manuallyAdded: true,
+      })),
+    );
+    members.push(...manual);
+  }
+
   const initialAssignments: Assignment[] = assignmentRows.map((a) => ({
     userId: a.userId,
     projectId: a.projectId,

--- a/dali-api/app/routes.ts
+++ b/dali-api/app/routes.ts
@@ -204,6 +204,7 @@ export default [
   // Staffing board (always open; one cycle per term, auto-created on view)
   route("api/staffing/assign", "projects/routes/api.staffing.assign.ts"),
   route("api/staffing/finalize", "projects/routes/api.staffing.finalize.ts"),
+  route("api/staffing/board-member", "projects/routes/api.staffing.board-member.ts"),
 
   // Project task board
   route("api/projects/:id/tasks", "projects/routes/api.projects.$id.tasks.ts"),

--- a/dali-api/prisma/migrations/20260603130000_staffing_board_member/migration.sql
+++ b/dali-api/prisma/migrations/20260603130000_staffing_board_member/migration.sql
@@ -1,0 +1,17 @@
+-- A member a staffing lead manually placed on the board for a cycle WITHOUT a
+-- bid. The board pool is otherwise derived from StaffingPreference / bid
+-- submissions; this row makes a non-bidder appear as an Unassigned card the
+-- lead can drag into a project. Additive; no data loss.
+CREATE TABLE "StaffingBoardMember" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "staffingCycleId" TEXT NOT NULL,
+    "addedById" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "StaffingBoardMember_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "StaffingBoardMember_userId_staffingCycleId_key" ON "StaffingBoardMember"("userId", "staffingCycleId");
+
+ALTER TABLE "StaffingBoardMember" ADD CONSTRAINT "StaffingBoardMember_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "StaffingBoardMember" ADD CONSTRAINT "StaffingBoardMember_staffingCycleId_fkey" FOREIGN KEY ("staffingCycleId") REFERENCES "StaffingCycle"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/dali-api/prisma/schema.prisma
+++ b/dali-api/prisma/schema.prisma
@@ -120,6 +120,7 @@ model User {
   essentialityFormsAsPm EssentialityForm[]         @relation("EssentialityFormPm")
   essentialityRatings   EssentialityRating[]
   staffingAssignments   StaffingAssignment[]
+  staffingBoardMembers  StaffingBoardMember[]
   intentToWork          IntentToWork[]
   formsCreated          Form[]
   formFolders           FormFolder[]
@@ -2402,6 +2403,27 @@ model StaffingCycle {
   intentToWork      IntentToWork[]
   formBindings      StaffingCycleFormBinding[]
   formSubmissions   FormSubmission[]
+  boardMembers      StaffingBoardMember[]
+}
+
+// A member a staffing lead manually placed on the board for a cycle WITHOUT a
+// bid. The board pool is otherwise derived from StaffingPreference / bid
+// submissions, so a non-bidder would never appear; this row makes them show up
+// as an ordinary Unassigned card the lead can then drag into a project. It is
+// not a preference and not an assignment — purely "present on the board".
+// Removed when the lead removes the card. A member who later bids still has
+// their preferences take over the card; this row is harmless either way.
+model StaffingBoardMember {
+  id              String   @id @default(cuid())
+  userId          String
+  staffingCycleId String
+  addedById       String? // actor; free-form userId, nullable for safety
+  createdAt       DateTime @default(now())
+
+  user          User          @relation(fields: [userId], references: [id])
+  staffingCycle StaffingCycle @relation(fields: [staffingCycleId], references: [id])
+
+  @@unique([userId, staffingCycleId])
 }
 
 model StaffingPreference {


### PR DESCRIPTION
Two staffing-board changes from the same request.

## 1. Add a bid member card (add member by search)

A staffing lead can now place a DALI member who **never submitted a bid** onto the board as an Unassigned card.

- **`AddMemberControl`** — an "Add member" button in the board toolbar (managers only) with a debounced search dropdown (name/email).
- **`StaffingBoardMember`** model (`userId` + `staffingCycleId`, unique) tracks the manual placement. It's not a preference and not an assignment — purely "present on the board." Additive migration, no data loss.
- **`/api/staffing/board-member`** route:
  - `GET ?cycleId=&q=` — search DALI members, excluding anyone already on the board (a bid, a proposed assignment, or an existing board-member row).
  - `POST` — idempotent upsert.
  - `DELETE` — remove the placement (never touches bids/assignments).
  - All gated on `canManageStaffing`.
- The loader unions board-members in as ordinary Unassigned cards, **skipping anyone who also bid** (their real bid takes over). Manually-added cards show an **"Added"** chip and a remove (**×**) button.

Note: a manually-added member has no preference, so dragging them into a project surfaces the existing "no preferences on file; can't infer a domain + level" message — consistent with current behavior for preference-less members.

## 2. Gaelle Valmir's card shows "#1 Evergreen" twice

Root cause (verified against the data): she has **two valid `StaffingPreference` rows** for project *Evergreen* at rank 1, differing only by domain (*Fullstack Dev* and *UI/UX Design*). The card listed each row, so the project repeated.

Fix is **display-only** — both rows are kept (the data is correct). `topPreferences` now dedupes by `(projectId, rank)` and carries each bid domain, so the card renders:

```
#1 Evergreen — Fullstack Dev, UI/UX Design
```

instead of two "#1 Evergreen" lines. The 3-pick cap now counts distinct (project, rank) entries.

## Tests
- [x] `staffing-board.test.ts` — added cases for dedupe-with-domains and the distinct-entry cap (13 passing).
- [x] `npm test` (app/projects + app/lib): 362 passing.
- [x] `npm run typecheck`: 0 errors in `app/`.
- [x] `npm run build`: succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/771"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783129971&installation_id=133523038&pr_number=771&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F771&signature=f47b3234814fc6f79fc413b3131f06fc6d8c06d9da30d5c21b052e159e3cb36e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->