### PR TITLE
Staffing finalize: harden Slack channel resolution + integration error messages

### DIFF
--- a/dali-api/app/lib/google-workspace.ts
+++ b/dali-api/app/lib/google-workspace.ts
@@ -235,33 +235,52 @@ export type GroupMemberResult =
   | { status: "error"; message: string };
 
 // Add a member (by email) to a group. Idempotent: a 409 (already a member) is
-// reported as { added: false } success. A 404 surfaces as an error (the group
-// or member email doesn't resolve) so the caller can report it.
+// reported as { added: false } success.
+//
+// A freshly-created group isn't immediately addressable by its email
+// (groupKey) — Google Directory propagates it over a few seconds, so the FIRST
+// finalize (which created the group) would 404 ("Resource Not Found: groupKey")
+// when adding members. We retry the 404 a few times with backoff to ride out
+// that propagation lag; a persistent 404 (or any other error) is returned so the
+// caller can report it.
 export async function addGroupMember(args: {
   groupEmail: string;
   memberEmail: string;
 }): Promise<GroupMemberResult> {
+  // ~0.5 + 1 + 2 + 4 + 8 = 15.5s of total backoff across the retries — enough to
+  // cover typical group-propagation lag without hanging the finalize for long.
+  const backoffsMs = [500, 1000, 2000, 4000, 8000];
   try {
     const token = await getAccessToken();
-    const res = await fetch(
-      `${DIRECTORY_GROUPS_URL}/${encodeURIComponent(args.groupEmail)}/members`,
-      {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${token}`,
-          "Content-Type": "application/json",
+    for (let attempt = 0; ; attempt++) {
+      const res = await fetch(
+        `${DIRECTORY_GROUPS_URL}/${encodeURIComponent(args.groupEmail)}/members`,
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ email: args.memberEmail, role: "MEMBER" }),
         },
-        body: JSON.stringify({ email: args.memberEmail, role: "MEMBER" }),
-      },
-    );
-    if (res.status === 409) {
-      return { status: "ok", added: false };
-    }
-    if (!res.ok) {
+      );
+      if (res.status === 409) {
+        return { status: "ok", added: false };
+      }
+      if (res.ok) {
+        return { status: "ok", added: true };
+      }
       const body = await res.text();
+      // Retry only the group-not-yet-propagated 404 (groupKey), and only while
+      // we have backoff budget left.
+      const isGroupKeyNotFound =
+        res.status === 404 && /groupKey/i.test(body);
+      if (isGroupKeyNotFound && attempt < backoffsMs.length) {
+        await new Promise((r) => setTimeout(r, backoffsMs[attempt]));
+        continue;
+      }
       return { status: "error", message: `Directory API ${res.status}: ${body.slice(0, 200)}` };
     }
-    return { status: "ok", added: true };
   } catch (err) {
     return {
       status: "error",

--- a/dali-api/app/projects/routes/api.staffing.finalize.ts
+++ b/dali-api/app/projects/routes/api.staffing.finalize.ts
@@ -569,5 +569,17 @@ export async function action({ request }: Route.ActionArgs) {
 }
 
 function errMsg(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
+  const raw = err instanceof Error ? err.message : String(err);
+  // Append an actionable hint for the common integration-config failures so a
+  // lead can self-diagnose without reading API docs.
+  if (/missing_scope/i.test(raw)) {
+    return `${raw} — the Slack bot token is missing a scope. Needs channels:manage + channels:read (create/invite), chat:write (announce), and users:read.email (resolve members). Add them in the Slack app config and reinstall.`;
+  }
+  if (/not_in_channel|channel_not_found/i.test(raw)) {
+    return `${raw} — the Slack bot isn't a member of that channel. Invite the bot to it, or let finalize create the channel.`;
+  }
+  if (/\bNot Found\b/.test(raw) && /teams\/members/.test(raw)) {
+    return `${raw} — couldn't add a GitHub team member. Check that the GitHub App is installed on GITHUB_ORG with the "Members: read & write" org permission, and that each member's githubUsername is a real GitHub login.`;
+  }
+  return raw;
 }

--- a/dali-api/app/projects/routes/api.staffing.finalize.ts
+++ b/dali-api/app/projects/routes/api.staffing.finalize.ts
@@ -3,7 +3,12 @@ import { prisma } from "~/lib/db";
 import { requireAuth } from "~/lib/auth";
 import { canManageStaffing } from "~/lib/roles";
 import { withCors, handlePreflight } from "~/lib/cors";
-import { postMessage, ensureChannel, inviteUsersToChannel } from "~/slack/lib/slack-client";
+import {
+  postMessage,
+  ensureChannel,
+  inviteUsersToChannel,
+  slackMissingScopeMsg,
+} from "~/slack/lib/slack-client";
 import { resolveSlackIdsForInvite } from "~/members/lib/slack-sync.server";
 import { ensureTeam, addTeamMember } from "~/lib/github";
 import {
@@ -573,7 +578,7 @@ function errMsg(err: unknown): string {
   // Append an actionable hint for the common integration-config failures so a
   // lead can self-diagnose without reading API docs.
   if (/missing_scope/i.test(raw)) {
-    return `${raw} — the Slack bot token is missing a scope. Needs channels:manage + channels:read (create/invite), chat:write (announce), and users:read.email (resolve members). Add them in the Slack app config and reinstall.`;
+    return slackMissingScopeMsg(err, raw);
   }
   if (/not_in_channel|channel_not_found/i.test(raw)) {
     return `${raw} — the Slack bot isn't a member of that channel. Invite the bot to it, or let finalize create the channel.`;

--- a/dali-api/app/projects/routes/api.staffing.term-channel.ts
+++ b/dali-api/app/projects/routes/api.staffing.term-channel.ts
@@ -3,7 +3,7 @@ import { prisma } from "~/lib/db";
 import { requireAuth } from "~/lib/auth";
 import { canManageStaffing } from "~/lib/roles";
 import { withCors, handlePreflight } from "~/lib/cors";
-import { ensureChannel, inviteUsersToChannel } from "~/slack/lib/slack-client";
+import { ensureChannel, inviteUsersToChannel, slackMissingScopeMsg } from "~/slack/lib/slack-client";
 import { resolveSlackIdsForInvite } from "~/members/lib/slack-sync.server";
 import { logAuditEvent } from "~/lib/audit";
 
@@ -29,7 +29,7 @@ function isBody(x: unknown): x is Body {
 function errMsg(err: unknown): string {
   const raw = err instanceof Error ? err.message : String(err);
   if (/missing_scope/i.test(raw)) {
-    return `${raw} — the Slack bot token is missing a scope. Needs channels:manage + channels:read (create/invite), chat:write, and users:read.email. Add them in the Slack app config and reinstall.`;
+    return slackMissingScopeMsg(err, raw);
   }
   if (/not_in_channel|channel_not_found/i.test(raw)) {
     return `${raw} — the Slack bot isn't a member of that channel.`;

--- a/dali-api/app/projects/routes/api.staffing.term-channel.ts
+++ b/dali-api/app/projects/routes/api.staffing.term-channel.ts
@@ -27,7 +27,14 @@ function isBody(x: unknown): x is Body {
 }
 
 function errMsg(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
+  const raw = err instanceof Error ? err.message : String(err);
+  if (/missing_scope/i.test(raw)) {
+    return `${raw} — the Slack bot token is missing a scope. Needs channels:manage + channels:read (create/invite), chat:write, and users:read.email. Add them in the Slack app config and reinstall.`;
+  }
+  if (/not_in_channel|channel_not_found/i.test(raw)) {
+    return `${raw} — the Slack bot isn't a member of that channel.`;
+  }
+  return raw;
 }
 
 export async function action({ request }: Route.ActionArgs) {

--- a/dali-api/app/slack/lib/slack-client.ts
+++ b/dali-api/app/slack/lib/slack-client.ts
@@ -154,7 +154,23 @@ export async function ensureChannel(
     const msg = err instanceof Error ? err.message : String(err);
     if (/name_taken/.test(msg)) {
       const existing = await findChannelByName(safe);
-      if (existing) return { ...existing, created: false };
+      if (existing) {
+        // An archived channel keeps its name reserved (so create still reports
+        // name_taken) but can't be posted to or invited to until reopened.
+        // Unarchive it so the rest of the finalize flow works; needs
+        // channels:manage, which the same get-or-create path already requires.
+        if (existing.archived) {
+          await client().conversations.unarchive({ channel: existing.id });
+        }
+        return { id: existing.id, name: existing.name, created: false };
+      }
+      // Name is taken but we couldn't resolve the channel — almost always a
+      // missing channels:read scope (listing returned nothing) rather than a
+      // truly missing channel. Say so instead of bubbling a bare name_taken.
+      throw new Error(
+        `${msg} — a channel named "${safe}" already exists but couldn't be resolved. ` +
+          `The Slack bot likely needs the channels:read (and groups:read for private channels) scope to look it up.`,
+      );
     }
     throw err;
   }
@@ -180,6 +196,25 @@ export async function inviteUsersToChannel(
   }
 }
 
+// Build an actionable message for a Slack missing_scope failure. Slack's
+// PlatformError carries the raw API response on `err.data`, which for
+// missing_scope includes `needed` (the exact scope this call required) and
+// `provided` (what the token actually has). Surfacing `needed` points the lead
+// at the ONE scope to add, instead of a static guess-list of every scope the
+// feature ever uses — the common confusion when most of the list is already
+// granted (e.g. the channel-resolve path needs channels:read specifically).
+export function slackMissingScopeMsg(err: unknown, raw: string): string {
+  const data =
+    typeof err === "object" && err !== null && "data" in err
+      ? (err as { data?: { needed?: string; provided?: string } }).data
+      : undefined;
+  const needed = data?.needed?.trim();
+  if (needed) {
+    return `${raw} — the Slack bot token is missing the "${needed}" scope. Add it in the Slack app config (Bot Token Scopes) and reinstall the app to the workspace.`;
+  }
+  return `${raw} — the Slack bot token is missing a required scope. Check the call's needed scope in the Slack app config (Bot Token Scopes) and reinstall.`;
+}
+
 function sanitizeChannelName(name: string): string {
   // Slack channel names: lowercase, no spaces/periods, ≤80 chars, hyphens ok.
   return name
@@ -191,19 +226,24 @@ function sanitizeChannelName(name: string): string {
 
 async function findChannelByName(
   name: string,
-): Promise<{ id: string; name: string } | null> {
-  // Page through public channels to find an exact name match. Small workspaces
-  // resolve in one page; we cap at a few pages to bound the call.
+): Promise<{ id: string; name: string; archived: boolean } | null> {
+  // Page through channels to find an exact name match. conversations.create
+  // reports name_taken for ARCHIVED and PRIVATE channels too, so the resolve
+  // fallback must look at those — otherwise a re-used name (the common case for
+  // a channel "shared with the project page") fails with a raw name_taken even
+  // though we could have found it. Include archived + private channels in the
+  // listing; exclude_archived defaults to false so archived ones are returned.
   let cursor: string | undefined;
   for (let i = 0; i < 10; i++) {
     const res = await client().conversations.list({
-      exclude_archived: true,
-      types: "public_channel",
+      types: "public_channel,private_channel",
       limit: 1000,
       cursor,
     });
     const match = (res.channels ?? []).find((c) => c.name === name);
-    if (match?.id) return { id: match.id, name: match.name ?? name };
+    if (match?.id) {
+      return { id: match.id, name: match.name ?? name, archived: !!match.is_archived };
+    }
     cursor = res.response_metadata?.next_cursor || undefined;
     if (!cursor) break;
   }


### PR DESCRIPTION
## Summary

Fixes the "Post roster to Slack" finalize step failing on real Slack workspaces with misleading errors, plus a related Google-group retry/error-message pass.

### Slack channel resolution (this change)
- **`name_taken` now resolves the existing channel reliably.** `ensureChannel`'s fallback only listed *non-archived public* channels, so a re-used channel name — archived, private, or "shared with the project page" — fell through to `null` and re-threw a bare `name_taken`. `findChannelByName` now lists public **and** private channels and includes archived ones; an archived match is **unarchived** before use (needs `channels:manage`, already required by this path).
- **Unresolvable name_taken gives an actionable message** naming the likely-missing `channels:read` / `groups:read` scope, instead of a bare `name_taken`.
- **`missing_scope` now reports Slack's actual `needed` scope** (from `err.data.needed`) via a shared `slackMissingScopeMsg` helper, replacing the static guess-list that pointed leads at scopes they already had. Used by both the finalize and term-channel routes.

### Prior commit on this branch
- Staffing finalize: retry Google group adds + actionable integration errors.

## Scope notes for reviewers
- Listing **private** channels in the resolve fallback requires the bot's `groups:read` scope; the workspace currently grants `groups:history` but not `groups:read`. Public + archived public channels resolve fine without it; private-channel resolution will need that scope added. The new error message calls this out.
- No schema/migration changes. No collab-doc changes.

## Testing
- `npm run typecheck` — no errors in the edited files (pre-existing errors remain only under `scripts/`).
- `npm test app/members/__tests__/slack-sync.server.test.ts` — 4 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/821"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783785937&installation_id=133523038&pr_number=821&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F821&signature=3b7fe4b981f9648c7a0035e790b0ad23b87ce0a11c333b40e157bc24d275eb48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->