### PR TITLE
Core: materialize CoreAssignment rows across the election cycle (#832)

### DIFF
--- a/dali-api/app/admin-console/__tests__/admin-console.members.action.test.ts
+++ b/dali-api/app/admin-console/__tests__/admin-console.members.action.test.ts
@@ -5,6 +5,12 @@ vi.mock("~/lib/auth", () => ({
   requireAuth: vi.fn(),
 }));
 vi.mock("~/lib/roles");
+vi.mock("~/lib/core-cycle", () => ({
+  // Tests treat the cycle as a single term ("term-1"); fan-out behavior is
+  // exercised through the count of writes, not the cycle math.
+  coreCycleTermIds: vi.fn().mockResolvedValue(["term-1"]),
+  cycleSortKeyRange: vi.fn(),
+}));
 
 import { prisma } from "~/lib/db";
 import { requireAuth } from "~/lib/auth";
@@ -23,7 +29,10 @@ const mockPrisma = prisma as unknown as {
   };
   coreAssignment: {
     findFirst: ReturnType<typeof vi.fn>;
+    findMany: ReturnType<typeof vi.fn>;
+    findUnique: ReturnType<typeof vi.fn>;
     create: ReturnType<typeof vi.fn>;
+    createMany: ReturnType<typeof vi.fn>;
     deleteMany: ReturnType<typeof vi.fn>;
   };
   domainLeadAssignment: {
@@ -40,7 +49,10 @@ beforeEach(() => {
   };
   (mockPrisma as any).coreAssignment = {
     findFirst: vi.fn().mockResolvedValue(null),
+    findMany: vi.fn().mockResolvedValue([]),
+    findUnique: vi.fn().mockResolvedValue(null),
     create: vi.fn(),
+    createMany: vi.fn(),
     deleteMany: vi.fn(),
   };
   (mockPrisma as any).domainLeadAssignment = {
@@ -100,31 +112,36 @@ describe("admin-console.members action — gate", () => {
 });
 
 describe("admin-console.members action — add-core-title (Core or Admin)", () => {
-  it("creates a CoreAssignment with the free-text title when none exists", async () => {
+  it("materializes a CoreAssignment for every term in the cycle", async () => {
     asCore();
     await action({
       request: postForm({ intent: "add-core-title", userId: USER_ID, leadTitle: "Design Lead" }),
       params: {},
       context: {},
     } as any);
-    expect(mockPrisma.coreAssignment.findFirst).toHaveBeenCalledWith({
-      where: { userId: USER_ID, termId: TERM_ID, leadTitle: "Design Lead" },
-      select: { id: true },
+    // Reads existing cycle-mate rows first to compute the missing set.
+    expect(mockPrisma.coreAssignment.findMany).toHaveBeenCalledWith({
+      where: {
+        userId: USER_ID,
+        termId: { in: [TERM_ID] },
+        leadTitle: "Design Lead",
+      },
+      select: { termId: true },
     });
-    expect(mockPrisma.coreAssignment.create).toHaveBeenCalledWith({
-      data: { userId: USER_ID, termId: TERM_ID, leadTitle: "Design Lead" },
+    expect(mockPrisma.coreAssignment.createMany).toHaveBeenCalledWith({
+      data: [{ userId: USER_ID, termId: TERM_ID, leadTitle: "Design Lead" }],
     });
   });
 
-  it("is a no-op when an identical (user, term, title) row already exists", async () => {
+  it("is a no-op when the cycle is already fully covered", async () => {
     asCore();
-    mockPrisma.coreAssignment.findFirst.mockResolvedValueOnce({ id: "ca-1" });
+    mockPrisma.coreAssignment.findMany.mockResolvedValueOnce([{ termId: TERM_ID }]);
     await action({
       request: postForm({ intent: "add-core-title", userId: USER_ID, leadTitle: "PM" }),
       params: {},
       context: {},
     } as any);
-    expect(mockPrisma.coreAssignment.create).not.toHaveBeenCalled();
+    expect(mockPrisma.coreAssignment.createMany).not.toHaveBeenCalled();
   });
 
   it("treats an empty title as a null (untitled Core) row", async () => {
@@ -134,25 +151,45 @@ describe("admin-console.members action — add-core-title (Core or Admin)", () =
       params: {},
       context: {},
     } as any);
-    expect(mockPrisma.coreAssignment.findFirst).toHaveBeenCalledWith({
-      where: { userId: USER_ID, termId: TERM_ID, leadTitle: null },
-      select: { id: true },
+    expect(mockPrisma.coreAssignment.findMany).toHaveBeenCalledWith({
+      where: {
+        userId: USER_ID,
+        termId: { in: [TERM_ID] },
+        leadTitle: null,
+      },
+      select: { termId: true },
     });
-    expect(mockPrisma.coreAssignment.create).toHaveBeenCalledWith({
-      data: { userId: USER_ID, termId: TERM_ID, leadTitle: null },
+    expect(mockPrisma.coreAssignment.createMany).toHaveBeenCalledWith({
+      data: [{ userId: USER_ID, termId: TERM_ID, leadTitle: null }],
     });
   });
 });
 
 describe("admin-console.members action — remove-core-title", () => {
-  it("deletes by assignment id", async () => {
+  it("clears the (userId, leadTitle) across every term in the cycle", async () => {
     asCore();
+    // The action looks up the assignment first to resolve (userId, termId, leadTitle).
+    mockPrisma.coreAssignment.findUnique.mockResolvedValueOnce({
+      userId: USER_ID,
+      termId: TERM_ID,
+      leadTitle: "Design Lead",
+    });
     await action({
       request: postForm({ intent: "remove-core-title", assignmentId: "ca-1" }),
       params: {},
       context: {},
     } as any);
-    expect(mockPrisma.coreAssignment.deleteMany).toHaveBeenCalledWith({ where: { id: "ca-1" } });
+    expect(mockPrisma.coreAssignment.findUnique).toHaveBeenCalledWith({
+      where: { id: "ca-1" },
+      select: { userId: true, termId: true, leadTitle: true },
+    });
+    expect(mockPrisma.coreAssignment.deleteMany).toHaveBeenCalledWith({
+      where: {
+        userId: USER_ID,
+        leadTitle: "Design Lead",
+        termId: { in: [TERM_ID] },
+      },
+    });
   });
 });
 

--- a/dali-api/app/admin-console/__tests__/api.members.roles.test.ts
+++ b/dali-api/app/admin-console/__tests__/api.members.roles.test.ts
@@ -5,6 +5,12 @@ vi.mock("~/lib/auth", () => ({
   requireAuth: vi.fn(),
 }));
 vi.mock("~/lib/roles");
+vi.mock("~/lib/core-cycle", () => ({
+  // Tests only care that the action runs and validates the request body —
+  // not the cycle math — so stub to "current term only".
+  coreCycleTermIds: vi.fn().mockResolvedValue(["term-1"]),
+  cycleSortKeyRange: vi.fn(),
+}));
 vi.mock("~/lib/audit", () => ({ logAuditEvent: vi.fn() }));
 vi.mock("~/lib/cors", () => ({
   handlePreflight: () => null,
@@ -32,7 +38,9 @@ const mockPrisma = prisma as unknown as {
   };
   coreAssignment: {
     findFirst: ReturnType<typeof vi.fn>;
+    findMany: ReturnType<typeof vi.fn>;
     create: ReturnType<typeof vi.fn>;
+    createMany: ReturnType<typeof vi.fn>;
     deleteMany: ReturnType<typeof vi.fn>;
   };
   user: {
@@ -50,7 +58,9 @@ beforeEach(() => {
   };
   (mockPrisma as any).coreAssignment = {
     findFirst: vi.fn().mockResolvedValue(null),
+    findMany: vi.fn().mockResolvedValue([]),
     create: vi.fn(),
+    createMany: vi.fn(),
     deleteMany: vi.fn(),
   };
   (mockPrisma as any).user = {

--- a/dali-api/app/admin-console/lib/payroll-export.ts
+++ b/dali-api/app/admin-console/lib/payroll-export.ts
@@ -107,6 +107,9 @@ export type RoleCandidate = {
 };
 
 export async function listCoreCandidates(termId: string): Promise<RoleCandidate[]> {
+  // CoreAssignment rows are materialized per-term across the election cycle
+  // (writers in admin-console fan out across [Spring N, Spring N+1)), so a
+  // direct lookup by termId surfaces the full cohort.
   const rows = await prisma.coreAssignment.findMany({
     where: { termId },
     select: {

--- a/dali-api/app/admin-console/routes/admin-console.members.tsx
+++ b/dali-api/app/admin-console/routes/admin-console.members.tsx
@@ -4,6 +4,7 @@ import type { Route } from "./+types/admin-console.members";
 import { prisma } from "~/lib/db";
 import { requireAuth } from "~/lib/auth";
 import { isAdmin, isCore, currentTerm } from "~/lib/roles";
+import { coreCycleTermIds } from "~/lib/core-cycle";
 import { Users, Check } from "lucide-react";
 import {
   AdminToggle,
@@ -102,9 +103,15 @@ export async function action({ request }: Route.ActionArgs) {
     return null;
   }
 
-  // Free-text Core title for the current term. A member can hold multiple
-  // titles in the same term (schema-side: no unique on (userId, termId)).
-  // App-level guard: ignore exact-title duplicates rather than 409.
+  // Free-text Core title for the current Core cycle. A member can hold
+  // multiple titles in the same term (schema-side: no unique on
+  // (userId, termId, leadTitle)). App-level guard: ignore exact-title
+  // duplicates rather than 409.
+  //
+  // The Core "cycle" runs Spring → following Winter (4 terms). We materialize
+  // one CoreAssignment row per term in the cycle so every reader (payroll,
+  // search, isCore) can query by termId and get the same answer without
+  // re-deriving cycle math. See lib/core-cycle.ts.
   if (intent === "add-core-title") {
     const userId = formData.get("userId") as string;
     const rawTitle = String(formData.get("leadTitle") ?? "").trim();
@@ -116,21 +123,40 @@ export async function action({ request }: Route.ActionArgs) {
         { status: 500 },
       );
     }
-    const existing = await prisma.coreAssignment.findFirst({
-      where: { userId, termId: term.id, leadTitle },
-      select: { id: true },
+    const cycleTermIds = await coreCycleTermIds(term.id);
+    const existing = await prisma.coreAssignment.findMany({
+      where: { userId, termId: { in: cycleTermIds }, leadTitle },
+      select: { termId: true },
     });
-    if (!existing) {
-      await prisma.coreAssignment.create({
-        data: { userId, termId: term.id, leadTitle },
+    const alreadyCovered = new Set(existing.map((e) => e.termId));
+    const missing = cycleTermIds.filter((tid) => !alreadyCovered.has(tid));
+    if (missing.length > 0) {
+      await prisma.coreAssignment.createMany({
+        data: missing.map((termId) => ({ userId, termId, leadTitle })),
       });
     }
     return null;
   }
 
+  // Remove this Core title for the entire cycle the assignment belongs to —
+  // not just the single term the row was indexed by. (Multiple CoreAssignment
+  // rows fan out across the cycle on add; clearing all of them keeps the
+  // data consistent across surfaces.)
   if (intent === "remove-core-title") {
     const assignmentId = formData.get("assignmentId") as string;
-    await prisma.coreAssignment.deleteMany({ where: { id: assignmentId } });
+    const target = await prisma.coreAssignment.findUnique({
+      where: { id: assignmentId },
+      select: { userId: true, termId: true, leadTitle: true },
+    });
+    if (!target) return null;
+    const cycleTermIds = await coreCycleTermIds(target.termId);
+    await prisma.coreAssignment.deleteMany({
+      where: {
+        userId: target.userId,
+        leadTitle: target.leadTitle,
+        termId: { in: cycleTermIds },
+      },
+    });
     return null;
   }
 

--- a/dali-api/app/admin-console/routes/api.members.$memberId.roles.ts
+++ b/dali-api/app/admin-console/routes/api.members.$memberId.roles.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { prisma } from "~/lib/db";
 import { requireAuth } from "~/lib/auth";
 import { isAdmin, currentTerm } from "~/lib/roles";
+import { coreCycleTermIds } from "~/lib/core-cycle";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { parseJson } from "~/lib/validate";
 import { logAuditEvent } from "~/lib/audit";
@@ -78,19 +79,37 @@ export async function action({ request, params }: Route.ActionArgs) {
       await tx.adminMembership.deleteMany({ where: { userId } });
     }
 
+    // Core titles (Hiring Lead included) are cycle-scoped: one row per term
+    // in [Spring N, Spring N+1). We materialize the missing rows on add and
+    // clear them all on remove so cycle-mate terms stay consistent.
+    const cycleTermIds = await coreCycleTermIds(term.id);
     if (wantHiringLead) {
-      const exists = await tx.coreAssignment.findFirst({
-        where: { userId, termId: term.id, leadTitle: "Hiring Lead" },
-        select: { id: true },
+      const existing = await tx.coreAssignment.findMany({
+        where: {
+          userId,
+          termId: { in: cycleTermIds },
+          leadTitle: "Hiring Lead",
+        },
+        select: { termId: true },
       });
-      if (!exists) {
-        await tx.coreAssignment.create({
-          data: { userId, termId: term.id, leadTitle: "Hiring Lead" },
+      const covered = new Set(existing.map((e) => e.termId));
+      const missing = cycleTermIds.filter((tid) => !covered.has(tid));
+      if (missing.length > 0) {
+        await tx.coreAssignment.createMany({
+          data: missing.map((termId) => ({
+            userId,
+            termId,
+            leadTitle: "Hiring Lead",
+          })),
         });
       }
     } else {
       await tx.coreAssignment.deleteMany({
-        where: { userId, termId: term.id, leadTitle: "Hiring Lead" },
+        where: {
+          userId,
+          termId: { in: cycleTermIds },
+          leadTitle: "Hiring Lead",
+        },
       });
     }
   });

--- a/dali-api/app/lib/core-cycle.ts
+++ b/dali-api/app/lib/core-cycle.ts
@@ -1,0 +1,39 @@
+import { prisma } from "~/lib/db";
+
+// Core is elected in Spring (election cycle) and the lab's Core cohort stays
+// the same through the following Winter. We materialize one CoreAssignment row
+// per term in that window so every reader can just query by termId without
+// re-deriving cycle math.
+//
+// Cycle math (mirrors lib/roles.ts):
+//   Season digits — W=1, S=2, X=3, F=4. Cycle starts at the Spring of the
+//   given term's cycle and spans [Spring N, Spring N+1) in sortKey space,
+//   i.e. 10 consecutive sortKeys → 4 terms (S, X, F, W).
+//
+// This helper is intentionally parameterizable (any term, not just current)
+// so add/remove writers can fan out across the cycle of whichever term they
+// were handed.
+
+function cycleStartSortKey(sk: number): number {
+  const seasonDigit = sk % 10;
+  return seasonDigit === 1 ? sk - 9 : sk - seasonDigit + 2;
+}
+
+export function cycleSortKeyRange(termSortKey: number): { gte: number; lt: number } {
+  const start = cycleStartSortKey(termSortKey);
+  return { gte: start, lt: start + 10 };
+}
+
+export async function coreCycleTermIds(termId: string): Promise<string[]> {
+  const term = await prisma.term.findUnique({
+    where: { id: termId },
+    select: { sortKey: true },
+  });
+  if (!term) return [];
+  const range = cycleSortKeyRange(term.sortKey);
+  const terms = await prisma.term.findMany({
+    where: { sortKey: { gte: range.gte, lt: range.lt } },
+    select: { id: true },
+  });
+  return terms.map((t) => t.id);
+}

--- a/dali-api/app/lib/roles.ts
+++ b/dali-api/app/lib/roles.ts
@@ -1,4 +1,5 @@
 import { prisma } from "~/lib/db";
+import { cycleSortKeyRange } from "~/lib/core-cycle";
 
 // Phase 2 rewrite: role flags derived from the new typed assignment tables
 // (AdminMembership, CoreAssignment, DomainLeadAssignment) rather than the
@@ -220,35 +221,27 @@ export async function currentTermMemberWhere() {
 }
 
 /**
- * Spring sortKey at or before `sk`. A Core "cycle" runs from one Spring
- * election (W=1, S=2, X=3, F=4) through the following Winter, so the
- * cycle that contains a term is anchored by its preceding Spring. Winter
- * (digit 1) belongs to the previous calendar year's Spring cycle.
- */
-function cycleStartSortKey(sk: number): number {
-  const seasonDigit = sk % 10;
-  return seasonDigit === 1 ? sk - 9 : sk - seasonDigit + 2;
-}
-
-/**
  * Term IDs that constitute the active Core cycle. Core is elected in
- * Spring and auto-rolls over through the following Winter; the cycle
- * window spans `[Spring N, Spring N+1)` in sortKey space.
+ * Spring and the cycle window spans `[Spring N, Spring N+1)` in sortKey
+ * space.
  *
  * During a Spring term, the previous cycle is also active so an outgoing
- * Core keeps access through the election handoff (until they're either
- * re-elected, or replaced — at which point the new cycle's assignments
- * become the active set the following Summer).
+ * Core keeps access through the election handoff (until the new cycle's
+ * assignments take over the following Summer). Outside of Spring, the
+ * helper just returns the current cycle's term ids — same set the
+ * cycle-aware fan-out writes to CoreAssignment.
+ *
+ * Cycle math lives in `~/lib/core-cycle.ts` and is shared with the
+ * add/remove writers so reads + writes can't drift.
  */
 export async function getActiveCoreCycleTermIds(): Promise<string[]> {
   const term = await currentTerm();
   if (!term) return [];
-  const cycleStart = cycleStartSortKey(term.sortKey);
+  const currentRange = cycleSortKeyRange(term.sortKey);
   // Spring (digit 2) extends the window back one cycle for the handoff.
-  const lowerBound = term.sortKey % 10 === 2 ? cycleStart - 10 : cycleStart;
-  const upperBound = cycleStart + 10;
+  const lowerBound = term.sortKey % 10 === 2 ? currentRange.gte - 10 : currentRange.gte;
   const terms = await prisma.term.findMany({
-    where: { sortKey: { gte: lowerBound, lt: upperBound } },
+    where: { sortKey: { gte: lowerBound, lt: currentRange.lt } },
     select: { id: true },
   });
   return terms.map((t) => t.id);

--- a/dali-api/prisma/migrations/20260614000000_core_assignment_cycle_backfill/migration.sql
+++ b/dali-api/prisma/migrations/20260614000000_core_assignment_cycle_backfill/migration.sql
@@ -1,0 +1,50 @@
+-- Backfill: materialize CoreAssignment rows across the full election cycle.
+--
+-- Previously a Core election only wrote a single CoreAssignment row anchored
+-- on the Spring term it was set during; readers like `isCore` then derived
+-- cycle membership at query time. As of this migration, writers fan out the
+-- assignment across every term in the cycle window [Spring N, Spring N+1)
+-- (4 terms — S, X, F, W) so reads by termId can stand on their own.
+--
+-- This backfill makes existing data consistent with that contract.
+--
+-- Cycle math (mirrors app/lib/core-cycle.ts):
+--   Season digit = sortKey % 10. W=1, S=2, X=3, F=4.
+--   cycle_start =  (W) sk - 9, (S) sk, (X) sk - 1, (F) sk - 2.
+--   cycle window = [cycle_start, cycle_start + 10) — 4 consecutive terms.
+--
+-- For each distinct (userId, leadTitle, cycle_start) implied by the existing
+-- rows, we insert any missing (userId, termId, leadTitle) triples. The
+-- NOT EXISTS guard makes this idempotent and safe to re-run; we do not
+-- delete or modify any existing rows.
+
+INSERT INTO "CoreAssignment" (id, "userId", "termId", "leadTitle")
+SELECT
+  'cab_' || REPLACE(gen_random_uuid()::text, '-', '') AS id,
+  cycles."userId",
+  t.id                                                AS "termId",
+  cycles."leadTitle"
+FROM (
+  SELECT DISTINCT
+    ca."userId",
+    ca."leadTitle",
+    CASE
+      WHEN anchor."sortKey" % 10 = 1 THEN anchor."sortKey" - 9
+      ELSE anchor."sortKey" - (anchor."sortKey" % 10) + 2
+    END AS cycle_start
+  FROM "CoreAssignment" ca
+  JOIN "Term" anchor ON anchor.id = ca."termId"
+) cycles
+JOIN "Term" t
+  ON t."sortKey" >= cycles.cycle_start
+ AND t."sortKey" <  cycles.cycle_start + 10
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM "CoreAssignment" existing
+  WHERE existing."userId" = cycles."userId"
+    AND existing."termId" = t.id
+    AND (
+      (existing."leadTitle" IS NULL AND cycles."leadTitle" IS NULL)
+      OR existing."leadTitle" = cycles."leadTitle"
+    )
+);


### PR DESCRIPTION
Previously a Core election only wrote a single CoreAssignment row for the Spring term it ran in. Cycle rollover (#803) made isCore checks recognize that row across the full Spring→Winter window at READ time, but no other surface re-derived the same math, so features that queried CoreAssignment by termId (payroll export's Core section, the groups helper, the staffing finalize cohort check, etc.) saw the roster as empty for Summer / Fall / next Winter.

This makes the data side of the contract match the access side: every writer fans out across the cycle's 4 terms on add, and clears the matching (userId, leadTitle) across the cycle on remove. Existing rows are backfilled by an idempotent migration.

- New shared helper `~/lib/core-cycle.ts` with `coreCycleTermIds(termId)` and `cycleSortKeyRange(sortKey)`. `roles.ts` now imports the range helper instead of duplicating the cycle math.
- Writers updated:
  - `admin-console.members.tsx` add-core-title / remove-core-title: fan-out createMany / cycle-scoped deleteMany.
  - `api.members.$memberId.roles.ts` Hiring Lead toggle: same pattern, inside the existing $transaction.
- Backfill migration `20260614000000_core_assignment_cycle_backfill` inserts the missing (userId, termId, leadTitle) triples across every cycle implied by existing rows. Idempotent via NOT EXISTS guard.
- Reverts the payroll-export listCoreCandidates band-aid (b4adbed): the lookup is back to a plain `where: { termId }` because rows now exist directly for the selected term.
- Tests updated to assert the new findMany / createMany shape and the cycle-scoped delete; `~/lib/core-cycle` is mocked to a single term so existing schema-validation tests stay focused on input handling.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/833"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784061314&installation_id=133523038&pr_number=833&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F833&signature=a3f3283863ae6c88136bd2cca73d3a8f7126e988ae2aa4d198bde8e99b928030"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->