### PR TITLE
Core access: roll over Spring election through the cycle

### DIFF
--- a/dali-api/app/lib/__tests__/roles.test.ts
+++ b/dali-api/app/lib/__tests__/roles.test.ts
@@ -8,6 +8,7 @@ import {
   isInstructor,
   canViewForms,
   canViewStaffing,
+  getActiveCoreCycleTermIds,
 } from "~/lib/roles";
 
 // Phase 2: roles helpers now query AdminMembership / CoreAssignment /
@@ -22,7 +23,10 @@ const mockPrisma = prisma as unknown as {
   instructorAssignment: { findFirst: ReturnType<typeof vi.fn> };
   cycleReviewer: { findFirst: ReturnType<typeof vi.fn> };
   cycleInterviewer: { findFirst: ReturnType<typeof vi.fn> };
-  term: { findFirst: ReturnType<typeof vi.fn> };
+  term: {
+    findFirst: ReturnType<typeof vi.fn>;
+    findMany: ReturnType<typeof vi.fn>;
+  };
 };
 
 beforeEach(() => {
@@ -36,10 +40,12 @@ beforeEach(() => {
   (mockPrisma as any).instructorAssignment = { findFirst: vi.fn() };
   (mockPrisma as any).cycleReviewer = { findFirst: vi.fn() };
   (mockPrisma as any).cycleInterviewer = { findFirst: vi.fn() };
-  // Core access scopes to the current Term; default to one being present so
-  // a Core assignment in setRoleFlags is treated as current-term Core.
+  // Core access scopes to the active election cycle, looked up via
+  // currentTerm (findFirst) → cycle window (findMany). Default to a Spring
+  // term so Core checks resolve a non-empty cycle.
   (mockPrisma as any).term = {
-    findFirst: vi.fn().mockResolvedValue({ id: "term-1" }),
+    findFirst: vi.fn().mockResolvedValue({ id: "term-1", sortKey: 262 }),
+    findMany: vi.fn().mockResolvedValue([{ id: "term-1" }]),
   };
 });
 
@@ -153,6 +159,61 @@ describe("canViewForms (Core, Admin, or Instructor)", () => {
   it("false for a plain member", async () => {
     setRoleFlags({ member: true });
     expect(await canViewForms("u")).toBe(false);
+  });
+});
+
+describe("getActiveCoreCycleTermIds (Spring-anchored Core cycle)", () => {
+  // sortKey = year*10 + (W=1, S=2, X=3, F=4). A cycle window spans
+  // [Spring N, Spring N+1) — i.e. [Y*10+2, (Y+1)*10+2). During Spring,
+  // the prior cycle [(Y-1)*10+2, Y*10+2) is also active for the handoff.
+
+  function expectWindow(
+    currentSortKey: number,
+    expected: { gte: number; lt: number },
+  ) {
+    mockPrisma.term.findFirst.mockResolvedValue({
+      id: "current",
+      sortKey: currentSortKey,
+    });
+    mockPrisma.term.findMany.mockResolvedValue([]);
+    return getActiveCoreCycleTermIds().then(() => {
+      expect(mockPrisma.term.findMany).toHaveBeenCalledWith({
+        where: { sortKey: { gte: expected.gte, lt: expected.lt } },
+        select: { id: true },
+      });
+    });
+  }
+
+  it("Summer 26X → cycle is [26S, 27S)", async () => {
+    await expectWindow(263, { gte: 262, lt: 272 });
+  });
+
+  it("Fall 26F → cycle is [26S, 27S)", async () => {
+    await expectWindow(264, { gte: 262, lt: 272 });
+  });
+
+  it("Winter 27W rolls back to the prior Spring → cycle is [26S, 27S)", async () => {
+    await expectWindow(271, { gte: 262, lt: 272 });
+  });
+
+  it("Spring 27S includes prior cycle for election handoff → [26S, 28S)", async () => {
+    await expectWindow(272, { gte: 262, lt: 282 });
+  });
+
+  it("returns [] when there is no current term", async () => {
+    mockPrisma.term.findFirst.mockResolvedValue(null);
+    const ids = await getActiveCoreCycleTermIds();
+    expect(ids).toEqual([]);
+    expect(mockPrisma.term.findMany).not.toHaveBeenCalled();
+  });
+
+  it("returns the matched term IDs from findMany", async () => {
+    mockPrisma.term.findFirst.mockResolvedValue({ id: "x", sortKey: 263 });
+    mockPrisma.term.findMany.mockResolvedValue([
+      { id: "t-26s" },
+      { id: "t-26x" },
+    ]);
+    expect(await getActiveCoreCycleTermIds()).toEqual(["t-26s", "t-26x"]);
   });
 });
 

--- a/dali-api/app/lib/groups.ts
+++ b/dali-api/app/lib/groups.ts
@@ -1,10 +1,11 @@
 import { prisma } from "~/lib/db";
+import { getActiveCoreCycleTermIds } from "~/lib/roles";
 
 // Single source of truth for resolving a GroupDefinition to its member userIds.
 // Notification fan-out and meeting participant resolution both go through this.
 // Static groups return their explicit member list; Dynamic groups dispatch on
 // dynamicQuery and resolve against the underlying entity (term/project/domain
-// assignments, or current-term Core).
+// assignments, or the current Core cycle).
 export async function resolveGroupMembers(groupId: string): Promise<string[]> {
   const group = await prisma.groupDefinition.findUnique({
     where: { id: groupId },
@@ -73,10 +74,10 @@ async function resolveDomainMembers(domainId: string): Promise<string[]> {
 }
 
 async function resolveCoreMembers(): Promise<string[]> {
-  const termId = await getCurrentTermId();
-  if (!termId) return [];
+  const cycleTermIds = await getActiveCoreCycleTermIds();
+  if (cycleTermIds.length === 0) return [];
   const rows = await prisma.coreAssignment.findMany({
-    where: { termId },
+    where: { termId: { in: cycleTermIds } },
     select: { userId: true },
     distinct: ["userId"],
   });

--- a/dali-api/app/lib/roles.ts
+++ b/dali-api/app/lib/roles.ts
@@ -14,7 +14,7 @@ import { prisma } from "~/lib/db";
 
 export interface UserRoles {
   isLabMember: boolean;
-  /** Core (current term) or Admin. */
+  /** Core (current Spring-anchored cycle) or Admin. */
   isCore: boolean;
   isAdmin: boolean;
   isDomainLead: boolean;
@@ -34,17 +34,17 @@ export async function getUserRoles(userId: string): Promise<UserRoles> {
     .split(",")
     .filter(Boolean);
 
-  const term = await currentTerm();
+  const cycleTermIds = await getActiveCoreCycleTermIds();
 
   const [member, admin, core, domainLead, instructor] = await Promise.all([
     prisma.dALIMember.findUnique({ where: { userId }, select: { id: true } }),
     prisma.adminMembership.findUnique({ where: { userId }, select: { id: true } }),
-    // Core access tracks the current term: a former Core member from a past
-    // term shouldn't keep broad authority. If the Term table isn't seeded
-    // (term === null), no row can match — treat that as no Core access.
-    term
+    // Core access tracks the active election cycle (Spring N → Winter N+1,
+    // with the prior cycle overlapping during Spring elections). An empty
+    // Term table → no rows can match → treated as no Core access.
+    cycleTermIds.length > 0
       ? prisma.coreAssignment.findFirst({
-          where: { userId, termId: term.id },
+          where: { userId, termId: { in: cycleTermIds } },
           select: { id: true },
         })
       : Promise.resolve(null),
@@ -75,8 +75,9 @@ export async function getUserRoles(userId: string): Promise<UserRoles> {
 // ─── Individual checks (for route-level guards) ──────────────────────────────
 
 /**
- * Core (current term) or Admin. Past-term Core assignments do not count —
- * Core access is tied to the current Term. If the Term table is empty
+ * Core (active Spring-anchored cycle) or Admin. Cycle = the most recent
+ * Spring through the following Winter; during Spring elections, the prior
+ * cycle remains active for the handoff. If the Term table is empty
  * (e.g. seed hasn't run), Admin is the only path that passes.
  */
 export async function isCore(userId: string): Promise<boolean> {
@@ -89,10 +90,10 @@ export async function isCore(userId: string): Promise<boolean> {
     select: { id: true },
   });
   if (admin !== null) return true;
-  const term = await currentTerm();
-  if (!term) return false;
+  const cycleTermIds = await getActiveCoreCycleTermIds();
+  if (cycleTermIds.length === 0) return false;
   const core = await prisma.coreAssignment.findFirst({
-    where: { userId, termId: term.id },
+    where: { userId, termId: { in: cycleTermIds } },
     select: { id: true },
   });
   return core !== null;
@@ -193,6 +194,41 @@ export async function currentTerm() {
     where: { startDate: { gt: now } },
     orderBy: { sortKey: "asc" },
   });
+}
+
+/**
+ * Spring sortKey at or before `sk`. A Core "cycle" runs from one Spring
+ * election (W=1, S=2, X=3, F=4) through the following Winter, so the
+ * cycle that contains a term is anchored by its preceding Spring. Winter
+ * (digit 1) belongs to the previous calendar year's Spring cycle.
+ */
+function cycleStartSortKey(sk: number): number {
+  const seasonDigit = sk % 10;
+  return seasonDigit === 1 ? sk - 9 : sk - seasonDigit + 2;
+}
+
+/**
+ * Term IDs that constitute the active Core cycle. Core is elected in
+ * Spring and auto-rolls over through the following Winter; the cycle
+ * window spans `[Spring N, Spring N+1)` in sortKey space.
+ *
+ * During a Spring term, the previous cycle is also active so an outgoing
+ * Core keeps access through the election handoff (until they're either
+ * re-elected, or replaced — at which point the new cycle's assignments
+ * become the active set the following Summer).
+ */
+export async function getActiveCoreCycleTermIds(): Promise<string[]> {
+  const term = await currentTerm();
+  if (!term) return [];
+  const cycleStart = cycleStartSortKey(term.sortKey);
+  // Spring (digit 2) extends the window back one cycle for the handoff.
+  const lowerBound = term.sortKey % 10 === 2 ? cycleStart - 10 : cycleStart;
+  const upperBound = cycleStart + 10;
+  const terms = await prisma.term.findMany({
+    where: { sortKey: { gte: lowerBound, lt: upperBound } },
+    select: { id: true },
+  });
+  return terms.map((t) => t.id);
 }
 
 // ─── Staffing-board access ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Core access was scoped to the single current `Term`, so when the active term auto-advanced past Spring (e.g. into Summer/Fall/Winter) the Dynamic "Core" group resolved to empty and every `isCore` / `canViewStaffing` gate failed for members who hadn't been re-added to the new term.

Per the lab convention — *Core is elected each Spring and the elected slate carries through the following Winter* — this PR scopes Core to a **Spring-anchored cycle window** `[Spring N, Spring N+1)` in `Term.sortKey` space:

- A `Winter` term rolls back to the previous calendar year's Spring cycle.
- A `Spring` term overlaps the **prior** cycle too, so the outgoing Core keeps access through the election handoff and we never have a window with zero Core.

Implementation: new `getActiveCoreCycleTermIds()` helper in `app/lib/roles.ts`; `isCore`, `getUserRoles`, and the Dynamic Core group resolver in `app/lib/groups.ts` all query `coreAssignment` with `termId: { in: cycleTermIds }` instead of a single `termId`. No schema change.

## Test plan

- [x] `npm test` — 1169 unit tests pass, including new coverage in `roles.test.ts` for the cycle math across W/S/X/F and the Spring overlap.
- [x] `npm run typecheck` clean for `app/` (pre-existing errors in `scripts/` and one in `prisma/seeds/accepted-applicants.ts` are unrelated).
- [ ] Smoke-check after merging to dev: confirm Core group now resolves to the previously-elected slate, and that `isCore` returns true for them on staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/803"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783354076&installation_id=133523038&pr_number=803&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F803&signature=c95f54650daeead43f67a0ef56c7b92e44905341d9007d140fe6709c1fa0b103"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->