### PR TITLE
Projects: Core-only level patch for an existing assignment

### DIFF
--- a/dali-api/app/lib/audit.ts
+++ b/dali-api/app/lib/audit.ts
@@ -35,6 +35,7 @@ export const AUDIT_ACTIONS = [
   "staffing.board-member.add",
   "staffing.board-member.remove",
   "staffing.reorder",
+  "project.assignment.level",
   "slack.connect",
   "slack.disconnect",
   "account.linked",

--- a/dali-api/app/projects/routes/__tests__/api.assignment-level.test.ts
+++ b/dali-api/app/projects/routes/__tests__/api.assignment-level.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("~/lib/auth", () => ({ requireAuth: vi.fn() }));
+vi.mock("~/lib/db");
+vi.mock("~/lib/roles", () => ({ isCore: vi.fn() }));
+vi.mock("~/lib/audit", () => ({ logAuditEvent: vi.fn() }));
+vi.mock("~/lib/cors", () => ({
+  withCors: (_req: Request, res: Response) => res,
+  handlePreflight: () => null,
+}));
+
+import { requireAuth } from "~/lib/auth";
+import { prisma } from "~/lib/db";
+import { isCore } from "~/lib/roles";
+import { logAuditEvent } from "~/lib/audit";
+import { action } from "~/projects/routes/api.assignment-level";
+
+const CORE_USER = "user-core";
+const ASSIGNMENT_ID = "asn-1";
+const MEMBER_ID = "member-1";
+const PROJECT_ID = "proj-1";
+const TERM_ID = "term-1";
+const DOMAIN_ID = "domain-1";
+
+const mockPrisma = prisma as unknown as {
+  projectAssignment: { findUnique: ReturnType<typeof vi.fn>; update: ReturnType<typeof vi.fn> };
+  domainEligibility: { findUnique: ReturnType<typeof vi.fn> };
+  mentorshipPair: { count: ReturnType<typeof vi.fn> };
+};
+
+function req(level: string | null) {
+  return new Request(
+    `http://localhost/api/projects/assignments/${ASSIGNMENT_ID}/level`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: level === null ? "" : JSON.stringify({ level }),
+    },
+  );
+}
+
+function call(level: string | null) {
+  return action({
+    request: req(level),
+    params: { id: ASSIGNMENT_ID },
+  } as any);
+}
+
+function mockAssignment(level: "P1" | "P2" | "P3") {
+  mockPrisma.projectAssignment.findUnique.mockResolvedValue({
+    id: ASSIGNMENT_ID,
+    userId: MEMBER_ID,
+    projectId: PROJECT_ID,
+    termId: TERM_ID,
+    domainId: DOMAIN_ID,
+    level,
+    domain: { displayName: "Design" },
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(requireAuth).mockResolvedValue({
+    ok: true,
+    user: { sub: CORE_USER, email: "c@x.com", type: "user" },
+  } as any);
+  vi.mocked(isCore).mockResolvedValue(true);
+  mockPrisma.projectAssignment = {
+    findUnique: vi.fn(),
+    update: vi.fn().mockResolvedValue({}),
+  };
+  mockPrisma.domainEligibility = { findUnique: vi.fn() };
+  mockPrisma.mentorshipPair = { count: vi.fn().mockResolvedValue(0) };
+});
+
+describe("POST /api/projects/assignments/:id/level", () => {
+  it("rejects non-Core callers with 403", async () => {
+    vi.mocked(isCore).mockResolvedValue(false);
+    const res = await call("P2");
+    expect(res.status).toBe(403);
+    expect(mockPrisma.projectAssignment.update).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid level values with 400", async () => {
+    const res = await call("P4");
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when the assignment does not exist", async () => {
+    mockPrisma.projectAssignment.findUnique.mockResolvedValue(null);
+    const res = await call("P2");
+    expect(res.status).toBe(404);
+  });
+
+  it("no-ops when the requested level equals the current level", async () => {
+    mockAssignment("P2");
+    const res = await call("P2");
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ ok: true, unchanged: true });
+    expect(mockPrisma.projectAssignment.update).not.toHaveBeenCalled();
+    expect(mockPrisma.domainEligibility.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("blocks promotion above eligibility ceiling", async () => {
+    mockAssignment("P1");
+    mockPrisma.domainEligibility.findUnique.mockResolvedValue({ level: "P2" });
+    const res = await call("P3");
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ error: expect.stringContaining("Promote") });
+    expect(mockPrisma.projectAssignment.update).not.toHaveBeenCalled();
+  });
+
+  it("blocks any change when no eligibility row exists", async () => {
+    mockAssignment("P1");
+    mockPrisma.domainEligibility.findUnique.mockResolvedValue(null);
+    const res = await call("P2");
+    expect(res.status).toBe(400);
+    expect(mockPrisma.projectAssignment.update).not.toHaveBeenCalled();
+  });
+
+  it("blocks demotion while mentor still has mentees on the scope", async () => {
+    mockAssignment("P3");
+    mockPrisma.domainEligibility.findUnique.mockResolvedValue({ level: "P3" });
+    mockPrisma.mentorshipPair.count.mockResolvedValue(2);
+    const res = await call("P1");
+    expect(res.status).toBe(409);
+    expect(await res.json()).toMatchObject({ error: expect.stringContaining("2 mentees") });
+    expect(mockPrisma.projectAssignment.update).not.toHaveBeenCalled();
+    expect(mockPrisma.mentorshipPair.count).toHaveBeenCalledWith({
+      where: {
+        mentorUserId: MEMBER_ID,
+        projectId: PROJECT_ID,
+        termId: TERM_ID,
+        domainId: DOMAIN_ID,
+      },
+    });
+  });
+
+  it("allows promotion when within eligibility ceiling", async () => {
+    mockAssignment("P1");
+    mockPrisma.domainEligibility.findUnique.mockResolvedValue({ level: "P3" });
+    const res = await call("P3");
+    expect(res.status).toBe(200);
+    expect(mockPrisma.projectAssignment.update).toHaveBeenCalledWith({
+      where: { id: ASSIGNMENT_ID },
+      data: { level: "P3" },
+    });
+    expect(mockPrisma.mentorshipPair.count).not.toHaveBeenCalled();
+    expect(logAuditEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "project.assignment.level",
+        userId: CORE_USER,
+        targetId: MEMBER_ID,
+        metadata: expect.objectContaining({ from: "P1", to: "P3" }),
+      }),
+    );
+  });
+
+  it("allows demotion when no active mentees on the scope", async () => {
+    mockAssignment("P3");
+    mockPrisma.domainEligibility.findUnique.mockResolvedValue({ level: "P3" });
+    mockPrisma.mentorshipPair.count.mockResolvedValue(0);
+    const res = await call("P2");
+    expect(res.status).toBe(200);
+    expect(mockPrisma.projectAssignment.update).toHaveBeenCalledWith({
+      where: { id: ASSIGNMENT_ID },
+      data: { level: "P2" },
+    });
+  });
+});

