### PR TITLE
ci: move runners to blacksmith-2vcpu-ubuntu-2404

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   build-api:
     name: Build API
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v4
       - uses: superfly/flyctl-actions/setup-flyctl@master

--- a/.github/workflows/claude-auto-merge.yml
+++ b/.github/workflows/claude-auto-merge.yml
@@ -26,7 +26,7 @@ concurrency:
 
 jobs:
   scan:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     outputs:
       conflicts: ${{ steps.scan.outputs.conflicts }}
     steps:
@@ -128,7 +128,7 @@ jobs:
   resolve:
     needs: scan
     if: needs.scan.outputs.conflicts != '[]' && needs.scan.outputs.conflicts != ''
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/claude-ci-fix.yml
+++ b/.github/workflows/claude-ci-fix.yml
@@ -36,7 +36,7 @@ jobs:
     if: >
       github.event.workflow_run.event == 'pull_request' &&
       startsWith(github.event.workflow_run.head_branch, 'claude/issue-')
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 30
     concurrency:
       group: claude-ci-${{ github.event.workflow_run.head_sha }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -46,7 +46,7 @@ jobs:
       github.event_name == 'issues' &&
       github.event.action == 'labeled' &&
       github.event.label.name == 'claude'
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v6
         with:
@@ -92,7 +92,7 @@ jobs:
       contains(github.event.comment.body, '@claude') &&
       !startsWith(github.event.comment.body, '/implement') &&
       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v6
         with:
@@ -137,7 +137,7 @@ jobs:
       !github.event.issue.pull_request &&
       startsWith(github.event.comment.body, '/implement') &&
       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v6
         with:
@@ -233,7 +233,7 @@ jobs:
       github.event.review.state == 'changes_requested' &&
       startsWith(github.event.pull_request.head.ref, 'claude/issue-') &&
       github.event.sender.type != 'Bot'
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - name: Mint App token (so pushes trigger downstream workflows)
         id: app-token

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,7 +27,7 @@ jobs:
     #   - https://gh.io/supported-runners-and-hardware-resources
     #   - https://gh.io/using-larger-runners (GitHub.com only)
     # Consider using larger runners or machines with greater resources for possible analysis time improvements.
-    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'blacksmith-2vcpu-ubuntu-2404' }}
     permissions:
       # required for all workflows
       security-events: write

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   prep-neon-db:
     name: Prepare Neon database (${{ github.ref_name }})
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     if: github.ref_name == 'dev' || github.ref_name == 'staging'
     steps:
       - name: Wipe dev database
@@ -50,7 +50,7 @@ jobs:
     name: Deploy API (${{ github.ref_name }})
     needs: [prep-neon-db]
     if: always() && (needs.prep-neon-db.result == 'success' || needs.prep-neon-db.result == 'skipped')
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v4
       - uses: superfly/flyctl-actions/setup-flyctl@master

--- a/.github/workflows/migration-check.yml
+++ b/.github/workflows/migration-check.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   migration-check:
     name: Check migrations
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
 
     services:
       postgres:

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -19,7 +19,7 @@ jobs:
   prep-neon-db:
     name: Prepare Neon branch (preview-pr-${{ github.event.pull_request.number }})
     if: github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     outputs:
       branch_id: ${{ steps.connect.outputs.branch_id }}
     steps:
@@ -99,7 +99,7 @@ jobs:
     name: Deploy API (dali-api-pr-${{ github.event.pull_request.number }})
     needs: [prep-neon-db]
     if: github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     outputs:
       url: ${{ steps.urls.outputs.url }}
     steps:
@@ -260,7 +260,7 @@ jobs:
     name: Comment preview URL on PR
     needs: [deploy-api]
     if: github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     permissions:
       pull-requests: write
     steps:

--- a/.github/workflows/preview-sweeper.yml
+++ b/.github/workflows/preview-sweeper.yml
@@ -11,7 +11,7 @@ env:
 jobs:
   sweep:
     name: Destroy orphan previews
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     permissions:
       pull-requests: read
     steps:

--- a/.github/workflows/preview-teardown.yml
+++ b/.github/workflows/preview-teardown.yml
@@ -16,7 +16,7 @@ jobs:
   teardown:
     name: Destroy preview for PR #${{ github.event.pull_request.number }}
     if: github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: superfly/flyctl-actions/setup-flyctl@master
 

--- a/.github/workflows/promote-to-prod.yml
+++ b/.github/workflows/promote-to-prod.yml
@@ -18,7 +18,7 @@ jobs:
     if: |
       github.event.issue.pull_request != null &&
       startsWith(github.event.comment.body, '/push')
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     permissions:
       contents: read
       pull-requests: write
@@ -107,7 +107,7 @@ jobs:
 
   promote:
     needs: check
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/promote-to-staging.yml
+++ b/.github/workflows/promote-to-staging.yml
@@ -18,7 +18,7 @@ jobs:
     if: |
       github.event.issue.pull_request != null &&
       startsWith(github.event.comment.body, '/push')
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     permissions:
       contents: read
       pull-requests: write
@@ -107,7 +107,7 @@ jobs:
 
   promote:
     needs: check
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/sync-lockfiles.yml
+++ b/.github/workflows/sync-lockfiles.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   sync-lockfiles:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     permissions:
       contents: write
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test-api:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     defaults:
       run:
         working-directory: dali-api
@@ -22,7 +22,7 @@ jobs:
       - run: npm test
 
   e2e-api:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     defaults:
       run:
         working-directory: dali-api


### PR DESCRIPTION
## Summary
- Swaps every `runs-on: ubuntu-latest` in `.github/workflows/` to `blacksmith-2vcpu-ubuntu-2404` (24 occurrences across 14 workflows).
- `codeql.yml` keeps `macos-latest` for the Swift matrix branch; only the Ubuntu side moves.

## Heads-up
- Requires the Blacksmith GitHub App to be installed on the org/repo. If it isn't, jobs will queue and never pick up — check that before merging.

## Test plan
- [ ] Confirm Blacksmith app is installed for `dali-lab/dali-os`
- [ ] Watch this PR's CI checks (test, build-check, migration-check, codeql, preview-deploy) actually start and complete on Blacksmith
- [ ] Spot-check job timings vs. recent `dev` runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/813"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783650158&installation_id=133523038&pr_number=813&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F813&signature=15d63b086c2566bb95d14aa5113d526d79ae88d3572869e75eeb6711a69f0115"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->