### PR TITLE
Tour: one-and-done auto-show, gated on server flag only

### DIFF
--- a/dali-api/app/components/LaunchWelcome.tsx
+++ b/dali-api/app/components/LaunchWelcome.tsx
@@ -455,9 +455,8 @@ export function LaunchWelcome({
               Welcome to DALI OS
             </h2>
             <p className="text-sm text-muted-foreground mt-2 leading-relaxed">
-              Hi {firstName}. DALI OS is the home of everything DALI,
-              replacing Notion as the lab&apos;s internal site. Want a quick
-              tour?
+              Hi {firstName}. DALI OS is the home of everything DALI.
+              Want a quick tour?
             </p>
           </div>
           <div className="flex items-center justify-end gap-2 pt-2">

--- a/dali-api/app/components/LaunchWelcome.tsx
+++ b/dali-api/app/components/LaunchWelcome.tsx
@@ -259,16 +259,25 @@ export function LaunchWelcome({
   const titleId = useId();
 
   useEffect(() => {
-    // Server-driven auto-show wins over the browser's localStorage flag: a
-    // freshly-onboarded member sees the tour even in a browser where someone
-    // else dismissed it before.
-    if (shouldShowTour) {
-      setPhase("modal");
-      setStep(0);
+    // Auto-show is purely server-driven: only a freshly-onboarded member
+    // (onboardedAt set, tourCompletedAt null) sees the tour automatically.
+    // localStorage no longer triggers it — clearing browser state or opening
+    // incognito won't re-pop the welcome modal for an established member.
+    // localStorage IS still consulted to *resume* a tour mid-flight on reload,
+    // so a freshly-onboarded user who started the tour and then reloaded
+    // continues where they were instead of jumping back to step 0.
+    if (!shouldShowTour) {
+      setPhase("done");
       return;
     }
-    setPhase(readPhase());
-    setStep(readStep(steps.length));
+    const resumed = readPhase();
+    if (resumed === "card") {
+      setPhase("card");
+      setStep(readStep(steps.length));
+    } else {
+      setPhase("modal");
+      setStep(0);
+    }
   }, [steps.length, shouldShowTour]);
 
   // Manual re-run: a "Start tour" button (next to the DALI OS logo) dispatches


### PR DESCRIPTION
## Summary
- Auto-show is now strictly gated on `shouldShowTour` (server-derived from `onboardedAt && !tourCompletedAt`). Dropped the localStorage fallback in `LaunchWelcome`'s mount effect that re-popped the welcome modal whenever both `DONE_KEY` and `STEP_KEY` were absent — established members were seeing the tour again after clearing browser state or opening incognito, even though `tourCompletedAt` was set server-side.
- Mid-tour reload now resumes where the user was instead of resetting to step 0. Previously, `shouldShowTour=true` unconditionally forced `phase=modal` + `step=0` on every mount, so a freshly-onboarded user who started the tour and then reloaded got bounced back to the "Welcome to DALI OS" modal.

Manual replay via the HelpCircle "Start tour" button still works for everyone — it dispatches `dali:start-tour` and is unaffected.

## Test plan
- [ ] Brand-new member submits the welcome form → welcome modal pops on next page load → "Show me around" → Calendar step → Profile step → finish → `tourCompletedAt` is set → reload → no modal.
- [ ] Brand-new member starts the tour, clicks past the modal to step 1, then hard-reloads → resumes on step 1 (not back to the welcome modal).
- [ ] Established member (tourCompletedAt set), clears localStorage, opens incognito → no auto-modal.
- [ ] Established member clicks the HelpCircle "Start tour" button → welcome modal appears and the tour can be replayed.
- [ ] Member who dismisses the modal via Skip/X → `/api/tour/complete` runs → next page load no auto-show.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/782"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783137911&installation_id=133523038&pr_number=782&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F782&signature=d83e852f4ae9d312629076e8fdbb6e30091e5a3b658bd631a78993d41c7049ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->