### PR TITLE
Navigation: drop in-page back link, fix sidebar dedup on drifted tabs

### DIFF
--- a/dali-api/app/components/TabWorkspace.tsx
+++ b/dali-api/app/components/TabWorkspace.tsx
@@ -170,12 +170,14 @@ function appendWithLruCap(tabs: Tab[], protectedTabId: string): Tab[] {
   return [...tabs.slice(0, victimIdx), ...tabs.slice(victimIdx + 1)]
 }
 
-// Locate an open tab for `url`, matching on either its origin (so re-clicking
-// a sidebar section focuses a tab that has since drifted to a sub-page) or its
-// current url (so re-opening the exact deep link focuses it too).
+// Locate an open tab whose current url matches `url`. Re-clicking a sidebar
+// section while a tab opened from that section has drifted to a sub-page
+// (e.g. a cycle detail under Cycles) intentionally does NOT match — the user
+// gets a fresh tab on the section page rather than being snapped to the
+// drifted child, which lets them keep both views side-by-side.
 function findTabPane(state: WorkspaceState, url: string): { paneId: string; tabId: string } | null {
   for (const pane of state.panes) {
-    const tab = pane.tabs.find((t) => t.origin === url || t.url === url)
+    const tab = pane.tabs.find((t) => t.url === url)
     if (tab) return { paneId: pane.id, tabId: tab.id }
   }
   return null

--- a/dali-api/app/hiring/routes/lead.intern-to-full-cycle.$id.tsx
+++ b/dali-api/app/hiring/routes/lead.intern-to-full-cycle.$id.tsx
@@ -478,10 +478,7 @@ export default function InternToFullCycleSetup() {
     <div className="max-w-4xl mx-auto py-8 px-6 space-y-8">
       <header className="flex items-center justify-between">
         <div>
-          <Link to="/hiring/lead" className="text-xs text-muted-foreground hover:underline">
-            ← All cycles
-          </Link>
-          <h1 className="font-heading text-2xl font-bold text-dark-blue mt-1">{cycle.name}</h1>
+          <h1 className="font-heading text-2xl font-bold text-dark-blue">{cycle.name}</h1>
           <p className="text-xs text-muted-foreground mt-1">
             Fellowship cycle · {cycle.status}
           </p>


### PR DESCRIPTION
## Summary
- Removed the "← All cycles" link from the fellowship cycle detail header — back navigation is owned by the tab workspace, not the page body.
- `TabWorkspace.findTabPane` no longer matches on a tab's `origin` URL. When a tab opened from a sidebar section (e.g. Cycles) has drifted into a child page (e.g. a specific cycle), re-clicking the sidebar section now opens a fresh tab on the section page rather than focusing the drifted child.

## Audit
Swept `app/forms/`, `app/hiring/`, `app/projects/`, `app/education/`, `app/members/`, `app/partners/`, `app/internal-processes/`, `app/admin-console/` for in-page back links (`← Back`, `Back to`, `navigate(-1)`, `ArrowLeft`/`ChevronLeft` used as back). Only one true in-page back link was found (the one removed in this PR). Other matches were modal cancel buttons (e.g. "Go back" in the force-close confirm), calendar month paginators, or the workspace's own back-arrow chevrons — all intentional.

## Test plan
- [ ] Open a fellowship cycle from the Cycles list — confirm the "← All cycles" link is gone from the header.
- [ ] In Cycles, open a specific cycle so the tab URL drifts to `/hiring/lead/cycle/<id>`. Click "Cycles" in the sidebar again → a new tab opens on the cycles list rather than focusing the drifted tab.
- [ ] Click "Cycles" in the sidebar when the existing tab is still on `/hiring/lead` → still de-dupes (focuses the existing tab).
- [ ] Cmd/Ctrl+click and middle-click on sidebar sections still split / open in background as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/773"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783130961&installation_id=133523038&pr_number=773&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F773&signature=1845c36653f9c1aedb11596355cdc46aecfed597159487d810bd2fd52124aafb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->