### PR TITLE
Staffing finalize: retry Google group adds + actionable integration errors

### DIFF
--- a/dali-api/app/lib/google-workspace.ts
+++ b/dali-api/app/lib/google-workspace.ts
@@ -235,33 +235,52 @@ export type GroupMemberResult =
   | { status: "error"; message: string };
 
 // Add a member (by email) to a group. Idempotent: a 409 (already a member) is
-// reported as { added: false } success. A 404 surfaces as an error (the group
-// or member email doesn't resolve) so the caller can report it.
+// reported as { added: false } success.
+//
+// A freshly-created group isn't immediately addressable by its email
+// (groupKey) — Google Directory propagates it over a few seconds, so the FIRST
+// finalize (which created the group) would 404 ("Resource Not Found: groupKey")
+// when adding members. We retry the 404 a few times with backoff to ride out
+// that propagation lag; a persistent 404 (or any other error) is returned so the
+// caller can report it.
 export async function addGroupMember(args: {
   groupEmail: string;
   memberEmail: string;
 }): Promise<GroupMemberResult> {
+  // ~0.5 + 1 + 2 + 4 + 8 = 15.5s of total backoff across the retries — enough to
+  // cover typical group-propagation lag without hanging the finalize for long.
+  const backoffsMs = [500, 1000, 2000, 4000, 8000];
   try {
     const token = await getAccessToken();
-    const res = await fetch(
-      `${DIRECTORY_GROUPS_URL}/${encodeURIComponent(args.groupEmail)}/members`,
-      {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${token}`,
-          "Content-Type": "application/json",
+    for (let attempt = 0; ; attempt++) {
+      const res = await fetch(
+        `${DIRECTORY_GROUPS_URL}/${encodeURIComponent(args.groupEmail)}/members`,
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ email: args.memberEmail, role: "MEMBER" }),
         },
-        body: JSON.stringify({ email: args.memberEmail, role: "MEMBER" }),
-      },
-    );
-    if (res.status === 409) {
-      return { status: "ok", added: false };
-    }
-    if (!res.ok) {
+      );
+      if (res.status === 409) {
+        return { status: "ok", added: false };
+      }
+      if (res.ok) {
+        return { status: "ok", added: true };
+      }
       const body = await res.text();
+      // Retry only the group-not-yet-propagated 404 (groupKey), and only while
+      // we have backoff budget left.
+      const isGroupKeyNotFound =
+        res.status === 404 && /groupKey/i.test(body);
+      if (isGroupKeyNotFound && attempt < backoffsMs.length) {
+        await new Promise((r) => setTimeout(r, backoffsMs[attempt]));
+        continue;
+      }
       return { status: "error", message: `Directory API ${res.status}: ${body.slice(0, 200)}` };
     }
-    return { status: "ok", added: true };
   } catch (err) {
     return {
       status: "error",

--- a/dali-api/app/projects/routes/api.staffing.finalize.ts
+++ b/dali-api/app/projects/routes/api.staffing.finalize.ts
@@ -569,5 +569,17 @@ export async function action({ request }: Route.ActionArgs) {
 }
 
 function errMsg(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
+  const raw = err instanceof Error ? err.message : String(err);
+  // Append an actionable hint for the common integration-config failures so a
+  // lead can self-diagnose without reading API docs.
+  if (/missing_scope/i.test(raw)) {
+    return `${raw} — the Slack bot token is missing a scope. Needs channels:manage + channels:read (create/invite), chat:write (announce), and users:read.email (resolve members). Add them in the Slack app config and reinstall.`;
+  }
+  if (/not_in_channel|channel_not_found/i.test(raw)) {
+    return `${raw} — the Slack bot isn't a member of that channel. Invite the bot to it, or let finalize create the channel.`;
+  }
+  if (/\bNot Found\b/.test(raw) && /teams\/members/.test(raw)) {
+    return `${raw} — couldn't add a GitHub team member. Check that the GitHub App is installed on GITHUB_ORG with the "Members: read & write" org permission, and that each member's githubUsername is a real GitHub login.`;
+  }
+  return raw;
 }

--- a/dali-api/app/projects/routes/api.staffing.term-channel.ts
+++ b/dali-api/app/projects/routes/api.staffing.term-channel.ts
@@ -27,7 +27,14 @@ function isBody(x: unknown): x is Body {
 }
 
 function errMsg(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
+  const raw = err instanceof Error ? err.message : String(err);
+  if (/missing_scope/i.test(raw)) {
+    return `${raw} — the Slack bot token is missing a scope. Needs channels:manage + channels:read (create/invite), chat:write, and users:read.email. Add them in the Slack app config and reinstall.`;
+  }
+  if (/not_in_channel|channel_not_found/i.test(raw)) {
+    return `${raw} — the Slack bot isn't a member of that channel.`;
+  }
+  return raw;
 }
 
 export async function action({ request }: Route.ActionArgs) {


### PR DESCRIPTION
## Context

Running the finalize automations on staging surfaced real failures. Most are external **config** (Slack bot scopes, GitHub App org permission), but one is a code bug. This PR fixes the code bug and makes the config ones legible.

## Fixes

### 1. Gmail: retry group-member adds through propagation lag (real bug)
A freshly-created Google Workspace group isn't immediately addressable by its email — Directory API propagates it over a few seconds. So the **first** finalize (which creates the group) 404'd with `Resource Not Found: groupKey` when it then tried to add members.

`addGroupMember` now **retries that specific 404 with backoff** (~15s total: 0.5/1/2/4/8s) to ride out the lag. A persistent 404, or any other error, still surfaces. (A re-run previously "fixed" it because the group had propagated by then — now the first run works.)

### 2. Actionable error messages (UX)
So a lead can self-diagnose config issues without reading API docs:
- **Slack `missing_scope`** → "the Slack bot token is missing a scope. Needs channels:manage + channels:read, chat:write, users:read.email. Add them and reinstall."
- **GitHub team-members `Not Found`** → "check the GitHub App is installed on GITHUB_ORG with **Members: Read & write** org permission, and each githubUsername is a real login."

Applied to both the per-project finalize Slack/GitHub steps and the term-channel endpoint.

## Not in scope (config, on the deployer)
- Slack: the bot token needs the scopes above (then reinstall).
- GitHub: the App needs **Organization permissions → Members → Read & write**, re-approved by an org owner, and installed on `GITHUB_ORG`.

## Test plan
- `npm run typecheck` — clean.
- On staging with a configured Google Workspace: a first-time project finalize now adds members instead of 404ing (the group create + member add succeed in one run).
- Trigger a Slack/GitHub failure → the result message now includes the actionable hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/818"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783717782&installation_id=133523038&pr_number=818&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F818&signature=f5cf011b60e73af2bd09dd1412f963116f4dd15df477c3be4a91a2dd23a1c751"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->