### PR TITLE
Staffing board: add domain-level filter

### DIFF
--- a/dali-api/app/projects/components/StaffingBoard.tsx
+++ b/dali-api/app/projects/components/StaffingBoard.tsx
@@ -22,6 +22,7 @@ import { MemberCard } from "./MemberCard";
 import { BidModal } from "./BidModal";
 import { FinalizeModal } from "./FinalizeModal";
 import { AddMemberControl } from "./AddMemberControl";
+import { DomainFilter } from "./DomainFilter";
 
 type ProjectMeta = { id: string; name: string; status: "Active" | "Paused" | "Archived" };
 
@@ -35,6 +36,11 @@ type Props = {
   cycleId: string;
   termId: string;
   terms: { id: string; code: string }[];
+  // Domain filter: all domains for the dropdown, plus the currently-selected id
+  // ("" = all). Selecting one narrows the board to members eligible in (or
+  // already bid/staffed in) that domain. Driven server-side via ?domain=.
+  domains: { id: string; name: string }[];
+  selectedDomainId: string;
   projects: ProjectMeta[];
   members: MemberInput[];
   initialAssignments: Assignment[];
@@ -51,6 +57,8 @@ export function StaffingBoard({
   cycleId,
   termId,
   terms,
+  domains,
+  selectedDomainId,
   projects,
   members,
   initialAssignments,
@@ -165,6 +173,20 @@ export function StaffingBoard({
     <div className="flex flex-col gap-3">
       <div className="flex items-center justify-end gap-3 flex-wrap">
         {canManage && <AddMemberControl cycleId={cycleId} />}
+        <DomainFilter
+          domains={domains}
+          value={selectedDomainId}
+          onChange={(id) => {
+            setSearchParams(
+              (prev) => {
+                if (id) prev.set("domain", id);
+                else prev.delete("domain");
+                return prev;
+              },
+              { replace: true },
+            );
+          }}
+        />
         <div className="flex items-center gap-2">
           <label className="sr-only" htmlFor="staffing-term">
             Term

--- a/dali-api/app/projects/lib/__tests__/staffing-board.test.ts
+++ b/dali-api/app/projects/lib/__tests__/staffing-board.test.ts
@@ -171,16 +171,16 @@ describe("buildBoard", () => {
       members: [
         member({
           domainLevels: [
-            { domainName: "Engineering", level: "P3" },
-            { domainName: "Design", level: "P1" },
+            { domainId: "eng", domainName: "Engineering", level: "P3" },
+            { domainId: "design", domainName: "Design", level: "P1" },
           ],
         }),
       ],
       assignments: [],
     });
     expect(board[UNASSIGNED][0].domainLevels).toEqual([
-      { domainName: "Engineering", level: "P3" },
-      { domainName: "Design", level: "P1" },
+      { domainId: "eng", domainName: "Engineering", level: "P3" },
+      { domainId: "design", domainName: "Design", level: "P1" },
     ]);
   });
 });

--- a/dali-api/app/projects/lib/staffing-board.ts
+++ b/dali-api/app/projects/lib/staffing-board.ts
@@ -15,6 +15,7 @@ export type Preference = {
 // A domain the member is eligible in, with their level there. Sourced from
 // DomainEligibility (one row per user+domain). Shown on every card.
 export type DomainLevel = {
+  domainId: string;
   domainName: string;
   level: Level;
 };

--- a/dali-api/app/projects/routes/projects.staffing.tsx
+++ b/dali-api/app/projects/routes/projects.staffing.tsx
@@ -90,6 +90,16 @@ export async function loader({ request }: Route.LoaderArgs) {
   );
   const selectedTermId = selectedTerm.id;
 
+  // Optional domain filter (?domain=<id>). Narrows the member pool to people
+  // eligible in that domain. Validated against real domains so a stale id falls
+  // back to "all". Empty/absent = all domains. The filter is applied to the
+  // assembled `members` list below, after all pools are built.
+  const requestedDomainId = new URL(request.url).searchParams.get("domain");
+  const selectedDomainId =
+    requestedDomainId && requestedDomainId !== ""
+      ? requestedDomainId
+      : null;
+
   // The pool of members on the board is everyone who submitted at least one
   // StaffingPreference for this cycle. Members who didn't bid don't show up.
   const preferences = await prisma.staffingPreference.findMany({
@@ -121,7 +131,7 @@ export async function loader({ request }: Route.LoaderArgs) {
         domainEligibilities: {
           select: {
             level: true,
-            domain: { select: { displayName: true } },
+            domain: { select: { id: true, displayName: true } },
           },
         },
       },
@@ -233,7 +243,11 @@ export async function loader({ request }: Route.LoaderArgs) {
       new Set(u.coreAssignments.map((a) => a.leadTitle).filter((t): t is string => !!t)),
     ),
     domainLevels: u.domainEligibilities
-      .map((e) => ({ domainName: e.domain.displayName, level: e.level as Level }))
+      .map((e) => ({
+        domainId: e.domain.id,
+        domainName: e.domain.displayName,
+        level: e.level as Level,
+      }))
       .sort((a, b) => a.domainName.localeCompare(b.domainName)),
     preferences,
     bidFields: bidFieldsByUser.get(u.id) ?? [],
@@ -272,7 +286,7 @@ export async function loader({ request }: Route.LoaderArgs) {
         adminMembership: { select: { id: true } },
         coreAssignments: { select: { leadTitle: true } },
         domainEligibilities: {
-          select: { level: true, domain: { select: { displayName: true } } },
+          select: { level: true, domain: { select: { id: true, displayName: true } } },
         },
       },
     });
@@ -308,7 +322,7 @@ export async function loader({ request }: Route.LoaderArgs) {
         adminMembership: { select: { id: true } },
         coreAssignments: { select: { leadTitle: true } },
         domainEligibilities: {
-          select: { level: true, domain: { select: { displayName: true } } },
+          select: { level: true, domain: { select: { id: true, displayName: true } } },
         },
       },
     });