--- a/dali-api/app/projects/routes/api.assignment-level.ts
+++ b/dali-api/app/projects/routes/api.assignment-level.ts
@@ -1,0 +1,140 @@
+import type { Route } from "./+types/api.assignment-level";
+import { prisma } from "~/lib/db";
+import { requireAuth } from "~/lib/auth";
+import { isCore } from "~/lib/roles";
+import { withCors, handlePreflight } from "~/lib/cors";
+import { logAuditEvent } from "~/lib/audit";
+
+// POST /api/projects/assignments/:id/level
+//
+// Core-only correction tool for an already-finalized ProjectAssignment.level.
+// The staffing flow remains the primary path for setting levels; this exists
+// so Core can fix mistakes without rerunning a cycle.
+//
+// Guards:
+//   - Eligibility ceiling: target level must be <= DomainEligibility.level
+//     for (userId, domainId). Promotions still happen through the eligibility
+//     editor, not here.
+//   - Mentor orphan: any demotion is blocked while the member still holds
+//     MentorshipPair rows as mentor on (project, term, domain). Reassign the
+//     mentees first.
+
+type Body = { level: "P1" | "P2" | "P3" };
+
+const LEVEL_RANK: Record<"P1" | "P2" | "P3", number> = { P1: 1, P2: 2, P3: 3 };
+
+function isBody(x: unknown): x is Body {
+  if (!x || typeof x !== "object") return false;
+  const o = x as Record<string, unknown>;
+  return o.level === "P1" || o.level === "P2" || o.level === "P3";
+}
+
+export async function action({ request, params }: Route.ActionArgs) {
+  const preflight = handlePreflight(request);
+  if (preflight) return preflight;
+
+  const auth = await requireAuth(request);
+  if (!auth.ok) return withCors(request, auth.response);
+
+  if (request.method !== "POST") {
+    return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));
+  }
+
+  if (!(await isCore(auth.user.sub))) {
+    return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return withCors(request, Response.json({ error: "Invalid JSON" }, { status: 400 }));
+  }
+  if (!isBody(body)) {
+    return withCors(request, Response.json({ error: "Invalid body" }, { status: 400 }));
+  }
+
+  const assignment = await prisma.projectAssignment.findUnique({
+    where: { id: params.id },
+    select: {
+      id: true,
+      userId: true,
+      projectId: true,
+      termId: true,
+      domainId: true,
+      level: true,
+      domain: { select: { displayName: true } },
+    },
+  });
+  if (!assignment) {
+    return withCors(request, Response.json({ error: "Assignment not found" }, { status: 404 }));
+  }
+
+  if (assignment.level === body.level) {
+    return withCors(request, Response.json({ ok: true, unchanged: true }));
+  }
+
+  const eligibility = await prisma.domainEligibility.findUnique({
+    where: {
+      userId_domainId: { userId: assignment.userId, domainId: assignment.domainId },
+    },
+    select: { level: true },
+  });
+  const ceiling = eligibility?.level ?? null;
+  if (!ceiling || LEVEL_RANK[body.level] > LEVEL_RANK[ceiling]) {
+    return withCors(
+      request,
+      Response.json(
+        {
+          error: `Member is not eligible for ${body.level} in ${assignment.domain.displayName}. Promote them in the eligibility editor first.`,
+        },
+        { status: 400 },
+      ),
+    );
+  }
+
+  const isDemotion = LEVEL_RANK[body.level] < LEVEL_RANK[assignment.level];
+  if (isDemotion) {
+    const menteeCount = await prisma.mentorshipPair.count({
+      where: {
+        mentorUserId: assignment.userId,
+        projectId: assignment.projectId,
+        termId: assignment.termId,
+        domainId: assignment.domainId,
+      },
+    });
+    if (menteeCount > 0) {
+      return withCors(
+        request,
+        Response.json(
+          {
+            error: `Cannot demote: member is mentoring ${menteeCount} mentee${menteeCount === 1 ? "" : "s"} in ${assignment.domain.displayName}. Reassign mentees first.`,
+          },
+          { status: 409 },
+        ),
+      );
+    }
+  }
+
+  await prisma.projectAssignment.update({
+    where: { id: assignment.id },
+    data: { level: body.level },
+  });
+
+  await logAuditEvent({
+    action: "project.assignment.level",
+    userId: auth.user.sub,
+    targetId: assignment.userId,
+    metadata: {
+      assignmentId: assignment.id,
+      projectId: assignment.projectId,
+      termId: assignment.termId,
+      domainId: assignment.domainId,
+      from: assignment.level,
+      to: body.level,
+    },
+    request,
+  });
+
+  return withCors(request, Response.json({ ok: true, level: body.level }));
+}

