### PR TITLE
Tasks: deep-link from GitHub mirror to the task modal

### DIFF
--- a/dali-api/app/projects/components/TaskBoard.tsx
+++ b/dali-api/app/projects/components/TaskBoard.tsx
@@ -1,4 +1,5 @@
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
+import { useSearchParams } from "react-router";
 import { DndContext, useDraggable, useDroppable, type DragEndEvent } from "@dnd-kit/core";
 import { GripVertical } from "lucide-react";
 import {
@@ -36,7 +37,25 @@ export function TaskBoard({ projectId, initialTasks, options, canManage }: Props
   const [tasks, setTasks] = useState<TaskCardModel[]>(initialTasks);
   const [error, setError] = useState<string | null>(null);
   const [isCreating, setIsCreating] = useState(false);
-  const [openTaskId, setOpenTaskId] = useState<string | null>(null);
+
+  // The open task is tracked in the URL (`?task=<id>`) so GitHub issue mirrors
+  // and other external links can deep-link straight to a task.
+  const [searchParams, setSearchParams] = useSearchParams();
+  const openTaskId = searchParams.get("task");
+  const setOpenTaskId = useCallback(
+    (id: string | null) => {
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          if (id) next.set("task", id);
+          else next.delete("task");
+          return next;
+        },
+        { replace: true, preventScrollReset: true },
+      );
+    },
+    [setSearchParams],
+  );
 
   const board = useMemo(() => buildTaskBoard(tasks), [tasks]);
   const openTask = openTaskId ? tasks.find((t) => t.id === openTaskId) ?? null : null;

--- a/dali-api/app/projects/lib/github-task-sync.ts
+++ b/dali-api/app/projects/lib/github-task-sync.ts
@@ -82,7 +82,7 @@ export async function createIssueForTask(taskId: string, repoInput: string): Pro
     const gh = githubAppClient();
 
     const { assignees, missing } = resolveAssignees(task.assignees);
-    const body = `Tracked in dalios: ${appBaseUrl()}/projects/${task.projectId}/tasks/${task.id}`;
+    const body = `Tracked in dalios: ${appBaseUrl()}/projects/${task.projectId}?tab=work&task=${task.id}`;
 
     const res = await gh.rest.issues.create({
       owner,


### PR DESCRIPTION
## Summary
- The \"Tracked in dalios\" comment on mirrored GitHub issues linked to `/projects/<id>/tasks/<id>`, which 404s — `TaskBoard` kept the open task in local React state with no URL binding.
- Bind `openTaskId` to a `task` search param on `TaskBoard` (using `useSearchParams`, `replace: true`, `preventScrollReset: true`) so the modal opens straight from a URL and closes back to a clean URL.
- Update `github-task-sync.ts` to emit `…/projects/<id>?tab=work&task=<id>` so the link lands on the work tab with the task open.

Existing mirrored issues still carry the old URL — re-syncing them isn't part of this change. New issues created after merge will get the working link.

## Test plan
- [ ] On a project's work tab, click a task — URL gains `?tab=work&task=<id>`; refreshing reopens the modal.
- [ ] Close the modal — `task` param is removed, `tab=work` stays.
- [ ] Create a new task on a project linked to a GitHub repo; click the link in the auto-generated issue comment → lands on the work tab with that task's modal open.
- [ ] Visit `…?tab=work&task=<bogus-id>` — board renders, modal stays closed (no crash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/817"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783652074&installation_id=133523038&pr_number=817&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F817&signature=62c8efc72ecec0e9642d7ed5ed85a5dbdb056e3777fc48fb6756770a10594c99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->