### PR TITLE
Staffing board: drag-reorder cards within a column

### DIFF
--- a/dali-api/app/lib/audit.ts
+++ b/dali-api/app/lib/audit.ts
@@ -31,6 +31,7 @@ export const AUDIT_ACTIONS = [
   "staffing.finalize",
   "staffing.board-member.add",
   "staffing.board-member.remove",
+  "staffing.reorder",
   "document.delete",
   "projectFile.create",
   "projectFile.version",

--- a/dali-api/app/projects/components/MemberCard.tsx
+++ b/dali-api/app/projects/components/MemberCard.tsx
@@ -1,4 +1,5 @@
-import { useDraggable } from "@dnd-kit/core";
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 import { initialsFromName } from "~/lib/display";
 import type { MemberCardModel, Level } from "../lib/staffing-board";
 
@@ -21,12 +22,14 @@ type Props = {
 };
 
 export function MemberCard({ card, columnId, projectNames, domainNames, onOpenBid, onRemove, draggable }: Props) {
-  const dragId = `${columnId}::${card.userId}`;
-  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
-    id: dragId,
-    data: { userId: card.userId, fromColumn: columnId },
-    disabled: !draggable,
-  });
+  // The card's sortable id is its userId (unique per board). Column membership
+  // travels in `data` so the drag handler knows where the card came from.
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
+    useSortable({
+      id: card.userId,
+      data: { userId: card.userId, fromColumn: columnId },
+      disabled: !draggable,
+    });
 
   const fullName = `${card.firstName} ${card.lastName}`.trim();
 
