### PR TITLE
Payroll export: opt-in Core + Instructor sections, with cycle-aware CoreAssignment fan-out

### DIFF
--- a/dali-api/app/admin-console/lib/payroll-export.ts
+++ b/dali-api/app/admin-console/lib/payroll-export.ts
@@ -8,6 +8,13 @@ export const PRIMARY_SUPERVISOR_NETID = "f0077bn";
 export const SECONDARY_SUPERVISOR_NETID = "d1207c2";
 export const ANTICIPATED_HOURS_PER_WEEK = "15";
 
+// Lab-wide chart string for non-project payroll (Core + Instructor). Project
+// rows pull their chart string from Project.chartString; these rows share one
+// internal funding line. Type left blank — payroll didn't specify one for
+// internal lines.
+export const CORE_INSTRUCTOR_CHART_STRING_TYPE = "";
+export const CORE_INSTRUCTOR_CHART_STRING = "18.722.161028.128512.3000";
+
 // 16-column header, order matters — Dartmouth payroll imports column-by-column.
 export const CSV_HEADERS = [
   "Student NetID",
@@ -85,6 +92,153 @@ function resolveJobCode(
     jobCode: best.jobCode,
     hourlyWage: best.payRateUsdHour ? best.payRateUsdHour.toString() : "",
   };
+}
+
+// Member candidate for the Core / Instructor checkbox sections on the export
+// page. One row per user per term (deduped across multiple Core titles or
+// multiple instructor offerings). `subtitle` is just for the UI — the lead
+// titles or offering names so admins can recognize who they're including.
+export type RoleCandidate = {
+  userId: string;
+  netId: string | null;
+  firstName: string;
+  lastName: string;
+  subtitle: string;
+};
+
+export async function listCoreCandidates(termId: string): Promise<RoleCandidate[]> {
+  const rows = await prisma.coreAssignment.findMany({
+    where: { termId },
+    select: {
+      userId: true,
+      leadTitle: true,
+      user: { select: { netId: true, firstName: true, lastName: true } },
+    },
+  });
+
+  const byUser = new Map<string, RoleCandidate & { titles: string[] }>();
+  for (const r of rows) {
+    const existing = byUser.get(r.userId);
+    if (existing) {
+      if (r.leadTitle) existing.titles.push(r.leadTitle);
+    } else {
+      byUser.set(r.userId, {
+        userId: r.userId,
+        netId: r.user.netId,
+        firstName: r.user.firstName,
+        lastName: r.user.lastName,
+        subtitle: "",
+        titles: r.leadTitle ? [r.leadTitle] : [],
+      });
+    }
+  }
+
+  return [...byUser.values()]
+    .map(({ titles, ...c }) => ({ ...c, subtitle: titles.join(", ") }))
+    .sort((a, b) =>
+      (a.lastName + a.firstName).localeCompare(b.lastName + b.firstName),
+    );
+}
+
+export async function listInstructorCandidates(termId: string): Promise<RoleCandidate[]> {
+  const rows = await prisma.instructorAssignment.findMany({
+    where: { termId },
+    select: {
+      userId: true,
+      user: { select: { netId: true, firstName: true, lastName: true } },
+      offering: { select: { title: true } },
+    },
+  });
+
+  const byUser = new Map<string, RoleCandidate & { offerings: string[] }>();
+  for (const r of rows) {
+    const existing = byUser.get(r.userId);
+    if (existing) {
+      existing.offerings.push(r.offering.title);
+    } else {
+      byUser.set(r.userId, {
+        userId: r.userId,
+        netId: r.user.netId,
+        firstName: r.user.firstName,
+        lastName: r.user.lastName,
+        subtitle: "",
+        offerings: [r.offering.title],
+      });
+    }
+  }
+
+  return [...byUser.values()]
+    .map(({ offerings, ...c }) => ({ ...c, subtitle: offerings.join(", ") }))
+    .sort((a, b) =>
+      (a.lastName + a.firstName).localeCompare(b.lastName + b.firstName),
+    );
+}
+
+// Shared helper for Core/Instructor row generation. Same shape as project
+// rows, but the chart string is the lab-wide internal line and the job code
+// comes from the (assignmentType, NULL level, NULL domain) wildcard row.
+async function buildNonProjectRows(
+  termId: string,
+  selectedUserIds: Set<string>,
+  candidates: RoleCandidate[],
+  assignmentType: "Core" | "Instructor",
+): Promise<PayrollRow[]> {
+  if (selectedUserIds.size === 0) return [];
+
+  const [jobLookups, term] = await Promise.all([
+    prisma.jobCodeLookup.findMany({
+      where: { assignmentType },
+      select: { level: true, domainId: true, jobCode: true, payRateUsdHour: true },
+    }),
+    prisma.term.findUnique({
+      where: { id: termId },
+      select: { startDate: true, endDate: true },
+    }),
+  ]);
+  if (!term) return [];
+
+  const hireStart = formatDate(term.startDate);
+  const hireEnd = formatDate(term.endDate);
+  // Core/Instructor lookups don't carry level or domain — pass empty strings
+  // and let the wildcard rows match.
+  const job = resolveJobCode(jobLookups, "", "");
+
+  return candidates
+    .filter((c) => selectedUserIds.has(c.userId))
+    .map((c) => {
+      const warnings: string[] = [];
+      if (!job) warnings.push(`No JobCodeLookup for ${assignmentType}`);
+      if (!c.netId) warnings.push("User missing NetID");
+
+      return {
+        netId: c.netId ?? "",
+        firstName: c.firstName,
+        lastName: c.lastName,
+        jobId: job?.jobCode ?? "",
+        hourlyWage: job?.hourlyWage ?? "",
+        hireStart,
+        hireEnd,
+        chartStringType: CORE_INSTRUCTOR_CHART_STRING_TYPE,
+        chartString: CORE_INSTRUCTOR_CHART_STRING,
+        warnings,
+      };
+    });
+}
+
+export async function buildCoreRows(
+  termId: string,
+  selectedUserIds: Set<string>,
+): Promise<PayrollRow[]> {
+  const candidates = await listCoreCandidates(termId);
+  return buildNonProjectRows(termId, selectedUserIds, candidates, "Core");
+}
+
+export async function buildInstructorRows(
+  termId: string,
+  selectedUserIds: Set<string>,
+): Promise<PayrollRow[]> {
+  const candidates = await listInstructorCandidates(termId);
+  return buildNonProjectRows(termId, selectedUserIds, candidates, "Instructor");
 }
 
 export async function buildPayrollRows(termId: string): Promise<PayrollRow[]> {

--- a/dali-api/app/admin-console/routes/admin-console.payroll-export.csv.ts
+++ b/dali-api/app/admin-console/routes/admin-console.payroll-export.csv.ts
@@ -4,11 +4,19 @@ import { prisma } from "~/lib/db";
 import { requireAuth } from "~/lib/auth";
 import { isAdmin } from "~/lib/roles";
 import {
+  buildCoreRows,
+  buildInstructorRows,
   buildPayrollRows,
   formatDate,
   pickDefaultTermId,
   rowsToCsv,
 } from "~/admin-console/lib/payroll-export";
+
+// Comma-separated user-id list → Set. Empty/null → empty set (= no rows).
+function parseIdList(raw: string | null): Set<string> {
+  if (!raw) return new Set();
+  return new Set(raw.split(",").map((s) => s.trim()).filter(Boolean));
+}
 
 // Resource route — no default export, no layout wrapping. Returning a Response
 // from a route that's nested under the app layout would have the layout shell
@@ -40,8 +48,17 @@ export async function loader({ request }: Route.LoaderArgs) {
     return new Response("No terms available", { status: 404 });
   }
 
-  const rows = await buildPayrollRows(selectedTerm.id);
-  const csv = rowsToCsv(rows);
+  // Project rows always included; Core + Instructor rows only for the
+  // user-ids the admin checked on the page (passed via ?core= / ?instructor=).
+  const coreIds = parseIdList(url.searchParams.get("core"));
+  const instructorIds = parseIdList(url.searchParams.get("instructor"));
+
+  const [projectRows, coreRows, instructorRows] = await Promise.all([
+    buildPayrollRows(selectedTerm.id),
+    buildCoreRows(selectedTerm.id, coreIds),
+    buildInstructorRows(selectedTerm.id, instructorIds),
+  ]);
+  const csv = rowsToCsv([...projectRows, ...coreRows, ...instructorRows]);
   const filename = `payroll-${selectedTerm.code}-${formatDate(new Date())}.csv`;
 
   return new Response(csv, {

--- a/dali-api/app/admin-console/routes/admin-console.payroll-export.tsx
+++ b/dali-api/app/admin-console/routes/admin-console.payroll-export.tsx
@@ -1,13 +1,17 @@
+import { useMemo, useState } from "react";
 import { Form, redirect, useLoaderData, useSearchParams } from "react-router";
 import type { Route } from "./+types/admin-console.payroll-export";
 import { prisma } from "~/lib/db";
 import { requireAuth } from "~/lib/auth";
 import { isAdmin } from "~/lib/roles";
-import { Download, FileDown, AlertTriangle } from "lucide-react";
+import { Download, FileDown, AlertTriangle, Users } from "lucide-react";
 import {
   buildPayrollRows,
+  listCoreCandidates,
+  listInstructorCandidates,
   pickDefaultTermId,
   type PayrollRow,
+  type RoleCandidate,
 } from "~/admin-console/lib/payroll-export";
 
 export const meta: Route.MetaFunction = () => [
@@ -38,16 +42,28 @@ export async function loader({ request }: Route.LoaderArgs) {
   const selectedTerm = terms.find((t) => t.id === selectedTermId);
 
   if (!selectedTerm) {
-    return { terms: [], selectedTermId: null, rows: [] as PayrollRow[] };
+    return {
+      terms: [],
+      selectedTermId: null,
+      projectRows: [] as PayrollRow[],
+      coreCandidates: [] as RoleCandidate[],
+      instructorCandidates: [] as RoleCandidate[],
+    };
   }
 
-  const rows = await buildPayrollRows(selectedTerm.id);
+  const [projectRows, coreCandidates, instructorCandidates] = await Promise.all([
+    buildPayrollRows(selectedTerm.id),
+    listCoreCandidates(selectedTerm.id),
+    listInstructorCandidates(selectedTerm.id),
+  ]);
 
   return {
     terms: terms.map((t) => ({ id: t.id, code: t.code })),
     selectedTermId: selectedTerm.id,
     selectedTermCode: selectedTerm.code,
-    rows,
+    projectRows,
+    coreCandidates,
+    instructorCandidates,
   };
 }
 
@@ -55,7 +71,17 @@ export default function PayrollExport() {
   const data = useLoaderData<typeof loader>();
   const [searchParams] = useSearchParams();
 
-  if (!("rows" in data) || !data.selectedTermId) {
+  // Selection state for the Core / Instructor checkbox sections. Default to
+  // every candidate checked — admins uncheck people who didn't work that
+  // term (Summer is the main case). State is not persisted across reloads.
+  const [coreSelected, setCoreSelected] = useState<Set<string>>(
+    () => new Set(("coreCandidates" in data ? data.coreCandidates : []).map((c) => c.userId)),
+  );
+  const [instructorSelected, setInstructorSelected] = useState<Set<string>>(
+    () => new Set(("instructorCandidates" in data ? data.instructorCandidates : []).map((c) => c.userId)),
+  );
+
+  if (!("projectRows" in data) || !data.selectedTermId) {
     return (
       <div className="space-y-4">
         <header className="flex items-center gap-3">
@@ -69,9 +95,26 @@ export default function PayrollExport() {
     );
   }
 
-  const { terms, selectedTermId, selectedTermCode, rows } = data;
-  const rowsWithWarnings = rows.filter((r) => r.warnings.length > 0).length;
-  const csvHref = `/admin-console/payroll-export.csv?termId=${encodeURIComponent(selectedTermId)}`;
+  const {
+    terms,
+    selectedTermId,
+    selectedTermCode,
+    projectRows,
+    coreCandidates,
+    instructorCandidates,
+  } = data;
+
+  const projectWarnings = projectRows.filter((r) => r.warnings.length > 0).length;
+  const totalRows =
+    projectRows.length + coreSelected.size + instructorSelected.size;
+
+  const csvHref = useMemo(() => {
+    const params = new URLSearchParams({ termId: selectedTermId });
+    if (coreSelected.size > 0) params.set("core", [...coreSelected].join(","));
+    if (instructorSelected.size > 0)
+      params.set("instructor", [...instructorSelected].join(","));
+    return `/admin-console/payroll-export.csv?${params.toString()}`;
+  }, [selectedTermId, coreSelected, instructorSelected]);
 
   return (
     <div className="space-y-6">
@@ -80,7 +123,7 @@ export default function PayrollExport() {
           <FileDown className="w-6 h-6 text-foreground/80" />
           <h1 className="text-2xl font-bold text-foreground">Payroll export</h1>
           <span className="px-2.5 py-0.5 rounded-full text-xs font-medium bg-muted text-muted-foreground">
-            {rows.length} {rows.length === 1 ? "row" : "rows"}
+            {totalRows} {totalRows === 1 ? "row" : "rows"}
           </span>
         </div>
         <div className="flex items-center gap-3">
@@ -111,9 +154,6 @@ export default function PayrollExport() {
           <a
             href={csvHref}
             download
-            // reloadDocument tells React Router not to intercept this link as a
-            // client navigation. The browser does a real GET to the resource
-            // route, which streams the CSV with Content-Disposition: attachment.
             data-discover="false"
             className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-md bg-gray-900 text-white hover:bg-gray-800 transition-colors"
           >
@@ -123,66 +163,194 @@ export default function PayrollExport() {
       </header>
 
       <p className="text-sm text-muted-foreground">
-        One row per project assignment in <strong>{selectedTermCode}</strong>.
-        Primary supervisor, secondary supervisor, and anticipated hours per
-        week are constants; phone, term, and max-hours columns are intentionally
-        blank per the payroll spec.
+        Project assignments are auto-included. Core and Instructor sections are
+        opt-in per member — uncheck anyone who isn't working in{" "}
+        <strong>{selectedTermCode}</strong>. Primary supervisor, secondary
+        supervisor, and anticipated hours/week are constants; phone, term, and
+        max-hours columns are intentionally blank per the payroll spec.
       </p>
 
-      {rowsWithWarnings > 0 && (
-        <div className="flex items-start gap-2 bg-amber-50 border border-amber-200 text-amber-900 text-sm rounded-md px-3 py-2">
-          <AlertTriangle className="w-4 h-4 mt-0.5 flex-shrink-0" />
-          <span>
-            {rowsWithWarnings} {rowsWithWarnings === 1 ? "row has" : "rows have"}{" "}
-            missing data (see the warnings column). The CSV will still download —
-            those cells will be empty.
+      {/* ─── Project section ──────────────────────────────────────────────── */}
+      <section className="space-y-2">
+        <header className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <h2 className="text-base font-semibold text-foreground">
+              Project assignments
+            </h2>
+            <span className="px-2 py-0.5 rounded-full text-xs font-medium bg-muted text-muted-foreground">
+              {projectRows.length}
+            </span>
+          </div>
+          {projectWarnings > 0 && (
+            <span className="inline-flex items-center gap-1 text-xs text-amber-700">
+              <AlertTriangle className="w-3.5 h-3.5" />
+              {projectWarnings} row{projectWarnings === 1 ? "" : "s"} with missing data
+            </span>
+          )}
+        </header>
+        <div className="bg-card border border-border rounded-lg overflow-x-auto">
+          <table className="w-full text-xs min-w-[1100px]">
+            <thead>
+              <tr className="border-b border-border bg-muted/50">
+                <th className="text-left px-3 py-2 font-medium text-muted-foreground">NetID</th>
+                <th className="text-left px-3 py-2 font-medium text-muted-foreground">Name</th>
+                <th className="text-left px-3 py-2 font-medium text-muted-foreground">Job ID</th>
+                <th className="text-left px-3 py-2 font-medium text-muted-foreground">Wage</th>
+                <th className="text-left px-3 py-2 font-medium text-muted-foreground">Hire Start</th>
+                <th className="text-left px-3 py-2 font-medium text-muted-foreground">Hire End</th>
+                <th className="text-left px-3 py-2 font-medium text-muted-foreground">Chart Type</th>
+                <th className="text-left px-3 py-2 font-medium text-muted-foreground">Chart String</th>
+                <th className="text-left px-3 py-2 font-medium text-muted-foreground">Warnings</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {projectRows.length === 0 && (
+                <tr>
+                  <td colSpan={9} className="px-3 py-8 text-center text-muted-foreground/70">
+                    No project assignments for this term.
+                  </td>
+                </tr>
+              )}
+              {projectRows.map((r, i) => (
+                <tr key={i} className="hover:bg-muted/50">
+                  <td className="px-3 py-2 text-foreground font-mono">{r.netId || "—"}</td>
+                  <td className="px-3 py-2 text-foreground">
+                    {r.firstName} {r.lastName}
+                  </td>
+                  <td className="px-3 py-2 text-foreground font-mono">{r.jobId || "—"}</td>
+                  <td className="px-3 py-2 text-foreground">{r.hourlyWage || "—"}</td>
+                  <td className="px-3 py-2 text-muted-foreground">{r.hireStart}</td>
+                  <td className="px-3 py-2 text-muted-foreground">{r.hireEnd}</td>
+                  <td className="px-3 py-2 text-foreground">{r.chartStringType || "—"}</td>
+                  <td className="px-3 py-2 text-foreground font-mono break-all">{r.chartString || "—"}</td>
+                  <td className="px-3 py-2 text-amber-700">
+                    {r.warnings.length > 0 ? r.warnings.join("; ") : ""}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <CandidateSection
+        title="Core"
+        candidates={coreCandidates}
+        selected={coreSelected}
+        setSelected={setCoreSelected}
+        emptyLabel="No Core assignments for this term."
+      />
+
+      <CandidateSection
+        title="Instructors"
+        candidates={instructorCandidates}
+        selected={instructorSelected}
+        setSelected={setInstructorSelected}
+        emptyLabel="No Instructor assignments for this term."
+      />
+    </div>
+  );
+}
+
+// Checkbox section for Core / Instructor candidates. Shows a small roster, a
+// Select all / Clear toggle, and per-row checkboxes. Selection state lives in
+// the parent and drives the CSV download URL.
+function CandidateSection({
+  title,
+  candidates,
+  selected,
+  setSelected,
+  emptyLabel,
+}: {
+  title: string;
+  candidates: RoleCandidate[];
+  selected: Set<string>;
+  setSelected: (s: Set<string>) => void;
+  emptyLabel: string;
+}) {
+  const allChecked = candidates.length > 0 && selected.size === candidates.length;
+
+  function toggle(userId: string) {
+    const next = new Set(selected);
+    if (next.has(userId)) next.delete(userId);
+    else next.add(userId);
+    setSelected(next);
+  }
+
+  function toggleAll() {
+    if (allChecked) setSelected(new Set());
+    else setSelected(new Set(candidates.map((c) => c.userId)));
+  }
+
+  return (
+    <section className="space-y-2">
+      <header className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Users className="w-4 h-4 text-foreground/70" />
+          <h2 className="text-base font-semibold text-foreground">{title}</h2>
+          <span className="px-2 py-0.5 rounded-full text-xs font-medium bg-muted text-muted-foreground">
+            {selected.size} of {candidates.length}
           </span>
         </div>
-      )}
-
+        {candidates.length > 0 && (
+          <button
+            type="button"
+            onClick={toggleAll}
+            className="text-xs font-medium text-accent-coral hover:underline"
+          >
+            {allChecked ? "Clear all" : "Select all"}
+          </button>
+        )}
+      </header>
       <div className="bg-card border border-border rounded-lg overflow-x-auto">
-        <table className="w-full text-xs min-w-[1100px]">
+        <table className="w-full text-xs">
           <thead>
             <tr className="border-b border-border bg-muted/50">
+              <th className="w-10 px-3 py-2"></th>
               <th className="text-left px-3 py-2 font-medium text-muted-foreground">NetID</th>
               <th className="text-left px-3 py-2 font-medium text-muted-foreground">Name</th>
-              <th className="text-left px-3 py-2 font-medium text-muted-foreground">Job ID</th>
-              <th className="text-left px-3 py-2 font-medium text-muted-foreground">Wage</th>
-              <th className="text-left px-3 py-2 font-medium text-muted-foreground">Hire Start</th>
-              <th className="text-left px-3 py-2 font-medium text-muted-foreground">Hire End</th>
-              <th className="text-left px-3 py-2 font-medium text-muted-foreground">Chart Type</th>
-              <th className="text-left px-3 py-2 font-medium text-muted-foreground">Chart String</th>
-              <th className="text-left px-3 py-2 font-medium text-muted-foreground">Warnings</th>
+              <th className="text-left px-3 py-2 font-medium text-muted-foreground">
+                {title === "Core" ? "Title(s)" : "Offering(s)"}
+              </th>
             </tr>
           </thead>
           <tbody className="divide-y divide-border">
-            {rows.length === 0 && (
+            {candidates.length === 0 && (
               <tr>
-                <td colSpan={9} className="px-3 py-8 text-center text-muted-foreground/70">
-                  No project assignments for this term.
+                <td colSpan={4} className="px-3 py-6 text-center text-muted-foreground/70">
+                  {emptyLabel}
                 </td>
               </tr>
             )}
-            {rows.map((r, i) => (
-              <tr key={i} className="hover:bg-muted/50">
-                <td className="px-3 py-2 text-foreground font-mono">{r.netId || "—"}</td>
-                <td className="px-3 py-2 text-foreground">
-                  {r.firstName} {r.lastName}
-                </td>
-                <td className="px-3 py-2 text-foreground font-mono">{r.jobId || "—"}</td>
-                <td className="px-3 py-2 text-foreground">{r.hourlyWage || "—"}</td>
-                <td className="px-3 py-2 text-muted-foreground">{r.hireStart}</td>
-                <td className="px-3 py-2 text-muted-foreground">{r.hireEnd}</td>
-                <td className="px-3 py-2 text-foreground">{r.chartStringType || "—"}</td>
-                <td className="px-3 py-2 text-foreground font-mono break-all">{r.chartString || "—"}</td>
-                <td className="px-3 py-2 text-amber-700">
-                  {r.warnings.length > 0 ? r.warnings.join("; ") : ""}
-                </td>
-              </tr>
-            ))}
+            {candidates.map((c) => {
+              const checked = selected.has(c.userId);
+              return (
+                <tr
+                  key={c.userId}
+                  className={`hover:bg-muted/50 ${checked ? "" : "opacity-50"}`}
+                >
+                  <td className="px-3 py-2">
+                    <input
+                      type="checkbox"
+                      checked={checked}
+                      onChange={() => toggle(c.userId)}
+                      aria-label={`Include ${c.firstName} ${c.lastName} in payroll export`}
+                      className="cursor-pointer"
+                    />
+                  </td>
+                  <td className="px-3 py-2 text-foreground font-mono">{c.netId || "—"}</td>
+                  <td className="px-3 py-2 text-foreground">
+                    {c.firstName} {c.lastName}
+                  </td>
+                  <td className="px-3 py-2 text-muted-foreground">
+                    {c.subtitle || "—"}
+                  </td>
+                </tr>
+              );
+            })}
           </tbody>
         </table>
       </div>
-    </div>
+    </section>
   );
 }


### PR DESCRIPTION
## Summary

Two related pieces:

### 1. Payroll export — Core + Instructor sections (the feature)
Core members and Instructors aren't tracked in `ProjectAssignment`, so the export missed them. The export page now has two checkbox sections (Core, Instructor) defaulting to every assignment for the selected term checked. Admins uncheck whoever isn't working (the Summer-term use case).

### 2. CoreAssignment cycle materialization (the underlying fix)
While building #1, the Core section came back empty for Summer because `CoreAssignment` rows were only ever written for the Spring term a Core member was elected in. The cycle rollover (#803) made `isCore` *derive* membership across the cycle at read time, but no other reader did, so every feature that queried CoreAssignment by termId (payroll, groups, staffing finalize, search) saw the roster as empty for Summer / Fall / next Winter.

This PR replaces the temporary "look up the Spring anchor in payroll" band-aid with a proper fix: every writer fans out across the cycle's 4 terms on add, and clears the matching `(userId, leadTitle)` across the cycle on remove. A backfill migration materializes the missing rows for everything that's already in the DB.

## CSV behavior (unchanged from the original payroll feature)

| Row source | Job ID | Wage | Chart String Type | Full Chart String |
|---|---|---|---|---|
| ProjectAssignment | `JobCodeLookup` by (Project, level, domain) | same | `Project.chartStringType` | `Project.chartString` |
| CoreAssignment (checked) | `JobCodeLookup` (Core, *, *) → `4890` | $20 | blank | `18.722.161028.128512.3000` |
| InstructorAssignment (checked) | `JobCodeLookup` (Instructor, *, *) → `7523` | $19 | blank | `18.722.161028.128512.3000` |

## Cycle materialization details

- **New helper** `app/lib/core-cycle.ts` exports `coreCycleTermIds(termId)` and `cycleSortKeyRange(sortKey)`. `roles.ts` imports the range helper instead of duplicating the cycle math.
- **Writers** updated:
  - `admin-console.members.tsx` `add-core-title` / `remove-core-title`: `createMany` across the cycle / cycle-scoped `deleteMany`.
  - `api.members.$memberId.roles.ts` Hiring Lead toggle: same pattern, inside the existing `$transaction`.
- **Backfill migration** `prisma/migrations/20260614000000_core_assignment_cycle_backfill` inserts the missing `(userId, termId, leadTitle)` triples across every cycle implied by existing rows. Idempotent via `NOT EXISTS` — safe to re-run, won't touch existing rows.
- **Band-aid revert**: `listCoreCandidates` in the payroll lib is back to a plain `where: { termId }` query.
- `isCore` / `getActiveCoreCycleTermIds` still implement the Spring outgoing-cycle handoff overlap rule. That's a *read-time* policy for one specific term (Spring), not a data shape concern.

## Test plan

### Payroll export
- [ ] Open `/admin-console/payroll-export`, pick a term that has CoreAssignments. Confirm the Core section lists every Core member for that term, all checked by default. Row count badge reflects projects + Core + Instructor.
- [ ] Uncheck two Core members. Download CSV. Confirm those two are NOT in the file but every other Core member is.
- [ ] Verify Core rows show Job ID `4890`, wage `20`, chart string `18.722.161028.128512.3000`.
- [ ] Switch terms with the picker. Confirm Core + Instructor candidate lists refresh and selection state resets to "all checked" for the new term.

### Cycle materialization
- [ ] Apply migration `20260614000000_core_assignment_cycle_backfill` on a preview env. Run `SELECT "termId", COUNT(*) FROM "CoreAssignment" GROUP BY "termId" ORDER BY 1;` and confirm Core counts now appear for non-Spring terms.
- [ ] As Core/Admin, open `/admin-console/members`, add a new Core title to a member. Verify rows were written for every term in the current cycle (`SELECT "termId" FROM "CoreAssignment" WHERE "userId" = '<id>' AND "leadTitle" = '<title>'`).
- [ ] Remove that title. Verify all cycle rows for that `(userId, leadTitle)` are gone.
- [ ] Confirm `isCore` still resolves correctly during a Spring term (handoff overlap with outgoing cycle should still pass).
- [ ] On the payroll export page, switch to a Summer / Fall / Winter term in the current cycle. Confirm Core section is populated.
- [ ] Re-run the backfill migration; row counts shouldn't change (idempotency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)