### PR TITLE
Slack invite: resolve unlinked members by email and persist the id

### DIFF
--- a/dali-api/app/members/lib/slack-sync.server.ts
+++ b/dali-api/app/members/lib/slack-sync.server.ts
@@ -43,3 +43,65 @@ export async function syncSlackUserId(
   }
   return { status: "skipped", slackUserId: null };
 }
+
+// A user whose Slack id we want to resolve for a channel invite. slackUserId may
+// already be set (we use it as-is) or null (we look it up by email and persist).
+export type SlackInviteCandidate = {
+  id: string;
+  slackUserId: string | null;
+  daliEmail: string | null;
+  dartmouthEmail: string | null;
+  personalEmail: string | null;
+};
+
+// Resolve Slack ids for a set of users for a channel invite. For anyone already
+// linked, use their stored slackUserId. For anyone unlinked, look them up by
+// email (daliEmail → dartmouthEmail → personalEmail) and PERSIST the resolved id
+// to their User row so it's there next time — fixing the common case where most
+// members never visited Settings → Slack. Returns the deduped resolvable ids
+// plus the ids of users we couldn't resolve (no Slack account for any email).
+//
+// Best-effort: a lookup failure or a unique collision leaves that user
+// unresolved rather than throwing, so one bad email never blocks the invite.
+export async function resolveSlackIdsForInvite(
+  candidates: SlackInviteCandidate[],
+): Promise<{ slackIds: string[]; unresolvedUserIds: string[] }> {
+  // De-dupe by user id (Core/Admin/roster sets overlap).
+  const byId = new Map<string, SlackInviteCandidate>();
+  for (const c of candidates) if (!byId.has(c.id)) byId.set(c.id, c);
+
+  const slackIds = new Set<string>();
+  const unresolvedUserIds: string[] = [];
+
+  for (const u of byId.values()) {
+    if (u.slackUserId) {
+      slackIds.add(u.slackUserId);
+      continue;
+    }
+    const emails = [u.daliEmail, u.dartmouthEmail, u.personalEmail].filter(
+      (e): e is string => !!e,
+    );
+    let resolved: string | null = null;
+    for (const email of emails) {
+      const id = await lookupSlackUserByEmail(email);
+      if (id) {
+        resolved = id;
+        break;
+      }
+    }
+    if (!resolved) {
+      unresolvedUserIds.push(u.id);
+      continue;
+    }
+    // Persist for next time; tolerate a unique collision (another user already
+    // mapped to this id) by still using the id for THIS invite.
+    try {
+      await prisma.user.update({ where: { id: u.id }, data: { slackUserId: resolved } });
+    } catch {
+      // leave stored value as-is; we still invite by the resolved id below.
+    }
+    slackIds.add(resolved);
+  }
+
+  return { slackIds: [...slackIds], unresolvedUserIds };
+}

--- a/dali-api/app/projects/routes/api.staffing.finalize.ts
+++ b/dali-api/app/projects/routes/api.staffing.finalize.ts
@@ -4,6 +4,7 @@ import { requireAuth } from "~/lib/auth";
 import { canManageStaffing } from "~/lib/roles";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { postMessage, ensureChannel, inviteUsersToChannel } from "~/slack/lib/slack-client";
