### PR TITLE
Staffing board: keep dragged card above project columns

### DIFF
--- a/dali-api/app/projects/components/MemberCard.tsx
+++ b/dali-api/app/projects/components/MemberCard.tsx
@@ -22,15 +22,11 @@ type Props = {
 
 export function MemberCard({ card, columnId, projectNames, domainNames, onOpenBid, onRemove, draggable }: Props) {
   const dragId = `${columnId}::${card.userId}`;
-  const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
     id: dragId,
     data: { userId: card.userId, fromColumn: columnId },
     disabled: !draggable,
   });
-
-  const style: React.CSSProperties = transform
-    ? { transform: `translate3d(${transform.x}px, ${transform.y}px, 0)`, zIndex: 50 }
-    : {};
 
   const fullName = `${card.firstName} ${card.lastName}`.trim();
 
@@ -38,13 +34,17 @@ export function MemberCard({ card, columnId, projectNames, domainNames, onOpenBi
   // still see the card and can click it to open the bid modal.
   const dragProps = draggable ? { ...attributes, ...listeners } : {};
 
+  // The dragged card is rendered separately by DragOverlay (a portal that sits
+  // above every column), so the in-place node here just dims while dragging —
+  // no transform/zIndex, which would otherwise leave the card trapped inside
+  // its column's stacking context and slide UNDER adjacent columns.
+  //
   // Clicking anywhere on the card opens the member's bid. The DndContext uses
   // a small activation-distance constraint, so a pointer press that doesn't
   // move past the threshold lands here as a click rather than starting a drag.
   return (
     <div
       ref={setNodeRef}
-      style={style}
       {...dragProps}
       onClick={onOpenBid}
       role="button"
@@ -59,8 +59,37 @@ export function MemberCard({ card, columnId, projectNames, domainNames, onOpenBi
       title="View bid"
       className={`bg-card border border-border rounded-md p-2.5 flex flex-col gap-1.5 select-none ${
         draggable ? "cursor-grab active:cursor-grabbing" : "cursor-pointer"
-      } ${isDragging ? "opacity-60 shadow-lg" : "hover:bg-muted/20"}`}
+      } ${isDragging ? "opacity-40" : "hover:bg-muted/20"}`}
     >
+      <MemberCardBody
+        card={card}
+        fullName={fullName}
+        projectNames={projectNames}
+        domainNames={domainNames}
+        onRemove={onRemove}
+      />
+    </div>
+  );
+}
+
+// The card's visual content, shared by the in-column MemberCard and the
+// DragOverlay's floating copy so the dragged card looks identical to its
+// resting state.
+function MemberCardBody({
+  card,
+  fullName,
+  projectNames,
+  domainNames,
+  onRemove,
+}: {
+  card: MemberCardModel;
+  fullName: string;
+  projectNames: Record<string, string>;
+  domainNames: Record<string, string>;
+  onRemove?: () => void;
+}) {
+  return (
+    <>
       <div className="flex items-start gap-2">
         <Avatar photoUrl={card.photoUrl} name={fullName} />
         <div className="min-w-0 flex-1">
@@ -107,6 +136,30 @@ export function MemberCard({ card, columnId, projectNames, domainNames, onOpenBi
 
       <DomainLevelStrip card={card} />
       <BidStrip card={card} projectNames={projectNames} domainNames={domainNames} />
+    </>
+  );
+}
+
+// A static, non-draggable copy of the card for DragOverlay to float above the
+// columns. Same body as MemberCard, with the resting card styling.
+export function MemberCardPreview({
+  card,
+  projectNames,
+  domainNames,
+}: {
+  card: MemberCardModel;
+  projectNames: Record<string, string>;
+  domainNames: Record<string, string>;
+}) {
+  const fullName = `${card.firstName} ${card.lastName}`.trim();
+  return (
+    <div className="bg-card border border-border rounded-md p-2.5 flex flex-col gap-1.5 select-none shadow-lg cursor-grabbing">
+      <MemberCardBody
+        card={card}
+        fullName={fullName}
+        projectNames={projectNames}
+        domainNames={domainNames}
+      />
     </div>
   );
 }

--- a/dali-api/app/projects/components/StaffingBoard.tsx
+++ b/dali-api/app/projects/components/StaffingBoard.tsx
@@ -2,11 +2,13 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams, useRevalidator } from "react-router";
 import {
   DndContext,
+  DragOverlay,
   PointerSensor,
   useDroppable,
   useSensor,
   useSensors,
   type DragEndEvent,
+  type DragStartEvent,
 } from "@dnd-kit/core";
 import {
   buildBoard,
@@ -18,7 +20,7 @@ import {
   type Preference,
 } from "../lib/staffing-board";
 import { CheckCircle2 } from "lucide-react";
-import { MemberCard } from "./MemberCard";
+import { MemberCard, MemberCardPreview } from "./MemberCard";
 import { BidModal } from "./BidModal";
 import { FinalizeModal } from "./FinalizeModal";
 import { AddMemberControl } from "./AddMemberControl";
@@ -74,6 +76,9 @@ export function StaffingBoard({
   const [openBidUserId, setOpenBidUserId] = useState<string | null>(null);
   // Project id whose finalize modal is open, or null.
   const [finalizeProjectId, setFinalizeProjectId] = useState<string | null>(null);
+  // userId of the card being dragged, or null. Drives the DragOverlay so the
+  // dragged card floats above every column instead of clipping under them.
+  const [activeCardUserId, setActiveCardUserId] = useState<string | null>(null);
 
   // Number of drag saves currently in flight. While > 0 we hold off adopting
   // server data so a live push from someone else can't revert our own unsaved
@@ -121,6 +126,17 @@ export function StaffingBoard({
     [members],
   );
 
+  // Flat userId → card lookup so DragOverlay can render the active card without
+  // knowing which column it came from.
+  const cardByUserId = useMemo(() => {
+    const map = new Map<string, MemberCardModel>();
+    for (const cards of Object.values(board)) {
+      for (const c of cards) map.set(c.userId, c);
+    }
+    return map;
+  }, [board]);
+  const activeCard = activeCardUserId ? cardByUserId.get(activeCardUserId) ?? null : null;
+
   // The whole member card is both draggable and clickable. A small activation
   // distance disambiguates the two: a press that moves <6px fires the card's
   // onClick (open bid); past that it starts a drag, suppressing the click.
@@ -128,7 +144,13 @@ export function StaffingBoard({
     useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
   );
 
+  function handleDragStart(event: DragStartEvent) {
+    const data = event.active.data.current as { userId?: string } | undefined;
+    setActiveCardUserId(data?.userId ?? null);
+  }
+
   function handleDragEnd(event: DragEndEvent) {
+    setActiveCardUserId(null);
     if (!canManage) return;
     const overId = event.over?.id;
     if (!overId || typeof overId !== "string") return;
@@ -272,7 +294,13 @@ export function StaffingBoard({
           iframe + other boards) the default useId differs between SSR and
           client, hydration-mismatches dnd-kit's internal ids, and drag never
           activates. A fixed id keeps server/client deterministic. */}
-      <DndContext id="staffing-board" sensors={sensors} onDragEnd={handleDragEnd}>
+      <DndContext
+        id="staffing-board"
+        sensors={sensors}
+        onDragStart={handleDragStart}
+        onDragEnd={handleDragEnd}
+        onDragCancel={() => setActiveCardUserId(null)}
+      >
         {/* pt-1 keeps each column's top border off the scroll-clip edge so it
             stays visible; px on the row prevents the first/last column border
             being shaved by overflow-x. */}
@@ -306,6 +334,18 @@ export function StaffingBoard({
             />
           ))}
         </div>
+
+        {/* The dragged card, portaled above every column so it can never clip
+            under an adjacent column's stacking context. */}
+        <DragOverlay>
+          {activeCard ? (
+            <MemberCardPreview
+              card={activeCard}
+              projectNames={projectNames}
+              domainNames={domainNames}
+            />
+          ) : null}
+        </DragOverlay>
       </DndContext>
 
       {openBidMember && (


### PR DESCRIPTION
## Summary

On the staffing page, a member card slid **under** the project columns while being dragged instead of floating over them.

**Cause:** the dragged card used an in-place `transform` + `zIndex: 50`, but it stayed inside its source column's DOM subtree. Adjacent columns establish their own stacking contexts (`overflow-x-auto`, opacity tones), so `zIndex` within the card couldn't lift it above sibling columns — it rendered beneath whichever column painted later.

**Fix:** switch to dnd-kit's `DragOverlay`, which portals the dragged card to the top of the stacking order, above every column.
- The in-place card now just dims (`opacity-40`) while dragging — no `transform`/`zIndex`.
- A new portaled `MemberCardPreview` renders the floating copy.
- Shared visual extracted into `MemberCardBody` so the dragged card is pixel-identical to its resting state.
- `onDragStart`/`onDragCancel` track the active card; `onDragEnd` clears it.

## Files
- `app/projects/components/MemberCard.tsx` — extract `MemberCardBody`, add `MemberCardPreview`, drop in-place transform.
- `app/projects/components/StaffingBoard.tsx` — `DragOverlay` + active-card state + drag-start/cancel handlers.

## Test plan
- `npm run typecheck` — clean for both changed files.
- `npm test` (staffing-board suite) — 19/19 pass.
- Manual: drag a card across columns — it should now float above all columns the whole way. (In-browser check recommended before merge.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/792"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783184426&installation_id=133523038&pr_number=792&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F792&signature=abfa808cd572f4e561c3d9ea52cb3995e92f6590af7af06acc7c0fd055bdc5fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->