### PR TITLE
Staffing Slack: invite Core+staff, editable channel/team fields, term channel

### DIFF
--- a/dali-api/app/lib/audit.ts
+++ b/dali-api/app/lib/audit.ts
@@ -29,6 +29,7 @@ export const AUDIT_ACTIONS = [
   "group.delete",
   "staffing.assign",
   "staffing.finalize",
+  "staffing.term_channel",
   "staffing.board-member.add",
   "staffing.board-member.remove",
   "staffing.reorder",

--- a/dali-api/app/projects/components/FinalizeModal.tsx
+++ b/dali-api/app/projects/components/FinalizeModal.tsx
@@ -50,12 +50,18 @@ export function FinalizeModal({
   cycleId,
   projectId,
   projectName,
+  defaultSlackChannel,
+  defaultGithubSlug,
 }: {
   open: boolean;
   onClose: () => void;
   cycleId: string;
   projectId: string;
   projectName: string;
+  // Pre-fill for the editable channel/team fields. Slack defaults to the
+  // project-name-derived channel; GitHub to the project's stored slug (or "").
+  defaultSlackChannel?: string;
+  defaultGithubSlug?: string;
 }) {
   const revalidator = useRevalidator();
   const [selected, setSelected] = useState<Set<Automation>>(
@@ -64,6 +70,57 @@ export function FinalizeModal({
   const [running, setRunning] = useState(false);
   const [results, setResults] = useState<Partial<Record<Automation, StepResult>> | null>(null);
   const [error, setError] = useState<string | null>(null);
+  // Editable identifiers, shared with the project details page. Slack defaults to
+  // the project's stored channel name (else derived); GitHub to its stored slug.
+  const initialSlack = defaultSlackChannel ?? "";
+  const initialGithub = defaultGithubSlug ?? "";
+  const [slackChannel, setSlackChannel] = useState(initialSlack);
+  const [githubSlug, setGithubSlug] = useState(initialGithub);
+  const [savingFields, setSavingFields] = useState(false);
+  const [savedNote, setSavedNote] = useState<string | null>(null);
+  const fieldsDirty = slackChannel !== initialSlack || githubSlug !== initialGithub;
+
+  // Persist the channel name + GitHub slug to the Project WITHOUT running
+  // automations (keeps the project details page in sync). Cancel reverts edits.
+  async function saveFields() {
+    setSavingFields(true);
+    setError(null);
+    setSavedNote(null);
+    try {
+      const res = await fetch("/api/staffing/finalize", {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          cycleId,
+          projectId,
+          automations: [],
+          saveFieldsOnly: true,
+          slackChannel: slackChannel.trim(),
+          githubTeamSlug: githubSlug.trim(),
+        }),
+      });
+      if (!res.ok) {
+        const json = (await res.json().catch(() => ({}))) as { error?: string };
+        setError(json.error ?? `Save failed: ${res.status}`);
+        return;
+      }
+      setSavedNote("Saved.");
+      // Reflect the new values on the project details page if it's open.
+      revalidator.revalidate();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Network error");
+    } finally {
+      setSavingFields(false);
+    }
+  }
+
+  function cancelFields() {
+    setSlackChannel(initialSlack);
+    setGithubSlug(initialGithub);
+    setSavedNote(null);
+    setError(null);
+  }
 
   function toggle(id: Automation) {
     setSelected((prev) => {
@@ -87,7 +144,13 @@ export function FinalizeModal({
         method: "POST",
         credentials: "include",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ cycleId, projectId, automations: ids }),
+        body: JSON.stringify({
+          cycleId,
+          projectId,
+          automations: ids,
+          slackChannel: slackChannel.trim() || undefined,
+          githubTeamSlug: githubSlug.trim() || undefined,
+        }),
       });
       const json = (await res.json().catch(() => ({}))) as {
         results?: Partial<Record<Automation, StepResult>>;
@@ -166,6 +229,52 @@ export function FinalizeModal({
                   )}
                 </div>
                 <p className="text-xs text-muted-foreground mt-0.5">{a.description}</p>
+                {a.id === "slack" && (
+                  <div className="mt-2">
+                    <label
+                      htmlFor="finalize-slack-channel"
+                      className="block text-[11px] font-medium text-foreground"
+                    >
+                      Channel name
+                    </label>
+                    <input
+                      id="finalize-slack-channel"
+                      type="text"
+                      value={slackChannel}
+                      disabled={running || savingFields}
+                      onChange={(e) => setSlackChannel(e.target.value)}
+                      placeholder="project-name"
+                      className="mt-1 w-full px-2 py-1 text-xs border border-border rounded-md bg-background text-foreground disabled:opacity-60"
+                    />
+                    <p className="text-[10px] text-muted-foreground mt-0.5">
+                      Lowercase + hyphens. Shared with the project page. Save to sync; the
+                      channel is get-or-created when this automation runs.
+                    </p>
+                  </div>
+                )}
+                {a.id === "github" && (
+                  <div className="mt-2">
+                    <label
+                      htmlFor="finalize-github-slug"
+                      className="block text-[11px] font-medium text-foreground"
+                    >
+                      Team slug
+                    </label>
+                    <input
+                      id="finalize-github-slug"
+                      type="text"
+                      value={githubSlug}
+                      disabled={running || savingFields}
+                      onChange={(e) => setGithubSlug(e.target.value)}
+                      placeholder="project-team"
+                      className="mt-1 w-full px-2 py-1 text-xs border border-border rounded-md bg-background text-foreground disabled:opacity-60"
+                    />
+                    <p className="text-[10px] text-muted-foreground mt-0.5">
+                      Shared with the project page. Save to sync; the team is get-or-created
+                      when this automation runs.
+                    </p>
+                  </div>
+                )}
                 {r && (
                   <p
                     className={`text-xs mt-1.5 ${
@@ -186,23 +295,53 @@ export function FinalizeModal({
         })}
       </ul>
 
-      <div className="flex justify-end gap-2 mt-4">
-        <button
-          type="button"
-          disabled={running}
-          onClick={() => run([...selected])}
-          className="px-3 py-1.5 text-sm font-medium rounded-md border border-border hover:bg-muted disabled:opacity-60 transition-colors"
-        >
-          {running ? "Running…" : "Run selected"}
-        </button>
-        <button
-          type="button"
-          disabled={running}
-          onClick={() => run(AUTOMATIONS.filter((a) => a.configured).map((a) => a.id))}
-          className="px-3 py-1.5 text-sm font-medium rounded-md bg-accent-coral text-white hover:bg-accent-coral/90 disabled:opacity-60 transition-colors"
-        >
-          {running ? "Running…" : "Run all"}
-        </button>
+      {/* Save/Cancel persist the channel + slug fields (synced to the project
+          details page) without running automations. Shown only when edited. */}
+      <div className="flex items-center justify-between gap-2 mt-4">
+        <div className="flex items-center gap-2 min-h-[1.75rem]">
+          {fieldsDirty && (
+            <>
+              <button
+                type="button"
+                disabled={savingFields || running}
+                onClick={saveFields}
+                className="px-3 py-1.5 text-sm font-medium rounded-md bg-accent-teal text-white hover:bg-accent-teal/90 disabled:opacity-60 transition-colors"
+              >
+                {savingFields ? "Saving…" : "Save fields"}
+              </button>
+              <button
+                type="button"
+                disabled={savingFields || running}
+                onClick={cancelFields}
+                className="px-3 py-1.5 text-sm font-medium rounded-md border border-border hover:bg-muted disabled:opacity-60 transition-colors"
+              >
+                Cancel
+              </button>
+            </>
+          )}
+          {savedNote && !fieldsDirty && (
+            <span className="text-xs text-accent-teal">{savedNote}</span>
+          )}
+        </div>
+
+        <div className="flex gap-2">
+          <button
+            type="button"
+            disabled={running || savingFields}
+            onClick={() => run([...selected])}
+            className="px-3 py-1.5 text-sm font-medium rounded-md border border-border hover:bg-muted disabled:opacity-60 transition-colors"
+          >
+            {running ? "Running…" : "Run selected"}
+          </button>
+          <button
+            type="button"
+            disabled={running || savingFields}
+            onClick={() => run(AUTOMATIONS.filter((a) => a.configured).map((a) => a.id))}
+            className="px-3 py-1.5 text-sm font-medium rounded-md bg-accent-coral text-white hover:bg-accent-coral/90 disabled:opacity-60 transition-colors"
+          >
+            {running ? "Running…" : "Run all"}
+          </button>
+        </div>
       </div>
     </Modal>
   );

--- a/dali-api/app/projects/components/StaffingBoard.tsx
+++ b/dali-api/app/projects/components/StaffingBoard.tsx
@@ -28,7 +28,26 @@ import { FinalizeModal } from "./FinalizeModal";
 import { AddMemberControl } from "./AddMemberControl";
 import { DomainFilter } from "./DomainFilter";
 
-type ProjectMeta = { id: string; name: string; status: "Active" | "Paused" | "Archived" };
+type ProjectMeta = {
+  id: string;
+  name: string;
+  status: "Active" | "Paused" | "Archived";
+  // Pre-fill the Finalize modal's editable fields (shared with the project page).
+  githubTeamSlug?: string | null;
+  slackChannelName?: string | null;
+};
+
+// Slack channel names: lowercase, hyphens for spaces, no other punctuation, ≤80.
+// Mirrors the server's sanitizeChannelName so the modal's default matches what
+// ensureChannel would derive from the project name.
+function deriveChannelName(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9-_\s]/g, "")
+    .trim()
+    .replace(/\s+/g, "-")
+    .slice(0, 80);
+}
 
 // Expected headcount per (project, domain) for this term — already summed
 // across levels and sorted by domain name in the loader. Keyed by projectId.
@@ -289,8 +308,11 @@ export function StaffingBoard({
     ? assignments.find((a) => a.userId === openBidUserId)?.projectId ?? null
     : null;
 
+  const termCode = terms.find((t) => t.id === termId)?.code ?? "";
+
   return (
     <div className="flex flex-col gap-3">
+      {canManage && <TermChannelBanner termId={termId} termCode={termCode} />}
       <div className="flex items-center justify-end gap-3 flex-wrap">
         {canManage && <AddMemberControl cycleId={cycleId} />}
         <DomainFilter
@@ -419,8 +441,102 @@ export function StaffingBoard({
           cycleId={cycleId}
           projectId={finalizeProjectId}
           projectName={projectNames[finalizeProjectId] ?? "project"}
+          defaultSlackChannel={
+            projects.find((p) => p.id === finalizeProjectId)?.slackChannelName ??
+            deriveChannelName(projectNames[finalizeProjectId] ?? "")
+          }
+          defaultGithubSlug={
+            projects.find((p) => p.id === finalizeProjectId)?.githubTeamSlug ?? ""
+          }
         />
       )}
+    </div>
+  );
+}
+
+// Full-width banner: get-or-create a term-wide Slack channel (e.g. #26x) and
+// invite all current-term Core + Admin/staff + everyone assigned to a project
+// this term. The channel name is editable, defaulting to the term code.
+function TermChannelBanner({ termId, termCode }: { termId: string; termCode: string }) {
+  const deriveTermChannel = (code: string) =>
+    code
+      .toLowerCase()
+      .replace(/[^a-z0-9-_\s]/g, "")
+      .trim()
+      .replace(/\s+/g, "-")
+      .slice(0, 80);
+
+  const [channel, setChannel] = useState(deriveTermChannel(termCode));
+  const [running, setRunning] = useState(false);
+  const [result, setResult] = useState<{ ok: boolean; message: string } | null>(null);
+
+  // Keep the field in sync when the selected term changes.
+  useEffect(() => {
+    setChannel(deriveTermChannel(termCode));
+    setResult(null);
+  }, [termCode]);
+
+  async function run() {
+    if (!channel.trim()) return;
+    setRunning(true);
+    setResult(null);
+    try {
+      const res = await fetch("/api/staffing/term-channel", {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ termId, channel: channel.trim() }),
+      });
+      const json = (await res.json().catch(() => ({}))) as { message?: string; error?: string };
+      if (!res.ok) {
+        setResult({ ok: false, message: json.error ?? `Failed: ${res.status}` });
+        return;
+      }
+      setResult({ ok: true, message: json.message ?? "Done." });
+    } catch (err) {
+      setResult({ ok: false, message: err instanceof Error ? err.message : "Network error" });
+    } finally {
+      setRunning(false);
+    }
+  }
+
+  return (
+    <div className="w-full rounded-lg border border-accent-coral/30 bg-accent-coral/10 px-4 py-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+      <div className="min-w-0">
+        <p className="text-sm font-heading font-semibold text-foreground">
+          Term Slack channel{termCode ? ` for ${termCode}` : ""}
+        </p>
+        <p className="text-xs text-muted-foreground">
+          Get-or-create a channel and invite all Core, staff, and everyone assigned to a project
+          this term.
+        </p>
+        {result && (
+          <p className={`text-xs mt-1 ${result.ok ? "text-accent-teal" : "text-destructive"}`}>
+            {result.ok ? "✓ " : "✗ "}
+            {result.message}
+          </p>
+        )}
+      </div>
+      <div className="flex items-center gap-2 flex-shrink-0">
+        <span className="text-sm text-muted-foreground">#</span>
+        <input
+          type="text"
+          value={channel}
+          disabled={running}
+          onChange={(e) => setChannel(e.target.value)}
+          placeholder="26x"
+          aria-label="Term channel name"
+          className="w-32 px-2 py-1 text-sm border border-border rounded-md bg-background text-foreground disabled:opacity-60 focus:outline-none focus:ring-2 focus:ring-accent-coral/30"
+        />
+        <button
+          type="button"
+          disabled={running || !channel.trim()}
+          onClick={run}
+          className="px-3 py-1.5 text-sm font-medium rounded-md bg-accent-coral text-white hover:bg-accent-coral/90 disabled:opacity-60 transition-colors whitespace-nowrap"
+        >
+          {running ? "Creating…" : "Create + invite"}
+        </button>
+      </div>
     </div>
   );
 }

--- a/dali-api/app/projects/routes/api.staffing.finalize.ts
+++ b/dali-api/app/projects/routes/api.staffing.finalize.ts
@@ -42,7 +42,20 @@ type Automation = (typeof AUTOMATIONS)[number];
 
 type StepResult = { status: "ok" | "skipped" | "error"; message: string };
 
-type Body = { cycleId: string; projectId: string; automations: string[] };
+type Body = {
+  cycleId: string;
+  projectId: string;
+  automations: string[];
+  // Optional editable overrides from the Finalize modal. Empty/absent = use the
+  // project's stored/derived value. When supplied, they are also persisted to the
+  // Project (slackChannel → the get-or-created channel's id; githubTeamSlug → the
+  // slug field).
+  slackChannel?: string;
+  githubTeamSlug?: string;
+  // When true, persist the channel/slug fields to the Project and skip all
+  // automations (the modal's "Save").
+  saveFieldsOnly?: boolean;
+};
 
 function isBody(x: unknown): x is Body {
   if (!x || typeof x !== "object") return false;
@@ -51,7 +64,10 @@ function isBody(x: unknown): x is Body {
     typeof o.cycleId === "string" &&
     typeof o.projectId === "string" &&
     Array.isArray(o.automations) &&
-    o.automations.every((a) => typeof a === "string")
+    o.automations.every((a) => typeof a === "string") &&
+    (o.slackChannel === undefined || typeof o.slackChannel === "string") &&
+    (o.githubTeamSlug === undefined || typeof o.githubTeamSlug === "string") &&
+    (o.saveFieldsOnly === undefined || typeof o.saveFieldsOnly === "boolean")
   );
 }
 
@@ -84,7 +100,9 @@ export async function action({ request }: Route.ActionArgs) {
       (AUTOMATIONS as readonly string[]).includes(a),
     ),
   );
-  if (selected.size === 0) {
+  // saveFieldsOnly persists fields with no automations selected, so the empty
+  // check only applies to a real automation run.
+  if (!body.saveFieldsOnly && selected.size === 0) {
     return withCors(request, Response.json({ error: "No automations selected" }, { status: 400 }));
   }
 
@@ -102,12 +120,34 @@ export async function action({ request }: Route.ActionArgs) {
       name: true,
       githubTeamSlug: true,
       slackChannelId: true,
+      slackChannelName: true,
       repoUrls: true,
       teamGroupEmail: true,
     },
   });
   if (!project) {
     return withCors(request, Response.json({ error: "Project not found" }, { status: 404 }));
+  }
+
+  // ── saveFieldsOnly ───────────────────────────────────────────────────────────
+  // The Finalize modal's "Save" persists the editable channel name + GitHub slug
+  // to the Project WITHOUT running any automations, so the project details page and
+  // the modal stay in sync. No Slack/GitHub API calls here — the channel is
+  // materialized when an automation actually runs.
+  if (body.saveFieldsOnly) {
+    const data: { slackChannelName?: string | null; githubTeamSlug?: string | null } = {};
+    if (body.slackChannel !== undefined) {
+      const v = body.slackChannel.trim();
+      data.slackChannelName = v === "" ? null : v;
+    }
+    if (body.githubTeamSlug !== undefined) {
+      const v = body.githubTeamSlug.trim();
+      data.githubTeamSlug = v === "" ? null : v;
+    }
+    if (Object.keys(data).length > 0) {
+      await prisma.project.update({ where: { id: project.id }, data });
+    }
+    return withCors(request, Response.json({ saved: true }));
   }
 
   const results: Record<Automation, StepResult> = {} as Record<Automation, StepResult>;
@@ -259,25 +299,43 @@ export async function action({ request }: Route.ActionArgs) {
           ).map((d) => [d.id, d.displayName]),
         );
 
-        // 1. Resolve the channel: reuse the stored id, else create one from the
-        //    project name and backfill the id for next time.
+        // 1. Resolve the channel. The desired name is the modal edit, else the
+        //    stored shared name, else the project name. Reuse the stored id unless
+        //    there's none yet or the desired name differs — then get-or-create and
+        //    persist BOTH the resulting id and the name (shared with project
+        //    details).
+        const desiredName =
+          body.slackChannel?.trim() || project.slackChannelName || project.name;
         let channelId = project.slackChannelId;
         let channelNote = "reused channel";
-        if (!channelId) {
-          const ch = await ensureChannel(project.name);
+        const nameChanged = desiredName !== project.slackChannelName;
+        if (!channelId || nameChanged) {
+          const ch = await ensureChannel(desiredName);
           channelId = ch.id;
           channelNote = ch.created ? `created #${ch.name}` : `found #${ch.name}`;
           await prisma.project.update({
             where: { id: project.id },
-            data: { slackChannelId: channelId },
+            data: { slackChannelId: channelId, slackChannelName: desiredName },
           });
         }
 
-        // 2. Invite confirmed members who have a synced Slack id.
-        const slackIds = roster
-          .map((r) => r.user.slackUserId)
-          .filter((id): id is string => !!id);
-        const missing = roster.length - slackIds.length;
+        // 2. Build the invite set: confirmed roster + all current-term Core + all
+        //    Admin/staff. Each resolved to a synced slackUserId; nulls dropped and
+        //    counted per group so the lead sees who's missing a Slack account.
+        const [coreRows, adminRows] = await Promise.all([
+          prisma.coreAssignment.findMany({
+            where: { termId: cycle.termId },
+            select: { user: { select: { slackUserId: true } } },
+          }),
+          prisma.adminMembership.findMany({
+            select: { user: { select: { slackUserId: true } } },
+          }),
+        ]);
+        const memberIds = roster.map((r) => r.user.slackUserId).filter((id): id is string => !!id);
+        const coreIds = coreRows.map((r) => r.user.slackUserId).filter((id): id is string => !!id);
+        const adminIds = adminRows.map((r) => r.user.slackUserId).filter((id): id is string => !!id);
+        const slackIds = [...new Set([...memberIds, ...coreIds, ...adminIds])];
+        const missingMembers = roster.length - memberIds.length;
         const inv = await inviteUsersToChannel(channelId, slackIds);
 
         // 3. Announce the team: name — domain (level), plus repos.
@@ -297,10 +355,10 @@ export async function action({ request }: Route.ActionArgs) {
 
         const parts = [
           channelNote,
-          `invited ${inv.invited}`,
+          `invited ${inv.invited} (members ${memberIds.length}, core ${coreIds.length}, admin ${adminIds.length})`,
           `announced ${roster.length} member(s)`,
         ];
-        if (missing > 0) parts.push(`${missing} without a synced Slack id`);
+        if (missingMembers > 0) parts.push(`${missingMembers} member(s) without a synced Slack id`);
         results.slack = { status: "ok", message: `${parts.join("; ")}.` };
       } catch (err) {
         results.slack = { status: "error", message: errMsg(err) };
@@ -408,12 +466,16 @@ export async function action({ request }: Route.ActionArgs) {
   // membership PUT are both idempotent, and we never remove anyone. Roster
   // members without a stored githubUsername are skipped and reported.
   if (selected.has("github")) {
+    // The slug is editable in the Finalize modal; an edit overrides (and is
+    // persisted to) Project.githubTeamSlug, so it no longer has to be pre-set on
+    // the project page.
+    const slug = body.githubTeamSlug?.trim() || project.githubTeamSlug;
     if (!process.env.GITHUB_ORG) {
       results.github = { status: "skipped", message: "GITHUB_ORG not set." };
-    } else if (!project.githubTeamSlug) {
+    } else if (!slug) {
       results.github = {
         status: "skipped",
-        message: "No GitHub team configured for this project — set one on the project page.",
+        message: "No GitHub team slug provided — enter one in the Finalize modal.",
       };
     } else {
       try {
@@ -435,9 +497,16 @@ export async function action({ request }: Route.ActionArgs) {
           else missing.push(`${r.user.firstName} ${r.user.lastName}`);
         }
 
-        const team = await ensureTeam(project.githubTeamSlug);
+        const team = await ensureTeam(slug);
         for (const username of withHandle) {
           await addTeamMember(team.slug, username);
+        }
+        // Persist the slug if the lead changed it (so future runs reuse it).
+        if (slug !== project.githubTeamSlug) {
+          await prisma.project.update({
+            where: { id: project.id },
+            data: { githubTeamSlug: slug },
+          });
         }
 
         const parts = [

--- a/dali-api/app/projects/routes/api.staffing.term-channel.ts
+++ b/dali-api/app/projects/routes/api.staffing.term-channel.ts
@@ -1,0 +1,116 @@
+import type { Route } from "./+types/api.staffing.term-channel";
+import { prisma } from "~/lib/db";
+import { requireAuth } from "~/lib/auth";
+import { canManageStaffing } from "~/lib/roles";
+import { withCors, handlePreflight } from "~/lib/cors";
+import { ensureChannel, inviteUsersToChannel } from "~/slack/lib/slack-client";
+import { logAuditEvent } from "~/lib/audit";
+
+// POST /api/staffing/term-channel
+//
+// Get-or-create a term-wide Slack channel (e.g. #26x) and invite everyone active
+// for that term: all current-term Core, all Admin/staff, and everyone with a
+// ProjectAssignment in the term. Idempotent — safe to re-run.
+//
+// Body: { termId: string; channel?: string }  — channel defaults to the term code.
+
+type Body = { termId: string; channel?: string };
+
+function isBody(x: unknown): x is Body {
+  if (!x || typeof x !== "object") return false;
+  const o = x as Record<string, unknown>;
+  return (
+    typeof o.termId === "string" &&
+    (o.channel === undefined || typeof o.channel === "string")
+  );
+}
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+export async function action({ request }: Route.ActionArgs) {
+  const preflight = handlePreflight(request);
+  if (preflight) return preflight;
+
+  const auth = await requireAuth(request);
+  if (!auth.ok) return withCors(request, auth.response);
+  if (request.method !== "POST") {
+    return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));
+  }
+  if (!(await canManageStaffing(auth.user.sub))) {
+    return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return withCors(request, Response.json({ error: "Invalid JSON" }, { status: 400 }));
+  }
+  if (!isBody(body)) {
+    return withCors(request, Response.json({ error: "Invalid body" }, { status: 400 }));
+  }
+
+  if (!process.env.SLACK_BOT_TOKEN) {
+    return withCors(request, Response.json({ error: "SLACK_BOT_TOKEN not set." }, { status: 400 }));
+  }
+
+  const term = await prisma.term.findUnique({
+    where: { id: body.termId },
+    select: { id: true, code: true },
+  });
+  if (!term) {
+    return withCors(request, Response.json({ error: "Term not found" }, { status: 404 }));
+  }
+
+  try {
+    // Invite set: current-term Core + all Admin/staff + everyone with a
+    // ProjectAssignment this term. Resolve to synced slackUserIds; nulls dropped
+    // and counted per group so the lead sees who's missing a Slack account.
+    const [coreRows, adminRows, assignmentRows] = await Promise.all([
+      prisma.coreAssignment.findMany({
+        where: { termId: term.id },
+        select: { user: { select: { slackUserId: true } } },
+      }),
+      prisma.adminMembership.findMany({
+        select: { user: { select: { slackUserId: true } } },
+      }),
+      prisma.projectAssignment.findMany({
+        where: { termId: term.id },
+        select: { user: { select: { slackUserId: true } } },
+      }),
+    ]);
+    const coreIds = coreRows.map((r) => r.user.slackUserId).filter((id): id is string => !!id);
+    const adminIds = adminRows.map((r) => r.user.slackUserId).filter((id): id is string => !!id);
+    const memberIds = assignmentRows
+      .map((r) => r.user.slackUserId)
+      .filter((id): id is string => !!id);
+    const slackIds = [...new Set([...coreIds, ...adminIds, ...memberIds])];
+
+    const desiredName = body.channel?.trim() || term.code;
+    const ch = await ensureChannel(desiredName);
+    const inv = await inviteUsersToChannel(ch.id, slackIds);
+
+    const missingTotal =
+      coreRows.length + adminRows.length + assignmentRows.length - slackIds.length;
+    const parts = [
+      ch.created ? `created #${ch.name}` : `found #${ch.name}`,
+      `invited ${inv.invited} (core ${coreIds.length}, admin ${adminIds.length}, project members ${memberIds.length})`,
+    ];
+    if (missingTotal > 0) parts.push(`some without a synced Slack id`);
+
+    await logAuditEvent({
+      action: "staffing.term_channel",
+      userId: auth.user.sub,
+      metadata: { termId: term.id, channel: ch.name, invited: inv.invited },
+    });
+
+    return withCors(
+      request,
+      Response.json({ ok: true, channel: ch.name, message: `${parts.join("; ")}.` }),
+    );
+  } catch (err) {
+    return withCors(request, Response.json({ error: errMsg(err) }, { status: 500 }));
+  }
+}

--- a/dali-api/app/projects/routes/projects.$id.tsx
+++ b/dali-api/app/projects/routes/projects.$id.tsx
@@ -96,6 +96,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
       repoUrls: true,
       deploymentUrl: true,
       githubTeamSlug: true,
+      slackChannelName: true,
       overviewPageId: true,
       prdPageId: true,
       projectTerms: {
@@ -465,6 +466,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
       repoUrls: project.repoUrls,
       deploymentUrl: project.deploymentUrl,
       githubTeamSlug: project.githubTeamSlug,
+      slackChannelName: project.slackChannelName,
       overviewPageId: project.overviewPageId,
       prdPageId: project.prdPageId,
       startTerm,
@@ -670,6 +672,7 @@ export async function action({ request, params }: Route.ActionArgs) {
   const deploymentUrlRaw = (form.get("deploymentUrl") as string | null)?.trim() ?? "";
   const termCountRaw = (form.get("termCount") as string | null) ?? "";
   const githubTeamRaw = (form.get("githubTeamSlug") as string | null)?.trim() ?? "";
+  const slackChannelRaw = (form.get("slackChannelName") as string | null)?.trim() ?? "";
 
   // Normalize to a GitHub-safe team slug: lowercase, non-alphanumerics → single
   // hyphens, trimmed. Empty clears the field (automation then skips).
@@ -680,6 +683,19 @@ export async function action({ request, params }: Route.ActionArgs) {
           .toLowerCase()
           .replace(/[^a-z0-9]+/g, "-")
           .replace(/^-+|-+$/g, "");
+
+  // Slack channel name: lowercase, hyphens, ≤80 (Slack's channel-name rules), to
+  // match what the finalize step would derive. Empty clears it. Editing here is
+  // metadata-only — the channel is get-or-created when an automation runs.
+  const slackChannelName =
+    slackChannelRaw === ""
+      ? null
+      : slackChannelRaw
+          .toLowerCase()
+          .replace(/[^a-z0-9-_\s]/g, "")
+          .trim()
+          .replace(/\s+/g, "-")
+          .slice(0, 80);
 
   // repoUrls textarea: one URL per line, blanks dropped.
   const repoUrls = repoUrlsRaw
@@ -700,6 +716,7 @@ export async function action({ request, params }: Route.ActionArgs) {
       deploymentUrl: deploymentUrlRaw === "" ? null : deploymentUrlRaw,
       termCount,
       githubTeamSlug,
+      slackChannelName,
     },
   });
   return redirect(`/projects/${params.id}`);
@@ -1397,6 +1414,23 @@ function DetailsSegment({
               ) : (
                 <span className="px-2 py-1.5 text-sm text-foreground">
                   {project.githubTeamSlug ?? "—"}
+                </span>
+              )}
+            </label>
+
+            <label className="flex flex-col gap-1 text-xs">
+              <span className="text-muted-foreground">Slack channel</span>
+              {editing ? (
+                <input
+                  name="slackChannelName"
+                  type="text"
+                  defaultValue={project.slackChannelName ?? ""}
+                  placeholder="project-name"
+                  className="px-2 py-1.5 text-sm border border-border rounded-md bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-accent-coral/30"
+                />
+              ) : (
+                <span className="px-2 py-1.5 text-sm text-foreground">
+                  {project.slackChannelName ?? "—"}
                 </span>
               )}
             </label>

--- a/dali-api/app/projects/routes/projects.staffing.tsx
+++ b/dali-api/app/projects/routes/projects.staffing.tsx
@@ -156,7 +156,8 @@ export async function loader({ request }: Route.LoaderArgs) {
         projectTerms: { some: { termId: selectedTerm.id } },
       },
       orderBy: [{ status: "asc" }, { name: "asc" }],
-      select: { id: true, name: true, status: true },
+      // githubTeamSlug pre-fills the Finalize modal's editable GitHub field.
+      select: { id: true, name: true, status: true, githubTeamSlug: true, slackChannelName: true },
     }),
     prisma.domain.findMany({ select: { id: true, displayName: true } }),
     // Expected headcount per (project, domain) for THIS term. ProjectRoleRequest
@@ -195,7 +196,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   if (stagedProjectIds.length > 0) {
     const strays = await prisma.project.findMany({
       where: { id: { in: stagedProjectIds }, status: { not: "Archived" } },
-      select: { id: true, name: true, status: true },
+      select: { id: true, name: true, status: true, githubTeamSlug: true, slackChannelName: true },
     });
     projects.push(...strays);
     projects.sort(

--- a/dali-api/app/routes.ts
+++ b/dali-api/app/routes.ts
@@ -209,6 +209,7 @@ export default [
   // Staffing board (always open; one cycle per term, auto-created on view)
   route("api/staffing/assign", "projects/routes/api.staffing.assign.ts"),
   route("api/staffing/finalize", "projects/routes/api.staffing.finalize.ts"),
+  route("api/staffing/term-channel", "projects/routes/api.staffing.term-channel.ts"),
   route("api/staffing/board-member", "projects/routes/api.staffing.board-member.ts"),
   route("api/staffing/events", "projects/routes/api.staffing.events.ts"),
   route("api/staffing/reorder", "projects/routes/api.staffing.reorder.ts"),

--- a/dali-api/prisma/migrations/20260610000000_add_project_slack_channel_name/migration.sql
+++ b/dali-api/prisma/migrations/20260610000000_add_project_slack_channel_name/migration.sql
@@ -1,0 +1,4 @@
+-- Human-editable Slack channel name, shared between the project details page and
+-- the staffing Finalize modal. slackChannelId (the live channel id) is backfilled
+-- when the channel is get-or-created on finalize / modal Save.
+ALTER TABLE "Project" ADD COLUMN "slackChannelName" TEXT;

--- a/dali-api/prisma/schema.prisma
+++ b/dali-api/prisma/schema.prisma
@@ -1891,11 +1891,15 @@ model Project {
   githubTeamSlug String?
 
   // The project's Slack channel id (e.g. "C0123ABC"), used to invite members +
-  // post the team announcement on staffing finalize. The channel NAME is always
-  // derived from the project name (slugified); finalize get-or-creates that
-  // channel and backfills this id so it's reused on later runs. Null until the
-  // first finalize that runs the Slack channel step.
+  // post the team announcement on staffing finalize. Backfilled by finalize/modal
+  // Save when the channel (named by slackChannelName) is get-or-created. Null
+  // until the first sync runs the Slack channel step.
   slackChannelId String?
+  // Human channel name (e.g. "project-alpha") — the SHARED source of truth edited
+  // on the project details page AND the staffing Finalize modal. Defaults to the
+  // slugified project name until set. Finalize/modal-Save get-or-creates this
+  // channel and backfills slackChannelId.
+  slackChannelName String?
 
   overviewPage Page? @relation("ProjectOverview", fields: [overviewPageId], references: [id])
   prdPage      Page? @relation("ProjectPRD", fields: [prdPageId], references: [id])


### PR DESCRIPTION
## What

Three improvements to the staffing Slack/GitHub automations:

### 1. Broader Slack invites
"Post roster to Slack" now invites **confirmed project members + all current-term Core + all Admin/staff** (deduped by synced `slackUserId`; members without one are skipped and counted in the result). The result message breaks down counts: `invited N (members M, core C, admin A)`.

### 2. Editable, shared channel name + team slug
The Slack channel name and GitHub team slug are now **editable in both the project details page and the Finalize modal**, pointing at the same stored value:
- New `Project.slackChannelName` (additive migration) — the shared source of truth. `slackChannelId` still holds the live channel id, backfilled when the channel is get-or-created. (`githubTeamSlug` was already shared.)
- The modal's fields get **Save** (persists to the Project without running automations, so the details page stays in sync — via a `saveFieldsOnly` path) and **Cancel**, separate from **Run**.
- Editing the channel name get-or-creates that channel on the next sync.

### 3. Term-wide Slack channel banner
A **full-width banner** on the staffing board (Core/Admin only) to get-or-create a **term channel** (e.g. `#26x`, editable name defaulting to the term code) and invite **all current-term Core + Admin/staff + everyone with a ProjectAssignment that term**.
- New `POST /api/staffing/term-channel` (`canManageStaffing`-gated) + a `staffing.term_channel` audit action.

## Schema / migration
New nullable `Project.slackChannelName` — **additive, no data loss**. Migration committed with the schema change.

## Test plan
- `npm run typecheck` — clean.
- Needs `SLACK_BOT_TOKEN` (+ `GITHUB_ORG` for the team step) on staging to verify the live invite/channel/team calls; env-not-set paths report "skipped"/error cleanly.
- Per-project finalize: edit channel/slug → **Save** persists (details page reflects it); **Run** invites confirmed + Core + Admin and get-or-creates the channel/team.
- Term banner: **Create + invite** get-or-creates `#<term>` and invites Core + Admin + all project-assigned members.

## Notes
- Editing the Slack channel **name** to a new value switches/creates a different channel on sync (old one left as-is, members not migrated) — intended.
- Project-details Slack edit is metadata-only (no live Slack call); the channel materializes at finalize / modal Save.
- The migration applies to staging/prod via `migrate deploy`; not applied manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/809"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783646735&installation_id=133523038&pr_number=809&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F809&signature=e7a005bbae38796eb13e0c8103e0ab91b959bc4926061ebdbcc382dd61ad84f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->