### PR TITLE
Payroll export: admin CSV with project chart strings (#814)

### DIFF
--- a/dali-api/app/admin-console/lib/payroll-export.ts
+++ b/dali-api/app/admin-console/lib/payroll-export.ts
@@ -1,0 +1,181 @@
+import { prisma } from "~/lib/db";
+
+// ─── Constants per payroll spec ──────────────────────────────────────────────
+// Single hardcoded primary/secondary supervisor for the whole lab. Per spec,
+// every row gets these NetIDs. If supervisors ever differ per project, replace
+// with a per-project field on Project (mirroring chartString).
+export const PRIMARY_SUPERVISOR_NETID = "f0077bn";
+export const SECONDARY_SUPERVISOR_NETID = "d1207c2";
+export const ANTICIPATED_HOURS_PER_WEEK = "15";
+
+// 16-column header, order matters — Dartmouth payroll imports column-by-column.
+export const CSV_HEADERS = [
+  "Student NetID",
+  "Student First Name",
+  "Student Last Name",
+  "Job ID",
+  "Primary Supervisor NetID",
+  "Secondary Supervisor NetID",
+  "Hourly Wage",
+  "Anticipated Hours per week",
+  "Hire Start Date",
+  "Hire End Date",
+  "Chart String Type",
+  "Full Chart String",
+  "Student Phone Number",
+  "Term",
+  "Max Hours – PTO",
+  "Max Hours – Mental Health",
+] as const;
+
+export type PayrollRow = {
+  netId: string;
+  firstName: string;
+  lastName: string;
+  jobId: string;
+  hourlyWage: string;
+  hireStart: string;
+  hireEnd: string;
+  chartStringType: string;
+  chartString: string;
+  // Tracked for the preview UI so admins can spot misconfigured projects /
+  // missing job-code lookups before downloading. Omitted from CSV cells, where
+  // a missing value is just an empty string.
+  warnings: string[];
+};
+
+// RFC 4180 quoting: wrap in quotes if value contains a comma, quote, or newline;
+// double up internal quotes.
+function csvCell(raw: string): string {
+  if (raw === "") return "";
+  if (/[",\n\r]/.test(raw)) return `"${raw.replace(/"/g, '""')}"`;
+  return raw;
+}
+
+export function formatDate(d: Date): string {
+  // ISO YYYY-MM-DD; Dartmouth payroll accepts this format.
+  return d.toISOString().slice(0, 10);
+}
+
+// JobCodeLookup uses nullable `level` and `domainId` as wildcards. Match the
+// most specific row first: exact (level, domain) > level-only > domain-only >
+// wildcard. Returns null if nothing matches (admin should seed JobCodeLookup
+// before relying on the export).
+function resolveJobCode(
+  lookups: Array<{
+    level: string | null;
+    domainId: string | null;
+    jobCode: string;
+    payRateUsdHour: { toString(): string } | null;
+  }>,
+  level: string,
+  domainId: string,
+): { jobCode: string; hourlyWage: string } | null {
+  const candidates = lookups
+    .filter((l) => (l.level === null || l.level === level))
+    .filter((l) => (l.domainId === null || l.domainId === domainId));
+  if (candidates.length === 0) return null;
+  candidates.sort((a, b) => {
+    const specA = (a.level !== null ? 2 : 0) + (a.domainId !== null ? 1 : 0);
+    const specB = (b.level !== null ? 2 : 0) + (b.domainId !== null ? 1 : 0);
+    return specB - specA;
+  });
+  const best = candidates[0];
+  return {
+    jobCode: best.jobCode,
+    hourlyWage: best.payRateUsdHour ? best.payRateUsdHour.toString() : "",
+  };
+}
+
+export async function buildPayrollRows(termId: string): Promise<PayrollRow[]> {
+  const [assignments, jobLookups, term] = await Promise.all([
+    prisma.projectAssignment.findMany({
+      where: { termId },
+      include: {
+        user: { select: { netId: true, firstName: true, lastName: true } },
+        project: {
+          select: { name: true, chartStringType: true, chartString: true },
+        },
+      },
+      orderBy: [{ user: { lastName: "asc" } }, { user: { firstName: "asc" } }],
+    }),
+    prisma.jobCodeLookup.findMany({
+      where: { assignmentType: "Project" },
+      select: { level: true, domainId: true, jobCode: true, payRateUsdHour: true },
+    }),
+    prisma.term.findUnique({
+      where: { id: termId },
+      select: { startDate: true, endDate: true },
+    }),
+  ]);
+
+  if (!term) return [];
+
+  const hireStart = formatDate(term.startDate);
+  const hireEnd = formatDate(term.endDate);
+
+  return assignments.map((a) => {
+    const warnings: string[] = [];
+    const job = resolveJobCode(jobLookups, a.level, a.domainId);
+    if (!job) warnings.push(`No JobCodeLookup for level=${a.level}`);
+    if (!a.project.chartString) warnings.push("Project missing chartString");
+    if (!a.user.netId) warnings.push("User missing NetID");
+
+    return {
+      netId: a.user.netId ?? "",
+      firstName: a.user.firstName,
+      lastName: a.user.lastName,
+      jobId: job?.jobCode ?? "",
+      hourlyWage: job?.hourlyWage ?? "",
+      hireStart,
+      hireEnd,
+      chartStringType: a.project.chartStringType ?? "",
+      chartString: a.project.chartString ?? "",
+      warnings,
+    };
+  });
+}
+
+export function rowsToCsv(rows: PayrollRow[]): string {
+  const lines: string[] = [];
+  lines.push(CSV_HEADERS.map(csvCell).join(","));
+  for (const r of rows) {
+    lines.push(
+      [
+        r.netId,
+        r.firstName,
+        r.lastName,
+        r.jobId,
+        PRIMARY_SUPERVISOR_NETID,
+        SECONDARY_SUPERVISOR_NETID,
+        r.hourlyWage,
+        ANTICIPATED_HOURS_PER_WEEK,
+        r.hireStart,
+        r.hireEnd,
+        r.chartStringType,
+        r.chartString,
+        "", // Student Phone Number — blank per spec
+        "", // Term — blank per spec
+        "", // Max Hours – PTO — blank per spec
+        "", // Max Hours – Mental Health — blank per spec
+      ]
+        .map(csvCell)
+        .join(","),
+    );
+  }
+  // RFC 4180 uses CRLF; payroll importers handle either, CRLF is safer for
+  // Excel on Windows.
+  return lines.join("\r\n") + "\r\n";
+}
+
+// Picks the term that contains today, falling back to the most recent term.
+// Shared so the page and the CSV route default to the same selection when no
+// explicit termId is on the URL.
+export function pickDefaultTermId(
+  terms: { id: string; startDate: Date; endDate: Date }[],
+  now: Date = new Date(),
+): string | null {
+  if (terms.length === 0) return null;
+  const current = terms.find((t) => t.startDate <= now && now <= t.endDate);
+  return (current ?? terms[0]).id;
+}

--- a/dali-api/app/admin-console/routes/admin-console.payroll-export.csv.ts
+++ b/dali-api/app/admin-console/routes/admin-console.payroll-export.csv.ts
@@ -1,0 +1,55 @@
+import type { Route } from "./+types/admin-console.payroll-export.csv";
+import { redirect } from "react-router";
+import { prisma } from "~/lib/db";
+import { requireAuth } from "~/lib/auth";
+import { isAdmin } from "~/lib/roles";
+import {
+  buildPayrollRows,
+  formatDate,
+  pickDefaultTermId,
+  rowsToCsv,
+} from "~/admin-console/lib/payroll-export";
+
+// Resource route — no default export, no layout wrapping. Returning a Response
+// from a route that's nested under the app layout would have the layout shell
+// rendered around it (i.e. an HTML page wrapping a CSV body). Splitting the
+// download into its own resource route under a non-layout path keeps it as a
+// pure byte stream.
+
+export async function loader({ request }: Route.LoaderArgs) {
+  const auth = await requireAuth(request);
+  if (!auth.ok) return redirect("/login");
+  if (!(await isAdmin(auth.user.sub))) {
+    return new Response("Forbidden", { status: 403 });
+  }
+
+  const url = new URL(request.url);
+  const requestedTermId = url.searchParams.get("termId");
+
+  const terms = await prisma.term.findMany({
+    orderBy: { sortKey: "desc" },
+    select: { id: true, code: true, startDate: true, endDate: true },
+  });
+
+  const selectedTermId =
+    (requestedTermId && terms.some((t) => t.id === requestedTermId)
+      ? requestedTermId
+      : pickDefaultTermId(terms));
+  const selectedTerm = terms.find((t) => t.id === selectedTermId);
+  if (!selectedTerm) {
+    return new Response("No terms available", { status: 404 });
+  }
+
+  const rows = await buildPayrollRows(selectedTerm.id);
+  const csv = rowsToCsv(rows);
+  const filename = `payroll-${selectedTerm.code}-${formatDate(new Date())}.csv`;
+
+  return new Response(csv, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/csv; charset=utf-8",
+      "Content-Disposition": `attachment; filename="${filename}"`,
+      "Cache-Control": "no-store",
+    },
+  });
+}

--- a/dali-api/app/admin-console/routes/admin-console.payroll-export.tsx
+++ b/dali-api/app/admin-console/routes/admin-console.payroll-export.tsx
@@ -1,0 +1,188 @@
+import { Form, redirect, useLoaderData, useSearchParams } from "react-router";
+import type { Route } from "./+types/admin-console.payroll-export";
+import { prisma } from "~/lib/db";
+import { requireAuth } from "~/lib/auth";
+import { isAdmin } from "~/lib/roles";
+import { Download, FileDown, AlertTriangle } from "lucide-react";
+import {
+  buildPayrollRows,
+  pickDefaultTermId,
+  type PayrollRow,
+} from "~/admin-console/lib/payroll-export";
+
+export const meta: Route.MetaFunction = () => [
+  { title: "Payroll export · Operations · DALI OS" },
+];
+
+// The CSV itself is served by the sibling resource route at
+// /admin-console/payroll-export.csv (no layout wrapping), so the Download
+// button is a plain link to that URL.
+
+export async function loader({ request }: Route.LoaderArgs) {
+  const auth = await requireAuth(request);
+  if (!auth.ok) return redirect("/login");
+  if (!(await isAdmin(auth.user.sub))) return redirect("/admin-console/members");
+
+  const url = new URL(request.url);
+  const requestedTermId = url.searchParams.get("termId");
+
+  const terms = await prisma.term.findMany({
+    orderBy: { sortKey: "desc" },
+    select: { id: true, code: true, startDate: true, endDate: true },
+  });
+
+  const selectedTermId =
+    (requestedTermId && terms.some((t) => t.id === requestedTermId)
+      ? requestedTermId
+      : pickDefaultTermId(terms));
+  const selectedTerm = terms.find((t) => t.id === selectedTermId);
+
+  if (!selectedTerm) {
+    return { terms: [], selectedTermId: null, rows: [] as PayrollRow[] };
+  }
+
+  const rows = await buildPayrollRows(selectedTerm.id);
+
+  return {
+    terms: terms.map((t) => ({ id: t.id, code: t.code })),
+    selectedTermId: selectedTerm.id,
+    selectedTermCode: selectedTerm.code,
+    rows,
+  };
+}
+
+export default function PayrollExport() {
+  const data = useLoaderData<typeof loader>();
+  const [searchParams] = useSearchParams();
+
+  if (!("rows" in data) || !data.selectedTermId) {
+    return (
+      <div className="space-y-4">
+        <header className="flex items-center gap-3">
+          <FileDown className="w-6 h-6 text-foreground/80" />
+          <h1 className="text-2xl font-bold text-foreground">Payroll export</h1>
+        </header>
+        <p className="text-sm text-muted-foreground">
+          No terms found. Seed Terms before generating a payroll export.
+        </p>
+      </div>
+    );
+  }
+
+  const { terms, selectedTermId, selectedTermCode, rows } = data;
+  const rowsWithWarnings = rows.filter((r) => r.warnings.length > 0).length;
+  const csvHref = `/admin-console/payroll-export.csv?termId=${encodeURIComponent(selectedTermId)}`;
+
+  return (
+    <div className="space-y-6">
+      <header className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center gap-3">
+          <FileDown className="w-6 h-6 text-foreground/80" />
+          <h1 className="text-2xl font-bold text-foreground">Payroll export</h1>
+          <span className="px-2.5 py-0.5 rounded-full text-xs font-medium bg-muted text-muted-foreground">
+            {rows.length} {rows.length === 1 ? "row" : "rows"}
+          </span>
+        </div>
+        <div className="flex items-center gap-3">
+          <Form method="get" className="flex items-center gap-2">
+            <label htmlFor="termId" className="text-sm text-muted-foreground">
+              Term
+            </label>
+            <select
+              id="termId"
+              name="termId"
+              defaultValue={selectedTermId}
+              onChange={(e) => e.currentTarget.form?.submit()}
+              className="px-3 py-1.5 text-sm border border-border rounded-md bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+            >
+              {terms.map((t) => (
+                <option key={t.id} value={t.id}>
+                  {t.code}
+                </option>
+              ))}
+            </select>
+            {/* Preserve any other params on submit (none today, future-proof). */}
+            {Array.from(searchParams.entries())
+              .filter(([k]) => k !== "termId")
+              .map(([k, v]) => (
+                <input key={k} type="hidden" name={k} value={v} />
+              ))}
+          </Form>
+          <a
+            href={csvHref}
+            download
+            // reloadDocument tells React Router not to intercept this link as a
+            // client navigation. The browser does a real GET to the resource
+            // route, which streams the CSV with Content-Disposition: attachment.
+            data-discover="false"
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-md bg-gray-900 text-white hover:bg-gray-800 transition-colors"
+          >
+            <Download className="w-4 h-4" /> Download CSV
+          </a>
+        </div>
+      </header>
+
+      <p className="text-sm text-muted-foreground">
+        One row per project assignment in <strong>{selectedTermCode}</strong>.
+        Primary supervisor, secondary supervisor, and anticipated hours per
+        week are constants; phone, term, and max-hours columns are intentionally
+        blank per the payroll spec.
+      </p>
+
+      {rowsWithWarnings > 0 && (
+        <div className="flex items-start gap-2 bg-amber-50 border border-amber-200 text-amber-900 text-sm rounded-md px-3 py-2">
+          <AlertTriangle className="w-4 h-4 mt-0.5 flex-shrink-0" />
+          <span>
+            {rowsWithWarnings} {rowsWithWarnings === 1 ? "row has" : "rows have"}{" "}
+            missing data (see the warnings column). The CSV will still download —
+            those cells will be empty.
+          </span>
+        </div>
+      )}
+
+      <div className="bg-card border border-border rounded-lg overflow-x-auto">
+        <table className="w-full text-xs min-w-[1100px]">
+          <thead>
+            <tr className="border-b border-border bg-muted/50">
+              <th className="text-left px-3 py-2 font-medium text-muted-foreground">NetID</th>
+              <th className="text-left px-3 py-2 font-medium text-muted-foreground">Name</th>
+              <th className="text-left px-3 py-2 font-medium text-muted-foreground">Job ID</th>
+              <th className="text-left px-3 py-2 font-medium text-muted-foreground">Wage</th>
+              <th className="text-left px-3 py-2 font-medium text-muted-foreground">Hire Start</th>
+              <th className="text-left px-3 py-2 font-medium text-muted-foreground">Hire End</th>
+              <th className="text-left px-3 py-2 font-medium text-muted-foreground">Chart Type</th>
+              <th className="text-left px-3 py-2 font-medium text-muted-foreground">Chart String</th>
+              <th className="text-left px-3 py-2 font-medium text-muted-foreground">Warnings</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border">
+            {rows.length === 0 && (
+              <tr>
+                <td colSpan={9} className="px-3 py-8 text-center text-muted-foreground/70">
+                  No project assignments for this term.
+                </td>
+              </tr>
+            )}
+            {rows.map((r, i) => (
+              <tr key={i} className="hover:bg-muted/50">
+                <td className="px-3 py-2 text-foreground font-mono">{r.netId || "—"}</td>
+                <td className="px-3 py-2 text-foreground">
+                  {r.firstName} {r.lastName}
+                </td>
+                <td className="px-3 py-2 text-foreground font-mono">{r.jobId || "—"}</td>
+                <td className="px-3 py-2 text-foreground">{r.hourlyWage || "—"}</td>
+                <td className="px-3 py-2 text-muted-foreground">{r.hireStart}</td>
+                <td className="px-3 py-2 text-muted-foreground">{r.hireEnd}</td>
+                <td className="px-3 py-2 text-foreground">{r.chartStringType || "—"}</td>
+                <td className="px-3 py-2 text-foreground font-mono break-all">{r.chartString || "—"}</td>
+                <td className="px-3 py-2 text-amber-700">
+                  {r.warnings.length > 0 ? r.warnings.join("; ") : ""}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/dali-api/app/components/Layout.tsx
+++ b/dali-api/app/components/Layout.tsx
@@ -360,6 +360,14 @@ export function Layout({ user, photoUrl, isCore = false, isAdmin = false, isDoma
       active: path.startsWith('/admin-console/analytics'),
       sub: null,
     },
+    {
+      label: 'Payroll export',
+      to: '/admin-console/payroll-export',
+      icon: FileText,
+      show: isAdmin,
+      active: path.startsWith('/admin-console/payroll-export'),
+      sub: null,
+    },
   ].filter((s) => s.show)
 
   const projectsSections = [

--- a/dali-api/app/projects/routes/projects.$id.tsx
+++ b/dali-api/app/projects/routes/projects.$id.tsx
@@ -97,6 +97,8 @@ export async function loader({ request, params }: Route.LoaderArgs) {
       deploymentUrl: true,
       githubTeamSlug: true,
       slackChannelName: true,
+      chartStringType: true,
+      chartString: true,
       overviewPageId: true,
       prdPageId: true,
       projectTerms: {
@@ -467,6 +469,8 @@ export async function loader({ request, params }: Route.LoaderArgs) {
       deploymentUrl: project.deploymentUrl,
       githubTeamSlug: project.githubTeamSlug,
       slackChannelName: project.slackChannelName,
+      chartStringType: project.chartStringType,
+      chartString: project.chartString,
       overviewPageId: project.overviewPageId,
       prdPageId: project.prdPageId,
       startTerm,
@@ -708,6 +712,16 @@ export async function action({ request, params }: Route.ActionArgs) {
   // falls back to 1 rather than erroring the whole form.
   const termCount = Math.max(1, Math.floor(Number(termCountRaw)) || 1);
 
+  // Payroll chart string — Core-only. Project members posting these fields
+  // are silently ignored rather than 403'd to keep the form forgiving.
+  const chartStringFields: { chartStringType?: string | null; chartString?: string | null } = {};
+  if (core) {
+    const chartStringTypeRaw = (form.get("chartStringType") as string | null)?.trim() ?? "";
+    const chartStringRaw = (form.get("chartString") as string | null)?.trim() ?? "";
+    chartStringFields.chartStringType = chartStringTypeRaw === "" ? null : chartStringTypeRaw;
+    chartStringFields.chartString = chartStringRaw === "" ? null : chartStringRaw;
+  }
+
   await prisma.project.update({
     where: { id: params.id },
     data: {
@@ -717,6 +731,7 @@ export async function action({ request, params }: Route.ActionArgs) {
       termCount,
       githubTeamSlug,
       slackChannelName,
+      ...chartStringFields,
     },
   });
   return redirect(`/projects/${params.id}`);
@@ -818,6 +833,7 @@ export default function ProjectDetail() {
           files={files}
           allTags={allTags}
           canEdit={canEdit}
+          canEditFinance={canEditScope}
           domainScopeGrid={domainScopeGrid}
           currentTerm={currentTerm}
           actionError={actionData?.error}
@@ -1346,9 +1362,11 @@ function TermsChipsEditor({
 function DetailsSegment({
   project,
   canEdit,
+  canEditFinance,
 }: {
   project: LoaderData["project"];
   canEdit: boolean;
+  canEditFinance: boolean;
 }) {
   const submit = useSubmit();
   const formRef = useRef<HTMLFormElement | null>(null);
@@ -1513,6 +1531,50 @@ function DetailsSegment({
               <span className="px-2 py-1.5 text-sm text-muted-foreground">—</span>
             )}
           </label>
+
+          {/* Payroll chart string — surfaced and editable only to Core (action
+              handler enforces the same gate). Read-only to project members. */}
+          {canEditFinance && (
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 pt-3 border-t border-border">
+              <label className="flex flex-col gap-1 text-xs sm:col-span-2">
+                <span className="text-muted-foreground font-medium">
+                  Payroll · used for payroll export
+                </span>
+              </label>
+              <label className="flex flex-col gap-1 text-xs">
+                <span className="text-muted-foreground">Chart string type</span>
+                {editing ? (
+                  <input
+                    name="chartStringType"
+                    type="text"
+                    defaultValue={project.chartStringType ?? ""}
+                    placeholder="e.g. Grant, Department"
+                    className="px-2 py-1.5 text-sm border border-border rounded-md bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-accent-coral/30"
+                  />
+                ) : (
+                  <span className="px-2 py-1.5 text-sm text-foreground">
+                    {project.chartStringType ?? "—"}
+                  </span>
+                )}
+              </label>
+              <label className="flex flex-col gap-1 text-xs">
+                <span className="text-muted-foreground">Full chart string</span>
+                {editing ? (
+                  <input
+                    name="chartString"
+                    type="text"
+                    defaultValue={project.chartString ?? ""}
+                    placeholder="full GL chart string"
+                    className="px-2 py-1.5 text-sm border border-border rounded-md bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-accent-coral/30 font-mono"
+                  />
+                ) : (
+                  <span className="px-2 py-1.5 text-sm text-foreground font-mono break-all">
+                    {project.chartString ?? "—"}
+                  </span>
+                )}
+              </label>
+            </div>
+          )}
         </Form>
       )}
     </EditableSection>
@@ -1685,6 +1747,7 @@ function OverviewTab({
   files,
   allTags,
   canEdit,
+  canEditFinance,
   domainScopeGrid,
   currentTerm,
   actionError,
@@ -1695,6 +1758,7 @@ function OverviewTab({
   files: LoaderData["files"];
   allTags: LoaderData["allTags"];
   canEdit: boolean;
+  canEditFinance: boolean;
   domainScopeGrid: LoaderData["domainScopeGrid"];
   currentTerm: LoaderData["currentTerm"];
   actionError?: string;
@@ -1746,7 +1810,11 @@ function OverviewTab({
           which expects the full field set. Section-level Save submits and
           closes; Cancel reverts (the wrapper remounts the body which resets
           defaultValue inputs). */}
-      <DetailsSegment project={project} canEdit={canEdit} />
+      <DetailsSegment
+        project={project}
+        canEdit={canEdit}
+        canEditFinance={canEditFinance}
+      />
 
       {/* Team — read-only summary, separate from the editable details. */}
       <section className="bg-card border border-border rounded-lg p-4">

--- a/dali-api/app/routes.ts
+++ b/dali-api/app/routes.ts
@@ -42,6 +42,7 @@ export default [
     route("admin-console/announcements", "admin-console/routes/admin-console.announcements.tsx"),
     route("admin-console/activity", "admin-console/routes/admin-console.activity.tsx"),
     route("admin-console/analytics", "admin-console/routes/admin-console.analytics.tsx"),
+    route("admin-console/payroll-export", "admin-console/routes/admin-console.payroll-export.tsx"),
 
     // Projects
     route("projects/list", "projects/routes/projects.list.tsx"),
@@ -250,6 +251,10 @@ export default [
 
   // Document export (server-rendered PDF / Word)
   route("documents/:pageId/export", "routes/documents.$pageId.export.ts"),
+
+  // Payroll CSV export (resource route — registered OUTSIDE the app layout so
+  // the Response streams as a bare CSV body, not wrapped in an HTML shell).
+  route("admin-console/payroll-export.csv", "admin-console/routes/admin-console.payroll-export.csv.ts"),
 
   // Partner application status (board drag-and-drop) + domain scope
   route("api/partner-applications/:id/status", "partners/routes/api.partner-applications.$id.status.ts"),

--- a/dali-api/prisma/migrations/20260609120000_project_chart_string/migration.sql
+++ b/dali-api/prisma/migrations/20260609120000_project_chart_string/migration.sql
@@ -1,0 +1,6 @@
+-- Dartmouth payroll chart string for each project. chartStringType is the GL
+-- account category (e.g. "Grant", "Department"); chartString is the full
+-- concatenated GL string. Both are admin-edited and surfaced in the payroll
+-- export. Nullable: admins backfill as projects come up for payroll.
+ALTER TABLE "Project" ADD COLUMN "chartStringType" TEXT;
+ALTER TABLE "Project" ADD COLUMN "chartString" TEXT;

--- a/dali-api/prisma/schema.prisma
+++ b/dali-api/prisma/schema.prisma
@@ -1901,6 +1901,13 @@ model Project {
   // channel and backfills slackChannelId.
   slackChannelName String?
 
+  // Dartmouth payroll chart string for this project. `chartStringType` is the
+  // GL account category (e.g. "Grant", "Department"); `chartString` is the
+  // full concatenated GL string. Both are admin-edited and surfaced in the
+  // payroll export. Null until an admin sets them.
+  chartStringType String?
+  chartString     String?
+
   overviewPage Page? @relation("ProjectOverview", fields: [overviewPageId], references: [id])
   prdPage      Page? @relation("ProjectPRD", fields: [prdPageId], references: [id])
 


### PR DESCRIPTION
* Payroll export: admin CSV with project chart strings

Adds an admin-only payroll export at /admin-console/payroll-export that emits one CSV row per ProjectAssignment in the selected term, in the 16-column shape Dartmouth payroll expects.

- Adds Project.chartStringType + Project.chartString; surfaced as a new "Payroll" section in the project Details segment, Core-only for both view and edit (action handler silently ignores writes from non-Core).
- Job ID + Hourly Wage resolved from JobCodeLookup (most-specific match by level/domain, with the schema's nullable-wildcard fallback).
- Primary/secondary supervisor and anticipated hours per week are hardcoded per spec; phone, term, and max-hours columns are blank.
- Preview table flags missing JobCodeLookup rows + projects without a chart string so admins can fix data before downloading.
- New admin-only sidebar entry under Operations.



* Payroll export: split CSV onto its own resource route

The .tsx route is nested under the app layout, so when its loader returned a text/csv Response React Router still rendered the layout shell around it — the download arrived as HTML wrapping the CSV body instead of a bare CSV stream.

Splits the CSV out to admin-console.payroll-export.csv.ts (no default export, registered outside the layout block) so the Response streams as-is. Shared row-building + RFC 4180 quoting move to ~/admin-console/lib/payroll-export.ts; the page route imports the same helpers for its preview table so the preview and the download stay guaranteed-identical.

Download button is now a plain link to /admin-console/payroll-export.csv rather than a ?format=csv variant of the page URL.



---------

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/824"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783872364&installation_id=133523038&pr_number=824&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F824&signature=4e69a7e38987edb422fa7c13cc82a2d68ee8d0d65eb6b156fe73dc676cbb8c5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->