### PR TITLE
Onboarding tour: focused 2-step replace + expand profile

### DIFF
--- a/dali-api/app/components/LaunchWelcome.tsx
+++ b/dali-api/app/components/LaunchWelcome.tsx
@@ -1,16 +1,11 @@
 import { useCallback, useEffect, useId, useRef, useState } from "react";
 import {
   PartyPopper,
-  FolderKanban,
   CalendarDays,
-  CalendarPlus,
   UserCircle2,
-  Users,
   ArrowRight,
   X as XIcon,
   Check,
-  Bot,
-  MonitorDown,
 } from "lucide-react";
 import { Modal } from "./Modal";
 
@@ -33,9 +28,10 @@ type TourStep = {
   matches?: (pathname: string) => boolean;
   /** Locates the sidebar element to highlight. Omitted for info-only steps. */
   findTarget?: () => HTMLElement | null;
-  /** Optional primary action for info-only steps. Click runs onClick AND
-   *  advances the tour. */
-  action?: { label: string; onClick: () => void };
+  /** Optional primary action shown alongside Next once the user has arrived
+   *  on the matched page (e.g. "Connect Google Calendar"). Click runs onClick
+   *  but does NOT advance — the user still hits Next to move on. */
+  arrivedAction?: { label: string; onClick: () => void };
 };
 
 /** Walks up through any iframe ancestors so the rect is in the parent
@@ -56,27 +52,6 @@ function getRectInParent(el: HTMLElement): DOMRect {
     doc = frame.ownerDocument;
   }
   return rect;
-}
-
-/** Search any same-origin iframe for a button matching the predicate. Used
- *  to target in-iframe tab pills (e.g. "Schedule Meeting" on the calendar). */
-function findInIframes(
-  predicate: (el: HTMLButtonElement) => boolean,
-): HTMLElement | null {
-  const iframes = document.querySelectorAll<HTMLIFrameElement>("iframe");
-  for (const iframe of iframes) {
-    try {
-      const doc = iframe.contentDocument;
-      if (!doc) continue;
-      const buttons = doc.querySelectorAll<HTMLButtonElement>("button");
-      for (const btn of buttons) {
-        if (predicate(btn)) return btn;
-      }
-    } catch {
-      // cross-origin iframe or detached — skip
-    }
-  }
-  return null;
 }
 
 function findInSidebar(predicate: (el: HTMLButtonElement) => boolean): HTMLElement | null {
@@ -103,135 +78,32 @@ function findByExactText(text: string) {
   return findInSidebar((btn) => (btn.textContent || "").trim() === text);
 }
 
-// The tour steps. A member who hasn't linked a Google Calendar gets an extra
-// "connect your calendar" step (moved here out of the onboarding checklist);
-// once linked it drops off. Built as a function so the calendar step is
-// conditional on the current user.
+// Two-step post-onboarding tour: walk a freshly-onboarded member through
+// (1) linking their Google Calendar so the lab can see their availability,
+// and (2) their profile page so they know where to update their details.
+// Step 1 is omitted if the member already has a Google calendar linked, so
+// a returning user who linked elsewhere only sees the profile step.
 function buildSteps(opts: { hasCalendarLink: boolean }): TourStep[] {
-  const steps: TourStep[] = [
-  {
-    icon: <FolderKanban className="w-4 h-4" />,
-    eyebrow: "Projects",
-    cta: (
-      <>
-        Open <strong>Projects</strong> from the sidebar.
-      </>
-    ),
-    arrived: <>All active projects live here.</>,
-    matches: (p) => p.startsWith("/projects"),
-    findTarget: () => findByExactText("Projects"),
-  },
-  {
-    icon: <CalendarDays className="w-4 h-4" />,
-    eyebrow: "Calendar",
-    cta: (
-      <>
-        Open <strong>Calendar</strong> from the sidebar.
-      </>
-    ),
-    arrived: <>Lab meetings and events.</>,
-    matches: (p) => p.startsWith("/calendar"),
-    findTarget: () => findByExactText("Calendar"),
-  },
-  {
-    icon: <CalendarPlus className="w-4 h-4" />,
-    eyebrow: "Schedule Meeting",
-    cta: (
-      <>
-        At the top of the Calendar, switch to{" "}
-        <strong>Schedule Meeting</strong>.
-      </>
-    ),
-    arrived: (
-      <>
-        See everyone&apos;s availability and create a meeting. No more
-        when2meets.
-      </>
-    ),
-    // No URL change happens when the pill is clicked (tab state lives in
-    // React state on the calendar page), so this step advances via a DOM
-    // click listener attached to the spotlit element instead of via
-    // dali:tabNavigated. See the find-target effect below.
-    findTarget: () =>
-      findInIframes(
-        (btn) => (btn.textContent || "").trim() === "Schedule Meeting",
-      ),
-  },
-  {
-    icon: <UserCircle2 className="w-4 h-4" />,
-    eyebrow: "Profile",
-    cta: (
-      <>
-        Open your <strong>profile</strong> from the bottom of the sidebar.
-      </>
-    ),
-    arrived: <>Add a photo and your details here.</>,
-    matches: (p) => p.startsWith("/profile"),
-    findTarget: () =>
-      findInSidebar((btn) => btn.getAttribute("aria-label") === "Open profile"),
-  },
-  {
-    icon: <Users className="w-4 h-4" />,
-    eyebrow: "Members",
-    cta: (
-      <>
-        Open <strong>Members</strong> from the sidebar.
-      </>
-    ),
-    arrived: <>Everyone in the lab.</>,
-    matches: (p) => p.startsWith("/members"),
-    findTarget: () => findByExactText("Members"),
-  },
-  {
-    icon: <MonitorDown className="w-4 h-4" />,
-    eyebrow: "Install the app",
-    cta: (
-      <>
-        Pin <strong>DALI OS</strong> to your taskbar. In Chrome, click the
-        install icon at the right of the address bar (or <strong>⋮ →
-        Install DALI OS</strong>).
-      </>
-    ),
-  },
-  {
-    icon: <Bot className="w-4 h-4" />,
-    eyebrow: "Connect any AI",
-    cta: (
-      <>
-        Connect any AI assistant to the <strong>DALI OS MCP</strong> and let
-        it read your DALI data for you.
-      </>
-    ),
-    action: {
-      label: "Open docs",
-      onClick: () => {
-        // Layout listens for dali:openTab on the parent window and opens it
-        // in the workspace iframe rather than navigating the top frame.
-        window.postMessage(
-          {
-            type: "dali:openTab",
-            url: "/help/mcp",
-            label: "Connect AI to DALI OS",
-          },
-          window.location.origin,
-        );
-      },
-    },
-  },
-  ];
+  const steps: TourStep[] = [];
 
-  // Offer calendar connect only when the member hasn't linked one yet.
   if (!opts.hasCalendarLink) {
     steps.push({
-      icon: <CalendarPlus className="w-4 h-4" />,
-      eyebrow: "Connect your calendar",
+      icon: <CalendarDays className="w-4 h-4" />,
+      eyebrow: "Calendar",
       cta: (
         <>
-          Connect your <strong>Google Calendar</strong> so the lab can see your
-          availability for scheduling.
+          Open <strong>Calendar</strong> from the sidebar.
         </>
       ),
-      action: {
+      arrived: (
+        <>
+          Connect your <strong>Google Calendar</strong> so the lab can see
+          your availability for scheduling.
+        </>
+      ),
+      matches: (p) => p.startsWith("/calendar"),
+      findTarget: () => findByExactText("Calendar"),
+      arrivedAction: {
         label: "Connect Google Calendar",
         onClick: () => {
           window.location.href = "/oauth/calendar/google/start";
@@ -239,6 +111,25 @@ function buildSteps(opts: { hasCalendarLink: boolean }): TourStep[] {
       },
     });
   }
+
+  steps.push({
+    icon: <UserCircle2 className="w-4 h-4" />,
+    eyebrow: "Profile",
+    cta: (
+      <>
+        Open your <strong>profile</strong> from the bottom of the sidebar.
+      </>
+    ),
+    arrived: (
+      <>
+        Review your details and add anything that&apos;s missing — you can
+        come back here anytime to edit.
+      </>
+    ),
+    matches: (p) => p.startsWith("/profile"),
+    findTarget: () =>
+      findInSidebar((btn) => btn.getAttribute("aria-label") === "Open profile"),
+  });
 
   return steps;
 }
@@ -669,34 +560,23 @@ export function LaunchWelcome({
                 Back to home
               </button>
             ) : arrived ? (
-              <button
-                ref={nextButtonRef}
-                type="button"
-                onClick={advance}
-                className="inline-flex items-center gap-1.5 rounded-lg bg-accent-coral px-3 py-1.5 text-sm font-semibold text-white hover:bg-accent-coral/90"
-              >
-                Next
-                <ArrowRight className="w-4 h-4" />
-              </button>
-            ) : current && !current.findTarget ? (
               <>
-                <button
-                  type="button"
-                  onClick={advance}
-                  className="text-xs text-muted-foreground hover:text-foreground"
-                >
-                  Skip
-                </button>
+                {current?.arrivedAction && (
+                  <button
+                    type="button"
+                    onClick={current.arrivedAction.onClick}
+                    className="inline-flex items-center gap-1.5 rounded-lg border border-accent-coral px-3 py-1.5 text-sm font-semibold text-accent-coral hover:bg-accent-coral/10"
+                  >
+                    {current.arrivedAction.label}
+                  </button>
+                )}
                 <button
                   ref={nextButtonRef}
                   type="button"
-                  onClick={() => {
-                    current.action?.onClick();
-                    advance();
-                  }}
+                  onClick={advance}
                   className="inline-flex items-center gap-1.5 rounded-lg bg-accent-coral px-3 py-1.5 text-sm font-semibold text-white hover:bg-accent-coral/90"
                 >
-                  {current.action?.label ?? "Next"}
+                  Next
                   <ArrowRight className="w-4 h-4" />
                 </button>
               </>

--- a/dali-api/app/routes/profile.tsx
+++ b/dali-api/app/routes/profile.tsx
@@ -6,6 +6,10 @@ import {
   FolderKanban,
   MessageSquare,
   Pencil,
+  User as UserIcon,
+  Github,
+  Linkedin,
+  Globe,
 } from "lucide-react";
 import { requireAuth } from "~/lib/auth";
 import { prisma } from "~/lib/db";
@@ -64,6 +68,13 @@ export async function loader({ request }: Route.LoaderArgs) {
         classYear: true,
         major: true,
         photoUrl: true,
+        hometown: true,
+        githubUsername: true,
+        linkedinUrl: true,
+        personalSite: true,
+        collegeId: true,
+        phoneNumber: true,
+        birthday: true,
       },
     }),
     getUserRoles(userId),
@@ -211,6 +222,73 @@ export default function Profile() {
 
       <section className="bg-card border border-border rounded-lg p-4 flex flex-col gap-3">
         <h2 className="inline-flex items-center gap-2 font-heading font-semibold text-foreground">
+          <UserIcon className="w-4 h-4 text-accent-coral" />
+          Personal
+        </h2>
+        <dl className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-2 text-sm">
+          <Detail label="Hometown" value={user.hometown} />
+          <Detail label="Birthday" value={formatBirthday(user.birthday)} />
+          <Detail label="Phone" value={user.phoneNumber} />
+          <Detail label="College ID" value={user.collegeId} />
+          <div>
+            <dt className="text-xs text-muted-foreground mb-0.5">GitHub</dt>
+            <dd className="text-sm text-foreground">
+              {user.githubUsername ? (
+                <a
+                  href={`https://github.com/${user.githubUsername}`}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="inline-flex items-center gap-1.5 text-accent-coral hover:underline"
+                >
+                  <Github className="w-3.5 h-3.5" />
+                  {user.githubUsername}
+                </a>
+              ) : (
+                "—"
+              )}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-xs text-muted-foreground mb-0.5">LinkedIn</dt>
+            <dd className="text-sm text-foreground">
+              {user.linkedinUrl ? (
+                <a
+                  href={user.linkedinUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="inline-flex items-center gap-1.5 text-accent-coral hover:underline"
+                >
+                  <Linkedin className="w-3.5 h-3.5" />
+                  Profile
+                </a>
+              ) : (
+                "—"
+              )}
+            </dd>
+          </div>
+          <div className="sm:col-span-2">
+            <dt className="text-xs text-muted-foreground mb-0.5">Personal site</dt>
+            <dd className="text-sm text-foreground">
+              {user.personalSite ? (
+                <a
+                  href={user.personalSite}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="inline-flex items-center gap-1.5 text-accent-coral hover:underline break-all"
+                >
+                  <Globe className="w-3.5 h-3.5 flex-shrink-0" />
+                  {user.personalSite}
+                </a>
+              ) : (
+                "—"
+              )}
+            </dd>
+          </div>
+        </dl>
+      </section>
+
+      <section className="bg-card border border-border rounded-lg p-4 flex flex-col gap-3">
+        <h2 className="inline-flex items-center gap-2 font-heading font-semibold text-foreground">
           <FolderKanban className="w-4 h-4 text-accent-coral" />
           My activity
           {termCode && (
@@ -268,6 +346,20 @@ export default function Profile() {
       </section>
     </div>
   );
+}
+
+// Birthday is stored at UTC midnight; format from UTC components so a viewer in
+// a negative-offset timezone doesn't see the previous day.
+function formatBirthday(value: string | Date | null | undefined): string | null {
+  if (!value) return null;
+  const d = typeof value === "string" ? new Date(value) : value;
+  if (Number.isNaN(d.getTime())) return null;
+  return d.toLocaleDateString(undefined, {
+    timeZone: "UTC",
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  });
 }
 
 function Detail({ label, value }: { label: string; value: string | null }) {


### PR DESCRIPTION
## Summary

- Replaces the old 7-step first-login tour (Projects → Calendar → Schedule Meeting → Profile → Members → Install → MCP → optional Connect Calendar) with a focused two-step version: **Calendar → Profile**. Trigger condition is unchanged: auto-shows once `DALIMember.onboardedAt` is set and `tourCompletedAt` is null, so it runs *after* the welcome form is submitted.
- The calendar step is skipped entirely if the member already has a Google calendar linked, so a returning member who linked elsewhere only sees the profile step.
- Adds an `arrivedAction` field on the tour-step shape so the "Connect Google Calendar" CTA can appear next to **Next** once the user lands on `/calendar` (no auto-advance — they confirm by hitting Next).
- Expands `/profile` to surface the remaining welcome-form fields: **hometown, birthday, phone, college ID, GitHub, LinkedIn, personal site**. Previously only major / class year / email made it through.
- Birthday formats from UTC components (it's stored at UTC midnight) so a viewer in a negative-offset timezone doesn't see the previous day.
- Filed #777 to remove `User.githubUrl` separately — it's trivially `https://github.com/<githubUsername>` and the form/MCP cleanup is out of scope here.

The welcome form's auto-clear on the home banner already worked — `submitMemberForm` calls `clearOnboardingTask` on submit — verified, no code change there.

## Test plan

- [ ] As a freshly-accepted member (`onboardedAt = null`): home banner still shows the "finish onboarding" task; clicking it opens the welcome form; submitting clears the task. Tour does NOT show yet.
- [ ] Same member, immediately after submitting the welcome form: the new 2-step tour auto-shows (welcome modal → "Show me around").
- [ ] Calendar step: sidebar Calendar button is spotlit + pulsing. Click it → land on `/calendar` → card flips to "arrived" with **Connect Google Calendar** button next to **Next**. Click Connect → OAuth round-trip → return to `/calendar` → step remains/resumes (localStorage persists). Click Next.
- [ ] Profile step: sidebar profile button spotlit. Click → land on `/profile` → "Review your details" message → click Next → "Welcome to DALI OS!" final card → **Back to home** returns to `/`.
- [ ] Member who already has a Google calendar linked: calendar step is skipped — tour starts directly on the profile step.
- [ ] `/profile` shows hometown, birthday (formatted from UTC), phone, college ID, GitHub (links to github.com/<username>), LinkedIn, personal site. Missing values show "—".
- [ ] Dismiss/skip tour persists (POST to `/api/tour/complete`) — does not auto-show again on next load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/778"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783133874&installation_id=133523038&pr_number=778&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F778&signature=377ec3bcc423a794b2881df66ab570614fdd205cca7c266e2c1dfcd5e6192e4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->