--- a/dali-api/app/projects/routes/projects.$id.tsx
+++ b/dali-api/app/projects/routes/projects.$id.tsx
@@ -4,6 +4,7 @@ import {
   Link,
   redirect,
   useActionData,
+  useFetcher,
   useLoaderData,
   useRevalidator,
   useSearchParams,
@@ -118,7 +119,11 @@ export async function loader({ request, params }: Route.LoaderArgs) {
       },
       assignments: {
         select: {
+          id: true,
           level: true,
+          userId: true,
+          termId: true,
+          domainId: true,
           user: { select: { id: true, firstName: true, lastName: true } },
           term: { select: { code: true, sortKey: true } },
           domain: { select: { id: true, name: true } },
@@ -350,9 +355,57 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   };
 
   // Team grouped by term, newest term first. Current = highest sortKey.
+  //
+  // For Core viewers we also surface per-assignment editing context:
+  //   - eligibilityLevel: ceiling enforced by /api/projects/assignments/:id/level
+  //   - activeMenteeCount: a P3→lower demotion is blocked while this > 0
+  // Both lookups are skipped for non-Core viewers (they see read-only badges).
+  const eligibilityCeilings = new Map<string, string>();
+  const menteeCounts = new Map<string, number>();
+  if (core && project.assignments.length > 0) {
+    const eligibilityPairs = new Map<string, { userId: string; domainId: string }>();
+    for (const a of project.assignments) {
+      eligibilityPairs.set(`${a.userId}:${a.domainId}`, {
+        userId: a.userId,
+        domainId: a.domainId,
+      });
+    }
+    const mentorUserIds = [...new Set(project.assignments.map((a) => a.userId))];
+    const [eligibilityRows, mentorRows] = await Promise.all([
+      prisma.domainEligibility.findMany({
+        where: { OR: [...eligibilityPairs.values()] },
+        select: { userId: true, domainId: true, level: true },
+      }),
+      // Over-fetch: any MentorshipPair on this project where any of our
+      // assignees is the mentor. We bucket client-side by the exact
+      // (mentorUserId, termId, domainId) tuple the endpoint checks.
+      prisma.mentorshipPair.findMany({
+        where: { projectId: project.id, mentorUserId: { in: mentorUserIds } },
+        select: { mentorUserId: true, termId: true, domainId: true },
+      }),
+    ]);
+    for (const e of eligibilityRows) {
+      eligibilityCeilings.set(`${e.userId}:${e.domainId}`, e.level);
+    }
+    for (const m of mentorRows) {
+      const key = `${m.mentorUserId}:${m.termId}:${m.domainId}`;
+      menteeCounts.set(key, (menteeCounts.get(key) ?? 0) + 1);
+    }
+  }
+
+  type TeamMember = {
+    assignmentId: string;
+    userId: string;
+    name: string;
+    domain: string;
+    domainId: string;
+    level: string;
+    eligibilityLevel: string | null;
+    activeMenteeCount: number;
+  };
   const teamByTerm = new Map<
     string,
-    { code: string; sortKey: number; members: { name: string; domain: string; level: string }[] }
+    { code: string; sortKey: number; members: TeamMember[] }
   >();
   for (const a of project.assignments) {
     const key = a.term.code;
@@ -360,9 +413,15 @@ export async function loader({ request, params }: Route.LoaderArgs) {
       teamByTerm.set(key, { code: a.term.code, sortKey: a.term.sortKey, members: [] });
     }
     teamByTerm.get(key)!.members.push({
+      assignmentId: a.id,
+      userId: a.userId,
       name: `${a.user.firstName} ${a.user.lastName}`.trim(),
       domain: a.domain.name,
+      domainId: a.domainId,
       level: a.level,
+      eligibilityLevel: eligibilityCeilings.get(`${a.userId}:${a.domainId}`) ?? null,
+      activeMenteeCount:
+        menteeCounts.get(`${a.userId}:${a.termId}:${a.domainId}`) ?? 0,
     });
   }
   const teams = [...teamByTerm.values()].sort((a, b) => b.sortKey - a.sortKey);
@@ -502,6 +561,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     boardOptions,
     canEdit,
     canEditScope,
+    canEditAssignmentLevel: core,
     canViewScope,
     currentTerm: current ? { id: current.id, code: current.code } : null,
     collabToken,
@@ -755,6 +815,7 @@ export default function ProjectDetail() {
     domainScopeGrid,
     canEdit,
     canEditScope,
+    canEditAssignmentLevel,
     canViewScope,
     currentTerm,
     collabToken,
@@ -834,6 +895,7 @@ export default function ProjectDetail() {
           allTags={allTags}
           canEdit={canEdit}
           canEditFinance={canEditScope}
+          canEditAssignmentLevel={canEditAssignmentLevel}
           domainScopeGrid={domainScopeGrid}
           currentTerm={currentTerm}
           actionError={actionData?.error}
@@ -1685,7 +1747,13 @@ function DomainChips({
   );
 }
 
-function TeamSection({ teams }: { teams: LoaderData["teams"] }) {
+function TeamSection({
+  teams,
+  canEdit,
+}: {
+  teams: LoaderData["teams"];
+  canEdit: boolean;
+}) {
   const [showAll, setShowAll] = useState(false);
   // teams is pre-sorted newest term first by the loader.
   const visible = showAll ? teams : teams.slice(0, 1);
@@ -1719,16 +1787,18 @@ function TeamSection({ teams }: { teams: LoaderData["teams"] }) {
                 )}
               </div>
               <div className="flex flex-wrap gap-2">
-                {team.members.map((m, j) => (
+                {team.members.map((m) => (
                   <span
-                    key={j}
-                    className="text-xs px-2 py-1 rounded-md border border-border text-foreground"
+                    key={m.assignmentId}
+                    className="text-xs px-2 py-1 rounded-md border border-border text-foreground inline-flex items-center gap-1"
                   >
                     {m.name}
-                    <span className="text-muted-foreground">
-                      {" "}
-                      · {m.domain} {m.level}
-                    </span>
+                    <span className="text-muted-foreground">· {m.domain}</span>
+                    {canEdit ? (
+                      <TeamLevelEditor member={m} />
+                    ) : (
+                      <span className="text-muted-foreground">{m.level}</span>
+                    )}
                   </span>
                 ))}
               </div>
@@ -1740,6 +1810,77 @@ function TeamSection({ teams }: { teams: LoaderData["teams"] }) {
   );
 }
 
+const LEVEL_OPTIONS: ("P1" | "P2" | "P3")[] = ["P1", "P2", "P3"];
+const LEVEL_RANK: Record<"P1" | "P2" | "P3", number> = { P1: 1, P2: 2, P3: 3 };
+
+function TeamLevelEditor({
+  member,
+}: {
+  member: LoaderData["teams"][number]["members"][number];
+}) {
+  const fetcher = useFetcher<{ ok?: boolean; error?: string }>();
+  const ceilingRank = member.eligibilityLevel
+    ? LEVEL_RANK[member.eligibilityLevel as "P1" | "P2" | "P3"]
+    : 0;
+  const currentRank = LEVEL_RANK[member.level as "P1" | "P2" | "P3"];
+  const blockedByMentees = member.activeMenteeCount > 0;
+
+  const value = (fetcher.formData?.get("level") as string | null) ?? member.level;
+  const busy = fetcher.state !== "idle";
+  const error = fetcher.data?.error;
+
+  function disabledReason(opt: "P1" | "P2" | "P3"): string | null {
+    if (opt === member.level) return null;
+    if (LEVEL_RANK[opt] > ceilingRank) {
+      return member.eligibilityLevel
+        ? `Eligible only up to ${member.eligibilityLevel} in ${member.domain}. Promote first.`
+        : `No ${member.domain} eligibility. Promote first.`;
+    }
+    if (blockedByMentees && LEVEL_RANK[opt] < currentRank) {
+      return `Mentoring ${member.activeMenteeCount} mentee${member.activeMenteeCount === 1 ? "" : "s"}. Reassign first.`;
+    }
+    return null;
+  }
+
+  return (
+    <span className="inline-flex items-center gap-1">
+      <select
+        aria-label={`Level for ${member.name} in ${member.domain}`}
+        className="text-xs bg-transparent text-muted-foreground rounded border border-transparent hover:border-border focus:border-border focus:outline-none px-0.5"
+        value={value}
+        disabled={busy}
+        onChange={(e) => {
+          const next = e.target.value;
+          if (next === member.level) return;
+          fetcher.submit(
+            { level: next },
+            {
+              method: "post",
+              action: `/api/projects/assignments/${member.assignmentId}/level`,
+              encType: "application/json",
+            },
+          );
+        }}
+      >
+        {LEVEL_OPTIONS.map((opt) => {
+          const reason = disabledReason(opt);
+          return (
+            <option key={opt} value={opt} disabled={reason !== null} title={reason ?? undefined}>
+              {opt}
+              {reason ? " (locked)" : ""}
+            </option>
+          );
+        })}
+      </select>
+      {error && (
+        <span className="text-[10px] text-destructive" title={error}>
+          !
+        </span>
+      )}
+    </span>
+  );
+}
+
 function OverviewTab({
   project,
   teams,
@@ -1748,6 +1889,7 @@ function OverviewTab({
   allTags,
   canEdit,
   canEditFinance,
+  canEditAssignmentLevel,
   domainScopeGrid,
   currentTerm,
   actionError,
@@ -1759,6 +1901,7 @@ function OverviewTab({
   allTags: LoaderData["allTags"];
   canEdit: boolean;
   canEditFinance: boolean;
+  canEditAssignmentLevel: boolean;
   domainScopeGrid: LoaderData["domainScopeGrid"];
   currentTerm: LoaderData["currentTerm"];
   actionError?: string;
@@ -1818,7 +1961,7 @@ function OverviewTab({
 
       {/* Team — read-only summary, separate from the editable details. */}
       <section className="bg-card border border-border rounded-lg p-4">
-        <TeamSection teams={teams} />
+        <TeamSection teams={teams} canEdit={canEditAssignmentLevel} />
       </section>
 
       {/* Documents — collab-doc pages; rows + Add open the doc as a split-screen

--- a/dali-api/app/routes.ts
+++ b/dali-api/app/routes.ts
@@ -216,6 +216,12 @@ export default [
   route("api/staffing/events", "projects/routes/api.staffing.events.ts"),
   route("api/staffing/reorder", "projects/routes/api.staffing.reorder.ts"),
 
+  // Core-only level correction for an already-finalized ProjectAssignment.
+  route(
+    "api/projects/assignments/:id/level",
+    "projects/routes/api.assignment-level.ts",
+  ),
+
   // Project task board
   route("api/projects/:id/tasks", "projects/routes/api.projects.$id.tasks.ts"),
   route("api/tasks/:id/move", "projects/routes/api.tasks.$id.move.ts"),


### PR DESCRIPTION
## Summary
- New `POST /api/projects/assignments/:id/level` endpoint lets Core fix a member's level on a finalized `ProjectAssignment` without rerunning a staffing cycle.
- Inline level `<select>` on the Teams section of the project page for Core viewers; everyone else still sees the read-only badge.
- Two server-enforced guards:
  - **Eligibility ceiling** — target level must be ≤ `DomainEligibility.level` for `(userId, domainId)`. Promotion still happens through the eligibility editor.
  - **Mentor orphan** — any demotion is blocked while the member still holds `MentorshipPair` rows as mentor on the same `(project, term, domain)`. Reassign mentees first.
- Audit-logged as `project.assignment.level` with `{from, to, assignmentId, projectId, termId, domainId}`.

## Notes
- The Staffing Flow remains the primary path for setting levels; this is a correction tool, not a parallel promotion path. Eligibility is not mirrored on this endpoint (unlike `staffing.finalize`).
- UI lists invalid options as disabled with a tooltip explaining the reason. The endpoint still validates regardless of client state.
- Loader only runs the eligibility + mentor-count lookups for Core viewers — non-Core paths add zero queries.

## Test plan
- [ ] Vitest suite for the endpoint covers: non-Core forbidden, invalid level, missing assignment, no-op same-level, eligibility ceiling block, missing-eligibility block, mentor-orphan block (409), happy-path promote, happy-path demote without mentees.
- [ ] Manually verify Teams tab: Core sees inline select; promote within eligibility succeeds; option above ceiling is disabled with tooltip; demote with active mentees is blocked.
- [ ] Confirm non-Core viewers still see read-only level badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/829"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784055314&installation_id=133523038&pr_number=829&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F829&signature=971e3744d12d20765bc91fec37c6f492a6858994ab85c4794b387e7cc34aea82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->