### PR TITLE
Auth: link applicant CAS account to member Google account on first login

### DIFF
--- a/dali-api/app/lib/__tests__/linking.test.ts
+++ b/dali-api/app/lib/__tests__/linking.test.ts
@@ -13,6 +13,11 @@ const mockPrisma = prisma as unknown as {
   };
   session: { updateMany: ReturnType<typeof vi.fn> };
   oAuthSession: { updateMany: ReturnType<typeof vi.fn> };
+  dALIMember: {
+    findUnique: ReturnType<typeof vi.fn>;
+    updateMany: ReturnType<typeof vi.fn>;
+    deleteMany: ReturnType<typeof vi.fn>;
+  };
   $transaction: ReturnType<typeof vi.fn>;
 };
 
@@ -39,18 +44,62 @@ describe("linkCasToGoogleUser", () => {
     lastName: "User",
   };
 
-  it("merges separate users via transaction", async () => {
+  it("merges separate users via transaction (re-parents DALIMember when CAS user has none)", async () => {
     // first call: findUnique by id (googleUser), second: findUnique by netId (casUser)
     mockPrisma.user.findUnique
       .mockResolvedValueOnce(googleUser)
       .mockResolvedValueOnce(casUser);
 
     const mergedUser = { ...casUser, daliEmail: googleUser.daliEmail };
+    const memberUpdateMany = vi.fn().mockResolvedValue({ count: 1 });
+    const memberDeleteMany = vi.fn().mockResolvedValue({ count: 0 });
+    const userDelete = vi.fn().mockResolvedValue({});
+
     mockPrisma.$transaction.mockImplementation(async (fn: any) => {
-      // provide a mock tx with the same methods
       const tx = {
         session: { updateMany: vi.fn().mockResolvedValue({}) },
         oAuthSession: { updateMany: vi.fn().mockResolvedValue({}) },
+        dALIMember: {
+          findUnique: vi.fn().mockResolvedValue(null), // CAS user has no DALIMember
+          updateMany: memberUpdateMany,
+          deleteMany: memberDeleteMany,
+        },
+        user: {
+          delete: userDelete,
+          update: vi.fn().mockResolvedValue(mergedUser),
+        },
+      };
+      return fn(tx);
+    });
+
+    const result = await linkCasToGoogleUser("g1", "d12345a");
+    expect(result).toEqual(mergedUser);
+    expect(memberUpdateMany).toHaveBeenCalledWith({
+      where: { userId: googleUser.id },
+      data: { userId: casUser.id },
+    });
+    expect(memberDeleteMany).not.toHaveBeenCalled();
+    expect(userDelete).toHaveBeenCalledWith({ where: { id: googleUser.id } });
+  });
+
+  it("merges separate users (drops Google DALIMember when CAS user already has one)", async () => {
+    mockPrisma.user.findUnique
+      .mockResolvedValueOnce(googleUser)
+      .mockResolvedValueOnce(casUser);
+
+    const mergedUser = { ...casUser, daliEmail: googleUser.daliEmail };
+    const memberUpdateMany = vi.fn().mockResolvedValue({ count: 0 });
+    const memberDeleteMany = vi.fn().mockResolvedValue({ count: 1 });
+
+    mockPrisma.$transaction.mockImplementation(async (fn: any) => {
+      const tx = {
+        session: { updateMany: vi.fn().mockResolvedValue({}) },
+        oAuthSession: { updateMany: vi.fn().mockResolvedValue({}) },
+        dALIMember: {
+          findUnique: vi.fn().mockResolvedValue({ id: "existing-member" }),
+          updateMany: memberUpdateMany,
+          deleteMany: memberDeleteMany,
+        },
         user: {
           delete: vi.fn().mockResolvedValue({}),
           update: vi.fn().mockResolvedValue(mergedUser),
@@ -61,7 +110,10 @@ describe("linkCasToGoogleUser", () => {
 
     const result = await linkCasToGoogleUser("g1", "d12345a");
     expect(result).toEqual(mergedUser);
-    expect(mockPrisma.$transaction).toHaveBeenCalled();
+    expect(memberDeleteMany).toHaveBeenCalledWith({
+      where: { userId: googleUser.id },
+    });
+    expect(memberUpdateMany).not.toHaveBeenCalled();
   });
 
   it("returns same user when CAS user is the same record (no-op)", async () => {

--- a/dali-api/app/lib/audit.ts
+++ b/dali-api/app/lib/audit.ts
@@ -34,6 +34,7 @@ export const AUDIT_ACTIONS = [
   "staffing.reorder",
   "slack.connect",
   "slack.disconnect",
+  "account.linked",
   "document.delete",
   "projectFile.create",
   "projectFile.version",

--- a/dali-api/app/lib/linking.ts
+++ b/dali-api/app/lib/linking.ts
@@ -17,21 +17,39 @@ export async function linkCasToGoogleUser(googleUserId: string, netId: string) {
   const casUser = await prisma.user.findUnique({ where: { netId } });
 
   if (casUser && casUser.id !== googleUser.id) {
-    // merge: separate CAS user exists — absorb Google user into CAS user
+    // merge: separate CAS user exists — absorb Google user into CAS user.
+    // This branch only runs in the freshly-chained login flow, where the
+    // Google user was just created by upsertUserFromGoogle moments earlier
+    // and has no accumulated data beyond Session + OAuthSession + DALIMember.
+    // The backfill script handles the harder case of older duplicates.
     return prisma.$transaction(async (tx) => {
       const daliEmail = googleUser.daliEmail;
 
-      // migrate sessions to the surviving user
       await tx.session.updateMany({
         where: { userId: googleUser.id },
         data: { userId: casUser.id },
       });
 
-      // migrate OAuth sessions to the surviving user
       await tx.oAuthSession.updateMany({
         where: { userId: googleUser.id },
         data: { userId: casUser.id },
       });
+
+      // upsertUserFromGoogle always creates a DALIMember marker on the new
+      // user; the CAS-side applicant has none. Re-parent unless the CAS user
+      // somehow already has one (paranoia — shouldn't happen pre-acceptance).
+      const existingMember = await tx.dALIMember.findUnique({
+        where: { userId: casUser.id },
+        select: { id: true },
+      });
+      if (existingMember) {
+        await tx.dALIMember.deleteMany({ where: { userId: googleUser.id } });
+      } else {
+        await tx.dALIMember.updateMany({
+          where: { userId: googleUser.id },
+          data: { userId: casUser.id },
+        });
+      }
 
       await tx.user.delete({ where: { id: googleUser.id } });
       return tx.user.update({

--- a/dali-api/app/routes/auth.callback.cas.ts
+++ b/dali-api/app/routes/auth.callback.cas.ts
@@ -1,5 +1,5 @@
 import type { Route } from "./+types/auth.callback.cas";
-import { validateCasTicket } from "~/lib/auth";
+import { requireAuth, validateCasTicket } from "~/lib/auth";
 import { issueSession } from "~/lib/session";
 import { setSessionCookie } from "~/lib/cookies";
 import { getClientIp } from "~/lib/request-meta";
@@ -15,6 +15,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   const apiBase = process.env.API_BASE_URL ?? "http://localhost:3001";
 
   const ticket = url.searchParams.get("ticket");
+  const isLink = url.searchParams.get("link") === "1";
 
   if (!ticket) {
     await logAuditEvent({
@@ -28,9 +29,30 @@ export async function loader({ request }: Route.LoaderArgs) {
     });
   }
 
+  // Link mode: chained from /auth/callback/google when a fresh @dali.dartmouth
+  // .edu member has no netId yet. The session cookie identifies which User
+  // gets the netId. Identity is the cookie, not the CAS ticket — without a
+  // valid session we have no User to attach to. Fail closed.
+  const linkAuth = isLink ? await requireAuth(request) : null;
+  if (isLink && (!linkAuth || !linkAuth.ok)) {
+    await logAuditEvent({
+      action: "login.failure",
+      metadata: { provider: "cas", reason: "link_without_session" },
+      request,
+    });
+    return new Response(null, {
+      status: 302,
+      headers: { Location: "/login?error=link_session_missing" },
+    });
+  }
+
+  const serviceUrl = isLink
+    ? `${apiBase}/auth/callback/cas?link=1`
+    : `${apiBase}/auth/callback/cas`;
+
   let casUser;
   try {
-    casUser = await validateCasTicket(ticket, `${apiBase}/auth/callback/cas`);
+    casUser = await validateCasTicket(ticket, serviceUrl);
   } catch {
     await logAuditEvent({
       action: "login.failure",
@@ -40,6 +62,43 @@ export async function loader({ request }: Route.LoaderArgs) {
     return new Response(null, {
       status: 302,
       headers: { Location: "/login?error=cas_auth_failed" },
+    });
+  }
+
+  // Link mode merges into the cookie-identified user; the existing session
+  // cookie keeps working because linkCasToGoogleUser re-parents sessions to
+  // the surviving User row inside the same transaction.
+  if (isLink && linkAuth?.ok) {
+    try {
+      await upsertUserFromCas(casUser, { linkUserId: linkAuth.user.sub });
+    } catch {
+      await logAuditEvent({
+        action: "login.failure",
+        userId: linkAuth.user.sub,
+        metadata: {
+          provider: "cas",
+          reason: "link_failed",
+          netId: casUser.netId,
+        },
+        request,
+      });
+      return new Response(null, {
+        status: 302,
+        headers: { Location: "/?error=link_failed" },
+      });
+    }
+    await logAuditEvent({
+      action: "account.linked",
+      userId: linkAuth.user.sub,
+      metadata: {
+        provider: "cas",
+        netId: casUser.netId,
+      },
+      request,
+    });
+    return new Response(null, {
+      status: 302,
+      headers: { Location: "/" },
     });
   }
 

--- a/dali-api/app/routes/auth.callback.google.ts
+++ b/dali-api/app/routes/auth.callback.google.ts
@@ -115,7 +115,6 @@ export async function loader({ request }: Route.LoaderArgs) {
   // callback `/oauth/callback/google` which gates on a different signal.
   const { user } = await upsertUserFromGoogle(googleUser);
 
-  // Issue session and set cookie
   const session = await issueSession({
     userId: user.id,
     userAgent: request.headers.get("user-agent") ?? undefined,
@@ -131,10 +130,28 @@ export async function loader({ request }: Route.LoaderArgs) {
     },
     request,
   });
+
   const headers = new Headers();
   headers.append("Set-Cookie", clearStateCookie);
   setSessionCookie(headers, session.rawId);
-  headers.set("Location", "/");
 
+  // First Google login for a brand-new member (or an accepted applicant whose
+  // CAS-side User row hasn't been linked yet) → chain through CAS so we can
+  // merge with any existing applicant record. The session cookie identifies
+  // which User to attach the netId to on return; linkCasToGoogleUser handles
+  // the merge / no-op / attach cases. Mirrors the MCP-provider flow in
+  // oauth.callback.google.ts.
+  if (!user.netId) {
+    const casBase =
+      process.env.CAS_BASE_URL ?? "https://login.dartmouth.edu/cas";
+    const serviceUrl = `${apiBase}/auth/callback/cas?link=1`;
+    headers.set(
+      "Location",
+      `${casBase}/login?service=${encodeURIComponent(serviceUrl)}`,
+    );
+    return new Response(null, { status: 302, headers });
+  }
+
+  headers.set("Location", "/");
   return new Response(null, { status: 302, headers });
 }

--- a/dali-api/scripts/find-duplicate-user-accounts.ts
+++ b/dali-api/scripts/find-duplicate-user-accounts.ts
@@ -1,0 +1,107 @@
+/**
+ * Finds users who likely have two account rows: one from CAS (netId set, no
+ * daliEmail) and one from Google (@dali.dartmouth.edu daliEmail set, no netId).
+ * The heuristic: a Google user's email local-part equals a CAS user's netId.
+ *
+ * Going-forward, the standalone Google login (auth.callback.google.ts) chains
+ * through CAS the first time a new member logs in, and linkCasToGoogleUser
+ * merges them. This script surfaces pre-existing duplicates that pre-date the
+ * chain, so an operator can resolve them — typically the cheapest fix is to
+ * have the affected user log out and log back in with Google; the chain will
+ * route them through CAS and the merge happens automatically. For users who
+ * have already accumulated data on both rows (applications on CAS-side,
+ * project assignments on Google-side), the merge needs a careful per-pair SQL
+ * cleanup; this script does NOT automate that.
+ *
+ * Usage:
+ *   npx tsx --env-file .env scripts/find-duplicate-user-accounts.ts
+ */
+import { PrismaClient } from "../app/generated/prisma/client.js";
+import { PrismaPg } from "@prisma/adapter-pg";
+
+const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL! });
+const prisma = new PrismaClient({ adapter });
+
+async function main() {
+  const googleOnly = await prisma.user.findMany({
+    where: { daliEmail: { endsWith: "@dali.dartmouth.edu" }, netId: null },
+    select: {
+      id: true,
+      daliEmail: true,
+      firstName: true,
+      lastName: true,
+      createdAt: true,
+    },
+  });
+
+  if (googleOnly.length === 0) {
+    console.log("No Google-only users found. Nothing to report.");
+    return;
+  }
+
+  type Candidate = {
+    googleId: string;
+    googleEmail: string;
+    googleCreatedAt: Date;
+    casId: string;
+    casNetId: string;
+    casCreatedAt: Date;
+    name: string;
+  };
+  const candidates: Candidate[] = [];
+  const orphans: typeof googleOnly = [];
+
+  for (const g of googleOnly) {
+    const localPart = g.daliEmail!.split("@")[0];
+    const cas = await prisma.user.findUnique({
+      where: { netId: localPart },
+      select: { id: true, netId: true, createdAt: true },
+    });
+    if (cas) {
+      candidates.push({
+        googleId: g.id,
+        googleEmail: g.daliEmail!,
+        googleCreatedAt: g.createdAt,
+        casId: cas.id,
+        casNetId: cas.netId!,
+        casCreatedAt: cas.createdAt,
+        name: `${g.firstName} ${g.lastName}`,
+      });
+    } else {
+      orphans.push(g);
+    }
+  }
+
+  console.log(`Total Google-only users (no netId): ${googleOnly.length}`);
+  console.log(`  → match a CAS row by netId == daliEmail local-part: ${candidates.length}`);
+  console.log(`  → no CAS match (likely fine — chain will be no-op):   ${orphans.length}`);
+  console.log();
+
+  if (candidates.length > 0) {
+    console.log("Duplicate-pair candidates (review before merging):");
+    console.log("─".repeat(100));
+    for (const c of candidates) {
+      console.log(`  ${c.name}`);
+      console.log(`    Google user: ${c.googleId}  ${c.googleEmail}  (created ${c.googleCreatedAt.toISOString()})`);
+      console.log(`    CAS user:    ${c.casId}  netId=${c.casNetId}    (created ${c.casCreatedAt.toISOString()})`);
+      console.log();
+    }
+    console.log("Resolution:");
+    console.log("  Easiest: have the affected user log out and log back in via Google.");
+    console.log("  The standalone Google callback now chains through CAS and the");
+    console.log("  linkCasToGoogleUser merge runs automatically.");
+    console.log();
+    console.log("  If the Google-side user has accumulated data (project assignments,");
+    console.log("  tasks, mentor notes, etc.) since being created, prefer a careful");
+    console.log("  per-pair SQL cleanup over the chain — the chain deletes the");
+    console.log("  Google-side row in favor of the CAS-side row and only re-parents");
+    console.log("  Session / OAuthSession / DALIMember.");
+  }
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());


### PR DESCRIPTION
## Summary
- Newly-accepted members logging in with Google for the first time are chained through CAS so their applicant `User` row gets merged into the daliEmail-keyed row (mirrors the existing OAuth-provider chain).
- `linking.ts` merge branch now re-parents the `DALIMember` row that `upsertUserFromGoogle` always creates — without this the merge would FK-violate on `User.delete`.
- Adds `scripts/find-duplicate-user-accounts.ts` (report-only) for surfacing pre-existing duplicate pairs.

## The flow
1. Member clicks "Sign in with Google", lands at `/auth/callback/google`.
2. `upsertUserFromGoogle` creates/finds a `User` keyed on `daliEmail` + a `DALIMember` marker. Cookie session is issued.
3. If `!user.netId`, redirect to CAS with `service=…/auth/callback/cas?link=1` instead of `/`.
4. CAS returns. `?link=1` branch requires the cookie session (fail-closed), validates the ticket, and calls `upsertUserFromCas(…, { linkUserId })` → `linkCasToGoogleUser` handles merge / no-op / attach.
5. Session keeps working because `linkCasToGoogleUser` re-parents `Session` / `OAuthSession` / `DALIMember` to the surviving user inside the same transaction.

## Backfill
Scoped to a **report-only** script — the report tells the operator who's affected, and the cheapest resolution per affected user is to log out + log back in (the chain handles the merge automatically). Users with accumulated post-acceptance data on the Google-side row need careful per-pair SQL cleanup; the chain only re-parents Session / OAuthSession / DALIMember.

## Test plan
- [x] `npm test` — full unit suite (1164 tests) passes
- [x] `npm run typecheck` — clean for everything touched (pre-existing unrelated errors in `scripts/` and `prisma/seeds/`)
- [x] New `linking.test.ts` cases cover both DALIMember re-parent branches
- [ ] Manual: log in as a CAS-only applicant, accept them, then log in with their @dali.dartmouth.edu — verify they land at `/` with both `netId` and `daliEmail` set and applications intact
- [ ] Manual: brand-new member with no prior CAS row — verify the chain attaches netId without erroring
- [ ] Manual: re-login when already linked — verify no-op, no duplicate audit events

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/801"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783353890&installation_id=133523038&pr_number=801&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F801&signature=7e0344970a563f4f3b0e010e70788f57d4e06cacf9cb448b1e63635617e23b7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->