### PR TITLE
Staffing board: fix vanishing assignments after finalize + live updat…

### DIFF
--- a/dali-api/app/lib/roles.ts
+++ b/dali-api/app/lib/roles.ts
@@ -198,24 +198,14 @@ export async function currentTerm() {
 // ─── Staffing-board access ───────────────────────────────────────────────────
 
 /**
- * Allowed to read + modify the staffing board: admins, or Core members whose
- * leadTitle implies staffing authority (we match the substring "staffing"
- * case-insensitively so titles like "Staffing Lead", "Staffing Coordinator",
- * "Co-Lead, Staffing" all qualify without us hardcoding strings).
+ * Allowed to read + modify the staffing board: any Core member (admins, or
+ * anyone with a current-term CoreAssignment). Previously this was narrowed to
+ * Core members whose leadTitle contained "staffing", but every Core member who
+ * can view the board should also be able to manage it — same membership set as
+ * `isCore`, so the board's view + mutate gates align.
  */
 export async function canManageStaffing(userId: string): Promise<boolean> {
-  if (await isAdmin(userId)) return true;
-  const term = await currentTerm();
-  if (!term) return false;
-  const core = await prisma.coreAssignment.findFirst({
-    where: {
-      userId,
-      termId: term.id,
-      leadTitle: { contains: "staffing", mode: "insensitive" },
-    },
-    select: { id: true },
-  });
-  return core !== null;
+  return isCore(userId);
 }
 
 // ─── Cycle-scoped access ─────────────────────────────────────────────────────

--- a/dali-api/app/projects/components/StaffingBoard.tsx
+++ b/dali-api/app/projects/components/StaffingBoard.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams, useRevalidator } from "react-router";
 import {
   DndContext,
@@ -75,6 +75,40 @@ export function StaffingBoard({
   // Project id whose finalize modal is open, or null.
   const [finalizeProjectId, setFinalizeProjectId] = useState<string | null>(null);
 
+  // Number of drag saves currently in flight. While > 0 we hold off adopting
+  // server data so a live push from someone else can't revert our own unsaved
+  // optimistic move mid-drag. Once our save lands it revalidates and this clears.
+  const pendingSaves = useRef(0);
+
+  // Local `assignments` is the optimistic source of truth during a drag. When a
+  // revalidation lands (our own save, or a live push from another lead), the
+  // loader hands back fresh `initialAssignments` — adopt it so other people's
+  // edits actually appear. Keyed off the prop's identity: React Router gives a
+  // new array each loader run, so this only fires when server data changes.
+  useEffect(() => {
+    if (pendingSaves.current > 0) return;
+    setAssignments(initialAssignments);
+  }, [initialAssignments]);
+
+  // Live updates: subscribe to this cycle's SSE stream and revalidate on any
+  // pushed change (assign / finalize / board-member by anyone) or periodic sync.
+  // EventSource auto-reconnects, so a dropped connection self-heals. The bus is
+  // per-instance (see staffing-events.server.ts); the `sync` heartbeat is the
+  // cross-instance backstop.
+  const revalidate = revalidator.revalidate;
+  const revalidateRef = useRef(revalidate);
+  revalidateRef.current = revalidate;
+  useEffect(() => {
+    const es = new EventSource(
+      `/api/staffing/events?cycleId=${encodeURIComponent(cycleId)}`,
+      { withCredentials: true },
+    );
+    const onPush = () => revalidateRef.current();
+    es.addEventListener("change", onPush);
+    es.addEventListener("sync", onPush);
+    return () => es.close();
+  }, [cycleId]);
+
   const projectIds = useMemo(() => projects.map((p) => p.id), [projects]);
 
   const board = useMemo(
@@ -136,16 +170,26 @@ export function StaffingBoard({
     setAssignments(nextAssignments);
     setError(null);
 
+    pendingSaves.current += 1;
     void persist({
       cycleId,
       userId,
       projectId: targetProjectId,
       domainId: assignmentBody?.domainId,
       level: assignmentBody?.level,
-    }).catch((err) => {
-      setAssignments(prevAssignments);
-      setError(err instanceof Error ? err.message : "Failed to save assignment");
-    });
+    })
+      .then(() => {
+        // Reconcile with server truth (also adopts any concurrent edits that
+        // arrived while this save was in flight).
+        revalidator.revalidate();
+      })
+      .catch((err) => {
+        setAssignments(prevAssignments);
+        setError(err instanceof Error ? err.message : "Failed to save assignment");
+      })
+      .finally(() => {
+        pendingSaves.current = Math.max(0, pendingSaves.current - 1);
+      });
   }
 
   async function handleRemoveMember(userId: string) {

--- a/dali-api/app/projects/lib/__tests__/staffing-board.test.ts
+++ b/dali-api/app/projects/lib/__tests__/staffing-board.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   buildBoard,
+  dedupeLiveAssignments,
   resolveAssignmentInputs,
   UNASSIGNED,
   type MemberInput,
@@ -240,5 +241,47 @@ describe("resolveAssignmentInputs", () => {
       "p1",
     );
     expect(out).toBeNull();
+  });
+});
+
+describe("dedupeLiveAssignments", () => {
+  const row = (userId: string, status: "Proposed" | "Confirmed", projectId: string) => ({
+    userId,
+    status,
+    projectId,
+  });
+
+  it("keeps a lone Confirmed row so a finalized roster stays on the board", () => {
+    const out = dedupeLiveAssignments([row("u1", "Confirmed", "p1")]);
+    expect(out).toEqual([row("u1", "Confirmed", "p1")]);
+  });
+
+  it("prefers Proposed over Confirmed for the same user (in-progress re-edit wins)", () => {
+    // User was confirmed on p1, then dragged to p2 (fresh Proposed row).
+    const out = dedupeLiveAssignments([
+      row("u1", "Confirmed", "p1"),
+      row("u1", "Proposed", "p2"),
+    ]);
+    expect(out).toEqual([row("u1", "Proposed", "p2")]);
+  });
+
+  it("prefers Proposed regardless of input order", () => {
+    const out = dedupeLiveAssignments([
+      row("u1", "Proposed", "p2"),
+      row("u1", "Confirmed", "p1"),
+    ]);
+    expect(out).toEqual([row("u1", "Proposed", "p2")]);
+  });
+
+  it("returns one row per user across a mixed set", () => {
+    const out = dedupeLiveAssignments([
+      row("u1", "Confirmed", "p1"),
+      row("u2", "Proposed", "p1"),
+      row("u2", "Confirmed", "p1"),
+      row("u3", "Proposed", "p2"),
+    ]);
+    expect(out).toHaveLength(3);
+    expect(out.map((r) => r.userId).sort()).toEqual(["u1", "u2", "u3"]);
+    expect(out.find((r) => r.userId === "u2")?.status).toBe("Proposed");
   });
 });

--- a/dali-api/app/projects/lib/staffing-board.ts
+++ b/dali-api/app/projects/lib/staffing-board.ts
@@ -90,6 +90,29 @@ export type MemberCardModel = {
 export const UNASSIGNED = "__unassigned__";
 
 /**
+ * A member can hold both a Proposed and a Confirmed StaffingAssignment in the
+ * same cycle: dragging after finalize writes a fresh Proposed row without
+ * touching the audit-trail Confirmed one. The board (and finalize) treat a
+ * member's LIVE assignment as their Proposed row if present, else Confirmed —
+ * so an in-progress re-edit wins over the already-finalized position. Declined
+ * rows are audit only and must be filtered out before calling this.
+ *
+ * Returns one row per userId. Input order is otherwise preserved.
+ */
+export function dedupeLiveAssignments<T extends { userId: string; status: string }>(
+  rows: T[],
+): T[] {
+  const byUser = new Map<string, T>();
+  for (const r of rows) {
+    const existing = byUser.get(r.userId);
+    if (!existing || (existing.status === "Confirmed" && r.status === "Proposed")) {
+      byUser.set(r.userId, r);
+    }
+  }
+  return Array.from(byUser.values());
+}
+
+/**
  * Build the board's column→cards index from raw data. The output is stable
  * across re-renders: members sort by lastName, firstName; columns are not
  * pre-keyed here (the renderer iterates `projectIds` in display order and

--- a/dali-api/app/projects/lib/staffing-events.server.ts
+++ b/dali-api/app/projects/lib/staffing-events.server.ts
@@ -1,0 +1,50 @@
+// In-memory pub/sub for live staffing-board updates. A board mutation
+// (assign / finalize / board-member) calls publish(cycleId); every SSE client
+// subscribed to that cycle gets pinged and revalidates its loader.
+//
+// SCOPE: this bus is per-process. Prod runs multiple Fly machines
+// (min_machines_running >= 2), so a viewer on machine A will NOT receive
+// events published on machine B. That trade-off was accepted deliberately:
+// the SSE route also emits a low-frequency heartbeat the client treats as a
+// re-sync cue, so cross-instance edits still converge within that window
+// rather than never. If we later need exact cross-instance fan-out, swap the
+// internals here for Postgres LISTEN/NOTIFY (on DIRECT_URL) without touching
+// callers.
+
+type Subscriber = () => void;
+
+// cycleId → set of subscriber callbacks (one per open SSE connection).
+const subscribers = new Map<string, Set<Subscriber>>();
+
+// Survive Vite HMR / module re-evaluation in dev: keep one registry on global.
+const g = globalThis as unknown as { __staffingSubs?: Map<string, Set<Subscriber>> };
+const registry = g.__staffingSubs ?? subscribers;
+if (!g.__staffingSubs) g.__staffingSubs = registry;
+
+export function subscribeToCycle(cycleId: string, onEvent: Subscriber): () => void {
+  let set = registry.get(cycleId);
+  if (!set) {
+    set = new Set();
+    registry.set(cycleId, set);
+  }
+  set.add(onEvent);
+  return () => {
+    const s = registry.get(cycleId);
+    if (!s) return;
+    s.delete(onEvent);
+    if (s.size === 0) registry.delete(cycleId);
+  };
+}
+
+export function publishCycleChange(cycleId: string): void {
+  const set = registry.get(cycleId);
+  if (!set) return;
+  for (const fn of set) {
+    // A throwing/closed subscriber must not block the rest.
+    try {
+      fn();
+    } catch {
+      // ignore — the SSE route cleans up its own subscription on close.
+    }
+  }
+}

--- a/dali-api/app/projects/routes/api.staffing.assign.ts
+++ b/dali-api/app/projects/routes/api.staffing.assign.ts
@@ -4,6 +4,7 @@ import { requireAuth } from "~/lib/auth";
 import { canManageStaffing } from "~/lib/roles";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { logAuditEvent } from "~/lib/audit";
+import { publishCycleChange } from "../lib/staffing-events.server";
 
 // POST /api/staffing/assign
 //
@@ -114,6 +115,8 @@ export async function action({ request }: Route.ActionArgs) {
     },
     request,
   });
+
+  publishCycleChange(body.cycleId);
 
   return withCors(request, Response.json({ ok: true }));
 }

--- a/dali-api/app/projects/routes/api.staffing.board-member.ts
+++ b/dali-api/app/projects/routes/api.staffing.board-member.ts
@@ -4,6 +4,7 @@ import { requireAuth } from "~/lib/auth";
 import { canManageStaffing } from "~/lib/roles";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { logAuditEvent } from "~/lib/audit";
+import { publishCycleChange } from "../lib/staffing-events.server";
 
 // Staffing board membership for non-bidders.
 //
@@ -154,6 +155,7 @@ export async function action({ request }: Route.ActionArgs) {
       metadata: { cycleId: body.cycleId },
       request,
     });
+    publishCycleChange(body.cycleId);
     return withCors(request, Response.json({ ok: true }));
   }
 
@@ -185,5 +187,6 @@ export async function action({ request }: Route.ActionArgs) {
     metadata: { cycleId: body.cycleId },
     request,
   });
+  publishCycleChange(body.cycleId);
   return withCors(request, Response.json({ ok: true }));
 }

--- a/dali-api/app/projects/routes/api.staffing.events.ts
+++ b/dali-api/app/projects/routes/api.staffing.events.ts
@@ -1,0 +1,75 @@
+import type { Route } from "./+types/api.staffing.events";
+import { requireAuth } from "~/lib/auth";
+import { canViewStaffing } from "~/lib/roles";
+import { subscribeToCycle } from "../lib/staffing-events.server";
+
+// GET /api/staffing/events?cycleId=<id>
+//
+// Server-Sent Events stream for the staffing board. The client opens one per
+// open board; whenever anyone mutates this cycle (assign / finalize /
+// board-member), the server pushes a `change` event and the board revalidates.
+//
+// A periodic `sync` comment-event doubles as a keep-alive (so proxies don't
+// drop the idle connection) and as the cross-instance backstop: prod runs
+// multiple machines, so a client treats `sync` as "re-check the loader" to pick
+// up edits published on another instance. See staffing-events.server.ts.
+
+const SYNC_INTERVAL_MS = 25_000;
+
+export async function loader({ request }: Route.LoaderArgs) {
+  const auth = await requireAuth(request);
+  // EventSource can't read a redirect body; signal auth failure with a status
+  // the client's onerror handles by backing off.
+  if (!auth.ok) return new Response("Unauthorized", { status: 401 });
+  if (!(await canViewStaffing(auth.user.sub))) {
+    return new Response("Forbidden", { status: 403 });
+  }
+
+  const cycleId = new URL(request.url).searchParams.get("cycleId");
+  if (!cycleId) return new Response("cycleId required", { status: 400 });
+
+  const encoder = new TextEncoder();
+  let unsubscribe = () => {};
+  let interval: ReturnType<typeof setInterval> | undefined;
+
+  const stream = new ReadableStream({
+    start(controller) {
+      const send = (event: string, data: string) => {
+        try {
+          controller.enqueue(encoder.encode(`event: ${event}\ndata: ${data}\n\n`));
+        } catch {
+          // Controller closed (client gone) — teardown happens in cancel().
+        }
+      };
+
+      // Initial comment flushes headers so the browser marks the stream open.
+      controller.enqueue(encoder.encode(": connected\n\n"));
+
+      unsubscribe = subscribeToCycle(cycleId, () => send("change", "1"));
+      interval = setInterval(() => send("sync", "1"), SYNC_INTERVAL_MS);
+
+      // Abort fires when the client disconnects (tab close / navigation).
+      request.signal.addEventListener("abort", () => {
+        unsubscribe();
+        if (interval) clearInterval(interval);
+        try {
+          controller.close();
+        } catch {
+          // already closed
+        }
+      });
+    },
+    cancel() {
+      unsubscribe();
+      if (interval) clearInterval(interval);
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+    },
+  });
+}

--- a/dali-api/app/projects/routes/api.staffing.finalize.ts
+++ b/dali-api/app/projects/routes/api.staffing.finalize.ts
@@ -12,6 +12,8 @@ import {
   addGroupMember,
 } from "~/lib/google-workspace";
 import { logAuditEvent } from "~/lib/audit";
+import { dedupeLiveAssignments } from "../lib/staffing-board";
+import { publishCycleChange } from "../lib/staffing-events.server";
 
 // POST /api/staffing/finalize
 //
@@ -115,22 +117,33 @@ export async function action({ request }: Route.ActionArgs) {
   let confirmedCount = 0;
   if (selected.has("assignments")) {
     try {
-      const proposed = await prisma.staffingAssignment.findMany({
-        where: {
-          staffingCycleId: cycle.id,
-          projectId: project.id,
-          status: { in: ["Proposed", "Confirmed"] },
-        },
-        select: { id: true, userId: true, domainId: true, level: true, status: true },
+      // Finalize REPLACES the confirmed roster: the project's Confirmed set
+      // becomes exactly the board's current assignments for it. A member's
+      // live card is their Proposed row if present, else their Confirmed row
+      // (same dedupe the board does) — so someone dragged onto another project
+      // has a Proposed row elsewhere and must NOT stay confirmed here.
+      const cycleRows = await prisma.staffingAssignment.findMany({
+        where: { staffingCycleId: cycle.id, status: { in: ["Proposed", "Confirmed"] } },
+        select: { id: true, userId: true, projectId: true, domainId: true, level: true, status: true },
       });
+      // Target roster = members whose live assignment points at THIS project.
+      const target = dedupeLiveAssignments(cycleRows).filter((r) => r.projectId === project.id);
+      const targetUserIds = new Set(target.map((r) => r.userId));
 
-      for (const a of proposed) {
-        await prisma.$transaction(async (tx) => {
+      // Members currently Confirmed on this project who are no longer in the
+      // target roster (dragged off / to another project / unassigned). Decline
+      // their stale Confirmed rows and drop the ProjectAssignment for this
+      // project+cycle. DomainEligibility is left intact — it's monotonic and a
+      // promotion already granted isn't revoked by re-staffing.
+      const droppedRows = cycleRows.filter(
+        (r) => r.status === "Confirmed" && r.projectId === project.id && !targetUserIds.has(r.userId),
+      );
+
+      let droppedCount = 0;
+      await prisma.$transaction(async (tx) => {
+        for (const a of target) {
           if (a.status !== "Confirmed") {
-            await tx.staffingAssignment.update({
-              where: { id: a.id },
-              data: { status: "Confirmed" },
-            });
+            await tx.staffingAssignment.update({ where: { id: a.id }, data: { status: "Confirmed" } });
           }
           await tx.projectAssignment.upsert({
             where: {
@@ -162,15 +175,30 @@ export async function action({ request }: Route.ActionArgs) {
               promotedBy: auth.user.sub,
             },
           });
-        });
-        confirmedCount++;
-      }
+          confirmedCount++;
+        }
+
+        for (const d of droppedRows) {
+          await tx.staffingAssignment.update({ where: { id: d.id }, data: { status: "Declined" } });
+          await tx.projectAssignment.deleteMany({
+            where: {
+              userId: d.userId,
+              projectId: project.id,
+              termId: cycle.termId,
+              domainId: d.domainId,
+            },
+          });
+          droppedCount++;
+        }
+      });
+
+      const dropNote = droppedCount > 0 ? `, removed ${droppedCount}` : "";
       results.assignments = {
         status: "ok",
         message:
-          confirmedCount === 0
+          confirmedCount === 0 && droppedCount === 0
             ? "No proposed assignments for this project."
-            : `Confirmed ${confirmedCount} assignment${confirmedCount === 1 ? "" : "s"} → ProjectAssignment.`,
+            : `Confirmed ${confirmedCount} assignment${confirmedCount === 1 ? "" : "s"}${dropNote} → ProjectAssignment.`,
       };
     } catch (err) {
       results.assignments = { status: "error", message: errMsg(err) };
@@ -414,6 +442,10 @@ export async function action({ request }: Route.ActionArgs) {
     },
     request,
   });
+
+  // Finalize confirms/removes assignments — push so every open board reflects
+  // the new roster (cards moving from Proposed to finalized, drops disappearing).
+  publishCycleChange(cycle.id);
 
   return withCors(request, Response.json({ results }));
 }

--- a/dali-api/app/projects/routes/projects.staffing.tsx
+++ b/dali-api/app/projects/routes/projects.staffing.tsx
@@ -12,6 +12,7 @@ import { ensureStaffingCycle } from "../lib/staffing-cycle";
 import { getSlotBinding } from "../lib/form-slots";
 import { buildSubmissionView } from "../lib/submission-view.server";
 import { StaffingBoard } from "../components/StaffingBoard";
+import { dedupeLiveAssignments } from "../lib/staffing-board";
 import type {
   Assignment,
   BidField,
@@ -26,9 +27,9 @@ export async function loader({ request }: Route.LoaderArgs) {
   const auth = await requireAuth(request);
   if (!auth.ok) return redirect("/login");
   if (auth.user.type === "applicant") return redirect("/portal");
-  // Viewing the board is now Core/Admin only. Mutations are further gated
-  // by canManageStaffing (staffing leads); the UI hides drag affordances
-  // when canManage is false.
+  // Viewing and managing the board are both Core/Admin (canViewStaffing and
+  // canManageStaffing are the same membership set); the UI still hides drag
+  // affordances when canManage is false (e.g. a future read-only tier).
   if (!(await canViewStaffing(auth.user.sub))) return redirect("/");
 
   const canManage = await canManageStaffing(auth.user.sub);
@@ -116,7 +117,7 @@ export async function loader({ request }: Route.LoaderArgs) {
 
   const memberUserIds = Array.from(new Set(preferences.map((p) => p.userId)));
 
-  const [users, assignmentRows, projects, domains, roleRequests] = await Promise.all([
+  const [users, rawAssignmentRows, projects, domains, roleRequests] = await Promise.all([
     prisma.user.findMany({
       where: { id: { in: memberUserIds } },
       select: {
@@ -136,9 +137,12 @@ export async function loader({ request }: Route.LoaderArgs) {
         },
       },
     }),
+    // Both in-progress (Proposed) and finalized (Confirmed) assignments — a
+    // confirmed roster must stay on the board after finalize, not vanish.
+    // Declined rows are audit only. Deduped to one card per (user, cycle) below.
     prisma.staffingAssignment.findMany({
-      where: { staffingCycleId: cycle.id, status: "Proposed" },
-      select: { userId: true, projectId: true, domainId: true, level: true },
+      where: { staffingCycleId: cycle.id, status: { in: ["Proposed", "Confirmed"] } },
+      select: { userId: true, projectId: true, domainId: true, level: true, status: true },
     }),
     // Columns are the projects that actually RUN in the selected term
     // (ProjectTerm), not every non-archived project — otherwise the board lists
@@ -163,6 +167,10 @@ export async function loader({ request }: Route.LoaderArgs) {
       select: { projectId: true, domainId: true, slots: true },
     }),
   ]);
+
+  // Collapse a member's Proposed + Confirmed rows to one live card (see
+  // dedupeLiveAssignments) so a finalized roster stays on the board.
+  const assignmentRows = dedupeLiveAssignments(rawAssignmentRows);
 
   // Union in any non-archived project that's actually being staffed this cycle
   // (a bid, assignment, or role request) but lacks a ProjectTerm row for the

--- a/dali-api/app/routes.ts
+++ b/dali-api/app/routes.ts
@@ -205,6 +205,7 @@ export default [
   route("api/staffing/assign", "projects/routes/api.staffing.assign.ts"),
   route("api/staffing/finalize", "projects/routes/api.staffing.finalize.ts"),
   route("api/staffing/board-member", "projects/routes/api.staffing.board-member.ts"),
+  route("api/staffing/events", "projects/routes/api.staffing.events.ts"),
 
   // Project task board
   route("api/projects/:id/tasks", "projects/routes/api.projects.$id.tasks.ts"),


### PR DESCRIPTION
…es (#789)

* Staffing: let leads assign a non-bidding member via their eligibility

Dragging a member onto a project needs a domainId + level for the new StaffingAssignment. resolveAssignmentInputs only inferred those from a StaffingPreference, so a manually-added member with no bid (StaffingBoardMember, no preference) could never be placed — the board errored "no preferences on file." But such a member usually has exactly one DomainEligibility, which is the only domain+level they could be staffed at.

Add a fallback: when no bid resolves, use the member's DomainEligibility when they have exactly one. Multiple eligibilities stay ambiguous (still rejected, so no wrong domain is guessed). Thread domainId through DomainLevel + the loader's three eligibility selects so the fallback has the id it needs, and reword the board error to name the real condition.



* Staffing: team email group only (drop project user account); show it + deployment link

The finalize "gmail" automation created BOTH a project user account (<slug>@dali.dartmouth.edu → Project.calendarEmail) and a team Google Group (<slug>-team@… → Project.teamGroupEmail). The user account is a mailbox with a generated password we discard, and a group needs no password — so drop the user provisioning entirely and keep only the group (get-or-create + add confirmed roster). Project.calendarEmail remains a manual, lead-editable field.

Surface the generated team group email on the project detail page (read-only, next to Calendar email) — previously it was written but never shown.

Add a Project.deploymentUrl column (new migration) + an editable "Deployment" link on the detail page, mirroring the repo links.



* Image upload UX: header avatar on member page; real upload for project image

Member detail: move profile-photo upload out of the Profile box and onto the big header avatar — a camera icon overlays the image; clicking it picks → crops → uploads to S3 and saves immediately via a new update-photo action intent (admin-or-self, name not required). The Profile form no longer carries photoUrl, so a Profile save can't wipe the photo. New ProfilePhotoAvatar component.

Project detail: the image field was a free-text URL with no upload UI. Replace it with the existing PhotoUploadField (now parameterizable: label, hidden-input name, S3 key prefix, square|wide preview), storing the uploaded key in Project.imageUrl. Loader resolves imageUrl via resolvePhotoUrl (passes through legacy pasted URLs, presigns uploaded keys) for the header + control preview.



* Project image: click-the-banner upload + default banner when none

Make the project header banner itself the image-upload control (like the member header avatar): clicking it picks → crops → uploads → saves immediately via a new update-image action intent. Remove the separate image field from the project details box, and stop the details save from touching imageUrl (so it can't be wiped by an unrelated save).

When a project has no image, show a default banner (deterministic gradient + project initial) instead of nothing. New ProjectImageBanner component; PhotoUploadField reverted to its original form (no longer used here).



* Profile header matches member detail; left-align settings + help pages

Profile: center the header with the large 32×32 avatar (was a small 20×20 left-aligned row), matching the member detail page's identity block.

Settings + help: drop `mx-auto` from every page's main container so content left-aligns like the rest of the app (kept max-w for line length). 11 routes.



* Project description: Markdown (editor source in edit mode, rendered on display)

The project hub Description was plain text. In edit mode it's now a Markdown source textarea (monospace, with a hint); in read mode it renders the Markdown (headings, bold, lists, links, code, GFM tables/strikethrough).

Add a reusable Markdown component (react-markdown + remark-gfm). react-markdown is XSS-safe by default — raw HTML in the source is not rendered — and element styles map to the app's design tokens (no Tailwind typography plugin here).

Documents already use the Tiptap rich-text editor, so they're unchanged.



* Surface dietary restrictions on profile + member detail

The "Welcome to DALI!" profile form collects profile.dietaryRestrictions and correctly writes it to User.dietaryRestrictions, but no page ever displayed it — so the food question appeared to "not show." Add it:

- profile.tsx: read-only row in the Personal section (loader now selects it).
- members.$id.tsx: editable field (added to the select, TEXT_FIELDS, and labels); the existing TEXT_FIELDS save loop persists it.

(No write bug: verified in prod the 2 members who submitted the form both have their dietary answer stored. The field was simply never surfaced.)



* Staffing board: live updates across viewers

Assignment, board-member, and finalize mutations now publishCycleChange, and a new api/staffing/events SSE endpoint (staffing-events.server) pushes those to open boards so a drag by one lead reflects for everyone without a manual refresh. The loader now loads both Proposed and Confirmed assignments and collapses them per (user, cycle) via dedupeLiveAssignments, so a finalized roster stays on the board instead of vanishing.



* Staffing: any Core member can manage the board, not just staffing leads

canManageStaffing was narrower than canViewStaffing — it required a CoreAssignment whose leadTitle contained "staffing", so a Core member with another title could view the board but not drag-drop. Make it = isCore, so every Core member who can see the board can also manage it (view and mutate gates now align). The server-side assign/finalize/board-member checks all use this helper, so they widen consistently.



---------

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/791"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783183310&installation_id=133523038&pr_number=791&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F791&signature=86bb7708231a6870949399041698c7bd84d52f6efa49527d3042c91bdcf2c1e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->