### PR TITLE
Staffing finalize: harden Slack channel resolution + integration erro…

### DIFF
--- a/dali-api/app/projects/routes/api.staffing.finalize.ts
+++ b/dali-api/app/projects/routes/api.staffing.finalize.ts
@@ -3,7 +3,12 @@ import { prisma } from "~/lib/db";
 import { requireAuth } from "~/lib/auth";
 import { canManageStaffing } from "~/lib/roles";
 import { withCors, handlePreflight } from "~/lib/cors";
-import { postMessage, ensureChannel, inviteUsersToChannel } from "~/slack/lib/slack-client";
+import {
+  postMessage,
+  ensureChannel,
+  inviteUsersToChannel,
+  slackMissingScopeMsg,
+} from "~/slack/lib/slack-client";
 import { resolveSlackIdsForInvite } from "~/members/lib/slack-sync.server";
 import { ensureTeam, addTeamMember } from "~/lib/github";
 import {
@@ -573,7 +578,7 @@ function errMsg(err: unknown): string {
   // Append an actionable hint for the common integration-config failures so a
   // lead can self-diagnose without reading API docs.
   if (/missing_scope/i.test(raw)) {
-    return `${raw} — the Slack bot token is missing a scope. Needs channels:manage + channels:read (create/invite), chat:write (announce), and users:read.email (resolve members). Add them in the Slack app config and reinstall.`;
+    return slackMissingScopeMsg(err, raw);
   }
   if (/not_in_channel|channel_not_found/i.test(raw)) {
     return `${raw} — the Slack bot isn't a member of that channel. Invite the bot to it, or let finalize create the channel.`;

--- a/dali-api/app/projects/routes/api.staffing.term-channel.ts
+++ b/dali-api/app/projects/routes/api.staffing.term-channel.ts
@@ -3,7 +3,7 @@ import { prisma } from "~/lib/db";
 import { requireAuth } from "~/lib/auth";
 import { canManageStaffing } from "~/lib/roles";
 import { withCors, handlePreflight } from "~/lib/cors";
-import { ensureChannel, inviteUsersToChannel } from "~/slack/lib/slack-client";
+import { ensureChannel, inviteUsersToChannel, slackMissingScopeMsg } from "~/slack/lib/slack-client";
 import { resolveSlackIdsForInvite } from "~/members/lib/slack-sync.server";
 import { logAuditEvent } from "~/lib/audit";
 
@@ -29,7 +29,7 @@ function isBody(x: unknown): x is Body {
 function errMsg(err: unknown): string {
   const raw = err instanceof Error ? err.message : String(err);
   if (/missing_scope/i.test(raw)) {
-    return `${raw} — the Slack bot token is missing a scope. Needs channels:manage + channels:read (create/invite), chat:write, and users:read.email. Add them in the Slack app config and reinstall.`;
+    return slackMissingScopeMsg(err, raw);
   }
   if (/not_in_channel|channel_not_found/i.test(raw)) {
     return `${raw} — the Slack bot isn't a member of that channel.`;

--- a/dali-api/app/slack/lib/slack-client.ts
+++ b/dali-api/app/slack/lib/slack-client.ts
@@ -154,7 +154,23 @@ export async function ensureChannel(
     const msg = err instanceof Error ? err.message : String(err);
     if (/name_taken/.test(msg)) {
       const existing = await findChannelByName(safe);
-      if (existing) return { ...existing, created: false };
+      if (existing) {
+        // An archived channel keeps its name reserved (so create still reports
+        // name_taken) but can't be posted to or invited to until reopened.
+        // Unarchive it so the rest of the finalize flow works; needs
+        // channels:manage, which the same get-or-create path already requires.
+        if (existing.archived) {
+          await client().conversations.unarchive({ channel: existing.id });
+        }
+        return { id: existing.id, name: existing.name, created: false };
+      }
+      // Name is taken but we couldn't resolve the channel — almost always a
+      // missing channels:read scope (listing returned nothing) rather than a
+      // truly missing channel. Say so instead of bubbling a bare name_taken.
+      throw new Error(
+        `${msg} — a channel named "${safe}" already exists but couldn't be resolved. ` +
+          `The Slack bot likely needs the channels:read (and groups:read for private channels) scope to look it up.`,
+      );
     }
     throw err;
   }
@@ -180,6 +196,25 @@ export async function inviteUsersToChannel(
   }
 }
 
+// Build an actionable message for a Slack missing_scope failure. Slack's
+// PlatformError carries the raw API response on `err.data`, which for
+// missing_scope includes `needed` (the exact scope this call required) and
+// `provided` (what the token actually has). Surfacing `needed` points the lead
+// at the ONE scope to add, instead of a static guess-list of every scope the
+// feature ever uses — the common confusion when most of the list is already
+// granted (e.g. the channel-resolve path needs channels:read specifically).
+export function slackMissingScopeMsg(err: unknown, raw: string): string {
+  const data =
+    typeof err === "object" && err !== null && "data" in err
+      ? (err as { data?: { needed?: string; provided?: string } }).data
+      : undefined;
+  const needed = data?.needed?.trim();
+  if (needed) {
+    return `${raw} — the Slack bot token is missing the "${needed}" scope. Add it in the Slack app config (Bot Token Scopes) and reinstall the app to the workspace.`;
+  }
+  return `${raw} — the Slack bot token is missing a required scope. Check the call's needed scope in the Slack app config (Bot Token Scopes) and reinstall.`;
+}
+
 function sanitizeChannelName(name: string): string {
   // Slack channel names: lowercase, no spaces/periods, ≤80 chars, hyphens ok.
   return name
@@ -191,19 +226,24 @@ function sanitizeChannelName(name: string): string {
 
 async function findChannelByName(
   name: string,
-): Promise<{ id: string; name: string } | null> {
-  // Page through public channels to find an exact name match. Small workspaces
-  // resolve in one page; we cap at a few pages to bound the call.
+): Promise<{ id: string; name: string; archived: boolean } | null> {
+  // Page through channels to find an exact name match. conversations.create
+  // reports name_taken for ARCHIVED and PRIVATE channels too, so the resolve
+  // fallback must look at those — otherwise a re-used name (the common case for
+  // a channel "shared with the project page") fails with a raw name_taken even
+  // though we could have found it. Include archived + private channels in the
+  // listing; exclude_archived defaults to false so archived ones are returned.
   let cursor: string | undefined;
   for (let i = 0; i < 10; i++) {
     const res = await client().conversations.list({
-      exclude_archived: true,
-      types: "public_channel",
+      types: "public_channel,private_channel",
       limit: 1000,
       cursor,
     });
     const match = (res.channels ?? []).find((c) => c.name === name);
-    if (match?.id) return { id: match.id, name: match.name ?? name };
+    if (match?.id) {
+      return { id: match.id, name: match.name ?? name, archived: !!match.is_archived };
+    }
     cursor = res.response_metadata?.next_cursor || undefined;
     if (!cursor) break;
   }


### PR DESCRIPTION
…r messages (#821)

* Staffing finalize: retry Google group adds + actionable integration errors

Two reliability/UX fixes surfaced by running finalize on staging:

1. Gmail "Resource Not Found: groupKey" — a freshly-created Google group isn't immediately addressable by its email (Directory propagation lag), so the FIRST finalize (which creates the group) 404'd when adding members. addGroupMember now retries that specific 404 with backoff (~15s total) to ride out the lag; a persistent 404 or any other error still surfaces.

2. Clearer per-step error messages so config issues self-diagnose:
   - Slack "missing_scope" → names the scopes the bot needs (channels:manage + channels:read, chat:write, users:read.email) and says to reinstall.
   - GitHub team-members "Not Found" → points at the org "Members: Read & write" App permission + checking each githubUsername. Applied to both the per-project finalize and the term-channel endpoint.

No schema change. The Slack/GitHub failures themselves are external config (bot scopes / App org permission) — these just make them legible.



* Staffing Slack: resolve archived/private channels on name_taken; report exact missing scope

ensureChannel's name_taken fallback only listed non-archived public channels, so a re-used channel name (archived, private, or shared with the project page) fell through to null and re-threw a bare name_taken. Now findChannelByName lists public + private and includes archived channels, and an archived match is unarchived before use. When the name is taken but still unresolvable, the error names the likely-missing channels:read/groups:read scope instead of a bare name_taken.

Also surface Slack's actual `needed` scope from the missing_scope response (err.data.needed) via slackMissingScopeMsg, replacing the static guess-list that pointed leads at scopes they already had.



---------

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/823"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783787495&installation_id=133523038&pr_number=823&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F823&signature=0eff72f6d78d346de296ab94571706d83852c668670fbc44053ef91f230774dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->