### PR TITLE
Staffing finalize: skip assignments with an invalid domain instead of crashing

### DIFF
--- a/dali-api/app/projects/routes/api.staffing.finalize.ts
+++ b/dali-api/app/projects/routes/api.staffing.finalize.ts
@@ -127,8 +127,25 @@ export async function action({ request }: Route.ActionArgs) {
         select: { id: true, userId: true, projectId: true, domainId: true, level: true, status: true },
       });
       // Target roster = members whose live assignment points at THIS project.
-      const target = dedupeLiveAssignments(cycleRows).filter((r) => r.projectId === project.id);
-      const targetUserIds = new Set(target.map((r) => r.userId));
+      const liveTarget = dedupeLiveAssignments(cycleRows).filter((r) => r.projectId === project.id);
+      const targetUserIds = new Set(liveTarget.map((r) => r.userId));
+
+      // An assignment's domainId is unguarded (StaffingAssignment has no FK to
+      // Domain), so a blank/stale value can slip in — e.g. a bid whose domain
+      // reference resolved to "". ProjectAssignment.domainId DOES have that FK,
+      // so finalizing such a row throws an opaque FK violation and rolls back
+      // the whole project. Skip those rows and surface the members by name so a
+      // lead can fix the bid, instead of crashing the finalize.
+      const validDomainIds = new Set(
+        (await prisma.domain.findMany({ select: { id: true } })).map((d) => d.id),
+      );
+      const target = liveTarget.filter((r) => validDomainIds.has(r.domainId));
+      const skippedNames = (
+        await prisma.user.findMany({
+          where: { id: { in: liveTarget.filter((r) => !validDomainIds.has(r.domainId)).map((r) => r.userId) } },
+          select: { firstName: true, lastName: true },
+        })
+      ).map((u) => `${u.firstName} ${u.lastName}`.trim());
 
       // Members currently Confirmed on this project who are no longer in the
       // target roster (dragged off / to another project / unassigned). Decline
@@ -193,12 +210,19 @@ export async function action({ request }: Route.ActionArgs) {
       });
 
       const dropNote = droppedCount > 0 ? `, removed ${droppedCount}` : "";
+      const skipNote =
+        skippedNames.length > 0
+          ? ` Skipped ${skippedNames.length} with an invalid/blank domain (fix their bid): ${skippedNames.join(", ")}.`
+          : "";
       results.assignments = {
-        status: "ok",
+        // Flag as error when anyone was skipped so the lead sees the warning and
+        // follows up — the valid assignments still went through.
+        status: skippedNames.length > 0 ? "error" : "ok",
         message:
-          confirmedCount === 0 && droppedCount === 0
+          (confirmedCount === 0 && droppedCount === 0
             ? "No proposed assignments for this project."
-            : `Confirmed ${confirmedCount} assignment${confirmedCount === 1 ? "" : "s"}${dropNote} → ProjectAssignment.`,
+            : `Confirmed ${confirmedCount} assignment${confirmedCount === 1 ? "" : "s"}${dropNote} → ProjectAssignment.`) +
+          skipNote,
       };
     } catch (err) {
       results.assignments = { status: "error", message: errMsg(err) };


### PR DESCRIPTION
## Summary

Staffing **finalize** crashed with an opaque error when an assignment carried an invalid/blank `domainId`:

```
Invalid `prisma.projectAssignment.upsert()` invocation:
Foreign key constraint violated on the constraint: `ProjectAssignment_domainId_fkey`
```

**Root cause:** `StaffingAssignment.domainId` has **no FK** to `Domain`, so a blank value (`""`) can be stored — e.g. a bid whose domain reference resolved to empty. But `ProjectAssignment.domainId` **does** have that FK, so finalize copying the bad id into a `ProjectAssignment` aborted the whole project's transaction.

**Fix:** pre-validate each target assignment's `domainId` against the real `Domain` set. Process only the valid ones; report any skipped members by name in the step result (status `error` so the lead notices and fixes the bid). Valid assignments now finalize instead of the entire transaction rolling back.

## Scope
- Code-only, behavioural guard. No schema/migration.
- Diagnosed against prod: the trigger was 5 rows with `domainId = ""` (one assignment + four bids for two members). This PR stops the crash; the bad rows are addressed separately (domains set on those members).

## Follow-ups (not in this PR)
- Consider blocking empty `domainId` at the assign + bid-write paths, and/or adding an FK on `StaffingAssignment.domainId → Domain` (needs data cleanup + migration first) so this can't recur.

## Test plan
- `npm test` — 1137 pass.
- `npm run typecheck` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/796"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783188000&installation_id=133523038&pr_number=796&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F796&signature=6a39ba278f9943e627e07056d7286b5483ad8edf167bfbcd9cd01dafb8db1371"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->