### PR TITLE
Waitlists: cross-cycle view, accept/remove off the list

### DIFF
--- a/dali-api/app/hiring/lib/waitlist.server.ts
+++ b/dali-api/app/hiring/lib/waitlist.server.ts
@@ -1,0 +1,561 @@
+// Post-cycle waitlist management.
+//
+// The cycle-running flow puts applicants on the waitlist via the Final delibs
+// kanban — each waitlisted DomainApplication gets a Released Decision with
+// type=Waitlisted and a positional `waitlistRank`. This module is what happens
+// *after* the cycle closes: Core needs to view everyone still waitlisted across
+// all cycles, accept someone off the list when a spot opens, or remove someone
+// who's no longer relevant.
+//
+// Two rules worth knowing before reading this file:
+//
+//  1. Decisions are append-only — except `waitlistRank`. When the active
+//     waitlist shifts (someone accepted or removed), we MUTATE the rank field
+//     on the existing Released Waitlisted Decision rows. The append-only
+//     invariant on every other field still holds. See the matching comment on
+//     `decrementHigherRanks` below.
+//
+//  2. An "active" waitlist entry means the *latest Released Decision* for that
+//     DomainApplication has type=Waitlisted. Once we append a new
+//     Accepted/Rejected Released Decision, the previous Waitlisted entry
+//     becomes inactive automatically because the latest-released record wins.
+
+import { prisma } from "~/lib/db";
+import { sendEmail } from "~/lib/gmail";
+import { getApplicationsGmailRefreshToken } from "~/lib/gmail-integration";
+import { renderForSlot, decisionSlot } from "~/hiring/lib/email-variables";
+import { logAuditEvent } from "~/lib/audit";
+import { promoteToMember } from "~/members/lib/membership.server";
+import {
+  sendWelcome,
+  onboardingEmailHtml,
+} from "~/members/lib/welcome.server";
+import {
+  provisionNewMember,
+  type ProvisionResult,
+} from "~/members/lib/provisioning.server";
+import {
+  resolveCandidateEmail,
+  redirectBannerHtml,
+} from "~/lib/candidate-email";
+import type { Prisma } from "~/generated/prisma/client";
+
+// ─── List ────────────────────────────────────────────────────────────────────
+
+export interface WaitlistEntry {
+  domainApplicationId: string;
+  rank: number;
+  waitlistedAt: Date;
+  applicant: {
+    userId: string;
+    firstName: string | null;
+    lastName: string | null;
+    dartmouthEmail: string | null;
+  };
+  domain: {
+    id: string;
+    name: string;
+    displayName: string | null;
+  };
+  cycle: {
+    id: string;
+    name: string;
+    cycleType: string;
+    status: string;
+  };
+}
+
+/**
+ * Returns every DomainApplication whose latest Released Decision is
+ * Waitlisted, optionally restricted to one cycle. Sorted by domain
+ * (display name) then ascending rank.
+ */
+export async function listActiveWaitlistEntries(opts?: {
+  cycleId?: string;
+}): Promise<WaitlistEntry[]> {
+  // Pull candidates that have *any* released waitlisted decision; then filter
+  // app-side to those where the LATEST released decision is still Waitlisted
+  // (i.e. not superseded by a later Accept or Reject).
+  const candidates = await prisma.domainApplication.findMany({
+    where: {
+      decisions: { some: { stage: "Released", type: "Waitlisted" } },
+      ...(opts?.cycleId
+        ? { application: { applicationCycleId: opts.cycleId } }
+        : {}),
+    },
+    include: {
+      domain: {
+        select: { id: true, name: true, displayName: true },
+      },
+      decisions: {
+        where: { stage: "Released" },
+        orderBy: { createdAt: "desc" },
+        take: 1,
+      },
+      application: {
+        select: {
+          applicationCycleId: true,
+          user: {
+            select: {
+              id: true,
+              firstName: true,
+              lastName: true,
+              dartmouthEmail: true,
+            },
+          },
+          applicationCycle: {
+            select: {
+              id: true,
+              name: true,
+              cycleType: true,
+              statusUpdates: {
+                orderBy: { createdAt: "desc" },
+                take: 1,
+                select: { newStatus: true },
+              },
+            },
+          },
+        },
+      },
+    },
+  });
+
+  const entries: WaitlistEntry[] = [];
+  for (const da of candidates) {
+    const latest = da.decisions[0];
+    if (!latest || latest.type !== "Waitlisted") continue;
+    entries.push({
+      domainApplicationId: da.id,
+      rank: latest.waitlistRank ?? Number.MAX_SAFE_INTEGER,
+      waitlistedAt: latest.createdAt,
+      applicant: {
+        userId: da.application.user.id,
+        firstName: da.application.user.firstName,
+        lastName: da.application.user.lastName,
+        dartmouthEmail: da.application.user.dartmouthEmail,
+      },
+      domain: {
+        id: da.domain.id,
+        name: da.domain.name,
+        displayName: da.domain.displayName,
+      },
+      cycle: {
+        id: da.application.applicationCycle.id,
+        name: da.application.applicationCycle.name,
+        cycleType: da.application.applicationCycle.cycleType,
+        status:
+          da.application.applicationCycle.statusUpdates[0]?.newStatus ??
+          "Draft",
+      },
+    });
+  }
+
+  entries.sort((a, b) => {
+    const ad = a.domain.displayName ?? a.domain.name;
+    const bd = b.domain.displayName ?? b.domain.name;
+    if (ad !== bd) return ad.localeCompare(bd);
+    return a.rank - b.rank;
+  });
+  return entries;
+}
+
+// ─── Shared rank shift ───────────────────────────────────────────────────────
+
+/**
+ * Decrement waitlistRank by 1 on every active Waitlisted Released Decision in
+ * the same (cycle, domain) whose rank is strictly greater than `removedRank`.
+ *
+ * Mutating waitlistRank in place is the one carve-out from the Decision
+ * append-only invariant. See file header. We constrain by `id` to the latest
+ * Released Decision for each DomainApplication so we don't touch historical
+ * superseded rows.
+ */
+async function decrementHigherRanks(
+  tx: Prisma.TransactionClient,
+  cycleId: string,
+  domainId: string,
+  removedRank: number,
+): Promise<void> {
+  // Find the latest Released Decision per DomainApplication in this
+  // (cycle, domain). Then update only those that are still Waitlisted with a
+  // higher rank.
+  const candidates = await tx.domainApplication.findMany({
+    where: {
+      domainId,
+      application: { applicationCycleId: cycleId },
+      decisions: { some: { stage: "Released", type: "Waitlisted" } },
+    },
+    select: {
+      id: true,
+      decisions: {
+        where: { stage: "Released" },
+        orderBy: { createdAt: "desc" },
+        take: 1,
+        select: { id: true, type: true, waitlistRank: true },
+      },
+    },
+  });
+
+  const updates: Array<{ id: string; newRank: number }> = [];
+  for (const da of candidates) {
+    const latest = da.decisions[0];
+    if (!latest || latest.type !== "Waitlisted") continue;
+    if (latest.waitlistRank == null) continue;
+    if (latest.waitlistRank > removedRank) {
+      updates.push({ id: latest.id, newRank: latest.waitlistRank - 1 });
+    }
+  }
+
+  // updateMany can't do row-specific values, so we batch one-shot updates.
+  for (const u of updates) {
+    await tx.decision.update({
+      where: { id: u.id },
+      data: { waitlistRank: u.newRank },
+    });
+  }
+}
+
+async function currentCycleStatus(
+  tx: Prisma.TransactionClient,
+  cycleId: string,
+): Promise<string> {
+  const last = await tx.applicationCycleStatusUpdate.findFirst({
+    where: { applicationCycleId: cycleId },
+    orderBy: { createdAt: "desc" },
+    select: { newStatus: true },
+  });
+  return last?.newStatus ?? "Draft";
+}
+
+// ─── Accept off waitlist ─────────────────────────────────────────────────────
+
+export type AcceptResult =
+  | { ok: true; releasedDecisionId: string; cycleReopened: boolean }
+  | {
+      ok: false;
+      reason:
+        | "not-found"
+        | "not-waitlisted"
+        | "no-email-binding"
+        | "no-domain";
+      message: string;
+    };
+
+/**
+ * Accept someone off the waitlist:
+ *  1. If the cycle is Completed, force-transition it back to UnderReview so a
+ *     new Released Decision still belongs to a live cycle.
+ *  2. Append a new Released Decision (type=Accepted) on the same
+ *     DomainApplication. Re-uses the same side-effects as the standard
+ *     release flow: promoteToMember, provisionNewMember, sendWelcome,
+ *     templated email send.
+ *  3. Decrement the rank of every other still-waitlisted entry in the same
+ *     (cycle, domain).
+ *  4. Re-complete the cycle if we reopened it in step 1.
+ *
+ * Per design: this is Core-only. The caller is responsible for permission
+ * checking; this function just performs the action.
+ */
+export async function acceptFromWaitlist(args: {
+  domainApplicationId: string;
+  actorId: string;
+  request: Request;
+}): Promise<AcceptResult> {
+  const { domainApplicationId, actorId, request } = args;
+
+  const da = await prisma.domainApplication.findUnique({
+    where: { id: domainApplicationId },
+    include: {
+      domain: { select: { id: true, name: true, displayName: true } },
+      application: {
+        select: {
+          applicationCycleId: true,
+          userId: true,
+          user: {
+            select: { firstName: true, dartmouthEmail: true, netId: true },
+          },
+        },
+      },
+      decisions: {
+        where: { stage: "Released" },
+        orderBy: { createdAt: "desc" },
+        take: 1,
+      },
+    },
+  });
+
+  if (!da) {
+    return { ok: false, reason: "not-found", message: "Domain application not found." };
+  }
+  if (!da.domain) {
+    return { ok: false, reason: "no-domain", message: "Domain application has no linked domain." };
+  }
+  const latest = da.decisions[0];
+  if (!latest || latest.type !== "Waitlisted") {
+    return {
+      ok: false,
+      reason: "not-waitlisted",
+      message: "Applicant is not currently on the waitlist.",
+    };
+  }
+
+  const cycleId = da.application.applicationCycleId;
+  const binding = await prisma.cycleDecisionEmail.findUnique({
+    where: {
+      applicationCycleId_decisionType: {
+        applicationCycleId: cycleId,
+        decisionType: "Accepted",
+      },
+    },
+    include: { emailTemplateVersion: true },
+  });
+  if (!binding) {
+    return {
+      ok: false,
+      reason: "no-email-binding",
+      message:
+        "No email template is bound to Accepted in this cycle. Bind one on the Setup tab before accepting off the waitlist.",
+    };
+  }
+
+  // Transactional core: reopen → create Released Accept → shift ranks → re-complete.
+  // Side-effects (provisioning, email) run after the transaction so a Gmail or
+  // Workspace API blip doesn't roll back the membership grant.
+  const cycleStatusBefore = await currentCycleStatus(prisma, cycleId);
+  const reopened = cycleStatusBefore === "Completed";
+
+  const released = await prisma.$transaction(async (tx) => {
+    if (reopened) {
+      await tx.applicationCycleStatusUpdate.create({
+        data: {
+          applicationCycleId: cycleId,
+          newStatus: "UnderReview",
+          userId: actorId,
+        },
+      });
+    }
+
+    const rel = await tx.decision.create({
+      data: {
+        domainApplicationId: domainApplicationId,
+        type: "Accepted",
+        stage: "Released",
+        madeById: actorId,
+        notes: "Accepted off the waitlist.",
+        parentDecisionId: latest.id,
+      },
+    });
+
+    if (latest.waitlistRank != null) {
+      await decrementHigherRanks(tx, cycleId, da.domain.id, latest.waitlistRank);
+    }
+
+    if (reopened) {
+      await tx.applicationCycleStatusUpdate.create({
+        data: {
+          applicationCycleId: cycleId,
+          newStatus: "Completed",
+          userId: actorId,
+        },
+      });
+    }
+
+    return rel;
+  });
+
+  // Membership + provisioning. Mirrors api.decisions.$id.release.ts. Each step
+  // is best-effort: failures are logged, never thrown, so a partial side-effect
+  // failure doesn't leave the Released Decision orphaned.
+  let memberPromoted = false;
+  let welcomeNotified = false;
+  let provisionResult: ProvisionResult | null = null;
+  try {
+    const { created } = await promoteToMember({
+      userId: da.application.userId,
+      domainId: da.domain.id,
+      level: "P1",
+      actorId,
+    });
+    memberPromoted = created;
+  } catch (err) {
+    console.error("waitlist accept: promoteToMember failed:", err);
+  }
+
+  try {
+    provisionResult = await provisionNewMember({
+      userId: da.application.userId,
+      domainId: da.domain.id,
+    });
+  } catch (err) {
+    console.error("waitlist accept: provisionNewMember failed:", err);
+  }
+
+  try {
+    const u = da.application.user;
+    const welcomeEmail =
+      u?.dartmouthEmail ?? (u?.netId ? `${u.netId}@dartmouth.edu` : null);
+    const { notified } = await sendWelcome({
+      userId: da.application.userId,
+      actorId,
+      firstName: u?.firstName ?? "",
+      email: welcomeEmail,
+      daliEmail: provisionResult?.daliEmail ?? null,
+    });
+    welcomeNotified = notified;
+  } catch (err) {
+    console.error("waitlist accept: sendWelcome failed:", err);
+  }
+
+  // Acceptance email — same template + onboarding block as the standard
+  // release path, so the recipient sees one combined message.
+  let emailSent = false;
+  try {
+    const user = da.application.user;
+    const intendedEmail =
+      user?.dartmouthEmail ??
+      (user?.netId ? `${user.netId}@dartmouth.edu` : null);
+    const domainName = da.domain.displayName ?? da.domain.name ?? "";
+    const { to, redirectedFrom } = resolveCandidateEmail(intendedEmail);
+    if (to && user) {
+      const refreshToken = await getApplicationsGmailRefreshToken();
+      if (refreshToken) {
+        const { subject, html } = renderForSlot(
+          decisionSlot("Accepted"),
+          binding.emailTemplateVersion,
+          { firstName: user.firstName, domain: domainName },
+        );
+        const onboarding = onboardingEmailHtml(
+          provisionResult?.daliEmail ?? null,
+          provisionResult?.daliTempPassword ?? null,
+        );
+        await sendEmail({
+          refreshToken,
+          to,
+          subject,
+          html: redirectBannerHtml(redirectedFrom) + html + onboarding,
+        });
+        emailSent = true;
+      }
+    }
+  } catch (err) {
+    console.error("waitlist accept: email send failed:", err);
+  }
+
+  const provisioningForAudit = provisionResult
+    ? (() => {
+        const { daliTempPassword: _omit, ...rest } = provisionResult;
+        return rest;
+      })()
+    : null;
+
+  await logAuditEvent({
+    action: "waitlist.accept",
+    userId: actorId,
+    targetId: released.id,
+    metadata: {
+      decisionId: released.id,
+      parentDecisionId: latest.id,
+      domainApplicationId,
+      cycleId,
+      domainId: da.domain.id,
+      acceptedFromRank: latest.waitlistRank,
+      cycleReopened: reopened,
+      emailSent,
+      memberPromoted,
+      welcomeNotified,
+      provisioning: provisioningForAudit,
+    },
+    request,
+  });
+
+  return { ok: true, releasedDecisionId: released.id, cycleReopened: reopened };
+}
+
+// ─── Remove from waitlist ────────────────────────────────────────────────────
+
+export type RemoveResult =
+  | { ok: true; releasedDecisionId: string }
+  | {
+      ok: false;
+      reason: "not-found" | "not-waitlisted" | "no-domain";
+      message: string;
+    };
+
+/**
+ * Take someone off the waitlist without accepting them. Appends a Released
+ * Decision with type=Rejected (per design: the trade-off is that this looks
+ * identical to "rejected during cycle" in pure-history views — but the prior
+ * Waitlisted Released row remains in the lineage if anyone needs to dig).
+ *
+ * No email goes out: Core has already handled the human conversation.
+ */
+export async function removeFromWaitlist(args: {
+  domainApplicationId: string;
+  actorId: string;
+  request: Request;
+}): Promise<RemoveResult> {
+  const { domainApplicationId, actorId, request } = args;
+
+  const da = await prisma.domainApplication.findUnique({
+    where: { id: domainApplicationId },
+    include: {
+      domain: { select: { id: true } },
+      application: { select: { applicationCycleId: true } },
+      decisions: {
+        where: { stage: "Released" },
+        orderBy: { createdAt: "desc" },
+        take: 1,
+      },
+    },
+  });
+  if (!da) {
+    return { ok: false, reason: "not-found", message: "Domain application not found." };
+  }
+  if (!da.domain) {
+    return { ok: false, reason: "no-domain", message: "Domain application has no linked domain." };
+  }
+  const latest = da.decisions[0];
+  if (!latest || latest.type !== "Waitlisted") {
+    return {
+      ok: false,
+      reason: "not-waitlisted",
+      message: "Applicant is not currently on the waitlist.",
+    };
+  }
+
+  const cycleId = da.application.applicationCycleId;
+
+  const released = await prisma.$transaction(async (tx) => {
+    const rel = await tx.decision.create({
+      data: {
+        domainApplicationId,
+        type: "Rejected",
+        stage: "Released",
+        madeById: actorId,
+        notes: "Removed from the waitlist.",
+        parentDecisionId: latest.id,
+      },
+    });
+    if (latest.waitlistRank != null) {
+      await decrementHigherRanks(tx, cycleId, da.domain.id, latest.waitlistRank);
+    }
+    return rel;
+  });
+
+  await logAuditEvent({
+    action: "waitlist.remove",
+    userId: actorId,
+    targetId: released.id,
+    metadata: {
+      decisionId: released.id,
+      parentDecisionId: latest.id,
+      domainApplicationId,
+      cycleId,
+      domainId: da.domain.id,
+      removedFromRank: latest.waitlistRank,
+    },
+    request,
+  });
+
+  return { ok: true, releasedDecisionId: released.id };
+}