@@ -319,6 +333,29 @@ export async function loader({ request }: Route.LoaderArgs) {
       })),
     );
     members.push(...manual);
+  }
+
+  // Apply the domain filter to the member pool. A member stays if they're
+  // eligible in the domain, OR already have a bid/assignment in it — filtering
+  // out a member who's proposed-staffed in that domain would make a real
+  // assignment silently vanish from the board. Ignore an unknown domain id
+  // (treat as "all") so a stale ?domain= link doesn't empty the board.
+  const domainFilterActive =
+    selectedDomainId !== null && domains.some((d) => d.id === selectedDomainId);
+  if (domainFilterActive) {
+    const assignedUserIds = new Set(
+      assignmentRows
+        .filter((a) => a.domainId === selectedDomainId)
+        .map((a) => a.userId),
+    );
+    const filtered = members.filter(
+      (m) =>
+        m.domainLevels.some((d) => d.domainId === selectedDomainId) ||
+        m.preferences.some((p) => p.domainId === selectedDomainId) ||
+        assignedUserIds.has(m.userId),
+    );
+    members.length = 0;
+    members.push(...filtered);
   }
 
   const initialAssignments: Assignment[] = assignmentRows.map((a) => ({
@@ -387,6 +424,10 @@ export async function loader({ request }: Route.LoaderArgs) {
       termId: selectedTermId,
     },
     terms: terms.map((t) => ({ id: t.id, code: t.code })),
+    domains: [...domains]
+      .sort((a, b) => a.displayName.localeCompare(b.displayName))
+      .map((d) => ({ id: d.id, name: d.displayName })),
+    selectedDomainId: domainFilterActive ? selectedDomainId : "",
     canManage,
     projects,
     members,
@@ -441,6 +482,8 @@ export default function StaffingPage() {
         cycleId={data.cycle.id}
         termId={data.cycle.termId}
         terms={data.terms}
+        domains={data.domains}
+        selectedDomainId={data.selectedDomainId}
         projects={data.projects}
         members={data.members}
         initialAssignments={data.initialAssignments}


### PR DESCRIPTION
## What

Adds a **domain filter** to the staffing board, next to the existing term picker. Selecting a domain narrows the board to members who are relevant to that domain.

## How it works

- **Server-driven via `?domain=<id>`**, mirroring the existing term-filter convention — the selection survives refresh and is shareable/linkable. The loader resolves the param, validates it against real domains (an unknown id falls back to "all"), and filters the assembled member pool before returning.
- Reuses the existing `DomainFilter` dropdown component (already used on the Intent to Work / Project Bids boards), wired to `setSearchParams` so it preserves the current `?term=`.
- **A member stays on the board when** they're eligible in the selected domain (via `DomainEligibility`) **OR** they already have a bid (`StaffingPreference`) or a proposed assignment in that domain. This guard prevents a member who's already proposed-staffed in the domain from silently vanishing from the board when the filter is applied.

## Implementation notes

- `DomainLevel` gains a `domainId` field so filtering matches on a stable id rather than the display name. The card UI still renders `domainName`, so nothing visible changes there.
- The three `domainEligibilities` selects in the loader now also fetch `domain.id`.

## Testing

- `npm run typecheck` — clean for all changed files (pre-existing `scripts/*.ts` drift errors are unrelated and present on `dev`).
- `npm test` (staffing-board unit tests) — passing.
- The domain-filter logic is pure/server-side; the local seed DB has no staffing preferences, so a live UI screenshot wasn't possible without seeding a full cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/780"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783134390&installation_id=133523038&pr_number=780&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F780&signature=8dbcf008cb63ce66d76f548939d07f00de2b065ad54351689a07c7949816f9eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->