@@ -34,17 +37,22 @@ export function MemberCard({ card, columnId, projectNames, domainNames, onOpenBi
   // still see the card and can click it to open the bid modal.
   const dragProps = draggable ? { ...attributes, ...listeners } : {};
 
-  // The dragged card is rendered separately by DragOverlay (a portal that sits
-  // above every column), so the in-place node here just dims while dragging —
-  // no transform/zIndex, which would otherwise leave the card trapped inside
-  // its column's stacking context and slide UNDER adjacent columns.
+  // useSortable's transform/transition animate the SIBLINGS shifting to make
+  // room as a card is dragged over them. The dragged card itself is dimmed and
+  // its floating copy is rendered by DragOverlay (portaled above all columns),
+  // so it can never clip under an adjacent column's stacking context.
   //
   // Clicking anywhere on the card opens the member's bid. The DndContext uses
   // a small activation-distance constraint, so a pointer press that doesn't
   // move past the threshold lands here as a click rather than starting a drag.
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
   return (
     <div
       ref={setNodeRef}
+      style={style}
       {...dragProps}
       onClick={onOpenBid}
       role="button"

--- a/dali-api/app/projects/components/MemberCard.tsx
+++ b/dali-api/app/projects/components/MemberCard.tsx
@@ -22,15 +22,11 @@ type Props = {
 
 export function MemberCard({ card, columnId, projectNames, domainNames, onOpenBid, onRemove, draggable }: Props) {
   const dragId = `${columnId}::${card.userId}`;
-  const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
     id: dragId,
     data: { userId: card.userId, fromColumn: columnId },
     disabled: !draggable,
   });
-
-  const style: React.CSSProperties = transform
-    ? { transform: `translate3d(${transform.x}px, ${transform.y}px, 0)`, zIndex: 50 }
-    : {};
 
   const fullName = `${card.firstName} ${card.lastName}`.trim();
 
@@ -38,13 +34,17 @@ export function MemberCard({ card, columnId, projectNames, domainNames, onOpenBi
   // still see the card and can click it to open the bid modal.
   const dragProps = draggable ? { ...attributes, ...listeners } : {};
 
+  // The dragged card is rendered separately by DragOverlay (a portal that sits
+  // above every column), so the in-place node here just dims while dragging —
+  // no transform/zIndex, which would otherwise leave the card trapped inside
+  // its column's stacking context and slide UNDER adjacent columns.
+  //
   // Clicking anywhere on the card opens the member's bid. The DndContext uses
   // a small activation-distance constraint, so a pointer press that doesn't
   // move past the threshold lands here as a click rather than starting a drag.
   return (
     <div
       ref={setNodeRef}
-      style={style}
       {...dragProps}
       onClick={onOpenBid}
       role="button"
@@ -59,8 +59,37 @@ export function MemberCard({ card, columnId, projectNames, domainNames, onOpenBi
       title="View bid"
       className={`bg-card border border-border rounded-md p-2.5 flex flex-col gap-1.5 select-none ${
         draggable ? "cursor-grab active:cursor-grabbing" : "cursor-pointer"
-      } ${isDragging ? "opacity-60 shadow-lg" : "hover:bg-muted/20"}`}
+      } ${isDragging ? "opacity-40" : "hover:bg-muted/20"}`}
     >
+      <MemberCardBody
+        card={card}
+        fullName={fullName}
+        projectNames={projectNames}
+        domainNames={domainNames}
+        onRemove={onRemove}
+      />
+    </div>
+  );
+}
+
+// The card's visual content, shared by the in-column MemberCard and the
+// DragOverlay's floating copy so the dragged card looks identical to its
+// resting state.
+function MemberCardBody({
+  card,
+  fullName,
+  projectNames,
+  domainNames,
+  onRemove,
+}: {
+  card: MemberCardModel;
+  fullName: string;
+  projectNames: Record<string, string>;
+  domainNames: Record<string, string>;
+  onRemove?: () => void;
+}) {
+  return (
+    <>
       <div className="flex items-start gap-2">
         <Avatar photoUrl={card.photoUrl} name={fullName} />
         <div className="min-w-0 flex-1">
@@ -107,6 +136,30 @@ export function MemberCard({ card, columnId, projectNames, domainNames, onOpenBi
 
       <DomainLevelStrip card={card} />
       <BidStrip card={card} projectNames={projectNames} domainNames={domainNames} />
+    </>
+  );
+}
+
+// A static, non-draggable copy of the card for DragOverlay to float above the
+// columns. Same body as MemberCard, with the resting card styling.
+export function MemberCardPreview({
+  card,
+  projectNames,
+  domainNames,
+}: {
+  card: MemberCardModel;
+  projectNames: Record<string, string>;
+  domainNames: Record<string, string>;
+}) {
+  const fullName = `${card.firstName} ${card.lastName}`.trim();
+  return (
+    <div className="bg-card border border-border rounded-md p-2.5 flex flex-col gap-1.5 select-none shadow-lg cursor-grabbing">
+      <MemberCardBody
+        card={card}
+        fullName={fullName}
+        projectNames={projectNames}
+        domainNames={domainNames}
+      />
     </div>
   );
 }

--- a/dali-api/app/projects/components/StaffingBoard.tsx
+++ b/dali-api/app/projects/components/StaffingBoard.tsx
@@ -2,11 +2,13 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams, useRevalidator } from "react-router";
 import {
   DndContext,
+  DragOverlay,
   PointerSensor,
   useDroppable,
   useSensor,
   useSensors,
   type DragEndEvent,
+  type DragStartEvent,
 } from "@dnd-kit/core";
 import {
   buildBoard,
@@ -18,7 +20,7 @@ import {
   type Preference,
 } from "../lib/staffing-board";
 import { CheckCircle2 } from "lucide-react";
-import { MemberCard } from "./MemberCard";
+import { MemberCard, MemberCardPreview } from "./MemberCard";
 import { BidModal } from "./BidModal";
 import { FinalizeModal } from "./FinalizeModal";
 import { AddMemberControl } from "./AddMemberControl";
@@ -74,6 +76,9 @@ export function StaffingBoard({
   const [openBidUserId, setOpenBidUserId] = useState<string | null>(null);
   // Project id whose finalize modal is open, or null.
   const [finalizeProjectId, setFinalizeProjectId] = useState<string | null>(null);
+  // userId of the card being dragged, or null. Drives the DragOverlay so the
+  // dragged card floats above every column instead of clipping under them.
+  const [activeCardUserId, setActiveCardUserId] = useState<string | null>(null);
 
   // Number of drag saves currently in flight. While > 0 we hold off adopting
   // server data so a live push from someone else can't revert our own unsaved
@@ -121,6 +126,17 @@ export function StaffingBoard({
     [members],
   );
 
+  // Flat userId → card lookup so DragOverlay can render the active card without
+  // knowing which column it came from.
+  const cardByUserId = useMemo(() => {
+    const map = new Map<string, MemberCardModel>();
+    for (const cards of Object.values(board)) {
+      for (const c of cards) map.set(c.userId, c);
+    }
+    return map;
+  }, [board]);
+  const activeCard = activeCardUserId ? cardByUserId.get(activeCardUserId) ?? null : null;
+
   // The whole member card is both draggable and clickable. A small activation
   // distance disambiguates the two: a press that moves <6px fires the card's
   // onClick (open bid); past that it starts a drag, suppressing the click.
@@ -128,7 +144,13 @@ export function StaffingBoard({
     useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
   );
 
+  function handleDragStart(event: DragStartEvent) {
+    const data = event.active.data.current as { userId?: string } | undefined;
+    setActiveCardUserId(data?.userId ?? null);
+  }
+
   function handleDragEnd(event: DragEndEvent) {
+    setActiveCardUserId(null);
     if (!canManage) return;
     const overId = event.over?.id;
     if (!overId || typeof overId !== "string") return;
@@ -272,7 +294,13 @@ export function StaffingBoard({
           iframe + other boards) the default useId differs between SSR and
           client, hydration-mismatches dnd-kit's internal ids, and drag never
           activates. A fixed id keeps server/client deterministic. */}
-      <DndContext id="staffing-board" sensors={sensors} onDragEnd={handleDragEnd}>
+      <DndContext
+        id="staffing-board"
+        sensors={sensors}
+        onDragStart={handleDragStart}
+        onDragEnd={handleDragEnd}
+        onDragCancel={() => setActiveCardUserId(null)}
+      >
         {/* pt-1 keeps each column's top border off the scroll-clip edge so it
             stays visible; px on the row prevents the first/last column border
             being shaved by overflow-x. */}
@@ -306,6 +334,18 @@ export function StaffingBoard({
             />
           ))}
         </div>
+
+        {/* The dragged card, portaled above every column so it can never clip
+            under an adjacent column's stacking context. */}
+        <DragOverlay>
+          {activeCard ? (
+            <MemberCardPreview
+              card={activeCard}
+              projectNames={projectNames}
+              domainNames={domainNames}
+            />
+          ) : null}
+        </DragOverlay>
       </DndContext>
 
       {openBidMember && (

--- a/dali-api/app/projects/components/StaffingBoard.tsx
+++ b/dali-api/app/projects/components/StaffingBoard.tsx
@@ -4,12 +4,14 @@ import {
   DndContext,
   DragOverlay,
   PointerSensor,
+  closestCorners,
   useDroppable,
   useSensor,
   useSensors,
   type DragEndEvent,
   type DragStartEvent,
 } from "@dnd-kit/core";
+import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
 import {
   buildBoard,
   resolveAssignmentInputs,
@@ -46,6 +48,10 @@ type Props = {
   projects: ProjectMeta[];
   members: MemberInput[];
   initialAssignments: Assignment[];
+  // Manual within-column card order rows from the server (userId, columnKey,
+  // sortKey). buildBoard applies one only when columnKey matches the card's
+  // current column. Cards without a row sort by last name.
+  cardOrder: { userId: string; columnKey: string; sortKey: number }[];
   // Project id → name for label resolution. Covers archived projects a member
   // ranked that aren't board columns, so cards/modal never show a raw id.
   projectNames: Record<string, string>;
@@ -64,6 +70,7 @@ export function StaffingBoard({
   projects,
   members,
   initialAssignments,
+  cardOrder,
   projectNames,
   domainNames,
   demandByProject,
@@ -72,6 +79,9 @@ export function StaffingBoard({
   const [searchParams, setSearchParams] = useSearchParams();
   const revalidator = useRevalidator();
   const [assignments, setAssignments] = useState<Assignment[]>(initialAssignments);
+  // Optimistic copy of the server card order; drag updates it immediately and
+  // the persist+revalidate reconciles. Same lifecycle as `assignments`.
+  const [order, setOrder] = useState(cardOrder);
   const [error, setError] = useState<string | null>(null);
   const [openBidUserId, setOpenBidUserId] = useState<string | null>(null);
   // Project id whose finalize modal is open, or null.
@@ -93,7 +103,8 @@ export function StaffingBoard({
   useEffect(() => {
     if (pendingSaves.current > 0) return;
     setAssignments(initialAssignments);
-  }, [initialAssignments]);
+    setOrder(cardOrder);
+  }, [initialAssignments, cardOrder]);
 
   // Live updates: subscribe to this cycle's SSE stream and revalidate on any
   // pushed change (assign / finalize / board-member by anyone) or periodic sync.
@@ -117,8 +128,8 @@ export function StaffingBoard({
   const projectIds = useMemo(() => projects.map((p) => p.id), [projects]);
 
   const board = useMemo(
-    () => buildBoard({ projectIds, members, assignments }),
-    [projectIds, members, assignments],
+    () => buildBoard({ projectIds, members, assignments, cardOrder: order }),
+    [projectIds, members, assignments, order],
   );
 
   const memberById = useMemo(
@@ -158,20 +169,42 @@ export function StaffingBoard({
     const userId = data?.userId;
     const fromColumn = data?.fromColumn ?? UNASSIGNED;
     if (!userId) return;
-    if (overId === fromColumn) return;
 
     const member = memberById.get(userId);
     if (!member) return;
 
-    // Optimistic: update local state immediately.
-    const targetProjectId = overId === UNASSIGNED ? null : overId;
-    const prevAssignments = assignments;
+    // Resolve the target column + insertion index. `over` is either a card
+    // (its userId — drop relative to it) or a column droppable (its id — drop
+    // at the end). Column ids are UNASSIGNED or a project id; everything else
+    // is a card userId.
+    const isColumnId = overId === UNASSIGNED || projectIds.includes(overId);
+    const toColumn = isColumnId
+      ? overId
+      : findColumnOf(board, overId) ?? fromColumn;
+    const targetIds = (board[toColumn] ?? []).map((c) => c.userId);
+    const overIndex = isColumnId ? targetIds.length : targetIds.indexOf(overId);
+    const movedWithinColumn = fromColumn === toColumn;
 
-    let nextAssignments: Assignment[];
+    // No-op: dropped on itself, or back where it already was.
+    if (movedWithinColumn) {
+      const fromIndex = targetIds.indexOf(userId);
+      if (fromIndex === overIndex || (overIndex === -1)) return;
+    }
+
+    // Build the new ordered userId list for the destination column.
+    const withoutMoved = targetIds.filter((id) => id !== userId);
+    const insertAt = overIndex < 0 ? withoutMoved.length : Math.min(overIndex, withoutMoved.length);
+    const nextDestIds = [
+      ...withoutMoved.slice(0, insertAt),
+      userId,
+      ...withoutMoved.slice(insertAt),
+    ];
+
+    // A cross-column move also needs the assignment updated. Resolve domain +
+    // level for a project column; UNASSIGNED clears the assignment.
+    const targetProjectId = toColumn === UNASSIGNED ? null : toColumn;
     let assignmentBody: { domainId: string; level: "P1" | "P2" | "P3" } | null = null;
-    if (targetProjectId === null) {
-      nextAssignments = assignments.filter((a) => a.userId !== userId);
-    } else {
+    if (!movedWithinColumn && targetProjectId !== null) {
       assignmentBody = resolveAssignmentInputs(member, targetProjectId);
       if (!assignmentBody) {
         setError(
@@ -183,31 +216,48 @@ export function StaffingBoard({
         );
         return;
       }
-      const withoutOld = assignments.filter((a) => a.userId !== userId);
-      nextAssignments = [
-        ...withoutOld,
-        { userId, projectId: targetProjectId, domainId: assignmentBody.domainId, level: assignmentBody.level },
-      ];
     }
-    setAssignments(nextAssignments);
+
+    const prevAssignments = assignments;
+    const prevOrder = order;
+
+    // Optimistic assignment update (only when the column changed).
+    if (!movedWithinColumn) {
+      const withoutOld = assignments.filter((a) => a.userId !== userId);
+      setAssignments(
+        targetProjectId === null
+          ? withoutOld
+          : [
+              ...withoutOld,
+              { userId, projectId: targetProjectId, domainId: assignmentBody!.domainId, level: assignmentBody!.level },
+            ],
+      );
+    }
+
+    // Optimistic order update for the destination column. Other users' rows are
+    // preserved; the moved card and its new neighbours get fresh indices.
+    setOrder((prev) => mergeColumnOrder(prev, toColumn, nextDestIds, userId));
     setError(null);
 
     pendingSaves.current += 1;
-    void persist({
-      cycleId,
-      userId,
-      projectId: targetProjectId,
-      domainId: assignmentBody?.domainId,
-      level: assignmentBody?.level,
-    })
-      .then(() => {
-        // Reconcile with server truth (also adopts any concurrent edits that
-        // arrived while this save was in flight).
-        revalidator.revalidate();
-      })
+    const save = async () => {
+      if (!movedWithinColumn) {
+        await persist({
+          cycleId,
+          userId,
+          projectId: targetProjectId,
+          domainId: assignmentBody?.domainId,
+          level: assignmentBody?.level,
+        });
+      }
+      await persistOrder({ cycleId, columnKey: toColumn, userIds: nextDestIds });
+    };
+    void save()
+      .then(() => revalidator.revalidate())
       .catch((err) => {
         setAssignments(prevAssignments);
-        setError(err instanceof Error ? err.message : "Failed to save assignment");
+        setOrder(prevOrder);
+        setError(err instanceof Error ? err.message : "Failed to save");
       })
       .finally(() => {
         pendingSaves.current = Math.max(0, pendingSaves.current - 1);
@@ -297,6 +347,7 @@ export function StaffingBoard({
       <DndContext
         id="staffing-board"
         sensors={sensors}
+        collisionDetection={closestCorners}
         onDragStart={handleDragStart}
         onDragEnd={handleDragEnd}
         onDragCancel={() => setActiveCardUserId(null)}
@@ -410,6 +461,7 @@ function Column({
   onFinalize?: () => void;
 }) {
   const { isOver, setNodeRef } = useDroppable({ id });
+  const cardIds = cards.map((c) => c.userId);
   const toneClasses: Record<ColumnTone, string> = {
     muted: "border-border bg-muted/20",
     active: "border-accent-teal/40 bg-accent-teal/[0.04]",
@@ -459,25 +511,27 @@ function Column({
           min-h-0 lets it shrink within the column's max-height so overflow-y
           kicks in instead of stretching the page. */}
       <div className="flex flex-col gap-2 p-2 flex-1 min-h-0 overflow-y-auto">
-        {cards.length === 0 ? (
-          // min-h keeps an empty column a usable drop target.
-          <div className="text-xs text-muted-foreground italic text-center py-4 min-h-[12rem]">
-            Empty
-          </div>
-        ) : (
-          cards.map((card) => (
-            <MemberCard
-              key={card.userId}
-              card={card}
-              columnId={id}
-              projectNames={projectNames}
-              domainNames={domainNames}
-              onOpenBid={() => onOpenBid(card.userId)}
-              onRemove={onRemoveMember ? () => onRemoveMember(card.userId) : undefined}
-              draggable={draggable}
-            />
-          ))
-        )}
+        <SortableContext items={cardIds} strategy={verticalListSortingStrategy}>
+          {cards.length === 0 ? (
+            // min-h keeps an empty column a usable drop target.
+            <div className="text-xs text-muted-foreground italic text-center py-4 min-h-[12rem]">
+              Empty
+            </div>
+          ) : (
+            cards.map((card) => (
+              <MemberCard
+                key={card.userId}
+                card={card}
+                columnId={id}
+                projectNames={projectNames}
+                domainNames={domainNames}
+                onOpenBid={() => onOpenBid(card.userId)}
+                onRemove={onRemoveMember ? () => onRemoveMember(card.userId) : undefined}
+                draggable={draggable}
+              />
+            ))
+          )}
+        </SortableContext>
       </div>
     </div>
   );
@@ -500,4 +554,48 @@ async function persist(args: {
     const body = (await res.json().catch(() => ({}))) as { error?: string };
     throw new Error(body.error ?? `Request failed: ${res.status}`);
   }
+}
+
+async function persistOrder(args: {
+  cycleId: string;
+  columnKey: string;
+  userIds: string[];
+}): Promise<void> {
+  const res = await fetch("/api/staffing/reorder", {
+    method: "POST",
+    credentials: "include",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(args),
+  });
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as { error?: string };
+    throw new Error(body.error ?? `Reorder failed: ${res.status}`);
+  }
+}
+
+// The column a userId currently sits in, per the built board, or null.
+function findColumnOf(
+  board: Record<string, MemberCardModel[]>,
+  userId: string,
+): string | null {
+  for (const [columnKey, cards] of Object.entries(board)) {
+    if (cards.some((c) => c.userId === userId)) return columnKey;
+  }
+  return null;
+}
+
+// Replace the order rows for one column with `userIds` (in their new order),
+// preserving every other column's rows. The moved user's any prior-column row
+// is dropped so a stale entry can't linger.
+function mergeColumnOrder(
+  prev: { userId: string; columnKey: string; sortKey: number }[],
+  columnKey: string,
+  userIds: string[],
+  movedUserId: string,
+): { userId: string; columnKey: string; sortKey: number }[] {
+  const kept = prev.filter(
+    (o) => o.columnKey !== columnKey && o.userId !== movedUserId,
+  );
+  const fresh = userIds.map((userId, sortKey) => ({ userId, columnKey, sortKey }));
+  return [...kept, ...fresh];
 }

--- a/dali-api/app/projects/lib/__tests__/staffing-board.test.ts
+++ b/dali-api/app/projects/lib/__tests__/staffing-board.test.ts
@@ -186,6 +186,72 @@ describe("buildBoard", () => {
   });
 });
 
+describe("buildBoard cardOrder", () => {
+  const m = (userId: string, lastName: string) =>
+    member({ userId, firstName: userId.toUpperCase(), lastName });
+
+  it("falls back to last-name sort when no order is given", () => {
+    const board = buildBoard({
+      projectIds: [],
+      members: [m("c", "Carter"), m("a", "Adams"), m("b", "Baker")],
+      assignments: [],
+    });
+    expect(board[UNASSIGNED].map((c) => c.userId)).toEqual(["a", "b", "c"]);
+  });
+
+  it("orders cards in a column by their sortKey when present", () => {
+    const board = buildBoard({
+      projectIds: [],
+      members: [m("a", "Adams"), m("b", "Baker"), m("c", "Carter")],
+      assignments: [],
+      cardOrder: [
+        { userId: "c", columnKey: UNASSIGNED, sortKey: 0 },
+        { userId: "a", columnKey: UNASSIGNED, sortKey: 1 },
+        { userId: "b", columnKey: UNASSIGNED, sortKey: 2 },
+      ],
+    });
+    expect(board[UNASSIGNED].map((c) => c.userId)).toEqual(["c", "a", "b"]);
+  });
+
+  it("places ordered cards ahead of unordered ones (which keep name order)", () => {
+    const board = buildBoard({
+      projectIds: [],
+      members: [m("a", "Adams"), m("b", "Baker"), m("c", "Carter")],
+      assignments: [],
+      // Only c has an explicit position.
+      cardOrder: [{ userId: "c", columnKey: UNASSIGNED, sortKey: 0 }],
+    });
+    expect(board[UNASSIGNED].map((c) => c.userId)).toEqual(["c", "a", "b"]);
+  });
+
+  it("ignores an order row whose columnKey doesn't match the card's column", () => {
+    // 'a' is assigned to p1, but its saved order is for Unassigned — stale, so
+    // it must NOT apply in p1; p1 falls back to name order.
+    const board = buildBoard({
+      projectIds: ["p1"],
+      members: [
+        member({
+          userId: "a",
+          lastName: "Zimmer",
+          preferences: [{ projectId: "p1", domainId: "d1", level: "P1", preferenceRank: 1, notes: null }],
+        }),
+        member({
+          userId: "b",
+          lastName: "Adams",
+          preferences: [{ projectId: "p1", domainId: "d1", level: "P1", preferenceRank: 1, notes: null }],
+        }),
+      ],
+      assignments: [
+        { userId: "a", projectId: "p1", domainId: "d1", level: "P1" },
+        { userId: "b", projectId: "p1", domainId: "d1", level: "P1" },
+      ],
+      cardOrder: [{ userId: "a", columnKey: UNASSIGNED, sortKey: 0 }],
+    });
+    // Name order (Adams before Zimmer) since the order row is for a stale column.
+    expect(board.p1.map((c) => c.userId)).toEqual(["b", "a"]);
+  });
+});
+
 describe("resolveAssignmentInputs", () => {
   it("returns the bid for the target project when present", () => {
     const out = resolveAssignmentInputs(

--- a/dali-api/app/projects/lib/staffing-board.ts
+++ b/dali-api/app/projects/lib/staffing-board.ts
@@ -122,8 +122,24 @@ export function buildBoard(args: {
   projectIds: string[];
   members: MemberInput[];
   assignments: Assignment[];
+  // Manual card-order rows. A row applies only when its columnKey matches the
+  // card's resolved column, so a stale order from before a move is ignored.
+  // Cards with an applicable row sort first (ascending sortKey); the rest fall
+  // back to last-name.
+  cardOrder?: { userId: string; columnKey: string; sortKey: number }[];
 }): Record<string, MemberCardModel[]> {
-  const { projectIds, members, assignments } = args;
+  const { projectIds, members, assignments, cardOrder = [] } = args;
+
+  // (columnKey → (userId → sortKey)) for column-scoped lookup.
+  const orderByColumn = new Map<string, Map<string, number>>();
+  for (const o of cardOrder) {
+    let m = orderByColumn.get(o.columnKey);
+    if (!m) {
+      m = new Map();
+      orderByColumn.set(o.columnKey, m);
+    }
+    m.set(o.userId, o.sortKey);
+  }
 
   const byUser = new Map<string, Assignment>();
   for (const a of assignments) {
@@ -136,13 +152,7 @@ export function buildBoard(args: {
   const columns: Record<string, MemberCardModel[]> = { [UNASSIGNED]: [] };
   for (const pid of projectIds) columns[pid] = [];
 
-  const sortedMembers = [...members].sort((a, b) => {
-    const ln = a.lastName.localeCompare(b.lastName);
-    if (ln !== 0) return ln;
-    return a.firstName.localeCompare(b.firstName);
-  });
-
-  for (const m of sortedMembers) {
+  for (const m of members) {
     const assignment = byUser.get(m.userId) ?? null;
     const columnKey = assignment?.projectId && columns[assignment.projectId]
       ? assignment.projectId
@@ -150,6 +160,25 @@ export function buildBoard(args: {
 
     const card = toCard(m, columnKey, assignment);
     columns[columnKey].push(card);
+  }
+
+  // Order within each column: cards with a manual sortKey lead (ascending),
+  // then the rest alphabetically by last, first name. A card whose order was
+  // saved in a different column has no entry here (the loader keys order by
+  // user, not column), so it just falls into the alphabetical tail — correct,
+  // since its old position no longer applies.
+  const byName = (a: MemberCardModel, b: MemberCardModel) =>
+    a.lastName.localeCompare(b.lastName) || a.firstName.localeCompare(b.firstName);
+  for (const key of Object.keys(columns)) {
+    const order = orderByColumn.get(key);
+    columns[key].sort((a, b) => {
+      const oa = order?.get(a.userId);
+      const ob = order?.get(b.userId);
+      if (oa != null && ob != null) return oa - ob;
+      if (oa != null) return -1;
+      if (ob != null) return 1;
+      return byName(a, b);
+    });
   }
 
   return columns;

--- a/dali-api/app/projects/routes/api.staffing.reorder.ts
+++ b/dali-api/app/projects/routes/api.staffing.reorder.ts
@@ -1,0 +1,94 @@
+import type { Route } from "./+types/api.staffing.reorder";
+import { prisma } from "~/lib/db";
+import { requireAuth } from "~/lib/auth";
+import { canManageStaffing } from "~/lib/roles";
+import { withCors, handlePreflight } from "~/lib/cors";
+import { logAuditEvent } from "~/lib/audit";
+import { publishCycleChange } from "../lib/staffing-events.server";
+
+// POST /api/staffing/reorder
+//
+// Body: { cycleId, columnKey, userIds: string[] }
+//   Persist the order of cards in one board column. `userIds` is the column's
+//   full membership in display order; we write each user's index as its
+//   sortKey. `columnKey` is a project id or "__unassigned__".
+//
+// One StaffingCardOrder row per (cycle, user), upserted. Column membership
+// itself is derived from assignments elsewhere (the assign endpoint) — this
+// endpoint only records position, so it never moves a card between columns.
+
+type Body = { cycleId: string; columnKey: string; userIds: string[] };
+
+function isBody(x: unknown): x is Body {
+  if (!x || typeof x !== "object") return false;
+  const o = x as Record<string, unknown>;
+  return (
+    typeof o.cycleId === "string" &&
+    typeof o.columnKey === "string" &&
+    Array.isArray(o.userIds) &&
+    o.userIds.every((u) => typeof u === "string")
+  );
+}
+
+export async function action({ request }: Route.ActionArgs) {
+  const preflight = handlePreflight(request);
+  if (preflight) return preflight;
+
+  const auth = await requireAuth(request);
+  if (!auth.ok) return withCors(request, auth.response);
+  if (request.method !== "POST") {
+    return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));
+  }
+  if (!(await canManageStaffing(auth.user.sub))) {
+    return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return withCors(request, Response.json({ error: "Invalid JSON" }, { status: 400 }));
+  }
+  if (!isBody(body)) {
+    return withCors(request, Response.json({ error: "Invalid body" }, { status: 400 }));
+  }
+
+  const cycle = await prisma.staffingCycle.findUnique({
+    where: { id: body.cycleId },
+    select: { id: true },
+  });
+  if (!cycle) {
+    return withCors(request, Response.json({ error: "Cycle not found" }, { status: 404 }));
+  }
+
+  // Write each user's position as its index in the supplied order. Upsert keeps
+  // it idempotent and re-homes a card's columnKey when it lands in a new column.
+  await prisma.$transaction(
+    body.userIds.map((userId, index) =>
+      prisma.staffingCardOrder.upsert({
+        where: {
+          staffingCycleId_userId: { staffingCycleId: body.cycleId, userId },
+        },
+        update: { columnKey: body.columnKey, sortKey: index },
+        create: {
+          staffingCycleId: body.cycleId,
+          userId,
+          columnKey: body.columnKey,
+          sortKey: index,
+        },
+      }),
+    ),
+  );
+
+  await logAuditEvent({
+    action: "staffing.reorder",
+    userId: auth.user.sub,
+    targetId: body.cycleId,
+    metadata: { columnKey: body.columnKey, count: body.userIds.length },
+    request,
+  });
+
+  publishCycleChange(body.cycleId);
+
+  return withCors(request, Response.json({ ok: true }));
+}

--- a/dali-api/app/projects/routes/projects.staffing.tsx
+++ b/dali-api/app/projects/routes/projects.staffing.tsx
@@ -117,7 +117,8 @@ export async function loader({ request }: Route.LoaderArgs) {
 
   const memberUserIds = Array.from(new Set(preferences.map((p) => p.userId)));
 
-  const [users, rawAssignmentRows, projects, domains, roleRequests] = await Promise.all([
+  const [users, rawAssignmentRows, projects, domains, roleRequests, cardOrders] =
+    await Promise.all([
     prisma.user.findMany({
       where: { id: { in: memberUserIds } },
       select: {
@@ -165,6 +166,12 @@ export async function loader({ request }: Route.LoaderArgs) {
     prisma.projectRoleRequest.findMany({
       where: { termId: selectedTerm.id },
       select: { projectId: true, domainId: true, slots: true },
+    }),
+    // Manual within-column card order. columnKey is carried so a stale order
+    // from a card's previous column is ignored once it moves (see below).
+    prisma.staffingCardOrder.findMany({
+      where: { staffingCycleId: cycle.id },
+      select: { userId: true, sortKey: true, columnKey: true },
     }),
   ]);
 
@@ -440,6 +447,10 @@ export async function loader({ request }: Route.LoaderArgs) {
     projects,
     members,
     initialAssignments,
+    // Manual card order rows (userId, columnKey, sortKey). buildBoard applies a
+    // row only when its columnKey matches the card's current column, so a stale
+    // order from before a move is ignored. Sparse; unordered cards sort by name.
+    cardOrder: cardOrders,
     projectNames,
     domainNames,
     demandByProject,
@@ -495,6 +506,7 @@ export default function StaffingPage() {
         projects={data.projects}
         members={data.members}
         initialAssignments={data.initialAssignments}
+        cardOrder={data.cardOrder}
         projectNames={data.projectNames}
         domainNames={data.domainNames}
         demandByProject={data.demandByProject}

--- a/dali-api/app/routes.ts
+++ b/dali-api/app/routes.ts
@@ -206,6 +206,7 @@ export default [
   route("api/staffing/finalize", "projects/routes/api.staffing.finalize.ts"),
   route("api/staffing/board-member", "projects/routes/api.staffing.board-member.ts"),
   route("api/staffing/events", "projects/routes/api.staffing.events.ts"),
+  route("api/staffing/reorder", "projects/routes/api.staffing.reorder.ts"),
 
   // Project task board
   route("api/projects/:id/tasks", "projects/routes/api.projects.$id.tasks.ts"),

--- a/dali-api/package-lock.json
+++ b/dali-api/package-lock.json
@@ -10,6 +10,7 @@
         "@aws-sdk/s3-presigned-post": "^3.1038.0",
         "@aws-sdk/s3-request-presigner": "^3.1030.0",
         "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
         "@hocuspocus/extension-redis": "^3.4.4",
         "@hocuspocus/provider": "^3.4.4",
         "@hocuspocus/server": "^3.4.4",
@@ -1281,6 +1282,20 @@
       "peerDependencies": {
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@dnd-kit/utilities": {

--- a/dali-api/package.json
+++ b/dali-api/package.json
@@ -23,6 +23,7 @@
     "@aws-sdk/s3-presigned-post": "^3.1038.0",
     "@aws-sdk/s3-request-presigner": "^3.1030.0",
     "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
     "@hocuspocus/extension-redis": "^3.4.4",
     "@hocuspocus/provider": "^3.4.4",
     "@hocuspocus/server": "^3.4.4",

--- a/dali-api/prisma/migrations/20260604010000_staffing_card_order/migration.sql
+++ b/dali-api/prisma/migrations/20260604010000_staffing_card_order/migration.sql
@@ -1,0 +1,21 @@
+-- Manual position of a member's card within its staffing-board column. The
+-- column is derived from the member's assignment (or its absence = Unassigned);
+-- this row records only the card's order within that column. One row per
+-- (cycle, user); cards with no row fall back to last-name sort. Decoupled from
+-- StaffingAssignment so Unassigned bidders can be ordered too. Additive; no
+-- data loss.
+CREATE TABLE "StaffingCardOrder" (
+    "id" TEXT NOT NULL,
+    "staffingCycleId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "columnKey" TEXT NOT NULL,
+    "sortKey" INTEGER NOT NULL,
+    CONSTRAINT "StaffingCardOrder_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "StaffingCardOrder_staffingCycleId_userId_key" ON "StaffingCardOrder"("staffingCycleId", "userId");
+
+CREATE INDEX "StaffingCardOrder_staffingCycleId_columnKey_idx" ON "StaffingCardOrder"("staffingCycleId", "columnKey");
+
+ALTER TABLE "StaffingCardOrder" ADD CONSTRAINT "StaffingCardOrder_staffingCycleId_fkey" FOREIGN KEY ("staffingCycleId") REFERENCES "StaffingCycle"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "StaffingCardOrder" ADD CONSTRAINT "StaffingCardOrder_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/dali-api/prisma/schema.prisma
+++ b/dali-api/prisma/schema.prisma
@@ -121,6 +121,7 @@ model User {
   essentialityRatings   EssentialityRating[]
   staffingAssignments   StaffingAssignment[]
   staffingBoardMembers  StaffingBoardMember[]
+  staffingCardOrders    StaffingCardOrder[]
   intentToWork          IntentToWork[]
   formsCreated          Form[]
   formFolders           FormFolder[]
@@ -2417,6 +2418,7 @@ model StaffingCycle {
   formBindings      StaffingCycleFormBinding[]
   formSubmissions   FormSubmission[]
   boardMembers      StaffingBoardMember[]
+  cardOrders        StaffingCardOrder[]
 }
 
 // A member a staffing lead manually placed on the board for a cycle WITHOUT a
@@ -2712,6 +2714,30 @@ model StaffingAssignment {
 
   @@index([userId, termId])
   @@index([projectId, termId])
+}
+
+// Manual position of a member's card within its staffing-board column. The
+// column itself is DERIVED (from the member's assignment, or its absence =
+// Unassigned); this row records only where the card sits in that column's
+// order. One row per (cycle, user); cards with no row fall back to last-name
+// sort. Decoupled from StaffingAssignment so Unassigned bidders — who have no
+// assignment — can still be ordered. `columnKey` is the project id, or
+// "__unassigned__", recorded so a stale order from a previous column is ignored
+// once a card moves.
+model StaffingCardOrder {
+  id              String @id @default(cuid())
+  staffingCycleId String
+  userId          String
+  columnKey       String
+  // Sparse fractional/spread integer key: cards sort ascending by this. Saved
+  // as the card's index in the column on each reorder, so it stays dense.
+  sortKey         Int
+
+  staffingCycle StaffingCycle @relation(fields: [staffingCycleId], references: [id], onDelete: Cascade)
+  user          User          @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([staffingCycleId, userId])
+  @@index([staffingCycleId, columnKey])
 }
 
 // Distinct from the existing AssignmentStatus enum (which scopes


### PR DESCRIPTION
## Summary

Adds **drag-to-reorder of member cards within a staffing column**. Previously cards were sorted by last name with no way to change the order. Now a staffing lead can drag a card up/down within any column — including **Unassigned** — and the order persists across reloads and is shared with everyone viewing the board.

## How it works
- **New `StaffingCardOrder` table** `(cycle, user, columnKey, sortKey)` + migration. It records only a card's *position* in its column — the column itself stays derived from the assignment. Decoupled from `StaffingAssignment` so Unassigned bidders (who have no assignment row) can be ordered too.
- **`POST /api/staffing/reorder`** writes each user's index as its `sortKey` for one column and publishes a cycle change so other open boards live-update.
- **`buildBoard`** takes column-scoped order rows and sorts each column by `sortKey`, falling back to last name. An order row whose `columnKey` no longer matches the card's current column is **ignored**, so a stale order from before a move never applies.
- **Board UI** moves from `useDraggable` to **`@dnd-kit/sortable`** (`SortableContext` per column) for true positional drag; the existing `DragOverlay` still floats the dragged card above all columns. `handleDragEnd` now handles same-column reorder *and* cross-column moves with positional (cursor-located) drop, optimistically updating both order and assignment, then reconciling on revalidate.

## New dependency
- `@dnd-kit/sortable` — the first-party companion to the already-used `@dnd-kit/core`. Positional list reordering isn't feasible cleanly without it.

## Note on commits
This branch **stacks on the unmerged DragOverlay fix** (#792) since the reorder UI builds on it, so this PR shows 2 commits. If #792 merges first, only the reorder commit remains in the diff.

## Test plan
- `npm test` — 1141 pass (4 new `buildBoard` cardOrder tests: name fallback, sortKey order, partial order, stale-column ignore).
- `npm run typecheck` — clean for all changed files.
- `npm run build` — succeeds.
- **Migration** authored by hand (local DB was drifted, blocking `migrate dev`); it's a single additive `CREATE TABLE` — no data loss. Worth a glance in review.
- In-browser drag check (reorder within a column, cross-column positional drop, persistence on reload) still recommended before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/794"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783185661&installation_id=133523038&pr_number=794&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F794&signature=2217c66a1370f831cb17c250f1005f35afa894723d31afd12640925b28817025"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->