### PR TITLE
Settings: add Slack connect page to capture user's Slack ID

### DIFF
--- a/dali-api/app/lib/audit.ts
+++ b/dali-api/app/lib/audit.ts
@@ -31,6 +31,8 @@ export const AUDIT_ACTIONS = [
   "staffing.finalize",
   "staffing.board-member.add",
   "staffing.board-member.remove",
+  "slack.connect",
+  "slack.disconnect",
   "document.delete",
   "projectFile.create",
   "projectFile.version",

--- a/dali-api/app/routes.ts
+++ b/dali-api/app/routes.ts
@@ -159,6 +159,7 @@ export default [
   route("settings", "routes/settings._index.tsx"),
   route("settings/calendar", "routes/settings.calendar.tsx"),
   route("settings/sessions", "routes/settings.sessions.tsx"),
+  route("settings/slack", "routes/settings.slack.tsx"),
   route("settings/connected-apps", "routes/settings.connected-apps.tsx"),
 
   // Help pages (same shell convention as Settings).

--- a/dali-api/app/routes/settings._index.tsx
+++ b/dali-api/app/routes/settings._index.tsx
@@ -1,5 +1,5 @@
 import { Link, redirect } from "react-router";
-import { CalendarDays, Cable, KeyRound, UserCircle2 } from "lucide-react";
+import { CalendarDays, Cable, KeyRound, Slack, UserCircle2 } from "lucide-react";
 import { requireAuth } from "~/lib/auth";
 import type { Route } from "./+types/settings._index";
 
@@ -24,6 +24,12 @@ const CARDS = [
     title: "Calendar",
     body: "Linked Google accounts and which sub-calendars block your availability.",
     icon: CalendarDays,
+  },
+  {
+    to: "/settings/slack",
+    title: "Slack",
+    body: "Connect your Slack account so you're added to project channels when staffed.",
+    icon: Slack,
   },
   {
     to: "/settings/sessions",

--- a/dali-api/app/routes/settings.slack.tsx
+++ b/dali-api/app/routes/settings.slack.tsx
@@ -1,0 +1,202 @@
+// Settings → Slack. Lets a member connect their Slack account so DALI OS knows
+// their Slack user id (used to invite them to project channels at staffing
+// finalize). We resolve the id from their email via the bot token's
+// users.lookupByEmail — no per-user OAuth app exists — so "Connect" works only
+// when the member's Slack account uses one of their emails on file.
+
+import { redirect, useFetcher } from "react-router";
+import { Slack, CheckCircle2, Trash2 } from "lucide-react";
+import { requireAuth } from "~/lib/auth";
+import { prisma } from "~/lib/db";
+import { lookupSlackUserByEmail } from "~/slack/lib/slack-client";
+import { logAuditEvent } from "~/lib/audit";
+import type { Route } from "./+types/settings.slack";
+
+export const meta: Route.MetaFunction = () => [{ title: "Slack · Settings · DALI OS" }];
+
+export async function loader({ request }: Route.LoaderArgs) {
+  const auth = await requireAuth(request);
+  if (!auth.ok) return redirect("/login");
+  if (auth.user.type === "applicant") return redirect("/portal");
+
+  const user = await prisma.user.findUnique({
+    where: { id: auth.user.sub },
+    select: { slackUserId: true, daliEmail: true, dartmouthEmail: true, personalEmail: true },
+  });
+
+  const emails = [user?.daliEmail, user?.dartmouthEmail, user?.personalEmail].filter(
+    (e): e is string => !!e,
+  );
+
+  return {
+    slackUserId: user?.slackUserId ?? null,
+    // Whether the lookup is even possible / configured, shown as a hint.
+    configured: !!process.env.SLACK_BOT_TOKEN,
+    emails,
+  };
+}
+
+export async function action({ request }: Route.ActionArgs) {
+  const auth = await requireAuth(request);
+  if (!auth.ok) return Response.json({ error: "Unauthorized" }, { status: 401 });
+  if (auth.user.type === "applicant")
+    return Response.json({ error: "Forbidden" }, { status: 403 });
+
+  const userId = auth.user.sub;
+  const form = await request.formData();
+  const intent = String(form.get("intent") ?? "");
+
+  if (intent === "disconnect") {
+    await prisma.user.update({ where: { id: userId }, data: { slackUserId: null } });
+    await logAuditEvent({
+      action: "slack.disconnect",
+      userId,
+      targetId: userId,
+      metadata: {},
+      request,
+    });
+    return { ok: true, slackUserId: null, error: null };
+  }
+
+  if (intent === "connect") {
+    if (!process.env.SLACK_BOT_TOKEN) {
+      return { ok: false, slackUserId: null, error: "Slack isn't configured on the server." };
+    }
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { daliEmail: true, dartmouthEmail: true, personalEmail: true },
+    });
+    const emails = [user?.daliEmail, user?.dartmouthEmail, user?.personalEmail].filter(
+      (e): e is string => !!e,
+    );
+
+    // Try each email until Slack resolves an account.
+    let slackId: string | null = null;
+    for (const email of emails) {
+      slackId = await lookupSlackUserByEmail(email);
+      if (slackId) break;
+    }
+    if (!slackId) {
+      return {
+        ok: false,
+        slackUserId: null,
+        error:
+          "No Slack account found for your emails on file. Make sure your DALI Slack uses one of them, then try again.",
+      };
+    }
+
+    try {
+      await prisma.user.update({ where: { id: userId }, data: { slackUserId: slackId } });
+    } catch {
+      // Unique collision: this Slack id is already linked to another account.
+      return {
+        ok: false,
+        slackUserId: null,
+        error: "That Slack account is already linked to another DALI OS user.",
+      };
+    }
+    await logAuditEvent({
+      action: "slack.connect",
+      userId,
+      targetId: userId,
+      metadata: { slackUserId: slackId },
+      request,
+    });
+    return { ok: true, slackUserId: slackId, error: null };
+  }
+
+  return Response.json({ error: "Unknown intent" }, { status: 400 });
+}
+
+export default function SettingsSlackPage({ loaderData }: Route.ComponentProps) {
+  const { slackUserId, configured, emails } = loaderData;
+  const fetcher = useFetcher<typeof action>();
+  // Prefer the just-submitted result, falling back to the loaded state.
+  const connectedId =
+    fetcher.data && "slackUserId" in fetcher.data ? fetcher.data.slackUserId : slackUserId;
+  const error = fetcher.data && "error" in fetcher.data ? fetcher.data.error : null;
+  const busy = fetcher.state !== "idle";
+
+  return (
+    <main className="max-w-3xl p-8">
+      <header>
+        <h1 className="text-2xl font-semibold">Slack</h1>
+        <p className="mt-2 text-sm text-zinc-600">
+          Connect your Slack account so DALI OS can add you to your project's
+          Slack channel automatically when you're staffed. We match your Slack
+          account by the emails on your profile.
+        </p>
+      </header>
+
+      <section className="mt-6">
+        {!configured && (
+          <div className="mb-3 rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">
+            Slack isn't configured on the server, so connecting is unavailable
+            right now.
+          </div>
+        )}
+
+        {connectedId ? (
+          <div className="overflow-hidden rounded-md border border-zinc-200 border-l-4 border-l-[#4A154B] bg-white">
+            <div className="flex items-center justify-between bg-[#4A154B]/5 px-3 py-2">
+              <div className="flex min-w-0 items-center gap-2">
+                <Slack className="h-4 w-4 flex-shrink-0 text-[#4A154B]" />
+                <span className="truncate text-sm font-semibold text-zinc-900">
+                  Slack connected
+                </span>
+                <CheckCircle2 className="h-4 w-4 flex-shrink-0 text-green-600" />
+              </div>
+              <fetcher.Form method="post">
+                <input type="hidden" name="intent" value="disconnect" />
+                <button
+                  type="submit"
+                  disabled={busy}
+                  aria-label="Disconnect Slack"
+                  className="rounded-md p-1 text-zinc-500 hover:bg-red-50 hover:text-red-600 disabled:opacity-50"
+                >
+                  <Trash2 className="h-3.5 w-3.5" />
+                </button>
+              </fetcher.Form>
+            </div>
+            <div className="px-3 py-3">
+              <p className="text-xs text-zinc-600">
+                Slack member ID:{" "}
+                <code className="rounded bg-zinc-100 px-1.5 py-0.5 font-mono text-zinc-800">
+                  {connectedId}
+                </code>
+              </p>
+            </div>
+          </div>
+        ) : (
+          <div className="rounded-md border border-zinc-200 bg-white p-4">
+            <p className="text-sm text-zinc-600">
+              Your Slack account isn't connected yet.
+            </p>
+            {emails.length > 0 && (
+              <p className="mt-1 text-xs text-zinc-500">
+                We'll look you up by: {emails.join(", ")}.
+              </p>
+            )}
+            <fetcher.Form method="post" className="mt-3">
+              <input type="hidden" name="intent" value="connect" />
+              <button
+                type="submit"
+                disabled={busy || !configured}
+                className="inline-flex items-center gap-2 rounded-md bg-[#4A154B] px-3 py-1.5 text-sm font-semibold text-white hover:bg-[#611f69] disabled:opacity-50"
+              >
+                <Slack className="h-4 w-4" />
+                {busy ? "Connecting…" : "Connect Slack"}
+              </button>
+            </fetcher.Form>
+          </div>
+        )}
+
+        {error && (
+          <div className="mt-3 rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+            {error}
+          </div>
+        )}
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a **Settings → Slack** page so a member can connect their own Slack account and have DALI OS capture their `slackUserId`. That id is what staffing finalize uses to auto-invite the confirmed roster to a project's Slack channel — previously it was only ever populated automatically during onboarding/provisioning, with no self-serve path.

## How it works
- **Connect** resolves the member's Slack id from their emails on file (DALI → Dartmouth → personal) via the bot token's `users.lookupByEmail` (`lookupSlackUserByEmail`). There's no per-user Slack OAuth app configured (env has only `SLACK_BOT_TOKEN`/`SLACK_SIGNING_SECRET`), so this reuses the existing bot-token lookup rather than introducing an OAuth flow + new secrets.
- Shows the connected Slack **member ID**, a **Disconnect** action (clears `slackUserId`), and clear messaging when:
  - no Slack account matches the member's emails,
  - the resolved id is already linked to another DALI OS user (`@unique` collision),
  - Slack isn't configured on the server.
- New settings index card + `slack.connect` / `slack.disconnect` audit actions.

## Caveat
Lookup-by-email only succeeds when the member's Slack account uses one of the emails we have on file. If their Slack uses some other email, "Connect" reports that and there's no manual-paste fallback (could add one later if needed).

## Test plan
- `npm test` — 1159 pass.
- `npm run typecheck` — clean for all changed/new files.
- `npm run build` — succeeds.
- In-browser check (Connect → shows ID, Disconnect, the no-match message) recommended before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/797"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783188834&installation_id=133523038&pr_number=797&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F797&signature=b3d423481894f2c844b61a04750e7a0ce9cdea9fc8c7caa5f5db93a9f8ba21f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->