### PR TITLE
fix: backfilled users will clear the onboarding task as needed

### DIFF
--- a/dali-api/app/members/lib/welcome.server.ts
+++ b/dali-api/app/members/lib/welcome.server.ts
@@ -43,6 +43,15 @@ export async function sendWelcome(args: {
   // one step within it). It is a plain todo — NOT form-backed — so submitting
   // the profile form alone doesn't clear it; it stays until onboarding is fully
   // finished (clearOnboardingTask, called when onboardedAt is set).
+  const member = await prisma.dALIMember.findUnique({
+    where: { userId: args.userId },
+    select: { onboardedAt: true },
+  });
+  if (!member || member.onboardedAt) {
+    await clearOnboardingTask(args.userId);
+    return { notified: false };
+  }
+
   let notified = false;
   // Don't re-notify on a re-release: only create if there's no existing
   // onboarding todo for this member.
@@ -51,6 +60,7 @@ export async function sendWelcome(args: {
       recipientUserId: args.userId,
       kind: "SystemAnnouncement",
       link: ONBOARDING_LINK,
+      readAt: null,
     },
     select: { id: true },
   });

--- a/dali-api/app/routes/layout.tsx
+++ b/dali-api/app/routes/layout.tsx
@@ -10,6 +10,8 @@ import { resolvePhotoUrl } from '~/lib/photo'
 import { recordPageView } from '~/lib/analytics'
 import type { Route } from './+types/layout'
 
+const ONBOARDING_LINK = "/onboarding"
+
 export async function loader({ request }: Route.LoaderArgs) {
   const auth = await requireAuth(request)
   if (!auth.ok) return redirect('/login')
@@ -74,8 +76,55 @@ export async function loader({ request }: Route.LoaderArgs) {
   // the tour. Established members were backfilled (tourCompletedAt set), so only
   // the just-onboarded get it. A manual "start tour" button can re-run it later
   // regardless of this flag.
-  const shouldShowTour =
+  let shouldShowTour =
     !!me?.daliMember?.onboardedAt && me.daliMember.tourCompletedAt === null
+
+  // Self-heal users who are already onboarded but still have the new-member
+  // onboarding task. /onboarding redirects them home, so clear the stale task;
+  // if they were also marked tour-complete, let the existing launch tour show
+  // once.
+  if (me?.daliMember?.onboardedAt) {
+    const staleOnboardingTask = await prisma.notification.findFirst({
+      where: {
+        recipientUserId: auth.user.sub,
+        kind: "SystemAnnouncement",
+        link: ONBOARDING_LINK,
+        readAt: null,
+      },
+      select: { id: true },
+    })
+
+    if (staleOnboardingTask) {
+      if (me.daliMember.tourCompletedAt !== null) {
+        await prisma.$transaction([
+          prisma.notification.updateMany({
+            where: {
+              recipientUserId: auth.user.sub,
+              kind: "SystemAnnouncement",
+              link: ONBOARDING_LINK,
+              readAt: null,
+            },
+            data: { readAt: new Date() },
+          }),
+          prisma.dALIMember.updateMany({
+            where: { userId: auth.user.sub },
+            data: { tourCompletedAt: null },
+          }),
+        ])
+        shouldShowTour = true
+      } else {
+        await prisma.notification.updateMany({
+          where: {
+            recipientUserId: auth.user.sub,
+            kind: "SystemAnnouncement",
+            link: ONBOARDING_LINK,
+            readAt: null,
+          },
+          data: { readAt: new Date() },
+        })
+      }
+    }
+  }
 
   // Detect iframe context from Sec-Fetch-Dest. Modern browsers (Chrome, Firefox,
   // Safari 16+) set this automatically and it survives server-side redirects,


### PR DESCRIPTION
This may, in theory, fix an issue where if you click the onboarding task, it will open it and immediately close it. I have not tested it, since I do not have any internal access.


<img width="2815" height="1459" alt="image" src="https://github.com/user-attachments/assets/00021359-ff4f-4e48-93fd-f7a4873fb384" />

Intended fix: First-time users will now be able to click the task and go through it, rather than it being automatically closed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/804"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783373976&installation_id=133523038&pr_number=804&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F804&signature=509d226a21cf9faabbe33d94c64e8860550fc5b95b5b747f17bd516d5e06a37e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->