### PR TITLE
Tour: one-and-done auto-show, gated on server flag only (#782)

### DIFF
--- a/dali-api/app/components/LaunchWelcome.tsx
+++ b/dali-api/app/components/LaunchWelcome.tsx
@@ -259,16 +259,25 @@ export function LaunchWelcome({
   const titleId = useId();
 
   useEffect(() => {
-    // Server-driven auto-show wins over the browser's localStorage flag: a
-    // freshly-onboarded member sees the tour even in a browser where someone
-    // else dismissed it before.
-    if (shouldShowTour) {
-      setPhase("modal");
-      setStep(0);
+    // Auto-show is purely server-driven: only a freshly-onboarded member
+    // (onboardedAt set, tourCompletedAt null) sees the tour automatically.
+    // localStorage no longer triggers it — clearing browser state or opening
+    // incognito won't re-pop the welcome modal for an established member.
+    // localStorage IS still consulted to *resume* a tour mid-flight on reload,
+    // so a freshly-onboarded user who started the tour and then reloaded
+    // continues where they were instead of jumping back to step 0.
+    if (!shouldShowTour) {
+      setPhase("done");
       return;
     }
-    setPhase(readPhase());
-    setStep(readStep(steps.length));
+    const resumed = readPhase();
+    if (resumed === "card") {
+      setPhase("card");
+      setStep(readStep(steps.length));
+    } else {
+      setPhase("modal");
+      setStep(0);
+    }
   }, [steps.length, shouldShowTour]);
 
   // Manual re-run: a "Start tour" button (next to the DALI OS logo) dispatches
@@ -446,9 +455,8 @@ export function LaunchWelcome({
               Welcome to DALI OS
             </h2>
             <p className="text-sm text-muted-foreground mt-2 leading-relaxed">
-              Hi {firstName}. DALI OS is the home of everything DALI,
-              replacing Notion as the lab&apos;s internal site. Want a quick
-              tour?
+              Hi {firstName}. DALI OS is the home of everything DALI.
+              Want a quick tour?
             </p>
           </div>
           <div className="flex items-center justify-end gap-2 pt-2">


### PR DESCRIPTION
* Tour: gate auto-show on server flag only; resume mid-flight on reload

Two changes to LaunchWelcome's mount effect:

1. Drop the localStorage fallback that auto-popped the welcome modal whenever both DONE_KEY and STEP_KEY were absent. Established members who cleared browser state or opened incognito were seeing the tour again even though tourCompletedAt was set server-side. Auto-show is now strictly gated on shouldShowTour (onboardedAt && !tourCompletedAt), so the tour fires exactly once per user — after welcome-form submit — and never again unless they hit the manual HelpCircle button.

2. Resume mid-tour on reload. The previous branch forced phase=modal + step=0 whenever shouldShowTour was true, so a freshly-onboarded user who started the tour and then reloaded got bounced back to "Welcome to DALI OS." Now we check STEP_KEY first and stay on the current card.



* Tour: drop "replacing Notion" line from welcome modal copy



---------

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/783"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783137984&installation_id=133523038&pr_number=783&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F783&signature=721da804c3135f2454ecaeeb6c5c2964533a09d5d40d99109f090b175a5226ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->