+import { resolveSlackIdsForInvite } from "~/members/lib/slack-sync.server";
 import { ensureTeam, addTeamMember } from "~/lib/github";
 import {
   workspaceConfigured,
@@ -36,6 +37,15 @@ import { publishCycleChange } from "../lib/staffing-events.server";
 //                  "skipped" when the Admin SDK isn't configured.
 //   - github:      get-or-create the project's GITHUB_ORG team (from
 //                  Project.githubTeamSlug) and add the confirmed roster.
+
+// The User fields resolveSlackIdsForInvite needs: stored id + emails to look up.
+const SLACK_INVITE_USER_SELECT = {
+  id: true,
+  slackUserId: true,
+  daliEmail: true,
+  dartmouthEmail: true,
+  personalEmail: true,
+} as const;
 
 const AUTOMATIONS = ["assignments", "slack", "gmail", "github"] as const;
 type Automation = (typeof AUTOMATIONS)[number];
@@ -287,7 +297,17 @@ export async function action({ request }: Route.ActionArgs) {
           select: {
             level: true,
             domainId: true,
-            user: { select: { firstName: true, lastName: true, slackUserId: true } },
+            user: {
+              select: {
+                id: true,
+                firstName: true,
+                lastName: true,
+                slackUserId: true,
+                daliEmail: true,
+                dartmouthEmail: true,
+                personalEmail: true,
+              },
+            },
           },
         });
         const domainNames = new Map(
@@ -320,22 +340,25 @@ export async function action({ request }: Route.ActionArgs) {
         }
 
         // 2. Build the invite set: confirmed roster + all current-term Core + all
-        //    Admin/staff. Each resolved to a synced slackUserId; nulls dropped and
-        //    counted per group so the lead sees who's missing a Slack account.
+        //    Admin/staff. resolveSlackIdsForInvite uses each user's stored
+        //    slackUserId, OR looks it up by email and persists it for next time —
+        //    so members who never visited Settings → Slack still get invited.
         const [coreRows, adminRows] = await Promise.all([
           prisma.coreAssignment.findMany({
             where: { termId: cycle.termId },
-            select: { user: { select: { slackUserId: true } } },
+            select: { user: { select: SLACK_INVITE_USER_SELECT } },
           }),
           prisma.adminMembership.findMany({
-            select: { user: { select: { slackUserId: true } } },
+            select: { user: { select: SLACK_INVITE_USER_SELECT } },
           }),
         ]);
-        const memberIds = roster.map((r) => r.user.slackUserId).filter((id): id is string => !!id);
-        const coreIds = coreRows.map((r) => r.user.slackUserId).filter((id): id is string => !!id);
-        const adminIds = adminRows.map((r) => r.user.slackUserId).filter((id): id is string => !!id);
-        const slackIds = [...new Set([...memberIds, ...coreIds, ...adminIds])];
-        const missingMembers = roster.length - memberIds.length;
+        const candidates = [
+          ...roster.map((r) => r.user),
+          ...coreRows.map((r) => r.user),
+          ...adminRows.map((r) => r.user),
+        ];
+        const { slackIds, unresolvedUserIds } = await resolveSlackIdsForInvite(candidates);
+        const missingMembers = unresolvedUserIds.length;
         const inv = await inviteUsersToChannel(channelId, slackIds);
 
         // 3. Announce the team: name — domain (level), plus repos.
@@ -355,10 +378,12 @@ export async function action({ request }: Route.ActionArgs) {
 
         const parts = [
           channelNote,
-          `invited ${inv.invited} (members ${memberIds.length}, core ${coreIds.length}, admin ${adminIds.length})`,
+          `invited ${inv.invited} (members + core + admin)`,
           `announced ${roster.length} member(s)`,
         ];
-        if (missingMembers > 0) parts.push(`${missingMembers} member(s) without a synced Slack id`);
+        if (missingMembers > 0) {
+          parts.push(`${missingMembers} without a Slack account (no email match)`);
+        }
         results.slack = { status: "ok", message: `${parts.join("; ")}.` };
       } catch (err) {
         results.slack = { status: "error", message: errMsg(err) };

--- a/dali-api/app/projects/routes/api.staffing.term-channel.ts
+++ b/dali-api/app/projects/routes/api.staffing.term-channel.ts
@@ -4,6 +4,7 @@ import { requireAuth } from "~/lib/auth";
 import { canManageStaffing } from "~/lib/roles";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { ensureChannel, inviteUsersToChannel } from "~/slack/lib/slack-client";
+import { resolveSlackIdsForInvite } from "~/members/lib/slack-sync.server";
 import { logAuditEvent } from "~/lib/audit";
 
 // POST /api/staffing/term-channel
@@ -66,39 +67,47 @@ export async function action({ request }: Route.ActionArgs) {
 
   try {
     // Invite set: current-term Core + all Admin/staff + everyone with a
-    // ProjectAssignment this term. Resolve to synced slackUserIds; nulls dropped
-    // and counted per group so the lead sees who's missing a Slack account.
+    // ProjectAssignment this term. resolveSlackIdsForInvite uses each user's
+    // stored slackUserId, OR looks it up by email and persists it for next time —
+    // so members who never linked Slack still get invited.
+    const userSelect = {
+      id: true,
+      slackUserId: true,
+      daliEmail: true,
+      dartmouthEmail: true,
+      personalEmail: true,
+    } as const;
     const [coreRows, adminRows, assignmentRows] = await Promise.all([
       prisma.coreAssignment.findMany({
         where: { termId: term.id },
-        select: { user: { select: { slackUserId: true } } },
+        select: { user: { select: userSelect } },
       }),
       prisma.adminMembership.findMany({
-        select: { user: { select: { slackUserId: true } } },
+        select: { user: { select: userSelect } },
       }),
       prisma.projectAssignment.findMany({
         where: { termId: term.id },
-        select: { user: { select: { slackUserId: true } } },
+        select: { user: { select: userSelect } },
       }),
     ]);
-    const coreIds = coreRows.map((r) => r.user.slackUserId).filter((id): id is string => !!id);
-    const adminIds = adminRows.map((r) => r.user.slackUserId).filter((id): id is string => !!id);
-    const memberIds = assignmentRows
-      .map((r) => r.user.slackUserId)
-      .filter((id): id is string => !!id);
-    const slackIds = [...new Set([...coreIds, ...adminIds, ...memberIds])];
+    const candidates = [
+      ...coreRows.map((r) => r.user),
+      ...adminRows.map((r) => r.user),
+      ...assignmentRows.map((r) => r.user),
+    ];
+    const { slackIds, unresolvedUserIds } = await resolveSlackIdsForInvite(candidates);
 
     const desiredName = body.channel?.trim() || term.code;
     const ch = await ensureChannel(desiredName);
     const inv = await inviteUsersToChannel(ch.id, slackIds);
 
-    const missingTotal =
-      coreRows.length + adminRows.length + assignmentRows.length - slackIds.length;
     const parts = [
       ch.created ? `created #${ch.name}` : `found #${ch.name}`,
-      `invited ${inv.invited} (core ${coreIds.length}, admin ${adminIds.length}, project members ${memberIds.length})`,
+      `invited ${inv.invited} (core + admin + project members)`,
     ];
-    if (missingTotal > 0) parts.push(`some without a synced Slack id`);
+    if (unresolvedUserIds.length > 0) {
+      parts.push(`${unresolvedUserIds.length} without a Slack account (no email match)`);
+    }
 
     await logAuditEvent({
       action: "staffing.term_channel",


### PR DESCRIPTION
## Problem

The staffing Slack invites (per-project finalize + the term channel) only invited members whose `slackUserId` was already stored. On a project where most members never visited **Settings → Slack**, only the one linked member got added.

**Concrete case:** Make101 has a 6-person confirmed roster, but only Petros has a linked Slack id — so the invite added only Petros and silently skipped the other 5.

## Fix

New `resolveSlackIdsForInvite()` (in `slack-sync.server.ts`): for anyone **without** a stored `slackUserId`, look it up by email (`daliEmail → dartmouthEmail → personalEmail`) at invite time, **persist** the resolved id to their `User` row for next time, and invite them.

- Best-effort: a failed lookup or a unique collision leaves that user unresolved rather than throwing — one bad email never blocks the invite.
- Anyone with no Slack account matching any email is reported as unresolved (count in the result message).
- De-dupes across the Core / Admin / roster sets.

Wired into both invite paths:
- the per-project **"Post roster to Slack"** finalize step
- the **term-channel** endpoint

Now a member is invited as long as their DALI email matches a Slack account — even if they never linked Slack manually — and the lookup only happens once per person (the id is saved).

## Test plan
- `npm run typecheck` — clean.
- Needs `SLACK_BOT_TOKEN` with `users:read.email` on staging to verify live resolution.
- Run finalize Slack on a project whose roster is mostly unlinked (e.g. Make101) → confirm everyone with a matching Slack email is now invited, and their `slackUserId` is backfilled.

## Note
Depends on #809 (merged) — builds on the term-channel endpoint + finalize Slack invite-set it introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/811"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783647912&installation_id=133523038&pr_number=811&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F811&signature=d975a1b7e5e738457d4b9d3f514bf758dcea40dd92f1c227d9cf883a97fc92a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->