### PR TITLE
Seed: anchor seed term to now() so e2e isn't date-dependent

### DIFF
--- a/dali-api/prisma/seed.ts
+++ b/dali-api/prisma/seed.ts
@@ -39,16 +39,28 @@ async function main() {
   // local seed below references this term for the test hiring lead +
   // domain leads. Prod seeds a full 12-term window via
   // prisma/seeds/v0-reference.ts; locally one term is enough.
+  //
+  // The window is anchored to "now" (start 30 days ago, end 60 days out) so the
+  // seeded term is ALWAYS the active term — `currentTerm()` resolves by date, and
+  // a fixed calendar window would expire and lock every Core member out of the
+  // hiring/admin pages once the date passed (the e2e suite is date-independent
+  // this way). Prod is unaffected: it seeds the full 12-term calendar, so
+  // `currentTerm()` there falls back to the next upcoming term between terms.
+  const now = new Date();
+  const seedTermStart = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+  const seedTermEnd = new Date(now.getTime() + 60 * 24 * 60 * 60 * 1000);
   await prisma.term.upsert({
     where: { code: "26S" },
-    update: {},
+    // Update dates too, so an existing seed DB created before this fix (with the
+    // old fixed 2026-03-28 → 2026-06-05 window) is corrected on re-seed.
+    update: { startDate: seedTermStart, endDate: seedTermEnd },
     create: {
       code: "26S",
       year: 2026,
       season: "S",
       sortKey: 20262,
-      startDate: new Date("2026-03-28"),
-      endDate: new Date("2026-06-05"),
+      startDate: seedTermStart,
+      endDate: seedTermEnd,
     },
   });
 


### PR DESCRIPTION
## Problem

~9 e2e tests (`hiring lead (Core)` / `/hiring/lead` / `/admin-console/members` / hiring nav) started failing on **every** PR run after **2026-06-05**, regardless of the diff. The seeded Hiring Lead gets redirected to `/` (`Expected /\/admin-console\/members/, Received "http://localhost:3001/"`).

## Root cause

The local/e2e seed (`prisma/seed.ts`) created **only** term `26S` with a fixed window `2026-03-28 → 2026-06-05`. Once that `endDate` passed, the seeded DB had no active *or* upcoming term, so:

`currentTerm()` → `null` → `isCore()` → `false` → every Core-gated route redirects to `/`.

It's a **date-dependent time-bomb**: tests passed before June 5, fail after. `dev` last passed e2e on June 4; it would fail today too. (Surfaced while investigating #805, which is unrelated — that PR's diff touches no hiring/auth/seed code.)

## Fix

Anchor the seeded `26S` window to `now()` (start −30d, end +60d) so it's always the active term, and update the dates on re-seed so existing seed DBs are corrected. One file, additive logic.

**Prod is unaffected** — prod seeds the full 12-term calendar via `prisma/seeds/v0-reference.ts`, where `currentTerm()` already falls back to the next upcoming term (`26X`) between terms. Verified against the prod Term table: `currentTerm()` resolves to `26X` today, so there is no live Core-access incident.

## Test plan

- `prisma migrate reset --force && prisma db seed` → the seeded `26S` window contains today → `currentTerm()` resolves → the hiring-lead e2e suite passes.
- No prod change; no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/807"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783642699&installation_id=133523038&pr_number=807&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F807&signature=b1a5a335442a16213fdcbd9bd59e93914659192d417102b8b4e13219139adc85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->