### PR TITLE
Seed: anchor the seed term window to now() so e2e isn't date-dependen…

### DIFF
--- a/dali-api/prisma/seed.ts
+++ b/dali-api/prisma/seed.ts
@@ -39,16 +39,28 @@ async function main() {
   // local seed below references this term for the test hiring lead +
   // domain leads. Prod seeds a full 12-term window via
   // prisma/seeds/v0-reference.ts; locally one term is enough.
+  //
+  // The window is anchored to "now" (start 30 days ago, end 60 days out) so the
+  // seeded term is ALWAYS the active term — `currentTerm()` resolves by date, and
+  // a fixed calendar window would expire and lock every Core member out of the
+  // hiring/admin pages once the date passed (the e2e suite is date-independent
+  // this way). Prod is unaffected: it seeds the full 12-term calendar, so
+  // `currentTerm()` there falls back to the next upcoming term between terms.
+  const now = new Date();
+  const seedTermStart = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+  const seedTermEnd = new Date(now.getTime() + 60 * 24 * 60 * 60 * 1000);
   await prisma.term.upsert({
     where: { code: "26S" },
-    update: {},
+    // Update dates too, so an existing seed DB created before this fix (with the
+    // old fixed 2026-03-28 → 2026-06-05 window) is corrected on re-seed.
+    update: { startDate: seedTermStart, endDate: seedTermEnd },
     create: {
       code: "26S",
       year: 2026,
       season: "S",
       sortKey: 20262,
-      startDate: new Date("2026-03-28"),
-      endDate: new Date("2026-06-05"),
+      startDate: seedTermStart,
+      endDate: seedTermEnd,
     },
   });
 


### PR DESCRIPTION
…t (#807)

The local/e2e seed created only term 26S with a fixed window (2026-03-28 → 2026-06-05). Once that endDate passed (2026-06-06), the seeded DB had no active *or* upcoming term, so currentTerm() returned null, isCore() returned false for the seeded Hiring Lead, and every Core-gated route (/hiring/lead, /admin-console/members, nav) redirected to / — failing ~9 e2e tests on every PR run after 2026-06-05, regardless of the diff.

Anchor 26S to now() (start −30d, end +60d) so it's always the active term, and update the dates on re-seed so existing seed DBs are corrected. Prod is unaffected — it seeds the full 12-term calendar (prisma/seeds/v0-reference.ts), where currentTerm() already falls back to the next upcoming term between terms.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/808"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783643028&installation_id=133523038&pr_number=808&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F808&signature=9a931ae612763921ac547ba2b7ce3734f2ae799424affa2ac753b4dc0d46d17b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->