--- a/dali-api/app/hiring/routes/api.waitlist.$domainApplicationId.accept.ts
+++ b/dali-api/app/hiring/routes/api.waitlist.$domainApplicationId.accept.ts
@@ -1,0 +1,33 @@
+import type { Route } from "./+types/api.waitlist.$domainApplicationId.accept";
+import { requireAuth } from "~/lib/auth";
+import { isCore } from "~/lib/roles";
+import { acceptFromWaitlist } from "~/hiring/lib/waitlist.server";
+
+export async function action({ request, params }: Route.ActionArgs) {
+  if (request.method !== "POST") {
+    return Response.json({ error: "Method not allowed" }, { status: 405 });
+  }
+
+  const auth = await requireAuth(request);
+  if (!auth.ok) return auth.response;
+  if (!(await isCore(auth.user.sub))) {
+    return Response.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const result = await acceptFromWaitlist({
+    domainApplicationId: params.domainApplicationId,
+    actorId: auth.user.sub,
+    request,
+  });
+
+  if (!result.ok) {
+    const status =
+      result.reason === "not-found"
+        ? 404
+        : result.reason === "no-email-binding"
+          ? 409
+          : 409;
+    return Response.json({ error: result.message }, { status });
+  }
+  return Response.json(result, { status: 201 });
+}

--- a/dali-api/app/hiring/routes/api.waitlist.$domainApplicationId.remove.ts
+++ b/dali-api/app/hiring/routes/api.waitlist.$domainApplicationId.remove.ts
@@ -1,0 +1,28 @@
+import type { Route } from "./+types/api.waitlist.$domainApplicationId.remove";
+import { requireAuth } from "~/lib/auth";
+import { isCore } from "~/lib/roles";
+import { removeFromWaitlist } from "~/hiring/lib/waitlist.server";
+
+export async function action({ request, params }: Route.ActionArgs) {
+  if (request.method !== "POST") {
+    return Response.json({ error: "Method not allowed" }, { status: 405 });
+  }
+
+  const auth = await requireAuth(request);
+  if (!auth.ok) return auth.response;
+  if (!(await isCore(auth.user.sub))) {
+    return Response.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const result = await removeFromWaitlist({
+    domainApplicationId: params.domainApplicationId,
+    actorId: auth.user.sub,
+    request,
+  });
+
+  if (!result.ok) {
+    const status = result.reason === "not-found" ? 404 : 409;
+    return Response.json({ error: result.message }, { status });
+  }
+  return Response.json(result, { status: 201 });
+}

--- a/dali-api/app/hiring/routes/api.waitlist.ts
+++ b/dali-api/app/hiring/routes/api.waitlist.ts
@@ -1,0 +1,18 @@
+import type { Route } from "./+types/api.waitlist";
+import { requireAuth } from "~/lib/auth";
+import { isCore } from "~/lib/roles";
+import { listActiveWaitlistEntries } from "~/hiring/lib/waitlist.server";
+
+export async function loader({ request }: Route.LoaderArgs) {
+  const auth = await requireAuth(request);
+  if (!auth.ok) return auth.response;
+  if (!(await isCore(auth.user.sub))) {
+    return Response.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const url = new URL(request.url);
+  const cycleId = url.searchParams.get("cycleId") ?? undefined;
+
+  const entries = await listActiveWaitlistEntries({ cycleId });
+  return Response.json({ entries });
+}

--- a/dali-api/app/hiring/routes/lead.tsx
+++ b/dali-api/app/hiring/routes/lead.tsx
@@ -75,13 +75,21 @@ export default function HiringLeadDashboard() {
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold text-foreground">Hiring Cycles</h1>
-        <button
-          onClick={() => setShowModal(true)}
-          className="flex items-center gap-1.5 px-3 py-2 bg-accent-coral text-white text-sm font-medium rounded-md hover:bg-accent-coral/90 focus:outline-none focus:ring-2 focus:ring-blue-500"
-        >
-          <Plus className="w-4 h-4" />
-          New Cycle
-        </button>
+        <div className="flex items-center gap-2">
+          <Link
+            to="/hiring/lead/waitlists"
+            className="px-3 py-2 text-sm font-medium text-foreground/80 bg-card border border-border rounded-md hover:bg-muted"
+          >
+            Waitlists
+          </Link>
+          <button
+            onClick={() => setShowModal(true)}
+            className="flex items-center gap-1.5 px-3 py-2 bg-accent-coral text-white text-sm font-medium rounded-md hover:bg-accent-coral/90 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          >
+            <Plus className="w-4 h-4" />
+            New Cycle
+          </button>
+        </div>
       </div>
 
       {showModal && (

--- a/dali-api/app/hiring/routes/lead.waitlists.tsx
+++ b/dali-api/app/hiring/routes/lead.waitlists.tsx
@@ -1,0 +1,284 @@
+import { useMemo, useState } from "react";
+import { Link, redirect, useFetcher, useLoaderData } from "react-router";
+import { ArrowLeft, Check, X } from "lucide-react";
+import type { Route } from "./+types/lead.waitlists";
+import { requireAuth } from "~/lib/auth";
+import { isCore } from "~/lib/roles";
+import {
+  listActiveWaitlistEntries,
+  type WaitlistEntry,
+} from "~/hiring/lib/waitlist.server";
+
+export const meta: Route.MetaFunction = () => [
+  { title: "Waitlists · Hiring · DALI OS" },
+];
+
+export async function loader({ request }: Route.LoaderArgs) {
+  const auth = await requireAuth(request);
+  if (!auth.ok) return redirect("/login");
+  if (!(await isCore(auth.user.sub))) return redirect("/");
+
+  const entries = await listActiveWaitlistEntries();
+  return { entries };
+}
+
+type LoaderData = { entries: WaitlistEntry[] };
+
+function fullName(e: WaitlistEntry): string {
+  const f = e.applicant.firstName ?? "";
+  const l = e.applicant.lastName ?? "";
+  const joined = `${f} ${l}`.trim();
+  return joined || e.applicant.dartmouthEmail || "(unknown)";
+}
+
+export default function WaitlistsPage() {
+  const { entries } = useLoaderData<typeof loader>() as LoaderData;
+  const [cycleFilter, setCycleFilter] = useState<string>("all");
+
+  // Cycle chips: every cycle that contributes at least one active waitlister.
+  const cycleOptions = useMemo(() => {
+    const seen = new Map<string, { id: string; name: string; count: number }>();
+    for (const e of entries) {
+      const cur = seen.get(e.cycle.id);
+      if (cur) cur.count += 1;
+      else seen.set(e.cycle.id, { id: e.cycle.id, name: e.cycle.name, count: 1 });
+    }
+    return [...seen.values()].sort((a, b) => a.name.localeCompare(b.name));
+  }, [entries]);
+
+  const filtered = useMemo(() => {
+    if (cycleFilter === "all") return entries;
+    return entries.filter((e) => e.cycle.id === cycleFilter);
+  }, [entries, cycleFilter]);
+
+  const byDomain = useMemo(() => {
+    const map = new Map<string, { domain: WaitlistEntry["domain"]; rows: WaitlistEntry[] }>();
+    for (const e of filtered) {
+      const key = e.domain.id;
+      const slot = map.get(key);
+      if (slot) slot.rows.push(e);
+      else map.set(key, { domain: e.domain, rows: [e] });
+    }
+    for (const v of map.values()) {
+      v.rows.sort((a, b) => a.rank - b.rank);
+    }
+    return [...map.values()].sort((a, b) => {
+      const ad = a.domain.displayName ?? a.domain.name;
+      const bd = b.domain.displayName ?? b.domain.name;
+      return ad.localeCompare(bd);
+    });
+  }, [filtered]);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <Link
+            to="/hiring/lead"
+            className="text-muted-foreground/70 hover:text-foreground"
+            aria-label="Back to hiring cycles"
+          >
+            <ArrowLeft className="w-5 h-5" />
+          </Link>
+          <h1 className="text-2xl font-bold text-foreground">Waitlists</h1>
+        </div>
+        <span className="text-sm text-muted-foreground">
+          {entries.length} active waitlister{entries.length === 1 ? "" : "s"}
+        </span>
+      </div>
+
+      <p className="text-sm text-muted-foreground max-w-2xl">
+        Everyone currently waitlisted across all cycles. Accepting from here
+        runs the full release flow — member promotion, account provisioning,
+        and the acceptance email — even if the cycle is already completed.
+        Removing closes the waitlist entry without notifying the applicant.
+      </p>
+
+      {cycleOptions.length > 1 && (
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+            Filter by cycle
+          </span>
+          <button
+            onClick={() => setCycleFilter("all")}
+            className={`px-2.5 py-1 rounded-full text-xs font-medium ${
+              cycleFilter === "all"
+                ? "bg-foreground text-background"
+                : "bg-muted text-foreground/80 hover:bg-muted/70"
+            }`}
+          >
+            All ({entries.length})
+          </button>
+          {cycleOptions.map((c) => (
+            <button
+              key={c.id}
+              onClick={() => setCycleFilter(c.id)}
+              className={`px-2.5 py-1 rounded-full text-xs font-medium ${
+                cycleFilter === c.id
+                  ? "bg-foreground text-background"
+                  : "bg-muted text-foreground/80 hover:bg-muted/70"
+              }`}
+            >
+              {c.name} ({c.count})
+            </button>
+          ))}
+        </div>
+      )}
+
+      {byDomain.length === 0 ? (
+        <div className="bg-card border-2 border-dashed border-gray-300 rounded-xl p-8 text-center">
+          <p className="text-muted-foreground mb-1">
+            {entries.length === 0
+              ? "No one is currently on a waitlist."
+              : "No waitlisters match the selected cycle."}
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-6">
+          {byDomain.map((group) => (
+            <DomainSection key={group.domain.id} domain={group.domain} rows={group.rows} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function DomainSection({
+  domain,
+  rows,
+}: {
+  domain: WaitlistEntry["domain"];
+  rows: WaitlistEntry[];
+}) {
+  return (
+    <section className="bg-card border border-border rounded-xl overflow-hidden">
+      <header className="flex items-center justify-between px-5 py-3 bg-muted/40 border-b border-border">
+        <h2 className="text-sm font-semibold text-foreground">
+          {domain.displayName ?? domain.name}
+        </h2>
+        <span className="text-xs text-muted-foreground">
+          {rows.length} on the waitlist
+        </span>
+      </header>
+      <table className="w-full text-sm">
+        <thead className="text-xs uppercase tracking-wider text-muted-foreground/80">
+          <tr className="text-left">
+            <th className="px-5 py-2 w-16">Rank</th>
+            <th className="px-5 py-2">Applicant</th>
+            <th className="px-5 py-2">Cycle</th>
+            <th className="px-5 py-2">Waitlisted</th>
+            <th className="px-5 py-2 w-44 text-right">Actions</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-100">
+          {rows.map((r) => (
+            <WaitlistRow key={r.domainApplicationId} entry={r} />
+          ))}
+        </tbody>
+      </table>
+    </section>
+  );
+}
+
+function WaitlistRow({ entry }: { entry: WaitlistEntry }) {
+  const acceptFetcher = useFetcher();
+  const removeFetcher = useFetcher();
+  const busy =
+    acceptFetcher.state !== "idle" || removeFetcher.state !== "idle";
+
+  const acceptError =
+    acceptFetcher.data && (acceptFetcher.data as any).error
+      ? ((acceptFetcher.data as any).error as string)
+      : null;
+  const removeError =
+    removeFetcher.data && (removeFetcher.data as any).error
+      ? ((removeFetcher.data as any).error as string)
+      : null;
+
+  const onAccept = () => {
+    if (
+      !window.confirm(
+        `Accept ${fullName(entry)} off the waitlist? This will promote them to a member, provision their DALI account, and send the acceptance email.`,
+      )
+    )
+      return;
+    acceptFetcher.submit(
+      {},
+      {
+        method: "post",
+        action: `/api/hiring/waitlist/${entry.domainApplicationId}/accept`,
+        encType: "application/json",
+      },
+    );
+  };
+
+  const onRemove = () => {
+    if (
+      !window.confirm(
+        `Remove ${fullName(entry)} from the waitlist? No email will be sent. The applicant's other waitlist entries (if any) are unaffected.`,
+      )
+    )
+      return;
+    removeFetcher.submit(
+      {},
+      {
+        method: "post",
+        action: `/api/hiring/waitlist/${entry.domainApplicationId}/remove`,
+        encType: "application/json",
+      },
+    );
+  };
+
+  return (
+    <tr className="hover:bg-muted/40">
+      <td className="px-5 py-3 font-semibold text-foreground">#{entry.rank}</td>
+      <td className="px-5 py-3">
+        <Link
+          to={`/hiring/applications/${entry.domainApplicationId}`}
+          className="font-medium text-foreground hover:text-blue-600"
+        >
+          {fullName(entry)}
+        </Link>
+        {entry.applicant.dartmouthEmail && (
+          <div className="text-xs text-muted-foreground">
+            {entry.applicant.dartmouthEmail}
+          </div>
+        )}
+        {(acceptError || removeError) && (
+          <div className="mt-1 text-xs text-red-600">
+            {acceptError ?? removeError}
+          </div>
+        )}
+      </td>
+      <td className="px-5 py-3 text-muted-foreground">{entry.cycle.name}</td>
+      <td className="px-5 py-3 text-muted-foreground">
+        {new Date(entry.waitlistedAt).toLocaleDateString("en-US", {
+          month: "short",
+          day: "numeric",
+          year: "numeric",
+        })}
+      </td>
+      <td className="px-5 py-3">
+        <div className="flex items-center justify-end gap-2">
+          <button
+            onClick={onAccept}
+            disabled={busy}
+            className="inline-flex items-center gap-1 px-2.5 py-1 text-xs font-medium text-white bg-green-600 rounded-md hover:bg-green-700 disabled:opacity-50"
+          >
+            <Check className="w-3.5 h-3.5" />
+            Accept
+          </button>
+          <button
+            onClick={onRemove}
+            disabled={busy}
+            className="inline-flex items-center gap-1 px-2.5 py-1 text-xs font-medium text-foreground/80 bg-card border border-border rounded-md hover:bg-muted disabled:opacity-50"
+          >
+            <X className="w-3.5 h-3.5" />
+            Remove
+          </button>
+        </div>
+      </td>
+    </tr>
+  );
+}

--- a/dali-api/app/lib/audit.ts
+++ b/dali-api/app/lib/audit.ts
@@ -13,6 +13,8 @@ export const AUDIT_ACTIONS = [
   "role.change",
   "decision.finalize",
   "decision.release",
+  "waitlist.accept",
+  "waitlist.remove",
   "interview.invite-reminder.sent",
   "interview.complete",
   "interview.reopen",

--- a/dali-api/app/routes.ts
+++ b/dali-api/app/routes.ts
@@ -21,6 +21,7 @@ export default [
     route("hiring/lead", "hiring/routes/lead.tsx"),
     route("hiring/lead/cycle/:id", "hiring/routes/lead.cycle.$id.tsx"),
     route("hiring/lead/intern-to-full-cycle/:id", "hiring/routes/lead.intern-to-full-cycle.$id.tsx"),
+    route("hiring/lead/waitlists", "hiring/routes/lead.waitlists.tsx"),
     // Library — challenges, rubrics, and confidentiality agreements behind one
     // page with pills. The list views are consolidated here; the detail pages
     // keep their original paths.
@@ -288,6 +289,10 @@ export default [
 
   route("api/hiring/decisions/:id/finalize", "hiring/routes/api.decisions.$id.finalize.ts"),
   route("api/hiring/decisions/:id/release", "hiring/routes/api.decisions.$id.release.ts"),
+
+  route("api/hiring/waitlist", "hiring/routes/api.waitlist.ts"),
+  route("api/hiring/waitlist/:domainApplicationId/accept", "hiring/routes/api.waitlist.$domainApplicationId.accept.ts"),
+  route("api/hiring/waitlist/:domainApplicationId/remove", "hiring/routes/api.waitlist.$domainApplicationId.remove.ts"),
 
   route("api/hiring/interviews/:id/complete", "hiring/routes/api.interviews.$id.complete.ts"),
   route("api/hiring/interviews/:id/reassign", "hiring/routes/api.interviews.$id.reassign.ts"),

--- a/dali-api/prisma/seed.ts
+++ b/dali-api/prisma/seed.ts
@@ -39,16 +39,22 @@ async function main() {
   // local seed below references this term for the test hiring lead +
   // domain leads. Prod seeds a full 12-term window via
   // prisma/seeds/v0-reference.ts; locally one term is enough.
+  // endDate is intentionally far-future: the local seed has only one Term, and
+  // `currentTerm()` returns null once `now > endDate AND no upcoming term`,
+  // which flips `isCore` false for every seeded lead and redirects them out of
+  // every Core-gated route — quietly breaking every hiring/admin e2e the day
+  // the term ends. Prod uses the v0-reference seed's rolling 12-term window,
+  // so this evergreen endDate is local-only.
   await prisma.term.upsert({
     where: { code: "26S" },
-    update: {},
+    update: { endDate: new Date("2099-12-31") },
     create: {
       code: "26S",
       year: 2026,
       season: "S",
       sortKey: 20262,
       startDate: new Date("2026-03-28"),
-      endDate: new Date("2026-06-05"),
+      endDate: new Date("2099-12-31"),
     },
   });
 


### PR DESCRIPTION
## Summary

Adds **/hiring/lead/waitlists** for Core to manage everyone currently waitlisted across all cycles — the case where a spot opens up *after* a cycle has closed and you need to pull the next person off the list.

- **Primary view**: cross-cycle, grouped by domain, ranked ascending within each. Cycle-filter chips at the top.
- **Accept off waitlist**: force-reopens a `Completed` cycle, appends a Released `Accepted` Decision on the same `DomainApplication`, then re-completes. Re-uses the standard release side-effects: `promoteToMember`, `provisionNewMember`, `sendWelcome`, and the templated acceptance email + onboarding block.
- **Remove from waitlist**: appends a Released `Rejected` Decision. No email. An applicant's waitlist entries in other domains are unaffected.
- **Auto rank-shift**: after accept/remove, `waitlistRank` is decremented in place on the latest Released Waitlisted Decisions in the same (cycle, domain). This is the one carve-out from the Decision append-only invariant — documented in `waitlist.server.ts`.

Core-only at every layer (loader, both API actions). No schema/migration changes — purely Decision-row writes.

## Test plan
- [ ] Open /hiring/lead → see new **Waitlists** button in header.
- [ ] Navigate to /hiring/lead/waitlists; entries appear grouped by domain with ranks ascending.
- [ ] Cycle filter chips appear when ≥2 cycles contribute waitlisters; switching scopes the view; count updates.
- [ ] **Accept** on a Completed cycle's #2 waitlister: cycle transitions UnderReview → Completed; new Released Accepted Decision is created; #3 is now #2, #4 is now #3, etc.; member is promoted; provisioning runs; acceptance email lands in the candidate inbox (or redirected dev/staging inbox).
- [ ] Accept fails with a friendly 409 if the cycle has no `Accepted` email-template binding.
- [ ] **Remove** appends a Released Rejected Decision, shifts ranks, sends no email. Other-domain waitlist row for the same applicant is untouched.
- [ ] Non-Core user gets 403 on every endpoint.
- [ ] Run `npm run typecheck` — no new errors (pre-existing errors in `projects/`, `scripts/`, `prisma/seeds/` are unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/799"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783352515&installation_id=133523038&pr_number=799&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F799&signature=1faa712959af09022bf17910744d07a4cc97b7f05543f6142bd630b2f9feb405"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->