### PR TITLE
Onboarding board: show all accepted members, not just in-flight

### DIFF
--- a/dali-api/app/internal-processes/routes/__tests__/internal-processes.onboarding.test.ts
+++ b/dali-api/app/internal-processes/routes/__tests__/internal-processes.onboarding.test.ts
@@ -160,20 +160,23 @@ describe("internal-processes/onboarding loader", () => {
     expect(data.rows.map((r: any) => r.role)).toEqual(["Fullstack", "Design"]);
   });
 
-  it("excludes already-onboarded members (e.g. re-accepted Fellowship members)", async () => {
+  it("includes already-onboarded members (full accepted roster)", async () => {
     mockPrisma.applicationCycle.findMany.mockResolvedValue([
       { id: "cyc-new", name: "Spring 2026", cycleType: "Standard" },
     ]);
     mockPrisma.decision.findMany.mockResolvedValue([
-      // Already onboarded in a prior cycle, re-accepted here → keeps onboardedAt, hidden.
+      // Already onboarded → still listed; profileSubmitted reads true (all-green).
       decisionRow({ userId: "u1", first: "Ada", domainCode: "fullstack", domainName: "Fullstack", daliEmail: "ada@dali.dartmouth.edu", slackUserId: "U1", onboardedAt: new Date() }),
       decisionRow({ userId: "u2", first: "Bea", domainCode: "design", domainName: "Design", onboardedAt: null }),
     ]);
 
     const data = (await call()) as any;
-    expect(data.rows.map((r: any) => r.userId)).toEqual(["u2"]);
-    // The hidden member's domain also drops out of the filter dropdown.
-    expect(data.domains.map((d: any) => d.key)).toEqual(["design"]);
+    expect(data.rows.map((r: any) => r.userId)).toEqual(["u1", "u2"]);
+    // The onboarded member shows as profile-submitted; the other is still pending.
+    expect(data.rows.find((r: any) => r.userId === "u1").profileSubmitted).toBe(true);
+    expect(data.rows.find((r: any) => r.userId === "u2").profileSubmitted).toBe(false);
+    // Both domains appear in the filter dropdown now.
+    expect(data.domains.map((d: any) => d.key)).toEqual(["design", "fullstack"]);
   });
 
   it("filters rows by a valid ?domain=", async () => {

--- a/dali-api/app/internal-processes/routes/internal-processes.onboarding.tsx
+++ b/dali-api/app/internal-processes/routes/internal-processes.onboarding.tsx
@@ -79,11 +79,10 @@ export async function loader({ request }: Route.LoaderArgs) {
   for (const d of decisions) {
     const u = d.domainApplication.application.user;
     const dom = d.domainApplication.domain;
-    // Skip people who've already finished onboarding (e.g. a Fellowship-cycle
-    // member re-accepted into a new domain). They keep their existing
-    // onboardedAt/daliEmail/slackUserId, so there's nothing to track here — they'd
-    // just be all-green clutter on a board meant for in-flight onboarding.
-    if (u.daliMember?.onboardedAt != null) continue;
+    // Everyone accepted for the cycle is listed, including members who've already
+    // finished onboarding — their progress pills just read all-green
+    // (profileSubmitted derives from onboardedAt). The board is a full roster of
+    // accepted members and their onboarding state, not only in-flight ones.
     // Stable key for dedupe + the domain filter dropdown (code, falling back to
     // name); displayName is for display only and can change.
     const domainKey = dom.code ?? dom.name;


### PR DESCRIPTION
## What

The Onboarding page (`/internal-processes/onboarding`) listed accepted applicants for a cycle but **skipped anyone already onboarded** (`daliMember.onboardedAt != null`). The intent had been to keep the board focused on in-flight onboarding, but the desired behavior is a **full roster of everyone accepted for the cycle**.

This removes that skip. Already-onboarded members now stay listed; their progress pills render all-green because `profileSubmitted` already derives from `onboardedAt`, and the Slack/email/Figma columns read live off the user/member row.

## Why

A fully-onboarded accepted member (e.g. a QA applicant, or a real member who finished onboarding) was invisible on this page, which read as a bug — "onboarded but doesn't show up." The page is now an accepted-roster + onboarding-state view rather than an in-flight-only queue.

## Changes

- `internal-processes.onboarding.tsx` — drop the `if (u.daliMember?.onboardedAt != null) continue;` skip; update the surrounding comment.
- `__tests__/internal-processes.onboarding.test.ts` — flip the "excludes already-onboarded members" test to "includes already-onboarded members (full accepted roster)": asserts both users appear, the onboarded one has `profileSubmitted: true`, and both domains stay in the filter dropdown.

## Testing

- `npx vitest run` on the onboarding test file: 13/13 pass.
- Typecheck: no new errors in the touched files (pre-existing errors in `scripts/*` and other routes are unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/776"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783132896&installation_id=133523038&pr_number=776&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F776&signature=2827f699140a23377d62878b0993f08a0e0d94aa443043ad3cd770e92deda55b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->