### PR TITLE
Core: materialize CoreAssignment rows across the election cycle (#832)

### DIFF
--- a/DRY_AUDIT.md
+++ b/DRY_AUDIT.md
@@ -1,0 +1,249 @@
+# DRY Audit — DALI OS (`dali-api/`)
+
+Worktree: `.claude/worktrees/dry-analysis` on `worktree-dry-analysis` (off `origin/dev` @ `5fc083b`).
+Audit performed: 2026-06-14. Research-only — no files changed.
+
+Methodology: 6 parallel research agents covered separate axes (auth/role-gating, Prisma queries, constants/magic values, validation/Zod, UI components, integration glue + dates). All findings include `file:line` evidence.
+
+---
+
+## Top of the funnel — highest-leverage findings
+
+These are the items that came up in **multiple** axes and have real correctness/drift risk.
+
+### 1. No canonical "who is this user?" identity layer
+
+- `daliEmail ?? dartmouthEmail ?? personalEmail` inlined 13×
+- `${user.netId}@dartmouth.edu` reconstructed 11×
+- `${firstName} ${lastName}` reinvented 25× (about half unsafe — no `?? ""`, will render `"undefined undefined"`)
+- `"Unknown"` and `"—"` compete as missing-field sentinels
+
+`app/routes/portal.apply.tsx:450` already has the email fallback in the **wrong order** (`dartmouthEmail ?? daliEmail` — every other site prefers `daliEmail` first).
+
+Missing helpers: `primaryEmail(user)`, `fullName(user)`, `displayEmail(user)`, `DARTMOUTH_EMAIL_DOMAIN` constant.
+
+### 2. No canonical "is this user authorized?" layer above `requireAuth`
+
+`requireAuth()` is well-adopted (516 imports), but the 4–6 lines *after* it are open-coded ~50× per pattern:
+- "if applicant redirect to portal" — 48 copies
+- "if not Core return 403 with CORS-wrapped JSON" — 50+ copies
+- "if not Core-or-DomainLead return 403" — ~10 copies
+
+Three different `Unauthorized` response shapes coexist; four different `Forbidden` shapes coexist (`withCors`-wrapped JSON / bare `Response.json` / `new Response(JSON.stringify(...))` / plain text).
+
+Missing helpers: `requireCore(auth)`, `requireCoreOrDomainLead(auth)`, `requireMemberSession(request)`, `forbidden(request)`, `unauthorized(request)`.
+
+### 3. Three competing "is user Core?" implementations with different semantics — CORRECTNESS RISK
+
+- **Canonical** (`app/lib/roles.ts:83 isCore()`) — honors Admin override + cycle-window scope
+- **List-view inline** (`u.coreAssignments.length > 0`) in 5 loaders — ignores Admin override AND cycle scope
+  - `app/admin-console/routes/api.members.ts:62`
+  - `app/admin-console/routes/admin-console.members.tsx:62`
+  - `app/admin-console/routes/admin-console.domains.tsx:80`
+  - `app/mcp/tools/search-directory.ts:108`
+  - `app/mcp/tools/get-member-profile.ts:92`
+- **Staffing inline** (`coreAssignment.findMany({ termId })`) in `app/projects/routes/api.staffing.finalize.ts:352` and `api.staffing.term-channel.ts:88` — ignores cycle-window scope
+
+**Impact:** A user granted Admin only via `ADMIN_USER_IDS` env will appear `isAdmin=false` in every list view but `isAdmin=true` in route gates. This is the single highest correctness risk in the audit.
+
+### 4. Two competing "current term" helpers with different inter-term-gap behavior
+
+- `app/lib/roles.ts:186 currentTerm()` — falls back to next upcoming term in the inter-term gap
+- `app/lib/groups.ts:90 getCurrentTermId()` — returns `null` in that gap
+
+Both are called "current term" in code. Plus three open-coded copies in `app/hiring/lib/intern-eligibility.ts:11,35,58` (intentional, per comment, but it's the same query thrice).
+
+### 5. `<Button>` and `<Modal>` primitives exist and are essentially unused
+
+`app/components/ui/Button.tsx` and `app/components/Modal.tsx` are well-designed (Modal has focus-trap + Escape + scroll-lock + focus restore). But:
+
+- `bg-accent-coral text-white hover:bg-accent-coral/90` — 77 hand-rolled coral primary buttons
+- 8+ modals hand-roll `fixed inset-0 z-50 bg-black/40` overlays despite `Modal.tsx` being correct
+- Net: ~85 sites reimplementing what the design system already ships
+
+### 6. Two parallel environment systems
+
+- `NODE_ENV === "production"` — branches cookie security / security headers / dev gates (~20 sites)
+- `getAppEnv()` (returns `'dev' | 'staging' | 'prod'`) — branches email staging banners (2 sites)
+
+On Fly.io, **staging is `NODE_ENV=production`**, so the two axes disagree. The wrong branch can fire on staging silently.
+
+### 7. Three implementations of session lookup
+
+`app/lib/auth.ts:requireAuth`, `app/lib/mcp-auth.ts:authenticateMcpRequest`, `app/collab/auth.ts:verifyCollabToken` — same DB read + expiry + revoke checks, three different response shapes (HTTP/JSON, JSON-RPC, thrown strings). All three share `cookies.ts` for parsing but diverge for everything else.
+
+### 8. Google OAuth token refresh hand-rolled 5×
+
+`app/lib/gmail.ts:11`, `app/lib/google-calendar.ts:45`, `app/lib/oauth.ts:238`, `app/routes/integrations.calendar.google.callback.ts:69`, `app/routes/admin.authorize-gmail.callback.ts:60` — same `POST https://oauth2.googleapis.com/token` with different error wrappers and different env-var resolution. The four Google-authorize-redirect handlers are similarly near-twins with three different state-cookie names (`__dali_oauth_state`, `__dali_gmail_oauth_state`, `__dali_cal_oauth_state`) and two different state-length conventions (16 hex vs 32 base64url).
+
+### 9. `"America/New_York"` typed literally in 9 files
+
+Despite `app/lib/timezone.ts:2` exporting `APPLICATION_TZ`. Same for `" ET"` label vs `APPLICATION_TZ_LABEL`. Sites:
+
+- `app/calendar/routes/calendar.tsx:29`
+- `app/lib/availability.ts:244`
+- `app/hiring/lib/interview-time.ts:6`
+- `app/hiring/lib/interview-emails.ts:31`
+- `app/hiring/lib/extension-notice.ts:25`
+- `app/hiring/lib/interview-notifications.ts:32`
+- `app/hiring/routes/api.cycles.$cycleId.interview-config.ts:83,96`
+- `app/hiring/routes/api.cycles.$cycleId.coverage.ts:22`
+- `app/hiring/routes/lead.cycle.$id.tsx:1181`
+
+### 10. 30-day session window stored as 3 independent constants
+
+- `app/lib/session.ts:7 ROLLING_TTL_MS = 30 * 24 * 60 * 60 * 1000`
+- `app/lib/session.ts:8 ABSOLUTE_TTL_MS = 30 * 24 * 60 * 60 * 1000` (same value, separate name)
+- `app/lib/cookies.ts:10 SESSION_COOKIE_MAX_AGE_SECONDS = 30 * 24 * 60 * 60`
+
+The existing comment at `cookies.ts:5-9` even admits "independently enforced." Rotating the window to 14 days requires three edits.
+
+---
+
+## Domain-by-domain — critical drift hits
+
+### Auth / sessions / role gating
+
+- **`coreAssignments.length > 0` open-coded as "isCore"** in admin-console, members, MCP loaders. Ignores Admin-env override.
+- **"Core OR Domain-Lead" gate copied ~10× across hiring** with subtly different forms (sequential awaits, parallel `Promise.all`, single-line). No `requireHiringLead` helper.
+  - `app/hiring/routes/api.delibs.$id.moves.ts:24-26`
+  - `app/hiring/routes/api.delibs.$id.ts:41-43`
+  - `app/hiring/routes/api.cycles.$cycleId.delibs.ts:40-42`
+  - `app/hiring/routes/api.cycles.$cycleId.interviewers.ts:57-59`
+  - `app/hiring/routes/api.decisions.$id.finalize.ts:20-22`
+  - `app/hiring/routes/api.domain-applications.$id.decisions.ts:86-88`
+  - `app/hiring/routes/api.cycles.$cycleId.reviewers.ts:41`
+  - `app/hiring/routes/library.tsx:18-23,68-73`
+- **"Owner OR DomainLead OR Core" gate** repeated 3× across `api.reviews.$id.*` files (`submit.ts:40`, `unsubmit.ts:33`, `ts:179`).
+- **`api.* action prologue` is ~50 sites of identical 4-line preflight+auth+method+gate boilerplate** in `app/projects/routes/api.*.ts`.
+- **MCP tool prologue duplicated across 28 tools** — every `app/mcp/tools/*.ts` declares its own `class XxxError extends Error` and re-checks `isCore`.
+- **`canEdit` (project) disagrees with API gates.** `projects.$id.tsx:240` says `canEdit = core || isProjectMember`, but every project mutation API checks `isCore` only — UI offers edit affordances that the API silently 403s.
+- **"Admin OR self"** done 3× in `members/lib/profile-page.server.ts:207,294,306` with 3 separate `isAdmin(...)` DB reads in one request.
+- **`ADMIN_USER_IDS` env parse repeated 3× in `roles.ts`** (lines 33, 84, 104).
+- **"Not a DALI member" 403 boilerplate** in 11 hiring routes despite `roles.ts:173 requireMember()` existing and being used in only 3 places.
+
+### Prisma queries
+
+- **Staffing-board user select shape duplicated 3× in `projects.staffing.tsx`** (lines 122, 293, 329), and 5 more times elsewhere as the "lab member with role badges" shape.
+- **Nested `user: { select: { firstName, lastName } }` ("name card" mini-select) in 20+ files.** Plus the variant adding `daliEmail` in another 9.
+- **`{ daliMember: { isNot: null } }` "lab member" filter inlined 11×.**
+- **`orderBy: [{ lastName: "asc" }, { firstName: "asc" }]` duplicated in 10 member-list loaders.**
+- **`deriveCoreTitles` is a byte-identical helper in `members.tsx:134` and `members.groups.tsx:128`.** Two more sites (`projects.staffing.tsx:258`, `admin-console/routes/api.members.ts:63`) infer the same thing with three different dedupe rules.
+- **`role badges triple` (`adminMembership` + `coreAssignments` + `domainLeadAssignmentsAsUser`) duplicated 8×** with subtly different sub-selects. `search-directory.ts` filters `coreAssignments` by `termId`; `members.tsx` does not — so "isCore" silently differs by call site.
+- **`domain: { select: { id, displayName } }` and `displayName`-only** declared 25+ times. Also one site uses `domain: { select: { id, name } }` (note `name`, not `displayName`) at `projects.$id.tsx:124,196`.
+- **Sequential per-domain upsert loop in `app/hiring/lib/domain-application.ts:37-63`** — not wrapped in `$transaction`.
+
+### Constants & magic values
+
+- **`process.env.API_BASE_URL ?? <fallback>` repeated 14×** with three different fallbacks: `localhost:3001` (10×), `localhost:5173` (1×), `https://os.dali.dartmouth.edu` (2×). One file (`oauth.authorize.ts:144`) has the dev-port wrong.
+- **`Level = "P1" | "P2" | "P3"` redefined in 6 files**; only one (`admin-console/lib/eligibility.ts:6`) exports `ALLOWED_LEVELS`. The Prisma enum is deliberately avoided per comment in `bid-validation.ts:16`. `api.staffing.assign.ts:39` hand-rolls `if (o.level !== "P1" && o.level !== "P2" && o.level !== "P3")`.
+- **`applications@dali.dartmouth.edu` typed as a literal in 4 separate files** including 3 redundant `const GMAIL_USER = '...'` definitions (`gmail.ts:6`, `gmail-integration.ts:7`, `admin.authorize-gmail.callback.ts:10`).
+- **Staffing preference cap (`3`)** hardcoded in `bid-validation.ts:58` *and* in MCP prompts *and* in comments — even though `cycle.maxPreferencesPerMember` exists in the DB.
+- **`DAY_KEYS = ["SUN", "MON", ...]`** declared verbatim in `calendar.tsx:3173` and `home.tsx:617`.
+- **`@dali.dartmouth.edu` and `@dartmouth.edu` domain literals in 12+ files.** `WORKSPACE_DOMAIN` constant exists in `google-workspace.ts:27` but only used inside that one file.
+- **CAS_BASE_URL fallback `"https://login.dartmouth.edu/cas"` inlined 5×.**
+- **`"Forbidden"` JSON 403 hand-rolled 128×; `"Unauthorized"` 11×.** No `forbidden()` / `unauthorized()` helper.
+- **Cycle-start season-digit arithmetic uses bare magic numbers `9, 10, 1, 2`** at `roles.ts:228-230,248-249`. The fact that `W=1, S=2, X=3, F=4` is implicit in seed data; the math re-derives it inline.
+
+### Validation / FormData
+
+- **`safeJsonParse` declared byte-identically in 3 project routes** (`projects.project-bids.tsx:236`, `projects.intent-to-work.tsx:237`, `projects.level-up.tsx:381`) plus a near-twin pair in `forms-data.ts:211` / `public-form.ts:41`.
+- **The same id schema (`z.string().min(1).max(100)`) declared 17× across hiring/admin-console**, with another ~30 routes using `z.string().min(1)` (no cap) for the same conceptual fields.
+- **At least 4 different `Response.json({ error }, { status: 400 })` shapes** for the same Zod-rejected event: `{ error, details }`, `{ error }`, `{ error, status }`, `{ ok: false, reason }`. The calendar action schema parsed in two routes returns *different* shapes for the same schema (`calendar.tsx:332` vs `settings.calendar.tsx:96`).
+- **Hand-rolled `validateReviewPatch` in `api.reviews.$id.ts:39-160`** — 120 lines of imperative type-checking re-implementing Zod, plus a second copy of `VALID_RECOMMENDATIONS`.
+- **`NoteVersionSchema` declared byte-identically in 2 hiring routes** (`api.cycles.$cycleId.my-interviews.$interviewId.notes.ts:9`, `api.interview-assignments.$id.notes.ts:9`).
+- **Empty-string-to-null (`x === "" ? null : x`)** repeated 20+ times with three subtle variants (raw / `.slice(0,80)` / `.trim()`).
+- **Boolean-from-string** has at least 4 idioms (`=== "true"`, `=== "1"`, `Boolean()`, parseInt-then-check).
+- **No `.email()` call in the entire `app/` tree.** One ad-hoc regex (`api.email.send.ts:50`), one substring check (`profile-page.server.ts:328`).
+- **`parseJson()` adoption is half-done** — 41 routes use it, 8+ still hand-roll `safeJson + try/catch + safeParse`.
+- **Three ISO-datetime semantics**: `Date.parse(s)` refine (accepts "2024-13-01" silently), `z.string().datetime()`, `z.string().datetime({ offset: true })` — same logical field, three behaviors.
+- **75-line `coerceFormToAction` in `calendar.tsx:544`** reimplements what `z.coerce.*` + `z.preprocess` could fold into the schema.
+
+### UI / components
+
+- **77 hand-rolled coral primary buttons** (`bg-accent-coral text-white hover:bg-accent-coral/90`) — `<Button>` primitive has zero usage outside its own file.
+- **8+ hand-rolled modal overlays in `hiring/components/`** (Library lines 193/325/466, EmailTemplates, ApplicantContextModal, calendar personal-block popover, FormsBrowser folder-rename) bypass `Modal.tsx`. Drift includes missing Escape handling and inconsistent close-button styling.
+- **3 near-identical `Avatar` components** in `members.tsx:517`, `members.groups.tsx:844`, `MemberCard.tsx:196` — same fallback chip styling, different sizes.
+- **5 redefinitions of `STATUS_COLORS` / `DECISION_COLORS`** in hiring. `domain-lead.application.$id.tsx:42` uses `bg-purple-100` for `InvitedToInterview` while every other site uses `bg-blue-100` — visible drift.
+- **`formatDateTime` declared byte-identically in 4 hiring detail components** (`ConfidentialityAgreementDetail.tsx:8`, `EmailTemplateDetail.tsx:11`, `ChallengeDetail.tsx:10`, `RubricDetail.tsx:13`). Same files also each redefine `memberLabel`.
+- **3 user-picker UIs** (`AddMemberControl.tsx`, `admin-console.announcements.tsx`, `calendar.tsx`) — three completely different shapes for the same job.
+- **Form-row `<label><input/>` pattern inlined 34×** with two competing styles: design-token (`border-border`) vs. hiring-legacy (`border-gray-300 focus:ring-blue-500`). The hiring style ignores theme tokens and won't theme correctly.
+- **Table thead `bg-muted/30 text-muted-foreground text-xs uppercase tracking-wide` copy-pasted 7×.**
+- **Spinner `border-2 border-X border-t-Y rounded-full animate-spin` reimplemented 8×** plus 3 `<Loader2 className="animate-spin">` usages — no shared `<Spinner>`.
+- **Empty-state "No X yet" pattern repeats ~25×** in 3 different visual styles.
+
+### Integration glue + dates
+
+- **Google token refresh hand-rolled 5×** (top-of-funnel #8). Plus 4 authorize-redirect handlers with 3 different state-cookie names.
+- **`zonedWallTimeUtc` reimplemented 3×** in `general-calendar.ts:231`, `hiring/lib/scheduling.ts:570` (line-for-line copy), `api.calendar.group-availability.ts:85` — despite `lib/timezone.ts:104` being canonical.
+- **3 near-identical email-time formatters** (`interview-emails.ts:24`, `interview-notifications.ts:25`, `extension-notice.ts:23`) with different weekday widths and ET-suffix conventions.
+- **`getGmailRefreshToken()` declared verbatim in two hiring lib files** as a 1-line thin wrapper around the same import.
+- **Slack channel-sanitizer differs between server and client** (`slack-client.ts:218 sanitizeChannelName` vs `StaffingBoard.tsx:461 deriveTermChannel`) — client allows `_`, server collapses it to `-`. A name accepted in the UI is silently rewritten by the server.
+- **4 different "Slack not configured" shapes** across `slack-client.ts:20,129`, `api.staffing.finalize.ts:293`, `api.staffing.term-channel.ts:63`.
+- **CSV cell escaping is private to `admin-console/lib/payroll-export.ts:56`** — no shared `csv.ts` helper. The second CSV exporter will hand-roll it again.
+- **`SLACK_INVITE_USER_SELECT` shape declared 3×** (`api.staffing.finalize.ts:47`, `api.staffing.term-channel.ts:80` inline, `members/lib/slack-sync.server.ts:14` inline).
+- **PEM newline-restoration (`\\n` → `\n`) for Fly secrets** done twice — `github.ts:19 decodePem` and inline at `google-workspace.ts:86`.
+- **Random-token generation** scattered across 5 files with two ladders (16 hex for OAuth state, 32 base64url for sessions); `oauth.ts:84 generateOpaqueToken()` exists but isn't reused.
+- **Retry ladder `[500, 1000, 2000, 4000, 8000]`** hand-rolled at `google-workspace.ts:252` — the only retry in the codebase. The "staffing retry Google group adds" commit (#818) didn't factor it out.
+
+---
+
+## Already-DRY patterns worth extending
+
+The codebase has the right *primitives* in many places — they're just under-adopted. These are the canonical patterns to mimic.
+
+- **`requireAuth()`** (`app/lib/auth.ts:85`) — 516 imports. Right shape; missing the `requireCore` / `requireCoreOrDomainLead` siblings.
+- **`getUserRoles()`** (`app/lib/roles.ts:32`) — single parallel role fan-out; used by ~5 loaders correctly. The 100+ "two sequential `await isCore + await isDomainLead`" sites should funnel here.
+- **`hasCycleAccess(userId, cycleId)`** (`app/lib/roles.ts:277`) — model for the missing "core-or-domain-lead" helper.
+- **`logAuditEvent()`** (`app/lib/audit.ts:66`) — 100+ uniform call sites + a closed `AUDIT_ACTIONS` array. Best-in-class.
+- **`google-workspace.ts`** — discriminated-union `{ status, message }` results, `workspaceConfigured()` predicate, idempotent `ensure*` upserts. The model for every other integration module.
+- **`slack-client.ts:ensureChannel`** — get-or-create with `name_taken` handling. Right pattern.
+- **`lib/timezone.ts`** — `zonedWallTimeUtc`, `zonedDayStartUtc` are correct. The problem is 3 other files reimplement them.
+- **`lib/file-validation.ts`** — `MAX_UPLOAD_BYTES`, `fileMatchesAccept` shared correctly across 7 callsites.
+- **`lib/word-count.ts`** — same algorithm shared between portal form and live counter.
+- **`parseJson(request, schema)`** (`app/lib/validate.ts:13`) — clean drop-in adopted by 41 routes uniformly. Missing the `parseForm()` counterpart.
+- **`hiring/lib/email-variables.ts`** — slot-keyed template variables with a CI-pinned test. Right shape for shared templates.
+- **`forms/lib/forms-data.ts:runFormsAction`** — single action runner shared by 3 route entrypoints. Model for other feature modules.
+- **`REGISTRAR_DATES`** (`prisma/seeds/v0-reference.ts:88`) — single source of truth for the registrar calendar with sync comment.
+- **`COOKIE_SID = "__dali_sid"`** (`app/lib/cookies.ts:3`) — properly centralized.
+
+---
+
+## Outstanding questions
+
+These need a decision before any refactor work:
+
+1. **"isCore" semantic divergence (#3) — which behavior is correct?**
+   Should `ADMIN_USER_IDS` env-only admins appear as `isCore=true` in member lists? Today they don't, but route gates treat them as Core. This is a security-relevant decision, not just DRY.
+
+2. **`currentTerm()` vs `getCurrentTermId()` inter-term-gap behavior (#4) — null or fallback?**
+   In the gap between, say, 26S and 26X, should "current term" return null or roll forward to 26X?
+
+3. **Project `canEdit` (auth #5) — stale artifact or intended permission?**
+   `projects.$id.tsx:240` permits project members to attempt edits the API will then 403. Is the loader's `canEdit` the desired permission (and the API gates are too strict), or vice versa?
+
+4. **Modal/Button adoption strategy.**
+   One big migration pass or split by domain (hiring vs projects vs forms)?
+
+5. **Migration ordering.**
+   Roughly suggested order if you want to act on this:
+   1. Identity-layer helpers (`primaryEmail`, `fullName`, `DARTMOUTH_EMAIL_DOMAIN`) — small, mechanical, eliminates a confirmed drift bug.
+   2. The `isCore` semantic divergence — confirm semantic first, then unify.
+   3. `requireCore` + `requireCoreOrDomainLead` + `forbidden(request)` helpers — absorbs ~150 sites of route boilerplate and unifies response shapes.
+   4. `<Button>` and `<Modal>` adoption — high-volume, visible, low-risk mechanical refactor.
+
+---
+
+## Appendix — files most worth opening first
+
+Likely best-positioned places to land new shared helpers:
+
+- `app/lib/auth.ts` — for `requireCore`, `requireCoreOrDomainLead`, `forbidden`, `unauthorized`
+- `app/lib/display.ts` — for `fullName`, `primaryEmail`, `displayEmail`, `EMPTY_DISPLAY`
+- `app/lib/app-env.ts` — for `getApiBaseUrl()`, `getFrontendUrl()`, `DARTMOUTH_EMAIL_DOMAIN`, `APPLICATIONS_FROM_EMAIL`
+- `app/lib/roles.ts` — already hosts `currentTerm`, `getUserRoles`, `hasCycleAccess` — the missing helpers belong here too
+- `app/lib/validate.ts` — for `parseForm(request, schema)`, an `idSchema` atom, `nullableTrimmed()`
+- `app/components/ui/Button.tsx`, `app/components/Modal.tsx` — already exist, just need adoption
+- A new `app/lib/csv.ts` — for the next export to share
+- A new `app/lib/google-oauth.ts` — to consolidate the 5 token-refresh + 4 authorize-redirect copies
+- `app/lib/timezone.ts` — already canonical; needs `app/hiring/lib/scheduling.ts:570` and friends to delete their copies

--- a/DRY_DEFERRED.md
+++ b/DRY_DEFERRED.md
@@ -1,0 +1,288 @@
+# DRY Refactor — Deferred Next Steps
+
+Companion to [`DRY_AUDIT.md`](./DRY_AUDIT.md) and PR #834.
+
+This file lists everything the DRY audit flagged that **did not ship** in PR #834. Each item is sized so it can be picked up as its own follow-up PR. Items are ordered by priority: do the semantic corrections first (they're real correctness work, not style), then the mechanical adoptions.
+
+---
+
+## Phase 6 — Semantic corrections (do these first)
+
+These are correctness decisions already agreed on in the PR #834 review thread. They change behavior, so each gets its own PR.
+
+### 6.1 — `isCore` env-admin override should be honored everywhere
+**Decision:** Env admins ARE admins everywhere.
+
+**Problem:** `app/lib/roles.ts:83 isCore()` honors `ADMIN_USER_IDS` env override, but five list-view loaders compute `isCore: u.coreAssignments.length > 0` directly from the array. Result: a user granted Admin only via env appears `isAdmin=false` in member lists but `isAdmin=true` in route gates.
+
+**Sites to fix:**
+- `app/admin-console/routes/api.members.ts:62`
+- `app/admin-console/routes/admin-console.members.tsx:62`
+- `app/admin-console/routes/admin-console.domains.tsx:80`
+- `app/mcp/tools/search-directory.ts:108`
+- `app/mcp/tools/get-member-profile.ts:92`
+
+**Approach:** Compute `isCore`/`isAdmin` for each row by calling `getUserRoles(userId)` (the canonical helper at `roles.ts:32`) instead of deriving from the relation array. This is a small N+1 in the list views — acceptable for the page size, but if it bites, batch with a `getUserRolesBatch([userId])` helper.
+
+**Risk:** Low. Existing tests pass; new test should assert that an env-admin user appears as admin in the member list.
+
+---
+
+### 6.2 — Retire `getCurrentTermId()`; standardize on `currentTerm()`
+**Decision:** Roll-forward semantics win.
+
+**Problem:** Two competing "current term" helpers with different inter-term-gap behavior. `roles.ts:186 currentTerm()` rolls forward to the next upcoming term in the gap; `groups.ts:90 getCurrentTermId()` returns `null` in that gap.
+
+**Approach:**
+1. Find every caller of `getCurrentTermId()` and convert to `(await currentTerm())?.id`.
+2. Delete `getCurrentTermId()` from `groups.ts`.
+3. The 3 hand-rolled copies in `app/hiring/lib/intern-eligibility.ts:11,35,58` have a comment saying they "deliberately do NOT fall back" — leave those alone, but add a sibling `currentTermStrict()` helper to `roles.ts` and have them call it so the math isn't open-coded.
+
+**Risk:** Medium. Anywhere that branched on `null` in the inter-term gap will now get a term. Audit each call site for whether that change of behavior is acceptable (it usually is — UI surfaces want "what's coming up").
+
+---
+
+### 6.3 — Loosen project mutation APIs to match `projects.$id.tsx canEdit`
+**Decision:** UI's `canEdit = core || isProjectMember` is correct; API gates should match.
+
+**Problem:** The loader at `app/projects/routes/projects.$id.tsx:240` lets project members attempt edits the 14 mutation APIs then 403. Reconcile.
+
+**Sites to update** (each currently gates on `isCore` only):
+- `app/projects/routes/api.tasks.$id.ts:78`
+- `app/projects/routes/api.epics.$id.ts:55`
+- `app/projects/routes/api.stories.$id.ts:43`
+- `app/projects/routes/api.sprints.$id.ts:49`
+- `app/projects/routes/api.documents.$id.ts:32`
+- `app/projects/routes/api.epics.$id.description-doc.ts:34`
+- `app/projects/routes/api.projects.$id.tasks.ts:61`
+- `app/projects/routes/api.projects.$id.epics.ts:59`
+- `app/projects/routes/api.projects.$id.sprints.ts:48`
+- `app/projects/routes/api.projects.$id.documents.ts:33`
+- `app/projects/routes/api.epics.$id.stories.ts:44`
+- `app/projects/routes/api.tasks.$id.move.ts:36`
+- `app/projects/routes/api.files.$id.ts:97`
+- `app/projects/routes/api.projects.$id.files.ts:35`
+
+**Approach:**
+1. Add a `requireProjectEditAccess(request, projectId)` helper to `app/lib/auth.ts` returning the same `{ok, auth} | {ok, response}` shape. Predicate: `isCore(userId) || isProjectMember(userId, projectId)`. Where to derive `projectId` per route varies (`params.id` is sometimes the task ID, sometimes the project ID — read each).
+2. Replace `requireCore` with `requireProjectEditAccess` in the 14 routes.
+3. Write tests: project member edit succeeds; outsider 403s; Core still works.
+
+**Risk:** Medium-high — security-relevant. Confirm with a Core member that all 14 of these are intended to be project-member-editable. Some (e.g. `api.files.$id.ts` delete?) might actually be Core-only by policy.
+
+---
+
+## Phase 4 — UI primitive adoption (high-volume, mechanical, visible)
+
+These are the largest mechanical migrations in the audit. They should happen across several PRs split by domain (a single PR touching 85 button sites is unreviewable).
+
+### 4.1 — Adopt `<Button>` (PR per domain)
+**Problem:** `bg-accent-coral text-white hover:bg-accent-coral/90` is hand-rolled 77 times. `app/components/ui/Button.tsx` has zero usages outside its own file.
+
+**Split:** one PR per domain:
+- Projects (~10 sites): `FinalizeModal.tsx:340`, `TaskModal.tsx:263,271`, `SlotColumnMapper.tsx:598`, `StaffingBoard.tsx:535`, `SlotFormPicker.tsx:79`, `TaskBoard.tsx:195`, `EpicSprintManager.tsx:848,951,1041`, `projects.list.tsx:190,285`, `projects.level-up.tsx:646,731`, `projects.$id.tsx:1043`
+- Forms (~3): `MemberFormFillView.tsx:131`, `FormDetail.tsx:204,440`, `FormsBrowser.tsx:160`
+- Calendar (~2): `calendar.tsx:1414,2017`
+- Hiring (~1): `EmailTemplates.tsx:179`
+- Misc components (~1): `ApplicantErrorBoundary.tsx:66`
+- Plus the long tail (any new sites that landed since the audit)
+
+**Approach:** For each site, swap the `<button className="bg-accent-coral …">` for `<Button variant="primary">`. The component already supports `size="sm"|"md"`, `disabled`, `type`, `onClick`. Watch for sites that mix in extra utility classes (e.g. `mt-2`, `w-full`) — pass via `className` prop on `<Button>` (cn() handles merging).
+
+### 4.2 — Adopt `<Modal>` for hiring overlays
+**Problem:** 8 hand-rolled `fixed inset-0 z-50 bg-black/40` overlays bypass `app/components/Modal.tsx` (which has correct focus-trap + Escape + scroll-lock).
+
+**Sites:**
+- `app/hiring/components/Library.tsx:193,325,466`
+- `app/hiring/components/EmailTemplates.tsx:133`
+- `app/hiring/components/delibs/ApplicantContextModal.tsx:67`
+- `app/projects/routes/projects.level-up.tsx:691`
+- `app/calendar/routes/calendar.tsx:1914`
+- `app/forms/components/FormsBrowser.tsx:390`
+- `app/components/collab/VersionHistoryPanel.tsx:151`
+
+**Risk:** Low — `Modal.tsx` is the documented primitive, just adopt it. Watch for hand-rolled close buttons / X icons; reuse the Modal's built-in one.
+
+### 4.3 — Consolidate Avatar / RolePills / STATUS_COLORS / DECISION_COLORS
+**Problem:** Same UI elements re-implemented across `members.tsx`, `members.groups.tsx`, `MemberCard.tsx`, hiring routes. The DECISION_COLORS map at `domain-lead.application.$id.tsx:42` uses `bg-purple-100` for `InvitedToInterview` while every other site uses `bg-blue-100` — visible drift.
+
+**Approach:**
+1. Move `Avatar` and `RolePills` into `app/components/ui/` (alongside `Button` and `Card`); accept `size="sm"|"md"|"lg"` and an optional `showLevel` flag.
+2. Move `STATUS_COLORS`, `DECISION_COLORS`, `STAGE_LABELS` into `app/hiring/lib/labels.ts`; have all 5+ sites import.
+3. Fix the purple→blue drift while you're there (or document why purple was intentional).
+
+---
+
+## Phase 7 — Heavier rewrites
+
+### 7.1 — Replace `validateReviewPatch` with Zod
+**Problem:** `app/hiring/routes/api.reviews.$id.ts:39-160` is ~120 lines of imperative type-checking re-implementing what Zod does natively.
+
+**Approach:**
+```ts
+const ReviewPatchSchema = z.object({
+  scores: z.record(z.string().max(100), z.number().min(0).max(10))
+            .superRefine((scores, ctx) => { /* per-rubric limits */ }),
+  feedback: z.string().max(MAX_FEEDBACK),
+  recommendation: z.enum(VALID_RECOMMENDATIONS),
+  notes: z.string().max(MAX_NOTES).optional(),
+  // ...
+}).strict();
+```
+
+Then call `parseJson(request, ReviewPatchSchema)`. Also: deduplicate `VALID_RECOMMENDATIONS` (currently at both `api.reviews.$id.ts:8` AND `api.interviews.$id.complete.ts:10`) — extract to `hiring/lib/review.ts`.
+
+**Risk:** Medium. Custom validator may have asymmetric rules vs Zod. Read carefully; consider keeping a few `.refine`s for cross-field invariants.
+
+### 7.2 — Replace `coerceFormToAction` with `z.coerce` / `z.preprocess`
+**Problem:** `app/calendar/routes/calendar.tsx:544-618` is 75 lines of hand-rolled FormData → typed object coercion.
+
+**Approach:** Fold each branch into `CalendarActionSchema` itself using `z.coerce.number()`, `z.coerce.boolean()`, `z.preprocess((s) => JSON.parse(s), z.object({...}))`. After this, `parseForm(request, CalendarActionSchema)` (the new helper) replaces both `coerceFormToAction` AND the inline coercer in `routes/settings.calendar.tsx:82-94`.
+
+**Risk:** Medium. Touch surface includes the calendar's main action handler. Test with both create-event and edit-event flows.
+
+### 7.3 — Reconcile `getAppEnv()` vs `NODE_ENV === "production"`
+**Problem:** Two parallel "what environment am I in?" axes. On Fly.io, staging is `NODE_ENV=production` — the two can disagree.
+
+**Approach:**
+- Decide: is `'dev' | 'staging' | 'prod'` the canonical axis, or is `NODE_ENV` plus a separate flag?
+- Recommended: standardize on `getAppEnv()` for app-level branching (email staging banners, copy variants). Keep `NODE_ENV === "production"` only for things Node/security headers care about (cookie `Secure`, `x-frame-options`).
+- Sites to migrate: `app/lib/cookies.ts:12`, `app/lib/security-headers.ts:1`, `app/routes/login.tsx:63,80`, `app/lib/dev-login.ts:2`. Pick one rule and document it in `CLAUDE.md`.
+
+**Risk:** Medium. Cookie-secure / cookie-domain mistakes are silent in dev.
+
+---
+
+## Phase 3 — Adoption sites missed by PR #834
+
+The hiring-domain agent stalled mid-run. These small follow-ups complete Phase 3.
+
+### 3.1 — Hiring `idSchema` adoption
+Three files still inline `z.string().min(1).max(100)`:
+- `app/hiring/routes/api.my-interview.reschedule.ts:16` (and the action schema's `interviewId`/`newAvailabilityId` fields)
+- `app/hiring/routes/api.interviews.$id.reassign.ts:13-14`
+- `app/hiring/routes/api.domain-applications.$id.reviews.ts:10`
+
+**Approach:** Replace each with `idSchema` imported from `~/lib/validate`. Bundle into a tiny PR.
+
+### 3.2 — Hiring page-route `requireCoreOrDomainLead` adoption
+Four route files still inline the gate:
+- `app/hiring/routes/library.tsx:18-23, 68-73`
+- `app/hiring/routes/rubrics.$id.tsx:16, 34`
+- `app/hiring/routes/challenges.$id.tsx:16, 39`
+- `app/hiring/routes/applications.tsx:37`
+
+**Approach:** Adopt `requireCoreOrDomainLead(request)`. These are `.tsx` loaders, not API actions, so check whether they need to redirect (e.g. `/`) vs return a Response. Likely the existing pattern returns `Response.json(...)` even from loaders; if so, just swap.
+
+### 3.3 — `displayEmail(user)` adoption (skipped sites)
+Tighter `daliEmail ?? dartmouthEmail` chains that weren't migrated because they used a different fallback (`auth.user.email` vs `personalEmail`):
+- `app/mcp/tools/rsvp-to-notification.ts:69`
+- `app/routes/api.notifications.$id.rsvp.ts:63`
+- `app/routes/oauth.consent.tsx:64`
+
+**Approach:** Decide the canonical chain (almost certainly `primaryEmail(user) ?? auth.user.email`) and apply.
+
+---
+
+## Phase 5 — Remaining integration consolidation
+
+### 5.1 — `lib/audit.ts` metadata schema discriminator
+**Problem:** Each `AUDIT_ACTIONS` key has its own ad-hoc metadata shape. Today this is fine; future you will appreciate a discriminated union.
+
+**Approach:**
+```ts
+type AuditMetadata =
+  | { action: "staffing.assign"; cycleId: string; projectId: string; ... }
+  | { action: "staffing.finalize"; cycleId: string; ... }
+  | ...;
+```
+Type `logAuditEvent` so the `action` field constrains the `metadata` shape at compile time. Will surface drift between caller and reader.
+
+**Risk:** Type-only. No runtime change.
+
+### 5.2 — Slack response shape on "not configured"
+**Problem:** 4 different shapes for "Slack isn't configured":
+- `app/slack/lib/slack-client.ts:20-24` — throws
+- `app/slack/lib/slack-client.ts:129` — silent null
+- `app/projects/routes/api.staffing.finalize.ts:293` — `{ status: "skipped", message: "SLACK_BOT_TOKEN not set." }`
+- `app/projects/routes/api.staffing.term-channel.ts:63` — `{ error: "SLACK_BOT_TOKEN not set." }, 400`
+
+**Approach:** Standardize on the `{ status: "ok" | "skipped" | "error" }` discriminated-union shape that `google-workspace.ts` already uses. Wrap every Slack call in a `withSlackResult` helper that returns this shape; never throw.
+
+### 5.3 — Retry helper extraction
+**Problem:** `google-workspace.ts:252-281` has the only retry-with-backoff in the codebase, hand-rolled. The "staffing retry Google group adds" commit (#818) didn't factor it out.
+
+**Approach:** Extract `retry(fn, { backoffsMs, untilOk })` into `lib/retry.ts`. Convert the `addGroupMember` retry to use it. Future Slack/GitHub retries can adopt.
+
+---
+
+## Phase 2 — Remaining exact-duplicate dedupe
+
+### 2.1 — `forms/lib/forms-data.ts:safeParse` vs `public-form.ts:safeParse`
+Two `safeParse(s)` helpers with subtly different null-handling. Pick one (the null-tolerant version) and have the other re-export.
+
+### 2.2 — Three project routes' "user detail" page shells
+`app/projects/routes/projects.project-bids.$userId.tsx`, `projects.intent-to-work.$userId.tsx`, `projects.level-up.$userId.tsx` all render `<dl className="bg-card border border-border rounded-lg divide-y divide-border">` with identical row shells. Extract `<UserSubmissionShell>` to `app/projects/components/`.
+
+### 2.3 — Admin-console search-input + magnifier icon
+`admin-console.announcements.tsx:374,427`, `admin-console.domains.tsx:281,459`, `admin-console.members.tsx:214` — 5 sites of `<Search className="absolute …" /> + <input className="w-full pl-7 …" />`. Extract `<SearchInput>` to `app/components/ui/`.
+
+### 2.4 — Cancel button class
+`px-3 py-2 text-sm font-medium text-foreground/80 bg-card border border-gray-300 rounded-md hover:bg-muted/50` at 6 sites. Should be `<Button variant="secondary">` (part of phase 4.1).
+
+---
+
+## Lower-priority hygiene
+
+### H1 — `Level` type centralization
+PR #834 added `lib/level.ts` with `Level` and `ALL_LEVELS`. Adoption is incomplete:
+- `app/projects/lib/bid-validation.ts:18`
+- `app/projects/lib/staffing-board.ts:5`
+- `app/admin-console/lib/eligibility.ts:6-8`
+- `app/admin-console/routes/admin-console.domains.tsx:313,326,331,391`
+- `app/projects/routes/api.staffing.assign.ts:28,39` (hand-rolled validator can become `isLevel`)
+- `app/projects/components/MemberCard.tsx:7-9`
+- `app/projects/routes/projects.level-up.tsx:38-40,593`
+Each should `import { Level, ALL_LEVELS, isLevel } from "~/lib/level"`.
+
+### H2 — `Forbidden`/`Unauthorized` 403/401 plain-text holdouts
+Sites returning `new Response("Forbidden", { status: 403 })` (plain text) that PR #834 left alone because they weren't JSON:
+- `app/projects/routes/api.staffing.events.ts:23,25`
+- `app/admin-console/routes/admin-console.payroll-export.csv.ts:31`
+- `app/hiring/routes/lead.intern-to-full-cycle.$id.tsx:216`
+- Several `tsx` action handlers in `projects.intent-to-work.tsx:177`, `projects.level-up.tsx:309,354`, `projects.project-bids.tsx:173`
+
+Pick a canonical shape (`forbidden(request)` — JSON 403) and migrate, OR introduce a `forbiddenPlainText(request)` and adopt it.
+
+### H3 — Page-template name strings (`prisma/seeds/v0-reference.ts:192-200`)
+The template names (`Empty`, `Sprint Retro`, `Onboarding Doc`, etc.) live only in the seed file. If anything starts looking them up by string, extract to a shared `app/lib/page-templates.ts`. Not currently exploited; tracked for posterity.
+
+### H4 — Sentinel `"Unknown"` vs `"—"` for missing fields
+Two different sentinels coexist (`UNKNOWN_LABEL` and `EMPTY_DISPLAY` are both in `lib/display.ts` now). Decide policy:
+- `EMPTY_DISPLAY` (`—`) for table cells / structured data
+- `UNKNOWN_LABEL` (`Unknown`) for human prose ("Created by Unknown")
+
+Document the choice in `lib/display.ts` as a 2-line comment and migrate the ~10 inline `"Unknown"` / `"—"` literals to match.
+
+### H5 — Cycle-start season-digit math (`roles.ts:228-249`)
+Bare magic numbers `9, 10, 1, 2` encode the (W=1, S=2, X=3, F=4) season ordering. Extract a `SEASON_SORT_INDEX` const to `lib/terms.shared.ts` and reference it from the math. Currently correct; just not readable.
+
+### H6 — `getCurrentTermId` retirement (linked to 6.2)
+After 6.2 ships, delete the function and any tests pointing at it.
+
+---
+
+## Tracking
+
+For each item above:
+1. Open a GitHub issue if there isn't one already.
+2. Link the issue to this doc.
+3. When the PR lands, strike through the entry here (or delete the section).
+
+If priorities shift (e.g. you decide `<Button>` adoption is more urgent than the semantic corrections), re-order this file — the dependency graph is roughly:
+- 6.x semantic items are independent of each other.
+- 4.x UI adoption is independent of everything else.
+- 7.x rewrites depend on nothing.
+- 3.x / 5.x / H.x are smallest and can be parallelized.
+
+Total estimated work: ~12 follow-up PRs, the largest being 4.1 (Button adoption).

--- a/dali-api/app/admin-console/__tests__/admin-console.members.action.test.ts
+++ b/dali-api/app/admin-console/__tests__/admin-console.members.action.test.ts
@@ -3,6 +3,16 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 vi.mock("~/lib/db");
 vi.mock("~/lib/auth", () => ({
   requireAuth: vi.fn(),
+  requireCore: vi.fn(),
+  requireCoreOrDomainLead: vi.fn(),
+  requireMemberSession: vi.fn(),
+  forbidden: vi.fn((_req: Request) =>
+    Response.json({ error: "Forbidden" }, { status: 403 }),
+  ),
+  unauthorized: vi.fn((_req: Request) =>
+    Response.json({ error: "Unauthorized" }, { status: 401 }),
+  ),
+  redirectApplicantToPortal: vi.fn(() => null),
 }));
 vi.mock("~/lib/roles");
 vi.mock("~/lib/core-cycle", () => ({

--- a/dali-api/app/admin-console/__tests__/admin-console.members.action.test.ts
+++ b/dali-api/app/admin-console/__tests__/admin-console.members.action.test.ts
@@ -5,6 +5,12 @@ vi.mock("~/lib/auth", () => ({
   requireAuth: vi.fn(),
 }));
 vi.mock("~/lib/roles");
+vi.mock("~/lib/core-cycle", () => ({
+  // Tests treat the cycle as a single term ("term-1"); fan-out behavior is
+  // exercised through the count of writes, not the cycle math.
+  coreCycleTermIds: vi.fn().mockResolvedValue(["term-1"]),
+  cycleSortKeyRange: vi.fn(),
+}));
 
 import { prisma } from "~/lib/db";
 import { requireAuth } from "~/lib/auth";
@@ -23,7 +29,10 @@ const mockPrisma = prisma as unknown as {
   };
   coreAssignment: {
     findFirst: ReturnType<typeof vi.fn>;
+    findMany: ReturnType<typeof vi.fn>;
+    findUnique: ReturnType<typeof vi.fn>;
     create: ReturnType<typeof vi.fn>;
+    createMany: ReturnType<typeof vi.fn>;
     deleteMany: ReturnType<typeof vi.fn>;
   };
   domainLeadAssignment: {
@@ -40,7 +49,10 @@ beforeEach(() => {
   };
   (mockPrisma as any).coreAssignment = {
     findFirst: vi.fn().mockResolvedValue(null),
+    findMany: vi.fn().mockResolvedValue([]),
+    findUnique: vi.fn().mockResolvedValue(null),
     create: vi.fn(),
+    createMany: vi.fn(),
     deleteMany: vi.fn(),
   };
   (mockPrisma as any).domainLeadAssignment = {
@@ -100,31 +112,36 @@ describe("admin-console.members action — gate", () => {
 });
 
 describe("admin-console.members action — add-core-title (Core or Admin)", () => {
-  it("creates a CoreAssignment with the free-text title when none exists", async () => {
+  it("materializes a CoreAssignment for every term in the cycle", async () => {
     asCore();
     await action({
       request: postForm({ intent: "add-core-title", userId: USER_ID, leadTitle: "Design Lead" }),
       params: {},
       context: {},
     } as any);
-    expect(mockPrisma.coreAssignment.findFirst).toHaveBeenCalledWith({
-      where: { userId: USER_ID, termId: TERM_ID, leadTitle: "Design Lead" },
-      select: { id: true },
+    // Reads existing cycle-mate rows first to compute the missing set.
+    expect(mockPrisma.coreAssignment.findMany).toHaveBeenCalledWith({
+      where: {
+        userId: USER_ID,
+        termId: { in: [TERM_ID] },
+        leadTitle: "Design Lead",
+      },
+      select: { termId: true },
     });
-    expect(mockPrisma.coreAssignment.create).toHaveBeenCalledWith({
-      data: { userId: USER_ID, termId: TERM_ID, leadTitle: "Design Lead" },
+    expect(mockPrisma.coreAssignment.createMany).toHaveBeenCalledWith({
+      data: [{ userId: USER_ID, termId: TERM_ID, leadTitle: "Design Lead" }],
     });
   });
 
-  it("is a no-op when an identical (user, term, title) row already exists", async () => {
+  it("is a no-op when the cycle is already fully covered", async () => {
     asCore();
-    mockPrisma.coreAssignment.findFirst.mockResolvedValueOnce({ id: "ca-1" });
+    mockPrisma.coreAssignment.findMany.mockResolvedValueOnce([{ termId: TERM_ID }]);
     await action({
       request: postForm({ intent: "add-core-title", userId: USER_ID, leadTitle: "PM" }),
       params: {},
       context: {},
     } as any);
-    expect(mockPrisma.coreAssignment.create).not.toHaveBeenCalled();
+    expect(mockPrisma.coreAssignment.createMany).not.toHaveBeenCalled();
   });
 
   it("treats an empty title as a null (untitled Core) row", async () => {
@@ -134,25 +151,45 @@ describe("admin-console.members action — add-core-title (Core or Admin)", () =
       params: {},
       context: {},
     } as any);
-    expect(mockPrisma.coreAssignment.findFirst).toHaveBeenCalledWith({
-      where: { userId: USER_ID, termId: TERM_ID, leadTitle: null },
-      select: { id: true },
+    expect(mockPrisma.coreAssignment.findMany).toHaveBeenCalledWith({
+      where: {
+        userId: USER_ID,
+        termId: { in: [TERM_ID] },
+        leadTitle: null,
+      },
+      select: { termId: true },
     });
-    expect(mockPrisma.coreAssignment.create).toHaveBeenCalledWith({
-      data: { userId: USER_ID, termId: TERM_ID, leadTitle: null },
+    expect(mockPrisma.coreAssignment.createMany).toHaveBeenCalledWith({
+      data: [{ userId: USER_ID, termId: TERM_ID, leadTitle: null }],
     });
   });
 });
 
 describe("admin-console.members action — remove-core-title", () => {
-  it("deletes by assignment id", async () => {
+  it("clears the (userId, leadTitle) across every term in the cycle", async () => {
     asCore();
+    // The action looks up the assignment first to resolve (userId, termId, leadTitle).
+    mockPrisma.coreAssignment.findUnique.mockResolvedValueOnce({
+      userId: USER_ID,
+      termId: TERM_ID,
+      leadTitle: "Design Lead",
+    });
     await action({
       request: postForm({ intent: "remove-core-title", assignmentId: "ca-1" }),
       params: {},
       context: {},
     } as any);
-    expect(mockPrisma.coreAssignment.deleteMany).toHaveBeenCalledWith({ where: { id: "ca-1" } });
+    expect(mockPrisma.coreAssignment.findUnique).toHaveBeenCalledWith({
+      where: { id: "ca-1" },
+      select: { userId: true, termId: true, leadTitle: true },
+    });
+    expect(mockPrisma.coreAssignment.deleteMany).toHaveBeenCalledWith({
+      where: {
+        userId: USER_ID,
+        leadTitle: "Design Lead",
+        termId: { in: [TERM_ID] },
+      },
+    });
   });
 });
 

--- a/dali-api/app/admin-console/__tests__/api.domains.delete.test.ts
+++ b/dali-api/app/admin-console/__tests__/api.domains.delete.test.ts
@@ -3,6 +3,16 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 vi.mock("~/lib/db");
 vi.mock("~/lib/auth", () => ({
   requireAuth: vi.fn(),
+  requireCore: vi.fn(),
+  requireCoreOrDomainLead: vi.fn(),
+  requireMemberSession: vi.fn(),
+  forbidden: vi.fn((_req: Request) =>
+    Response.json({ error: "Forbidden" }, { status: 403 }),
+  ),
+  unauthorized: vi.fn((_req: Request) =>
+    Response.json({ error: "Unauthorized" }, { status: 401 }),
+  ),
+  redirectApplicantToPortal: vi.fn(() => null),
 }));
 vi.mock("~/lib/roles");
 

--- a/dali-api/app/admin-console/__tests__/api.members.roles.test.ts
+++ b/dali-api/app/admin-console/__tests__/api.members.roles.test.ts
@@ -5,6 +5,12 @@ vi.mock("~/lib/auth", () => ({
   requireAuth: vi.fn(),
 }));
 vi.mock("~/lib/roles");
+vi.mock("~/lib/core-cycle", () => ({
+  // Tests only care that the action runs and validates the request body —
+  // not the cycle math — so stub to "current term only".
+  coreCycleTermIds: vi.fn().mockResolvedValue(["term-1"]),
+  cycleSortKeyRange: vi.fn(),
+}));
 vi.mock("~/lib/audit", () => ({ logAuditEvent: vi.fn() }));
 vi.mock("~/lib/cors", () => ({
   handlePreflight: () => null,
@@ -32,7 +38,9 @@ const mockPrisma = prisma as unknown as {
   };
   coreAssignment: {
     findFirst: ReturnType<typeof vi.fn>;
+    findMany: ReturnType<typeof vi.fn>;
     create: ReturnType<typeof vi.fn>;
+    createMany: ReturnType<typeof vi.fn>;
     deleteMany: ReturnType<typeof vi.fn>;
   };
   user: {
@@ -50,7 +58,9 @@ beforeEach(() => {
   };
   (mockPrisma as any).coreAssignment = {
     findFirst: vi.fn().mockResolvedValue(null),
+    findMany: vi.fn().mockResolvedValue([]),
     create: vi.fn(),
+    createMany: vi.fn(),
     deleteMany: vi.fn(),
   };
   (mockPrisma as any).user = {

--- a/dali-api/app/admin-console/components/admin-console-shared.tsx
+++ b/dali-api/app/admin-console/components/admin-console-shared.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
 import { useFetcher } from "react-router";
 import { Shield, ChevronDown, X, Check, Plus } from "lucide-react";
+import { fullName } from "~/lib/display";
 
 // Phase 2 reshape: Member is rooted at User. Role flags derive from typed
 // assignment tables (AdminMembership, CoreAssignment, DomainLeadAssignment)
@@ -85,7 +86,7 @@ export interface DomainWithCounts extends DomainRow {
 }
 
 export function memberLabel(member: { firstName: string; lastName: string; daliEmail: string | null }) {
-  const name = `${member.firstName ?? ""} ${member.lastName ?? ""}`.trim();
+  const name = fullName(member);
   return name || member.daliEmail || "Unnamed member";
 }
 

--- a/dali-api/app/admin-console/lib/eligibility.ts
+++ b/dali-api/app/admin-console/lib/eligibility.ts
@@ -3,11 +3,11 @@
 // client bundle; pure values stay here so route components can render the
 // level picker without pulling a "*.server" file into the browser.
 
-export type Level = "P1" | "P2" | "P3";
+import { ALL_LEVELS, isLevel, type Level } from "~/lib/level";
 
-export const ALLOWED_LEVELS: Level[] = ["P1", "P2", "P3"];
+export { type Level };
+export const ALLOWED_LEVELS = ALL_LEVELS;
 
 export function parseLevel(raw: unknown): Level | null {
-  if (typeof raw !== "string") return null;
-  return (ALLOWED_LEVELS as string[]).includes(raw) ? (raw as Level) : null;
+  return isLevel(raw) ? raw : null;
 }

--- a/dali-api/app/admin-console/lib/payroll-export.ts
+++ b/dali-api/app/admin-console/lib/payroll-export.ts
@@ -1,4 +1,5 @@
 import { prisma } from "~/lib/db";
+import { rowsToCsv as rowsToCsvShared } from "~/lib/csv";
 
 // ─── Constants per payroll spec ──────────────────────────────────────────────
 // Single hardcoded primary/secondary supervisor for the whole lab. Per spec,
@@ -50,14 +51,6 @@ export type PayrollRow = {
   // a missing value is just an empty string.
   warnings: string[];
 };
-
-// RFC 4180 quoting: wrap in quotes if value contains a comma, quote, or newline;
-// double up internal quotes.
-function csvCell(raw: string): string {
-  if (raw === "") return "";
-  if (/[",\n\r]/.test(raw)) return `"${raw.replace(/"/g, '""')}"`;
-  return raw;
-}
 
 export function formatDate(d: Date): string {
   // ISO YYYY-MM-DD; Dartmouth payroll accepts this format.
@@ -294,35 +287,28 @@ export async function buildPayrollRows(termId: string): Promise<PayrollRow[]> {
 }
 
 export function rowsToCsv(rows: PayrollRow[]): string {
-  const lines: string[] = [];
-  lines.push(CSV_HEADERS.map(csvCell).join(","));
+  const allRows: unknown[][] = [CSV_HEADERS.slice()];
   for (const r of rows) {
-    lines.push(
-      [
-        r.netId,
-        r.firstName,
-        r.lastName,
-        r.jobId,
-        PRIMARY_SUPERVISOR_NETID,
-        SECONDARY_SUPERVISOR_NETID,
-        r.hourlyWage,
-        ANTICIPATED_HOURS_PER_WEEK,
-        r.hireStart,
-        r.hireEnd,
-        r.chartStringType,
-        r.chartString,
-        "", // Student Phone Number — blank per spec
-        "", // Term — blank per spec
-        "", // Max Hours – PTO — blank per spec
-        "", // Max Hours – Mental Health — blank per spec
-      ]
-        .map(csvCell)
-        .join(","),
-    );
+    allRows.push([
+      r.netId,
+      r.firstName,
+      r.lastName,
+      r.jobId,
+      PRIMARY_SUPERVISOR_NETID,
+      SECONDARY_SUPERVISOR_NETID,
+      r.hourlyWage,
+      ANTICIPATED_HOURS_PER_WEEK,
+      r.hireStart,
+      r.hireEnd,
+      r.chartStringType,
+      r.chartString,
+      "", // Student Phone Number — blank per spec
+      "", // Term — blank per spec
+      "", // Max Hours – PTO — blank per spec
+      "", // Max Hours – Mental Health — blank per spec
+    ]);
   }
-  // RFC 4180 uses CRLF; payroll importers handle either, CRLF is safer for
-  // Excel on Windows.
-  return lines.join("\r\n") + "\r\n";
+  return rowsToCsvShared(allRows);
 }
 
 // Picks the term that contains today, falling back to the most recent term.

--- a/dali-api/app/admin-console/lib/payroll-export.ts
+++ b/dali-api/app/admin-console/lib/payroll-export.ts
@@ -107,6 +107,9 @@ export type RoleCandidate = {
 };
 
 export async function listCoreCandidates(termId: string): Promise<RoleCandidate[]> {
+  // CoreAssignment rows are materialized per-term across the election cycle
+  // (writers in admin-console fan out across [Spring N, Spring N+1)), so a
+  // direct lookup by termId surfaces the full cohort.
   const rows = await prisma.coreAssignment.findMany({
     where: { termId },
     select: {

--- a/dali-api/app/admin-console/routes/admin-console.activity.tsx
+++ b/dali-api/app/admin-console/routes/admin-console.activity.tsx
@@ -3,6 +3,7 @@ import type { Route } from "./+types/admin-console.activity";
 import { prisma } from "~/lib/db";
 import { requireAuth } from "~/lib/auth";
 import { isAdmin } from "~/lib/roles";
+import { fullName } from "~/lib/display";
 import { AUDIT_ACTIONS } from "~/lib/audit";
 import {
   parseAuditFilters,
@@ -90,7 +91,7 @@ type PersonRow = { firstName: string; lastName: string; daliEmail: string | null
 
 function displayPerson(u: PersonRow | null, fallbackId: string | null) {
   if (u) {
-    const name = `${u.firstName} ${u.lastName}`.trim();
+    const name = fullName(u);
     return <span>{name || u.daliEmail || "—"}</span>;
   }
   // Has an id but couldn't resolve it (User row missing, or targetId points

--- a/dali-api/app/admin-console/routes/admin-console.announcements.tsx
+++ b/dali-api/app/admin-console/routes/admin-console.announcements.tsx
@@ -5,6 +5,8 @@ import { prisma } from "~/lib/db";
 import { listVisibleGroupsForUser } from "~/lib/groups";
 import { requireAuth } from "~/lib/auth";
 import { isCore, currentTermMemberWhere } from "~/lib/roles";
+import { MEMBER_LIST_ORDER_BY } from "~/lib/prisma-shapes";
+import { fullName } from "~/lib/display";
 import {
   Megaphone,
   Search,
@@ -36,7 +38,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   const [users, visibleGroups, forms] = await Promise.all([
     prisma.user.findMany({
       where: memberWhere,
-      orderBy: [{ lastName: "asc" }, { firstName: "asc" }],
+      orderBy: MEMBER_LIST_ORDER_BY,
       select: { id: true, firstName: true, lastName: true, daliEmail: true },
     }),
     listVisibleGroupsForUser(auth.user.sub),
@@ -50,7 +52,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   return {
     members: users.map((u) => ({
       id: u.id,
-      name: `${u.firstName} ${u.lastName}`.trim(),
+      name: fullName(u),
       email: u.daliEmail,
     })),
     groups: visibleGroups.map((g) => ({ id: g.id, name: g.name })),

--- a/dali-api/app/admin-console/routes/admin-console.announcements.tsx
+++ b/dali-api/app/admin-console/routes/admin-console.announcements.tsx
@@ -16,6 +16,7 @@ import {
   Paperclip,
   CheckCircle2,
 } from "lucide-react";
+import { SearchInput } from "~/components/ui/SearchInput";
 
 export const meta: Route.MetaFunction = () => [
   { title: "Announcements · Operations · DALI OS" },
@@ -373,16 +374,11 @@ export default function AnnouncementsPage() {
                 </span>
               ) : (
                 <>
-                  <div className="relative">
-                    <Search className="absolute left-2 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground" />
-                    <input
-                      type="text"
-                      placeholder="Search groups…"
-                      value={groupSearch}
-                      onChange={(e) => setGroupSearch(e.target.value)}
-                      className="w-full pl-7 pr-2 py-1.5 text-sm border border-border rounded-md bg-card text-foreground"
-                    />
-                  </div>
+                  <SearchInput
+                    value={groupSearch}
+                    onChange={(e) => setGroupSearch(e.target.value)}
+                    placeholder="Search groups…"
+                  />
                   {filteredGroups.length === 0 ? (
                     <span className="text-xs text-muted-foreground">
                       No matching groups.
@@ -425,16 +421,11 @@ export default function AnnouncementsPage() {
                   </span>
                 )}
               </div>
-              <div className="relative">
-                <Search className="absolute left-2 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground" />
-                <input
-                  type="text"
-                  placeholder="Search people…"
-                  value={search}
-                  onChange={(e) => setSearch(e.target.value)}
-                  className="w-full pl-7 pr-2 py-1.5 text-sm border border-border rounded-md bg-card text-foreground"
-                />
-              </div>
+              <SearchInput
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder="Search people…"
+              />
               <div className="max-h-64 overflow-y-auto border border-border rounded-md divide-y divide-border bg-card">
                 {filteredMembers.map((m) => (
                   <label

--- a/dali-api/app/admin-console/routes/admin-console.domains.tsx
+++ b/dali-api/app/admin-console/routes/admin-console.domains.tsx
@@ -7,7 +7,7 @@ import { requireAuth, forbidden } from "~/lib/auth";
 import { isAdmin, isCore, isAdminViaEnv, currentTerm } from "~/lib/roles";
 import { LAB_MEMBER_WHERE, MEMBER_LIST_ORDER_BY } from "~/lib/prisma-shapes";
 import { describeDomainUsage, DOMAIN_USAGE_COUNT_SELECT } from "./api.domains.$domainId";
-import { ALLOWED_LEVELS, parseLevel } from "~/admin-console/lib/eligibility";
+import { ALLOWED_LEVELS, parseLevel, type Level } from "~/admin-console/lib/eligibility";
 import {
   addOrUpdateEligibility,
   removeEligibility,
@@ -102,7 +102,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     })),
     eligibilities: d.eligibilities.map((e) => ({
       id: e.id,
-      level: e.level as "P1" | "P2" | "P3",
+      level: e.level as Level,
       user: {
         id: e.user.id,
         firstName: e.user.firstName,
@@ -312,7 +312,7 @@ function DomainLeadsForDomain({ domain, members }: { domain: DomainWithCounts; m
 // the level menu, while the styled badge underneath renders the current value.
 // Transparent background — distinguished by text color only (P1 muted, P2 teal,
 // P3 coral).
-const LEVEL_BADGE: Record<"P1" | "P2" | "P3", string> = {
+const LEVEL_BADGE: Record<Level, string> = {
   P1: "text-muted-foreground",
   P2: "text-accent-teal",
   P3: "text-accent-coral",
@@ -325,12 +325,12 @@ function EligibilityLevelSelect({
 }: {
   domainId: string;
   userId: string;
-  level: "P1" | "P2" | "P3";
+  level: Level;
 }) {
   const fetcher = useFetcher();
   // Optimistic: reflect the just-submitted level while the request is in flight.
   const pending = fetcher.formData?.get("level");
-  const shown = (typeof pending === "string" ? pending : level) as "P1" | "P2" | "P3";
+  const shown = (typeof pending === "string" ? pending : level) as Level;
   return (
     <fetcher.Form method="post" className="relative inline-flex">
       <input type="hidden" name="intent" value="set-eligibility-level" />

--- a/dali-api/app/admin-console/routes/admin-console.domains.tsx
+++ b/dali-api/app/admin-console/routes/admin-console.domains.tsx
@@ -4,7 +4,7 @@ import type { Route } from "./+types/admin-console.domains";
 import { prisma } from "~/lib/db";
 import { ensureDomainGroup } from "~/lib/groups";
 import { requireAuth, forbidden } from "~/lib/auth";
-import { isAdmin, isCore, currentTerm } from "~/lib/roles";
+import { isAdmin, isCore, isAdminViaEnv, currentTerm } from "~/lib/roles";
 import { LAB_MEMBER_WHERE, MEMBER_LIST_ORDER_BY } from "~/lib/prisma-shapes";
 import { describeDomainUsage, DOMAIN_USAGE_COUNT_SELECT } from "./api.domains.$domainId";
 import { ALLOWED_LEVELS, parseLevel } from "~/admin-console/lib/eligibility";
@@ -71,14 +71,15 @@ export async function loader({ request }: Route.LoaderArgs) {
     const currentCore = term !== null
       ? u.coreAssignments.filter((a) => a.termId === term.id)
       : [];
+    const isAdminUser = u.adminMembership !== null || isAdminViaEnv(u.id);
     return {
       id: u.id,
       firstName: u.firstName,
       lastName: u.lastName,
       daliEmail: u.daliEmail,
       isLabMember: true,
-      isAdmin: u.adminMembership !== null,
-      isCore: currentCore.length > 0,
+      isAdmin: isAdminUser,
+      isCore: isAdminUser || currentCore.length > 0,
       coreAssignments: currentCore.map((a) => ({ id: a.id, leadTitle: a.leadTitle })),
       domainLeadAssignments: u.domainLeadAssignmentsAsUser.map((a) => ({
         id: a.id,

--- a/dali-api/app/admin-console/routes/admin-console.domains.tsx
+++ b/dali-api/app/admin-console/routes/admin-console.domains.tsx
@@ -3,8 +3,9 @@ import { redirect, useLoaderData, useFetcher } from "react-router";
 import type { Route } from "./+types/admin-console.domains";
 import { prisma } from "~/lib/db";
 import { ensureDomainGroup } from "~/lib/groups";
-import { requireAuth } from "~/lib/auth";
+import { requireAuth, forbidden } from "~/lib/auth";
 import { isAdmin, isCore, currentTerm } from "~/lib/roles";
+import { LAB_MEMBER_WHERE, MEMBER_LIST_ORDER_BY } from "~/lib/prisma-shapes";
 import { describeDomainUsage, DOMAIN_USAGE_COUNT_SELECT } from "./api.domains.$domainId";
 import { ALLOWED_LEVELS, parseLevel } from "~/admin-console/lib/eligibility";
 import {
@@ -33,13 +34,13 @@ export async function loader({ request }: Route.LoaderArgs) {
 
   const [users, domains, term] = await Promise.all([
     prisma.user.findMany({
-      where: { daliMember: { isNot: null } },
+      where: { ...LAB_MEMBER_WHERE },
       include: {
         adminMembership: { select: { id: true } },
         coreAssignments: { select: { id: true, termId: true, leadTitle: true } },
         domainLeadAssignmentsAsUser: { include: { domain: true } },
       },
-      orderBy: [{ lastName: "asc" }, { firstName: "asc" }],
+      orderBy: MEMBER_LIST_ORDER_BY,
     }),
     prisma.domain.findMany({
       orderBy: { displayName: "asc" },
@@ -118,7 +119,7 @@ export async function action({ request }: Route.ActionArgs) {
   const auth = await requireAuth(request);
   if (!auth.ok) return auth.response;
   if (!(await isCore(auth.user.sub)))
-    return Response.json({ error: "Forbidden" }, { status: 403 });
+    return forbidden(request);
 
   const formData = await request.formData();
   const intent = formData.get("intent") as string;
@@ -127,7 +128,7 @@ export async function action({ request }: Route.ActionArgs) {
   // hiring-cycle state. Lead/eligibility assignments are open to Core.
   const adminOnly = intent === "create-domain" || intent === "delete-domain";
   if (adminOnly && !(await isAdmin(auth.user.sub)))
-    return Response.json({ error: "Forbidden" }, { status: 403 });
+    return forbidden(request);
 
   if (intent === "create-domain") {
     const name = String(formData.get("name") ?? "").trim();

--- a/dali-api/app/admin-console/routes/admin-console.members.tsx
+++ b/dali-api/app/admin-console/routes/admin-console.members.tsx
@@ -4,6 +4,7 @@ import type { Route } from "./+types/admin-console.members";
 import { prisma } from "~/lib/db";
 import { requireAuth } from "~/lib/auth";
 import { isAdmin, isCore, currentTerm } from "~/lib/roles";
+import { coreCycleTermIds } from "~/lib/core-cycle";
 import { Users, Check } from "lucide-react";
 import {
   AdminToggle,
@@ -102,9 +103,15 @@ export async function action({ request }: Route.ActionArgs) {
     return null;
   }
 
-  // Free-text Core title for the current term. A member can hold multiple
-  // titles in the same term (schema-side: no unique on (userId, termId)).
-  // App-level guard: ignore exact-title duplicates rather than 409.
+  // Free-text Core title for the current Core cycle. A member can hold
+  // multiple titles in the same term (schema-side: no unique on
+  // (userId, termId, leadTitle)). App-level guard: ignore exact-title
+  // duplicates rather than 409.
+  //
+  // The Core "cycle" runs Spring → following Winter (4 terms). We materialize
+  // one CoreAssignment row per term in the cycle so every reader (payroll,
+  // search, isCore) can query by termId and get the same answer without
+  // re-deriving cycle math. See lib/core-cycle.ts.
   if (intent === "add-core-title") {
     const userId = formData.get("userId") as string;
     const rawTitle = String(formData.get("leadTitle") ?? "").trim();
@@ -116,21 +123,40 @@ export async function action({ request }: Route.ActionArgs) {
         { status: 500 },
       );
     }
-    const existing = await prisma.coreAssignment.findFirst({
-      where: { userId, termId: term.id, leadTitle },
-      select: { id: true },
+    const cycleTermIds = await coreCycleTermIds(term.id);
+    const existing = await prisma.coreAssignment.findMany({
+      where: { userId, termId: { in: cycleTermIds }, leadTitle },
+      select: { termId: true },
     });
-    if (!existing) {
-      await prisma.coreAssignment.create({
-        data: { userId, termId: term.id, leadTitle },
+    const alreadyCovered = new Set(existing.map((e) => e.termId));
+    const missing = cycleTermIds.filter((tid) => !alreadyCovered.has(tid));
+    if (missing.length > 0) {
+      await prisma.coreAssignment.createMany({
+        data: missing.map((termId) => ({ userId, termId, leadTitle })),
       });
     }
     return null;
   }
 
+  // Remove this Core title for the entire cycle the assignment belongs to —
+  // not just the single term the row was indexed by. (Multiple CoreAssignment
+  // rows fan out across the cycle on add; clearing all of them keeps the
+  // data consistent across surfaces.)
   if (intent === "remove-core-title") {
     const assignmentId = formData.get("assignmentId") as string;
-    await prisma.coreAssignment.deleteMany({ where: { id: assignmentId } });
+    const target = await prisma.coreAssignment.findUnique({
+      where: { id: assignmentId },
+      select: { userId: true, termId: true, leadTitle: true },
+    });
+    if (!target) return null;
+    const cycleTermIds = await coreCycleTermIds(target.termId);
+    await prisma.coreAssignment.deleteMany({
+      where: {
+        userId: target.userId,
+        leadTitle: target.leadTitle,
+        termId: { in: cycleTermIds },
+      },
+    });
     return null;
   }
 

--- a/dali-api/app/admin-console/routes/admin-console.members.tsx
+++ b/dali-api/app/admin-console/routes/admin-console.members.tsx
@@ -3,7 +3,7 @@ import { redirect, useLoaderData } from "react-router";
 import type { Route } from "./+types/admin-console.members";
 import { prisma } from "~/lib/db";
 import { requireAuth, forbidden } from "~/lib/auth";
-import { isAdmin, isCore, currentTerm } from "~/lib/roles";
+import { isAdmin, isCore, isAdminViaEnv, currentTerm } from "~/lib/roles";
 import { LAB_MEMBER_WHERE, MEMBER_LIST_ORDER_BY } from "~/lib/prisma-shapes";
 import { coreCycleTermIds } from "~/lib/core-cycle";
 import { Users, Check } from "lucide-react";
@@ -54,14 +54,15 @@ export async function loader({ request }: Route.LoaderArgs) {
     const currentCore = term !== null
       ? u.coreAssignments.filter((a) => a.termId === term.id)
       : [];
+    const isAdminUser = u.adminMembership !== null || isAdminViaEnv(u.id);
     return {
       id: u.id,
       firstName: u.firstName,
       lastName: u.lastName,
       daliEmail: u.daliEmail,
       isLabMember: u.daliMember !== null,
-      isAdmin: u.adminMembership !== null,
-      isCore: currentCore.length > 0,
+      isAdmin: isAdminUser,
+      isCore: isAdminUser || currentCore.length > 0,
       coreAssignments: currentCore.map((a) => ({ id: a.id, leadTitle: a.leadTitle })),
       domainLeadAssignments: u.domainLeadAssignmentsAsUser.map((a) => ({
         id: a.id,

--- a/dali-api/app/admin-console/routes/admin-console.members.tsx
+++ b/dali-api/app/admin-console/routes/admin-console.members.tsx
@@ -2,8 +2,9 @@ import { useState } from "react";
 import { redirect, useLoaderData } from "react-router";
 import type { Route } from "./+types/admin-console.members";
 import { prisma } from "~/lib/db";
-import { requireAuth } from "~/lib/auth";
+import { requireAuth, forbidden } from "~/lib/auth";
 import { isAdmin, isCore, currentTerm } from "~/lib/roles";
+import { LAB_MEMBER_WHERE, MEMBER_LIST_ORDER_BY } from "~/lib/prisma-shapes";
 import { coreCycleTermIds } from "~/lib/core-cycle";
 import { Users, Check } from "lucide-react";
 import {
@@ -32,14 +33,14 @@ export async function loader({ request }: Route.LoaderArgs) {
 
   const [users, domains, term] = await Promise.all([
     prisma.user.findMany({
-      where: { daliMember: { isNot: null } },
+      where: { ...LAB_MEMBER_WHERE },
       include: {
         daliMember: { select: { id: true } },
         adminMembership: { select: { id: true } },
         coreAssignments: { select: { id: true, termId: true, leadTitle: true } },
         domainLeadAssignmentsAsUser: { include: { domain: true } },
       },
-      orderBy: [{ lastName: "asc" }, { firstName: "asc" }],
+      orderBy: MEMBER_LIST_ORDER_BY,
     }),
     prisma.domain.findMany({
       where: { active: true },
@@ -80,7 +81,7 @@ export async function action({ request }: Route.ActionArgs) {
   const auth = await requireAuth(request);
   if (!auth.ok) return auth.response;
   if (!(await isCore(auth.user.sub)))
-    return Response.json({ error: "Forbidden" }, { status: 403 });
+    return forbidden(request);
 
   const formData = await request.formData();
   const intent = formData.get("intent") as string;
@@ -88,7 +89,7 @@ export async function action({ request }: Route.ActionArgs) {
   // Admin-promotion is the only Admin-gated mutation on this page.
   if (intent === "set-admin") {
     if (!(await isAdmin(auth.user.sub)))
-      return Response.json({ error: "Forbidden" }, { status: 403 });
+      return forbidden(request);
     const userId = formData.get("userId") as string;
     const value = formData.get("value") === "true";
     if (value) {

--- a/dali-api/app/admin-console/routes/admin-console.payroll-export.csv.ts
+++ b/dali-api/app/admin-console/routes/admin-console.payroll-export.csv.ts
@@ -2,6 +2,7 @@ import type { Route } from "./+types/admin-console.payroll-export.csv";
 import { redirect } from "react-router";
 import { prisma } from "~/lib/db";
 import { requireAuth } from "~/lib/auth";
+import { csvResponse } from "~/lib/csv";
 import { isAdmin } from "~/lib/roles";
 import {
   buildCoreRows,
@@ -61,12 +62,8 @@ export async function loader({ request }: Route.LoaderArgs) {
   const csv = rowsToCsv([...projectRows, ...coreRows, ...instructorRows]);
   const filename = `payroll-${selectedTerm.code}-${formatDate(new Date())}.csv`;
 
-  return new Response(csv, {
+  return csvResponse(csv, filename, {
     status: 200,
-    headers: {
-      "Content-Type": "text/csv; charset=utf-8",
-      "Content-Disposition": `attachment; filename="${filename}"`,
-      "Cache-Control": "no-store",
-    },
+    headers: { "Cache-Control": "no-store" },
   });
 }

--- a/dali-api/app/admin-console/routes/admin-console.payroll-export.csv.ts
+++ b/dali-api/app/admin-console/routes/admin-console.payroll-export.csv.ts
@@ -1,7 +1,7 @@
 import type { Route } from "./+types/admin-console.payroll-export.csv";
 import { redirect } from "react-router";
 import { prisma } from "~/lib/db";
-import { requireAuth } from "~/lib/auth";
+import { requireAuth, forbidden } from "~/lib/auth";
 import { csvResponse } from "~/lib/csv";
 import { isAdmin } from "~/lib/roles";
 import {
@@ -29,7 +29,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   const auth = await requireAuth(request);
   if (!auth.ok) return redirect("/login");
   if (!(await isAdmin(auth.user.sub))) {
-    return new Response("Forbidden", { status: 403 });
+    return forbidden(request);
   }
 
   const url = new URL(request.url);

--- a/dali-api/app/admin-console/routes/api.audit-logs.ts
+++ b/dali-api/app/admin-console/routes/api.audit-logs.ts
@@ -1,6 +1,6 @@
 import type { Route } from "./+types/api.audit-logs";
 import { prisma } from "~/lib/db";
-import { requireAuth } from "~/lib/auth";
+import { requireAuth, forbidden } from "~/lib/auth";
 import { isAdmin } from "~/lib/roles";
 import { withCors, handlePreflight } from "~/lib/cors";
 import {
@@ -23,7 +23,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   const auth = await requireAuth(request);
   if (!auth.ok) return withCors(request, auth.response);
   if (!(await isAdmin(auth.user.sub)))
-    return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
+    return forbidden(request);
 
   const url = new URL(request.url);
   const limit = Math.min(

--- a/dali-api/app/admin-console/routes/api.domains.$domainId.leads.ts
+++ b/dali-api/app/admin-console/routes/api.domains.$domainId.leads.ts
@@ -1,7 +1,7 @@
 import type { Route } from "./+types/api.domains.$domainId.leads";
 import { z } from "zod";
 import { prisma } from "~/lib/db";
-import { requireAuth } from "~/lib/auth";
+import { requireAuth, forbidden } from "~/lib/auth";
 import { isAdmin, currentTerm } from "~/lib/roles";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { parseJson } from "~/lib/validate";
@@ -25,7 +25,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 
   const auth = await requireAuth(request);
   if (!auth.ok) return withCors(request, auth.response);
-  if (!(await isAdmin(auth.user.sub))) return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
+  if (!(await isAdmin(auth.user.sub))) return forbidden(request);
 
   const leads = await prisma.domainLeadAssignment.findMany({
     where: { domainId: params.domainId },
@@ -41,7 +41,7 @@ export async function action({ request, params }: Route.ActionArgs) {
 
   const auth = await requireAuth(request);
   if (!auth.ok) return withCors(request, auth.response);
-  if (!(await isAdmin(auth.user.sub))) return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
+  if (!(await isAdmin(auth.user.sub))) return forbidden(request);
 
   if (request.method === "POST") {
     const postBody = await parseJson(request, AddLeadSchema);

--- a/dali-api/app/admin-console/routes/api.domains.$domainId.ts
+++ b/dali-api/app/admin-console/routes/api.domains.$domainId.ts
@@ -1,6 +1,6 @@
 import type { Route } from "./+types/api.domains.$domainId";
 import { prisma } from "~/lib/db";
-import { requireAuth } from "~/lib/auth";
+import { requireAuth, forbidden } from "~/lib/auth";
 import { isAdmin } from "~/lib/roles";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { logAuditEvent } from "~/lib/audit";
@@ -70,7 +70,7 @@ export async function action({ request, params }: Route.ActionArgs) {
   const auth = await requireAuth(request);
   if (!auth.ok) return withCors(request, auth.response);
   if (!(await isAdmin(auth.user.sub)))
-    return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
+    return forbidden(request);
 
   if (request.method !== "DELETE") {
     return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));

--- a/dali-api/app/admin-console/routes/api.domains.ts
+++ b/dali-api/app/admin-console/routes/api.domains.ts
@@ -2,7 +2,7 @@ import type { Route } from "./+types/api.domains";
 import { z } from "zod";
 import { prisma } from "~/lib/db";
 import { ensureDomainGroup } from "~/lib/groups";
-import { requireAuth } from "~/lib/auth";
+import { requireAuth, forbidden } from "~/lib/auth";
 import { isCore, isDomainLead, isAdmin } from "~/lib/roles";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { parseJson } from "~/lib/validate";
@@ -25,7 +25,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     isAdmin(auth.user.sub),
   ]);
   if (!hl && !dl && !admin)
-    return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
+    return forbidden(request);
 
   const domains = await prisma.domain.findMany({
     orderBy: { displayName: "asc" },
@@ -55,7 +55,7 @@ export async function action({ request }: Route.ActionArgs) {
 
   const auth = await requireAuth(request);
   if (!auth.ok) return withCors(request, auth.response);
-  if (!(await isAdmin(auth.user.sub))) return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
+  if (!(await isAdmin(auth.user.sub))) return forbidden(request);
 
   if (request.method !== "POST") {
     return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));

--- a/dali-api/app/admin-console/routes/api.groups.$groupId.ts
+++ b/dali-api/app/admin-console/routes/api.groups.$groupId.ts
@@ -1,7 +1,7 @@
 import type { Route } from "./+types/api.groups.$groupId";
 import { z } from "zod";
 import { prisma } from "~/lib/db";
-import { requireAuth } from "~/lib/auth";
+import { requireAuth, forbidden } from "~/lib/auth";
 import { isAdmin } from "~/lib/roles";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { parseJson } from "~/lib/validate";
@@ -19,7 +19,7 @@ export async function action({ request, params }: Route.ActionArgs) {
   const auth = await requireAuth(request);
   if (!auth.ok) return withCors(request, auth.response);
   if (!(await isAdmin(auth.user.sub)))
-    return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
+    return forbidden(request);
 
   const groupId = params.groupId!;
 

--- a/dali-api/app/admin-console/routes/api.groups.ts
+++ b/dali-api/app/admin-console/routes/api.groups.ts
@@ -2,7 +2,7 @@ import type { Route } from "./+types/api.groups";
 import { z } from "zod";
 import { prisma } from "~/lib/db";
 import { listVisibleGroupsForUser } from "~/lib/groups";
-import { requireAuth } from "~/lib/auth";
+import { requireAuth, forbidden } from "~/lib/auth";
 import { isAdmin } from "~/lib/roles";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { parseJson } from "~/lib/validate";
@@ -20,7 +20,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   const auth = await requireAuth(request);
   if (!auth.ok) return withCors(request, auth.response);
   if (!(await isAdmin(auth.user.sub)))
-    return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
+    return forbidden(request);
 
   // Per-viewer visibility: a group surfaces only when the caller is a member.
   const groups = await listVisibleGroupsForUser(auth.user.sub);
@@ -34,7 +34,7 @@ export async function action({ request }: Route.ActionArgs) {
   const auth = await requireAuth(request);
   if (!auth.ok) return withCors(request, auth.response);
   if (!(await isAdmin(auth.user.sub)))
-    return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
+    return forbidden(request);
 
   if (request.method !== "POST") {
     return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));

--- a/dali-api/app/admin-console/routes/api.members.$memberId.roles.ts
+++ b/dali-api/app/admin-console/routes/api.members.$memberId.roles.ts
@@ -1,7 +1,7 @@
 import type { Route } from "./+types/api.members.$memberId.roles";
 import { z } from "zod";
 import { prisma } from "~/lib/db";
-import { requireAuth } from "~/lib/auth";
+import { requireAuth, forbidden } from "~/lib/auth";
 import { isAdmin, currentTerm } from "~/lib/roles";
 import { coreCycleTermIds } from "~/lib/core-cycle";
 import { withCors, handlePreflight } from "~/lib/cors";
@@ -27,7 +27,7 @@ export async function action({ request, params }: Route.ActionArgs) {
 
   const auth = await requireAuth(request);
   if (!auth.ok) return withCors(request, auth.response);
-  if (!(await isAdmin(auth.user.sub))) return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
+  if (!(await isAdmin(auth.user.sub))) return forbidden(request);
 
   if (request.method !== "PATCH") {
     return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));

--- a/dali-api/app/admin-console/routes/api.members.$memberId.roles.ts
+++ b/dali-api/app/admin-console/routes/api.members.$memberId.roles.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { prisma } from "~/lib/db";
 import { requireAuth } from "~/lib/auth";
 import { isAdmin, currentTerm } from "~/lib/roles";
+import { coreCycleTermIds } from "~/lib/core-cycle";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { parseJson } from "~/lib/validate";
 import { logAuditEvent } from "~/lib/audit";
@@ -78,19 +79,37 @@ export async function action({ request, params }: Route.ActionArgs) {
       await tx.adminMembership.deleteMany({ where: { userId } });
     }
 
+    // Core titles (Hiring Lead included) are cycle-scoped: one row per term
+    // in [Spring N, Spring N+1). We materialize the missing rows on add and
+    // clear them all on remove so cycle-mate terms stay consistent.
+    const cycleTermIds = await coreCycleTermIds(term.id);
     if (wantHiringLead) {
-      const exists = await tx.coreAssignment.findFirst({
-        where: { userId, termId: term.id, leadTitle: "Hiring Lead" },
-        select: { id: true },
+      const existing = await tx.coreAssignment.findMany({
+        where: {
+          userId,
+          termId: { in: cycleTermIds },
+          leadTitle: "Hiring Lead",
+        },
+        select: { termId: true },
       });
-      if (!exists) {
-        await tx.coreAssignment.create({
-          data: { userId, termId: term.id, leadTitle: "Hiring Lead" },
+      const covered = new Set(existing.map((e) => e.termId));
+      const missing = cycleTermIds.filter((tid) => !covered.has(tid));
+      if (missing.length > 0) {
+        await tx.coreAssignment.createMany({
+          data: missing.map((termId) => ({
+            userId,
+            termId,
+            leadTitle: "Hiring Lead",
+          })),
         });
       }
     } else {
       await tx.coreAssignment.deleteMany({
-        where: { userId, termId: term.id, leadTitle: "Hiring Lead" },
+        where: {
+          userId,
+          termId: { in: cycleTermIds },
+          leadTitle: "Hiring Lead",
+        },
       });
     }
   });

--- a/dali-api/app/admin-console/routes/api.members.ts
+++ b/dali-api/app/admin-console/routes/api.members.ts
@@ -1,8 +1,9 @@
 import type { Route } from "./+types/api.members";
 import { prisma } from "~/lib/db";
-import { requireAuth } from "~/lib/auth";
+import { requireAuth, forbidden } from "~/lib/auth";
 import { isAdmin, isCore, isDomainLead, currentTermMemberWhere } from "~/lib/roles";
 import { withCors, handlePreflight } from "~/lib/cors";
+import { LAB_MEMBER_WHERE, MEMBER_LIST_ORDER_BY } from "~/lib/prisma-shapes";
 
 // Phase 2: returns lab members rooted at User. Role shape derives from
 // AdminMembership / CoreAssignment / DomainLeadAssignment rows.
@@ -24,18 +25,18 @@ export async function loader({ request }: Route.LoaderArgs) {
     isCore(auth.user.sub),
     isDomainLead(auth.user.sub),
   ]);
-  if (!admin && !hiringLead && !domainLead) return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
+  if (!admin && !hiringLead && !domainLead) return forbidden(request);
 
   const url = new URL(request.url);
   const scope = url.searchParams.get("scope");
   const where =
     scope === "current"
       ? await currentTermMemberWhere()
-      : { daliMember: { isNot: null } };
+      : { ...LAB_MEMBER_WHERE };
 
   const users = await prisma.user.findMany({
     where,
-    orderBy: [{ lastName: "asc" }, { firstName: "asc" }],
+    orderBy: MEMBER_LIST_ORDER_BY,
     select: {
       id: true,
       firstName: true,

--- a/dali-api/app/admin-console/routes/api.members.ts
+++ b/dali-api/app/admin-console/routes/api.members.ts
@@ -1,7 +1,7 @@
 import type { Route } from "./+types/api.members";
 import { prisma } from "~/lib/db";
 import { requireAuth, forbidden } from "~/lib/auth";
-import { isAdmin, isCore, isDomainLead, currentTermMemberWhere } from "~/lib/roles";
+import { isAdmin, isCore, isDomainLead, isAdminViaEnv, currentTermMemberWhere } from "~/lib/roles";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { LAB_MEMBER_WHERE, MEMBER_LIST_ORDER_BY } from "~/lib/prisma-shapes";
 
@@ -43,7 +43,7 @@ export async function loader({ request }: Route.LoaderArgs) {
       lastName: true,
       daliEmail: true,
       adminMembership: { select: { id: true } },
-      coreAssignments: { select: { id: true, termId: true, leadTitle: true } },
+      coreAssignments: { select: { leadTitle: true } },
       domainLeadAssignmentsAsUser: {
         select: {
           id: true,
@@ -54,21 +54,24 @@ export async function loader({ request }: Route.LoaderArgs) {
     },
   });
 
-  const members = users.map((u) => ({
-    id: u.id,
-    firstName: u.firstName,
-    lastName: u.lastName,
-    daliEmail: u.daliEmail,
-    isAdmin: u.adminMembership !== null,
-    isCore: u.coreAssignments.length > 0,
-    coreTitles: u.coreAssignments
-      .map((a) => a.leadTitle)
-      .filter((t): t is string => !!t),
-    domainLeadAssignments: u.domainLeadAssignmentsAsUser.map((a) => ({
-      id: a.id,
-      domain: { id: a.domain.id, name: a.domain.displayName },
-    })),
-  }));
+  const members = users.map((u) => {
+    const isAdminUser = u.adminMembership !== null || isAdminViaEnv(u.id);
+    return {
+      id: u.id,
+      firstName: u.firstName,
+      lastName: u.lastName,
+      daliEmail: u.daliEmail,
+      isAdmin: isAdminUser,
+      isCore: isAdminUser || u.coreAssignments.length > 0,
+      coreTitles: u.coreAssignments
+        .map((a) => a.leadTitle)
+        .filter((t): t is string => !!t),
+      domainLeadAssignments: u.domainLeadAssignmentsAsUser.map((a) => ({
+        id: a.id,
+        domain: { id: a.domain.id, name: a.domain.displayName },
+      })),
+    };
+  });
 
   return withCors(request, Response.json(members));
 }

--- a/dali-api/app/admin-console/routes/api.notifications.send.ts
+++ b/dali-api/app/admin-console/routes/api.notifications.send.ts
@@ -1,7 +1,7 @@
 import type { Route } from "./+types/api.notifications.send";
 import { z } from "zod";
 import { prisma } from "~/lib/db";
-import { requireAuth } from "~/lib/auth";
+import { requireAuth, forbidden } from "~/lib/auth";
 import { isCore } from "~/lib/roles";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { parseJson } from "~/lib/validate";
@@ -42,7 +42,7 @@ export async function action({ request }: Route.ActionArgs) {
   const auth = await requireAuth(request);
   if (!auth.ok) return withCors(request, auth.response);
   if (!(await isCore(auth.user.sub)))
-    return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
+    return forbidden(request);
 
   if (request.method !== "POST") {
     return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));

--- a/dali-api/app/calendar/routes/api.calendar.group-availability.ts
+++ b/dali-api/app/calendar/routes/api.calendar.group-availability.ts
@@ -1,6 +1,6 @@
 import type { Route } from "./+types/api.calendar.group-availability";
 import { z } from "zod";
-import { requireAuth } from "~/lib/auth";
+import { requireAuth, forbidden } from "~/lib/auth";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { parseJson } from "~/lib/validate";
 import {
@@ -8,7 +8,7 @@ import {
   intersectFreeIntervals,
   type Interval,
 } from "~/lib/availability";
-import { getZonedYMD } from "~/lib/timezone";
+import { getZonedYMD, zonedDayStartUtc } from "~/lib/timezone";
 
 const Schema = z.object({
   userIds: z.array(z.string().min(1)).min(1).max(50),
@@ -53,7 +53,7 @@ function splitByZonedDay(
   let cursor = interval.start;
   while (cursor.getTime() < interval.end.getTime()) {
     const ymd = getZonedYMD(cursor, timezone);
-    const nextDayUtc = nextLocalMidnightUtc(cursor, timezone);
+    const nextDayUtc = zonedDayStartUtc(ymd.year, ymd.month, ymd.day + 1, timezone);
     const segmentEnd = nextDayUtc.getTime() < interval.end.getTime() ? nextDayUtc : interval.end;
     const startHour = localHourFractional(cursor, timezone);
     const durationHours = (segmentEnd.getTime() - cursor.getTime()) / 3_600_000;
@@ -82,36 +82,6 @@ function localHourFractional(d: Date, timezone: string): number {
   return (get("hour") % 24) + get("minute") / 60 + get("second") / 3600;
 }
 
-function nextLocalMidnightUtc(after: Date, timezone: string): Date {
-  // Find the local midnight of the day strictly after `after`.
-  const ymd = getZonedYMD(after, timezone);
-  // Walk forward day-by-day in local terms.
-  const oneDay = 24 * 60 * 60 * 1000;
-  for (let i = 1; i <= 2; i++) {
-    const guessUtc = new Date(Date.UTC(ymd.year, ymd.month - 1, ymd.day) + i * oneDay);
-    const guessYmd = getZonedYMD(guessUtc, timezone);
-    const midnightFmt = new Intl.DateTimeFormat("en-US", {
-      timeZone: timezone,
-      year: "numeric",
-      month: "2-digit",
-      day: "2-digit",
-      hour: "2-digit",
-      minute: "2-digit",
-      hour12: false,
-    });
-    const parts = midnightFmt.formatToParts(guessUtc);
-    const lp = (t: string) => parseInt(parts.find((p) => p.type === t)?.value ?? "0", 10);
-    const offsetMs =
-      Date.UTC(lp("year"), lp("month") - 1, lp("day"), lp("hour") % 24, lp("minute")) -
-      guessUtc.getTime();
-    const localMidnight = new Date(guessUtc.getTime() - offsetMs);
-    if (localMidnight.getTime() > after.getTime()) return localMidnight;
-    // Otherwise iterate (handles a day-boundary skew).
-    void guessYmd;
-  }
-  return new Date(after.getTime() + oneDay);
-}
-
 export async function action({ request }: Route.ActionArgs) {
   const preflight = handlePreflight(request);
   if (preflight) return preflight;
@@ -119,7 +89,7 @@ export async function action({ request }: Route.ActionArgs) {
   const auth = await requireAuth(request);
   if (!auth.ok) return withCors(request, auth.response);
   if (auth.user.type === "applicant")
-    return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
+    return forbidden(request);
 
   if (request.method !== "POST") {
     return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));

--- a/dali-api/app/calendar/routes/api.scheduled-meetings.$id.cancel.ts
+++ b/dali-api/app/calendar/routes/api.scheduled-meetings.$id.cancel.ts
@@ -1,5 +1,5 @@
 import type { Route } from "./+types/api.scheduled-meetings.$id.cancel";
-import { requireAuth } from "~/lib/auth";
+import { requireAuth, forbidden } from "~/lib/auth";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { cancelScheduledMeeting } from "~/lib/scheduled-meeting";
 
@@ -10,7 +10,7 @@ export async function action({ request, params }: Route.ActionArgs) {
   const auth = await requireAuth(request);
   if (!auth.ok) return withCors(request, auth.response);
   if (auth.user.type === "applicant")
-    return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
+    return forbidden(request);
 
   if (request.method !== "POST") {
     return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));

--- a/dali-api/app/calendar/routes/api.scheduled-meetings.ts
+++ b/dali-api/app/calendar/routes/api.scheduled-meetings.ts
@@ -1,6 +1,6 @@
 import type { Route } from "./+types/api.scheduled-meetings";
 import { z } from "zod";
-import { requireAuth } from "~/lib/auth";
+import { requireAuth, forbidden } from "~/lib/auth";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { parseJson } from "~/lib/validate";
 import {
@@ -33,7 +33,7 @@ export async function action({ request }: Route.ActionArgs) {
   const auth = await requireAuth(request);
   if (!auth.ok) return withCors(request, auth.response);
   if (auth.user.type === "applicant")
-    return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
+    return forbidden(request);
 
   if (request.method !== "POST") {
     return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));

--- a/dali-api/app/calendar/routes/calendar.tsx
+++ b/dali-api/app/calendar/routes/calendar.tsx
@@ -17,16 +17,16 @@ import {
   RefreshCw,
   RotateCcw,
 } from "lucide-react";
-import { requireAuth } from "~/lib/auth";
+import { requireAuth, forbidden, redirectApplicantToPortal } from "~/lib/auth";
+import { fullName } from "~/lib/display";
 import { prisma } from "~/lib/db";
 import { listVisibleGroupsForUser } from "~/lib/groups";
 import { currentTermMemberWhere } from "~/lib/roles";
 import { CalendarActionSchema } from "~/lib/calendar-schemas";
 import { fetchBusyEvents, listCalendarsForLink } from "~/lib/google-calendar";
-import { getZonedHourFraction, getZonedYMD, zonedDayStartUtc } from "~/lib/timezone";
+import { APPLICATION_TZ as DEFAULT_TIMEZONE, getZonedHourFraction, getZonedYMD, zonedDayStartUtc } from "~/lib/timezone";
 import type { Route } from "./+types/calendar";
 
-const DEFAULT_TIMEZONE = "America/New_York";
 const DEFAULT_BUFFER_MIN = 15;
 const DEFAULT_WORK_START_MIN = 9 * 60;
 const DEFAULT_WORK_END_MIN = 17 * 60;
@@ -160,7 +160,8 @@ function weekWindow(timezone: string, anchor?: Date): { start: Date; end: Date }
 export async function loader({ request }: Route.LoaderArgs) {
   const auth = await requireAuth(request);
   if (!auth.ok) return redirect("/login");
-  if (auth.user.type === "applicant") return redirect("/portal");
+  const portalRedirect = redirectApplicantToPortal(auth);
+  if (portalRedirect) return portalRedirect;
 
   const userId = auth.user.sub;
 
@@ -321,7 +322,7 @@ export async function action({ request }: Route.ActionArgs) {
   const auth = await requireAuth(request);
   if (!auth.ok) return auth.response;
   if (auth.user.type === "applicant")
-    return Response.json({ error: "Forbidden" }, { status: 403 });
+    return forbidden(request);
 
   const userId = auth.user.sub;
   const form = await request.formData();
@@ -2089,7 +2090,7 @@ function ScheduleView({ data }: { data: LoaderData }) {
 }
 
 function userLabel(u: UserOption) {
-  const name = `${u.firstName} ${u.lastName}`.trim();
+  const name = fullName(u);
   return name || u.daliEmail || u.id;
 }
 

--- a/dali-api/app/components/ApplicantErrorBoundary.tsx
+++ b/dali-api/app/components/ApplicantErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import { isRouteErrorResponse, Link, useRevalidator } from "react-router";
+import { Button } from "~/components/ui/Button";
 
 type SecondaryAction =
   | { kind: "back-to-portal" }
@@ -59,14 +60,14 @@ export function ApplicantErrorBoundary({
           {description}
         </p>
         <div className="flex flex-wrap items-center justify-center gap-3">
-          <button
-            type="button"
+          <Button
+            variant="primary"
+            size="md"
             onClick={() => revalidator.revalidate()}
             disabled={trying}
-            className="px-6 py-2.5 rounded-full bg-accent-coral text-white text-sm font-semibold hover:bg-accent-coral/90 transition disabled:opacity-50"
           >
             {trying ? "Trying..." : "Try again"}
-          </button>
+          </Button>
           {secondaryAction.kind === "back-to-portal" && (
             <Link
               to="/portal"

--- a/dali-api/app/components/ui/Avatar.tsx
+++ b/dali-api/app/components/ui/Avatar.tsx
@@ -1,0 +1,41 @@
+import { cn } from "~/lib/cn";
+import { initialsFromName } from "~/lib/display";
+
+export type AvatarSize = "sm" | "md" | "lg";
+
+export interface AvatarProps {
+  photoUrl?: string | null;
+  name: string;
+  size?: AvatarSize;
+  className?: string;
+}
+
+const SIZES: Record<AvatarSize, string> = {
+  sm: "w-8 h-8 text-[11px]",
+  md: "w-10 h-10 text-sm",
+  lg: "w-12 h-12 text-base",
+};
+
+export function Avatar({ photoUrl, name, size = "md", className }: AvatarProps) {
+  if (photoUrl) {
+    return (
+      <img
+        src={photoUrl}
+        alt={name}
+        className={cn("rounded-full object-cover", SIZES[size], className)}
+      />
+    );
+  }
+  return (
+    <div
+      className={cn(
+        "bg-accent-coral/15 text-accent-coral font-medium rounded-full flex items-center justify-center",
+        SIZES[size],
+        className,
+      )}
+      aria-label={name}
+    >
+      {initialsFromName(name)}
+    </div>
+  );
+}

--- a/dali-api/app/components/ui/RolePills.tsx
+++ b/dali-api/app/components/ui/RolePills.tsx
@@ -1,0 +1,59 @@
+import { cn } from "~/lib/cn";
+
+export type RolePillSize = "sm" | "md";
+
+export interface RolePillsProps {
+  isAdmin?: boolean;
+  isCore?: boolean;
+  coreTitles?: string[];
+  domainRoles?: Array<{ domainName: string; level?: string }>;
+  size?: RolePillSize;
+  showLevel?: boolean;
+  className?: string;
+}
+
+const SIZES: Record<RolePillSize, string> = {
+  sm: "text-[11px] px-1.5 py-0.5",
+  md: "text-xs px-2 py-0.5",
+};
+
+const PILL_BASE = "inline-flex items-center rounded-full font-medium";
+const ADMIN_TONE = "bg-accent-coral/15 text-accent-coral";
+const DEFAULT_TONE = "bg-muted text-foreground";
+
+export function RolePills({
+  isAdmin,
+  isCore,
+  coreTitles,
+  domainRoles,
+  size = "md",
+  showLevel = false,
+  className,
+}: RolePillsProps) {
+  const sizeClass = SIZES[size];
+  return (
+    <span className={cn("inline-flex flex-wrap gap-1", className)}>
+      {isAdmin && (
+        <span className={cn(PILL_BASE, ADMIN_TONE, sizeClass)}>Admin</span>
+      )}
+      {isCore && (
+        <span className={cn(PILL_BASE, DEFAULT_TONE, sizeClass)}>Core</span>
+      )}
+      {coreTitles?.map((title) => (
+        <span key={`core-${title}`} className={cn(PILL_BASE, DEFAULT_TONE, sizeClass)}>
+          {title}
+        </span>
+      ))}
+      {domainRoles?.map((role, i) => (
+        <span
+          key={`domain-${role.domainName}-${i}`}
+          className={cn(PILL_BASE, DEFAULT_TONE, sizeClass)}
+        >
+          {showLevel && role.level
+            ? `${role.domainName} · ${role.level}`
+            : role.domainName}
+        </span>
+      ))}
+    </span>
+  );
+}

--- a/dali-api/app/components/ui/SearchInput.tsx
+++ b/dali-api/app/components/ui/SearchInput.tsx
@@ -1,0 +1,37 @@
+import type { InputHTMLAttributes, ChangeEvent } from "react";
+import { Search } from "lucide-react";
+import { cn } from "~/lib/cn";
+
+export interface SearchInputProps
+  extends Omit<InputHTMLAttributes<HTMLInputElement>, "size"> {
+  value: string;
+  onChange: (e: ChangeEvent<HTMLInputElement>) => void;
+  placeholder?: string;
+  containerClassName?: string;
+}
+
+const INPUT_BASE =
+  "w-full pl-7 pr-2 py-1.5 text-sm border border-border rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-accent-coral/30";
+
+export function SearchInput({
+  value,
+  onChange,
+  placeholder,
+  className,
+  containerClassName,
+  ...props
+}: SearchInputProps) {
+  return (
+    <div className={cn("relative", containerClassName)}>
+      <Search className="absolute left-2 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground pointer-events-none" />
+      <input
+        type="search"
+        value={value}
+        onChange={onChange}
+        placeholder={placeholder}
+        className={cn(INPUT_BASE, className)}
+        {...props}
+      />
+    </div>
+  );
+}

--- a/dali-api/app/forms/components/FormDetail.tsx
+++ b/dali-api/app/forms/components/FormDetail.tsx
@@ -13,6 +13,7 @@ import {
 } from "lucide-react";
 import { FormBuilderTab } from "~/hiring/components/ChallengeBuilder";
 import { RichTextViewer, isEmptyDoc } from "~/components/RichTextViewer";
+import { Button } from "~/components/ui/Button";
 import type { Question } from "~/types";
 import type { loader } from "~/forms/routes/forms.edit.$formId";
 
@@ -199,13 +200,14 @@ export function FormDetail() {
             </p>
           </div>
           {!isEditing && (
-            <button
+            <Button
+              variant="primary"
+              size="sm"
               onClick={() => startEditing()}
-              className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-lg text-white bg-accent-coral hover:bg-accent-coral/90 shadow-sm"
             >
-              <Plus className="w-4 h-4 mr-2" />
+              <Plus className="w-4 h-4" />
               {hasDraft ? "Continue editing draft" : "New version"}
-            </button>
+            </Button>
           )}
         </div>
 
@@ -435,13 +437,14 @@ export function FormDetail() {
                 Get started by building this form.
               </p>
               <div className="mt-6">
-                <button
+                <Button
+                  variant="primary"
+                  size="sm"
                   onClick={() => startEditing()}
-                  className="inline-flex items-center px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-accent-coral hover:bg-accent-coral/90"
                 >
-                  <Plus className="w-4 h-4 mr-2" />
+                  <Plus className="w-4 h-4" />
                   Build form
-                </button>
+                </Button>
               </div>
             </div>
           )}

--- a/dali-api/app/forms/components/FormsBrowser.tsx
+++ b/dali-api/app/forms/components/FormsBrowser.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { Link, useFetcher } from "react-router";
 import { Folder, FileText, MoreVertical } from "lucide-react";
+import { Button } from "~/components/ui/Button";
 import type { FormCard, FolderCard } from "~/forms/lib/forms-data";
 
 function errorOf(data: unknown): string | null {
@@ -153,14 +154,15 @@ export function FormsBrowser({
         >
           + New folder
         </button>
-        <button
+        <Button
           type="button"
+          variant="primary"
+          size="sm"
           disabled={busy}
           onClick={createForm}
-          className="px-3 py-1.5 text-sm font-medium rounded-md bg-accent-coral text-white hover:bg-accent-coral/90 transition-colors disabled:opacity-60"
         >
           + New form
-        </button>
+        </Button>
         </div>
       </div>
 

--- a/dali-api/app/forms/components/MemberFormFillView.tsx
+++ b/dali-api/app/forms/components/MemberFormFillView.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { ChallengeQuestionField } from "~/hiring/components/ChallengeQuestionField";
 import { RichTextViewer, isEmptyDoc } from "~/components/RichTextViewer";
+import { Button } from "~/components/ui/Button";
 import type { Question } from "~/types";
 
 // The shared authenticated form-fill UI. Rendered both by /forms/fill/:token
@@ -125,13 +126,15 @@ export function MemberFormFillView({
           </div>
         ))}
 
-        <button
+        <Button
           type="submit"
+          variant="primary"
+          size="sm"
           disabled={state === "submitting"}
-          className="self-start px-4 py-2 text-sm font-medium rounded-lg bg-accent-coral text-white hover:bg-accent-coral/90 disabled:opacity-60 transition-colors"
+          className="self-start"
         >
           {state === "submitting" ? "Submitting…" : "Submit"}
-        </button>
+        </Button>
       </form>
     </>
   );

--- a/dali-api/app/forms/lib/forms-data.ts
+++ b/dali-api/app/forms/lib/forms-data.ts
@@ -117,13 +117,13 @@ export async function loadFormForEdit(
       createdByName: `${v.createdBy.firstName} ${v.createdBy.lastName}`.trim(),
       questions: (v.questions as unknown as Question[]) ?? [],
       // intro holds serialized ProseMirror JSON (see module note).
-      description: v.intro ? safeParse(v.intro) : null,
+      description: v.intro ? safeParseJsonString(v.intro) : null,
     })),
     draft: draftQuestions
       ? {
           questions: draftQuestions,
           // draftIntro mirrors FormVersion.intro (serialized ProseMirror JSON).
-          description: form.draftIntro ? safeParse(form.draftIntro) : null,
+          description: safeParseJsonString(form.draftIntro),
         }
       : null,
   };
@@ -196,7 +196,7 @@ export async function loadFormsLevel(folderId: string | null) {
               id: v.id,
               questions: (v.questions as unknown as Question[]) ?? [],
               // intro holds serialized ProseMirror JSON (see module note).
-              description: v.intro ? safeParse(v.intro) : null,
+              description: v.intro ? safeParseJsonString(v.intro) : null,
             }
           : null,
       };
@@ -208,7 +208,8 @@ export async function loadFormsLevel(folderId: string | null) {
   };
 }
 
-function safeParse(s: string): unknown {
+export function safeParseJsonString(s: string | null | undefined): unknown {
+  if (!s) return null;
   try {
     return JSON.parse(s);
   } catch {

--- a/dali-api/app/forms/lib/public-form.ts
+++ b/dali-api/app/forms/lib/public-form.ts
@@ -7,6 +7,7 @@
 import { prisma } from "~/lib/db";
 import type { Question } from "~/types";
 import { resolveReferenceOptions } from "./reference-sources";
+import { safeParseJsonString } from "./forms-data";
 import { currentTerm } from "~/lib/roles";
 import { interpretBidForm } from "~/projects/lib/bid-form-interpreter";
 import { validateBids, replaceBidSet } from "~/projects/lib/bid-validation";
@@ -37,15 +38,6 @@ export type PublicForm = {
   // surface "this form can't be completed publicly" rather than silently drop.
   questions: Question[];
 };
-
-function safeParse(s: string | null): unknown {
-  if (!s) return null;
-  try {
-    return JSON.parse(s);
-  } catch {
-    return null;
-  }
-}
 
 // Resolve a public token to its form's latest version. Returns null when the
 // token is unknown, the form is unpublished, or it has no versions yet —
@@ -96,7 +88,7 @@ export async function loadPublicForm(
     formId: form.id,
     name: form.name,
     versionId: version.id,
-    description: safeParse(version.intro),
+    description: safeParseJsonString(version.intro),
     questions: resolved,
   };
 }

--- a/dali-api/app/forms/routes/forms.$folderId.tsx
+++ b/dali-api/app/forms/routes/forms.$folderId.tsx
@@ -1,7 +1,7 @@
 import { redirect, useLoaderData, Link } from "react-router";
 import { ChevronRight } from "lucide-react";
 import type { Route } from "./+types/forms.$folderId";
-import { requireAuth } from "~/lib/auth";
+import { requireAuth, forbidden, redirectApplicantToPortal } from "~/lib/auth";
 import { isCore } from "~/lib/roles";
 import { loadFormsLevel, runFormsAction } from "~/forms/lib/forms-data";
 import { FormsBrowser } from "~/forms/components/FormsBrowser";
@@ -13,7 +13,8 @@ export const meta: Route.MetaFunction = ({ data }) => [
 export async function loader({ request, params }: Route.LoaderArgs) {
   const auth = await requireAuth(request);
   if (!auth.ok) return redirect("/login");
-  if (auth.user.type === "applicant") return redirect("/portal");
+  const portalRedirect = redirectApplicantToPortal(auth);
+  if (portalRedirect) return portalRedirect;
   if (!(await isCore(auth.user.sub))) return redirect("/");
 
   const level = await loadFormsLevel(params.folderId);
@@ -25,7 +26,7 @@ export async function action({ request }: Route.ActionArgs) {
   const auth = await requireAuth(request);
   if (!auth.ok) return auth.response;
   if (!(await isCore(auth.user.sub)))
-    return Response.json({ error: "Forbidden" }, { status: 403 });
+    return forbidden(request);
 
   const result = await runFormsAction(
     await request.formData(),

--- a/dali-api/app/forms/routes/forms.edit.$formId.tsx
+++ b/dali-api/app/forms/routes/forms.edit.$formId.tsx
@@ -1,6 +1,6 @@
 import { redirect } from "react-router";
 import type { Route } from "./+types/forms.edit.$formId";
-import { requireAuth } from "~/lib/auth";
+import { requireAuth, forbidden, redirectApplicantToPortal } from "~/lib/auth";
 import { isCore } from "~/lib/roles";
 import { prisma } from "~/lib/db";
 import { loadFormForEdit, runFormsAction } from "~/forms/lib/forms-data";
@@ -13,7 +13,8 @@ export const meta: Route.MetaFunction = ({ data }) => [
 export async function loader({ request, params }: Route.LoaderArgs) {
   const auth = await requireAuth(request);
   if (!auth.ok) return redirect("/login");
-  if (auth.user.type === "applicant") return redirect("/portal");
+  const portalRedirect = redirectApplicantToPortal(auth);
+  if (portalRedirect) return portalRedirect;
   if (!(await isCore(auth.user.sub))) return redirect("/");
 
   const form = await loadFormForEdit(params.formId);
@@ -34,7 +35,7 @@ export async function action({ request }: Route.ActionArgs) {
   const auth = await requireAuth(request);
   if (!auth.ok) return auth.response;
   if (!(await isCore(auth.user.sub)))
-    return Response.json({ error: "Forbidden" }, { status: 403 });
+    return forbidden(request);
 
   const result = await runFormsAction(await request.formData(), auth.user.sub);
   if ("error" in result)

--- a/dali-api/app/forms/routes/forms.tsx
+++ b/dali-api/app/forms/routes/forms.tsx
@@ -1,6 +1,6 @@
 import { redirect, useLoaderData } from "react-router";
 import type { Route } from "./+types/forms";
-import { requireAuth } from "~/lib/auth";
+import { requireAuth, forbidden, redirectApplicantToPortal } from "~/lib/auth";
 import { canViewForms } from "~/lib/roles";
 import { loadFormsLevel, runFormsAction } from "~/forms/lib/forms-data";
 import { FormsBrowser } from "~/forms/components/FormsBrowser";
@@ -10,7 +10,8 @@ export const meta: Route.MetaFunction = () => [{ title: "Forms · DALI OS" }];
 export async function loader({ request }: Route.LoaderArgs) {
   const auth = await requireAuth(request);
   if (!auth.ok) return redirect("/login");
-  if (auth.user.type === "applicant") return redirect("/portal");
+  const portalRedirect = redirectApplicantToPortal(auth);
+  if (portalRedirect) return portalRedirect;
   if (!(await canViewForms(auth.user.sub))) return redirect("/");
 
   const level = await loadFormsLevel(null);
@@ -21,7 +22,7 @@ export async function action({ request }: Route.ActionArgs) {
   const auth = await requireAuth(request);
   if (!auth.ok) return auth.response;
   if (!(await canViewForms(auth.user.sub)))
-    return Response.json({ error: "Forbidden" }, { status: 403 });
+    return forbidden(request);
 
   const result = await runFormsAction(
     await request.formData(),

--- a/dali-api/app/hiring/components/ChallengeDetail.tsx
+++ b/dali-api/app/hiring/components/ChallengeDetail.tsx
@@ -6,15 +6,7 @@ import { RichTextViewer, isEmptyDoc } from '~/components/RichTextViewer'
 import { ChallengePreviewModal } from '~/hiring/components/ChallengePreviewModal'
 import type { Question } from '~/types'
 import type { loader } from '~/hiring/routes/challenges.$id'
-
-function formatDateTime(iso: string | Date) {
-  const d = new Date(iso)
-  return (
-    d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' }) +
-    ' at ' +
-    d.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })
-  )
-}
+import { formatDateTime } from '~/lib/display'
 
 export function resolveDuplicateDomainId(version: { domainId: string | null }): string {
   // A general version's domainId is null; coerce to '' so the form's selected

--- a/dali-api/app/hiring/components/ConfidentialityAgreementDetail.tsx
+++ b/dali-api/app/hiring/components/ConfidentialityAgreementDetail.tsx
@@ -4,26 +4,7 @@ import { Plus, Clock, UserIcon, Pencil } from "lucide-react";
 import type { loader } from "~/hiring/routes/confidentiality-agreements.$id";
 import { RichTextEditor } from "~/components/RichTextEditor";
 import { RichTextViewer, isEmptyDoc } from "~/components/RichTextViewer";
-
-function formatDateTime(iso: string | Date) {
-  const d = new Date(iso);
-  return (
-    d.toLocaleDateString(undefined, {
-      month: "short",
-      day: "numeric",
-      year: "numeric",
-    }) +
-    " at " +
-    d.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" })
-  );
-}
-
-function memberLabel(
-  m: { firstName: string | null; lastName: string | null } | null | undefined,
-) {
-  if (!m) return "Unknown";
-  return `${m.firstName ?? ""} ${m.lastName ?? ""}`.trim() || "Unknown";
-}
+import { formatDateTime, fullName, UNKNOWN_LABEL } from "~/lib/display";
 
 const EMPTY_DOC = { type: "doc", content: [{ type: "paragraph" }] };
 
@@ -155,7 +136,7 @@ export function ConfidentialityAgreementDetail() {
                 </div>
                 <p className="text-xs text-muted-foreground mt-1 inline-flex items-center gap-1 truncate">
                   <UserIcon className="w-3 h-3 shrink-0" />
-                  {memberLabel(v.createdBy)}
+                  {v.createdBy ? fullName(v.createdBy) || UNKNOWN_LABEL : UNKNOWN_LABEL}
                 </p>
               </button>
             );

--- a/dali-api/app/hiring/components/EmailTemplateDetail.tsx
+++ b/dali-api/app/hiring/components/EmailTemplateDetail.tsx
@@ -7,20 +7,7 @@ import {
   TEMPLATE_VARIABLE_DESCRIPTIONS,
   lintTemplate,
 } from '~/hiring/lib/email-variables'
-
-function formatDateTime(iso: string | Date) {
-  const d = new Date(iso)
-  return (
-    d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' }) +
-    ' at ' +
-    d.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })
-  )
-}
-
-function memberLabel(m: { firstName: string | null; lastName: string | null } | null | undefined) {
-  if (!m) return 'Unknown'
-  return `${m.firstName ?? ''} ${m.lastName ?? ''}`.trim() || 'Unknown'
-}
+import { formatDateTime, fullName, UNKNOWN_LABEL } from '~/lib/display'
 
 function VariableReferencePanel() {
   return (
@@ -180,7 +167,7 @@ export function EmailTemplateDetail() {
                 </div>
                 <p className="text-xs text-muted-foreground mt-1 inline-flex items-center gap-1 truncate">
                   <UserIcon className="w-3 h-3 shrink-0" />
-                  {memberLabel(v.createdBy)}
+                  {v.createdBy ? fullName(v.createdBy) || UNKNOWN_LABEL : UNKNOWN_LABEL}
                 </p>
               </button>
             )

--- a/dali-api/app/hiring/components/EmailTemplates.tsx
+++ b/dali-api/app/hiring/components/EmailTemplates.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react'
 import { Link, Form, useLoaderData, useSearchParams } from 'react-router'
 import { Plus, Mail, ChevronRight, X } from 'lucide-react'
+import { Button } from '~/components/ui/Button'
+import { Modal } from '~/components/Modal'
 import type { loader } from '~/hiring/routes/email-templates'
 
 const GMAIL_ERROR_MESSAGES: Record<string, string> = {
@@ -75,13 +77,10 @@ export default function EmailTemplatesList() {
             to a decision type from the cycle admin page.
           </p>
         </div>
-        <button
-          onClick={() => setShowModal(true)}
-          className="inline-flex items-center justify-center px-4 py-2 border border-transparent text-sm font-medium rounded-lg text-white bg-accent-coral hover:bg-accent-coral/90 shadow-sm"
-        >
-          <Plus className="w-4 h-4 mr-2" />
+        <Button variant="primary" size="sm" onClick={() => setShowModal(true)}>
+          <Plus className="w-4 h-4" />
           New Template
-        </button>
+        </Button>
       </div>
 
       <div className="grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-6">
@@ -129,62 +128,52 @@ export default function EmailTemplatesList() {
         )}
       </div>
 
-      {showModal && (
-        <div
-          className="fixed inset-0 z-50 bg-black/40 flex items-center justify-center p-4"
-          onClick={() => setShowModal(false)}
-        >
-          <div
-            className="bg-card rounded-lg shadow-xl w-full max-w-sm p-6 space-y-4"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <div className="flex items-center justify-between">
-              <h2 className="text-lg font-semibold text-foreground">New Email Template</h2>
-              <button
-                onClick={() => setShowModal(false)}
-                className="text-muted-foreground/70 hover:text-muted-foreground"
-                aria-label="Close"
-              >
-                <X className="w-5 h-5" />
-              </button>
+      <Modal
+        open={showModal}
+        onClose={() => setShowModal(false)}
+        labelledBy="new-email-template-title"
+      >
+        <div className="space-y-4">
+          <h2 id="new-email-template-title" className="text-lg font-semibold text-foreground">
+            New Email Template
+          </h2>
+          <Form method="post" onSubmit={() => setShowModal(false)} className="space-y-4">
+            <input type="hidden" name="intent" value="create" />
+            <div>
+              <label className="block text-sm font-medium text-foreground/80 mb-1">
+                Template name
+              </label>
+              <input
+                type="text"
+                name="name"
+                value={newName}
+                onChange={(e) => setNewName(e.target.value)}
+                placeholder="e.g. Rejection — Standard"
+                className="w-full px-3 py-2 text-sm text-foreground border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                autoFocus
+                autoComplete="off"
+              />
             </div>
-            <Form method="post" onSubmit={() => setShowModal(false)} className="space-y-4">
-              <input type="hidden" name="intent" value="create" />
-              <div>
-                <label className="block text-sm font-medium text-foreground/80 mb-1">
-                  Template name
-                </label>
-                <input
-                  type="text"
-                  name="name"
-                  value={newName}
-                  onChange={(e) => setNewName(e.target.value)}
-                  placeholder="e.g. Rejection — Standard"
-                  className="w-full px-3 py-2 text-sm text-foreground border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-                  autoFocus
-                  autoComplete="off"
-                />
-              </div>
-              <div className="flex justify-end gap-2">
-                <button
-                  type="button"
-                  onClick={() => setShowModal(false)}
-                  className="px-3 py-2 text-sm font-medium text-foreground/80 bg-card border border-gray-300 rounded-md hover:bg-muted/50"
-                >
-                  Cancel
-                </button>
-                <button
-                  type="submit"
-                  disabled={!newName.trim()}
-                  className="px-3 py-2 text-sm font-medium text-white bg-accent-coral rounded-md hover:bg-accent-coral/90 disabled:opacity-50"
-                >
-                  Create
-                </button>
-              </div>
-            </Form>
-          </div>
+            <div className="flex justify-end gap-2">
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={() => setShowModal(false)}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="submit"
+                variant="primary"
+                size="sm"
+                disabled={!newName.trim()}
+              >
+                Create
+              </Button>
+            </div>
+          </Form>
         </div>
-      )}
+      </Modal>
     </div>
   )
 }

--- a/dali-api/app/hiring/components/Library.tsx
+++ b/dali-api/app/hiring/components/Library.tsx
@@ -6,9 +6,10 @@ import {
   ListOrdered,
   ShieldCheck,
   ChevronRight,
-  X,
   Trash2,
 } from "lucide-react";
+import { Button } from "~/components/ui/Button";
+import { Modal } from "~/components/Modal";
 import type { loader } from "~/hiring/routes/library";
 
 type Tab = "challenges" | "rubrics" | "agreements";
@@ -124,13 +125,10 @@ function ChallengesPanel({
               </option>
             ))}
           </select>
-          <button
-            onClick={() => setShowModal(true)}
-            className="inline-flex items-center justify-center px-4 py-2 border border-transparent text-sm font-medium rounded-lg text-white bg-accent-coral hover:bg-accent-coral/90 shadow-sm"
-          >
-            <Plus className="w-4 h-4 mr-2" />
+          <Button variant="primary" size="sm" onClick={() => setShowModal(true)}>
+            <Plus className="w-4 h-4" />
             New Challenge
-          </button>
+          </Button>
         </div>
       </div>
 
@@ -189,78 +187,68 @@ function ChallengesPanel({
         )}
       </div>
 
-      {showModal && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
-          <div
-            className="absolute inset-0 bg-black/10 backdrop-blur-[1px]"
-            onClick={() => setShowModal(false)}
-          />
-          <div
-            className="relative bg-card rounded-xl shadow-xl w-full max-w-md p-6 space-y-6"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <div className="flex items-center justify-between">
-              <h2 className="text-xl font-bold text-foreground">New Challenge</h2>
-              <button
-                onClick={() => setShowModal(false)}
-                className="text-muted-foreground/70 hover:text-muted-foreground p-1 rounded-md hover:bg-muted"
-              >
-                <X className="w-5 h-5" />
-              </button>
-            </div>
+      <Modal
+        open={showModal}
+        onClose={() => setShowModal(false)}
+        labelledBy="new-challenge-title"
+        className="fixed inset-0 z-50 flex items-center justify-center bg-black/10 backdrop-blur-[1px] p-4 sm:p-6 overflow-y-auto"
+        containerClassName="bg-card rounded-xl shadow-xl max-w-md w-full p-6 my-auto space-y-6"
+      >
+        <h2 id="new-challenge-title" className="text-xl font-bold text-foreground">
+          New Challenge
+        </h2>
 
-            <Form
-              method="post"
-              onSubmit={() => {
-                setNewChallengeName("");
-                setShowModal(false);
-              }}
-              className="space-y-4"
-            >
-              <input type="hidden" name="entity" value="challenge" />
-              <input type="hidden" name="intent" value="create" />
-              {isGeneral ? (
-                <input type="hidden" name="general" value="1" />
-              ) : (
-                <input type="hidden" name="domainId" value={activeDomain} />
-              )}
-              <div>
-                <label className="block text-sm font-medium text-foreground/80 mb-1">
-                  Challenge Name <span className="text-red-500">*</span>
-                </label>
-                <input
-                  type="text"
-                  name="name"
-                  value={newChallengeName}
-                  onChange={(e) => setNewChallengeName(e.target.value)}
-                  placeholder="e.g. Engineering Challenge Fall 2026"
-                  required
-                  autoFocus
-                  autoComplete="off"
-                  className="block w-full rounded-lg border border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm p-2.5 text-foreground bg-card placeholder-gray-400"
-                />
-              </div>
-
-              <div className="flex justify-end gap-3 pt-2 border-t border-border">
-                <button
-                  type="button"
-                  onClick={() => setShowModal(false)}
-                  className="px-4 py-2 border border-gray-300 shadow-sm text-sm font-medium rounded-lg text-foreground/80 bg-card hover:bg-muted/50"
-                >
-                  Cancel
-                </button>
-                <button
-                  type="submit"
-                  disabled={!newChallengeName.trim()}
-                  className="px-4 py-2 border border-transparent text-sm font-medium rounded-lg text-white bg-accent-coral hover:bg-accent-coral/90 shadow-sm disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                  Create Challenge
-                </button>
-              </div>
-            </Form>
+        <Form
+          method="post"
+          onSubmit={() => {
+            setNewChallengeName("");
+            setShowModal(false);
+          }}
+          className="space-y-4"
+        >
+          <input type="hidden" name="entity" value="challenge" />
+          <input type="hidden" name="intent" value="create" />
+          {isGeneral ? (
+            <input type="hidden" name="general" value="1" />
+          ) : (
+            <input type="hidden" name="domainId" value={activeDomain} />
+          )}
+          <div>
+            <label className="block text-sm font-medium text-foreground/80 mb-1">
+              Challenge Name <span className="text-red-500">*</span>
+            </label>
+            <input
+              type="text"
+              name="name"
+              value={newChallengeName}
+              onChange={(e) => setNewChallengeName(e.target.value)}
+              placeholder="e.g. Engineering Challenge Fall 2026"
+              required
+              autoFocus
+              autoComplete="off"
+              className="block w-full rounded-lg border border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm p-2.5 text-foreground bg-card placeholder-gray-400"
+            />
           </div>
-        </div>
-      )}
+
+          <div className="flex justify-end gap-3 pt-2 border-t border-border">
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => setShowModal(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              variant="primary"
+              size="sm"
+              disabled={!newChallengeName.trim()}
+            >
+              Create Challenge
+            </Button>
+          </div>
+        </Form>
+      </Modal>
     </div>
   );
 }
@@ -278,13 +266,10 @@ function RubricsPanel({ rubrics }: { rubrics: any[] }) {
             Manage rubrics and their versions independently of hiring cycles.
           </p>
         </div>
-        <button
-          onClick={() => setShowModal(true)}
-          className="inline-flex items-center justify-center px-4 py-2 border border-transparent text-sm font-medium rounded-lg text-white bg-accent-coral hover:bg-accent-coral/90 shadow-sm"
-        >
-          <Plus className="w-4 h-4 mr-2" />
+        <Button variant="primary" size="sm" onClick={() => setShowModal(true)}>
+          <Plus className="w-4 h-4" />
           New Rubric
-        </button>
+        </Button>
       </div>
 
       <div className="grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-6">
@@ -322,66 +307,57 @@ function RubricsPanel({ rubrics }: { rubrics: any[] }) {
         )}
       </div>
 
-      {showModal && (
-        <div
-          className="fixed inset-0 z-50 bg-black/40 flex items-center justify-center p-4"
-          onClick={() => setShowModal(false)}
-        >
-          <div
-            className="bg-card rounded-lg shadow-xl w-full max-w-sm p-6 space-y-4"
-            onClick={(e) => e.stopPropagation()}
+      <Modal
+        open={showModal}
+        onClose={() => setShowModal(false)}
+        labelledBy="new-rubric-title"
+      >
+        <div className="space-y-4">
+          <h2 id="new-rubric-title" className="text-lg font-semibold text-foreground">
+            New Rubric
+          </h2>
+          <Form
+            method="post"
+            onSubmit={() => setShowModal(false)}
+            className="space-y-4"
           >
-            <div className="flex items-center justify-between">
-              <h2 className="text-lg font-semibold text-foreground">New Rubric</h2>
-              <button
-                onClick={() => setShowModal(false)}
-                className="text-muted-foreground/70 hover:text-muted-foreground"
-              >
-                <X className="w-5 h-5" />
-              </button>
+            <input type="hidden" name="entity" value="rubric" />
+            <input type="hidden" name="intent" value="create" />
+            <div>
+              <label className="block text-sm font-medium text-foreground/80 mb-1">
+                Rubric name
+              </label>
+              <input
+                type="text"
+                name="name"
+                value={newRubricName}
+                onChange={(e) => setNewRubricName(e.target.value)}
+                placeholder="e.g. Design Challenge Rubric"
+                className="w-full px-3 py-2 text-sm text-foreground border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                autoFocus
+                autoComplete="off"
+              />
             </div>
-            <Form
-              method="post"
-              onSubmit={() => setShowModal(false)}
-              className="space-y-4"
-            >
-              <input type="hidden" name="entity" value="rubric" />
-              <input type="hidden" name="intent" value="create" />
-              <div>
-                <label className="block text-sm font-medium text-foreground/80 mb-1">
-                  Rubric name
-                </label>
-                <input
-                  type="text"
-                  name="name"
-                  value={newRubricName}
-                  onChange={(e) => setNewRubricName(e.target.value)}
-                  placeholder="e.g. Design Challenge Rubric"
-                  className="w-full px-3 py-2 text-sm text-foreground border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-                  autoFocus
-                  autoComplete="off"
-                />
-              </div>
-              <div className="flex justify-end gap-2">
-                <button
-                  type="button"
-                  onClick={() => setShowModal(false)}
-                  className="px-3 py-2 text-sm font-medium text-foreground/80 bg-card border border-gray-300 rounded-md hover:bg-muted/50"
-                >
-                  Cancel
-                </button>
-                <button
-                  type="submit"
-                  disabled={!newRubricName.trim()}
-                  className="px-3 py-2 text-sm font-medium text-white bg-accent-coral rounded-md hover:bg-accent-coral/90 disabled:opacity-50"
-                >
-                  Create
-                </button>
-              </div>
-            </Form>
-          </div>
+            <div className="flex justify-end gap-2">
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={() => setShowModal(false)}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="submit"
+                variant="primary"
+                size="sm"
+                disabled={!newRubricName.trim()}
+              >
+                Create
+              </Button>
+            </div>
+          </Form>
         </div>
-      )}
+      </Modal>
     </div>
   );
 }
@@ -410,13 +386,10 @@ function AgreementsPanel({
           </p>
         </div>
         {canEdit && (
-          <button
-            onClick={() => setShowModal(true)}
-            className="inline-flex items-center justify-center px-4 py-2 border border-transparent text-sm font-medium rounded-lg text-white bg-accent-coral hover:bg-accent-coral/90 shadow-sm"
-          >
-            <Plus className="w-4 h-4 mr-2" />
+          <Button variant="primary" size="sm" onClick={() => setShowModal(true)}>
+            <Plus className="w-4 h-4" />
             New Agreement
-          </button>
+          </Button>
         )}
       </div>
 
@@ -463,69 +436,57 @@ function AgreementsPanel({
         )}
       </div>
 
-      {showModal && (
-        <div
-          className="fixed inset-0 z-50 bg-black/40 flex items-center justify-center p-4"
-          onClick={() => setShowModal(false)}
-        >
-          <div
-            className="bg-card rounded-lg shadow-xl w-full max-w-sm p-6 space-y-4"
-            onClick={(e) => e.stopPropagation()}
+      <Modal
+        open={showModal}
+        onClose={() => setShowModal(false)}
+        labelledBy="new-agreement-title"
+      >
+        <div className="space-y-4">
+          <h2 id="new-agreement-title" className="text-lg font-semibold text-foreground">
+            New Confidentiality Agreement
+          </h2>
+          <Form
+            method="post"
+            onSubmit={() => setShowModal(false)}
+            className="space-y-4"
           >
-            <div className="flex items-center justify-between">
-              <h2 className="text-lg font-semibold text-foreground">
-                New Confidentiality Agreement
-              </h2>
-              <button
-                onClick={() => setShowModal(false)}
-                className="text-muted-foreground/70 hover:text-muted-foreground"
-                aria-label="Close"
-              >
-                <X className="w-5 h-5" />
-              </button>
+            <input type="hidden" name="entity" value="agreement" />
+            <input type="hidden" name="intent" value="create" />
+            <div>
+              <label className="block text-sm font-medium text-foreground/80 mb-1">
+                Agreement name
+              </label>
+              <input
+                type="text"
+                name="name"
+                value={newName}
+                onChange={(e) => setNewName(e.target.value)}
+                placeholder="e.g. Hiring Confidentiality — 2026"
+                className="w-full px-3 py-2 text-sm text-foreground border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                autoFocus
+                autoComplete="off"
+              />
             </div>
-            <Form
-              method="post"
-              onSubmit={() => setShowModal(false)}
-              className="space-y-4"
-            >
-              <input type="hidden" name="entity" value="agreement" />
-              <input type="hidden" name="intent" value="create" />
-              <div>
-                <label className="block text-sm font-medium text-foreground/80 mb-1">
-                  Agreement name
-                </label>
-                <input
-                  type="text"
-                  name="name"
-                  value={newName}
-                  onChange={(e) => setNewName(e.target.value)}
-                  placeholder="e.g. Hiring Confidentiality — 2026"
-                  className="w-full px-3 py-2 text-sm text-foreground border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-                  autoFocus
-                  autoComplete="off"
-                />
-              </div>
-              <div className="flex justify-end gap-2">
-                <button
-                  type="button"
-                  onClick={() => setShowModal(false)}
-                  className="px-3 py-2 text-sm font-medium text-foreground/80 bg-card border border-gray-300 rounded-md hover:bg-muted/50"
-                >
-                  Cancel
-                </button>
-                <button
-                  type="submit"
-                  disabled={!newName.trim()}
-                  className="px-3 py-2 text-sm font-medium text-white bg-accent-coral rounded-md hover:bg-accent-coral/90 disabled:opacity-50"
-                >
-                  Create
-                </button>
-              </div>
-            </Form>
-          </div>
+            <div className="flex justify-end gap-2">
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={() => setShowModal(false)}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="submit"
+                variant="primary"
+                size="sm"
+                disabled={!newName.trim()}
+              >
+                Create
+              </Button>
+            </div>
+          </Form>
         </div>
-      )}
+      </Modal>
     </div>
   );
 }

--- a/dali-api/app/hiring/components/RubricDetail.tsx
+++ b/dali-api/app/hiring/components/RubricDetail.tsx
@@ -9,15 +9,7 @@ import {
 } from 'lucide-react'
 import type { loader } from '~/hiring/routes/rubrics.$id'
 import type { RubricCriterion } from '~/types'
-
-function formatDateTime(iso: string | Date) {
-  const d = new Date(iso)
-  return (
-    d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' }) +
-    ' at ' +
-    d.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })
-  )
-}
+import { formatDateTime } from '~/lib/display'
 
 export function RubricDetail() {
   const { rubric } = useLoaderData<typeof loader>()

--- a/dali-api/app/hiring/components/analytics/CycleSelector.tsx
+++ b/dali-api/app/hiring/components/analytics/CycleSelector.tsx
@@ -1,23 +1,10 @@
 import { useNavigate, useSearchParams } from "react-router";
+import { STATUS_COLORS, STATUS_LABELS } from "~/hiring/lib/labels";
 
 interface CycleSelectorProps {
   cycles: Array<{ id: string; name: string; status: string }>;
   selectedCycleId: string;
 }
-
-const STATUS_COLORS: Record<string, string> = {
-  Draft: "bg-muted text-foreground/80",
-  Open: "bg-green-100 text-green-700",
-  UnderReview: "bg-yellow-100 text-yellow-700",
-  Completed: "bg-blue-100 text-blue-700",
-};
-
-const STATUS_LABELS: Record<string, string> = {
-  Draft: "Draft",
-  Open: "Open",
-  UnderReview: "Under Review",
-  Completed: "Completed",
-};
 
 export function CycleSelector({ cycles, selectedCycleId }: CycleSelectorProps) {
   const navigate = useNavigate();

--- a/dali-api/app/hiring/components/delibs/ApplicantContextModal.tsx
+++ b/dali-api/app/hiring/components/delibs/ApplicantContextModal.tsx
@@ -1,28 +1,12 @@
-import { useEffect } from "react";
 import { useFetcher } from "react-router";
-import { X } from "lucide-react";
 import { CollaborativeEditor } from "~/components/CollaborativeEditor";
-
-const RECOMMENDATION_COLORS: Record<string, string> = {
-  "Strong Hire": "bg-green-100 text-green-800",
-  Hire: "bg-green-50 text-green-700",
-  "Lean Hire": "bg-yellow-50 text-yellow-700",
-  "Lean No Hire": "bg-orange-50 text-orange-700",
-  "No Hire": "bg-red-100 text-red-700",
-};
-
-const DECISION_COLORS: Record<string, string> = {
-  Rejected: "bg-red-100 text-red-700",
-  InvitedToInterview: "bg-blue-100 text-blue-700",
-  Accepted: "bg-green-100 text-green-700",
-  Waitlisted: "bg-yellow-100 text-yellow-700",
-};
-
-const STAGE_LABELS: Record<string, string> = {
-  Draft: "Draft",
-  Final: "Finalized",
-  Released: "Released",
-};
+import { Modal } from "~/components/Modal";
+import {
+  DECISION_COLORS,
+  RECOMMENDATION_COLORS,
+  STAGE_LABELS,
+} from "~/hiring/lib/labels";
+import { useEffect } from "react";
 
 export interface ApplicantContextModalProps {
   domainApplicationId: string;
@@ -51,64 +35,50 @@ export function ApplicantContextModal({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [domainApplicationId]);
 
-  useEffect(() => {
-    function onKey(e: KeyboardEvent) {
-      if (e.key === "Escape") onClose();
-    }
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [onClose]);
-
   const data = fetcher.data as any;
   const isError = data && typeof data === "object" && "error" in data;
   const isLoading = fetcher.state === "loading" || (!data && !isError);
 
   return (
-    <div
-      className="fixed inset-0 z-50 bg-black/40 flex items-start justify-center p-4"
-      onClick={onClose}
+    <Modal
+      open
+      onClose={onClose}
+      labelledBy="applicant-context-title"
+      className="fixed inset-0 z-50 flex items-start justify-center bg-black/40 p-4 overflow-y-auto"
+      containerClassName="bg-card rounded-xl shadow-xl w-full max-w-5xl my-8 max-h-[90vh] flex flex-col"
     >
-      <div
-        className="bg-card rounded-xl shadow-xl w-full max-w-5xl my-8 max-h-[90vh] flex flex-col"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <div className="px-6 py-4 border-b border-border flex items-center justify-between bg-card rounded-t-xl flex-shrink-0">
-          <div>
-            {isLoading || isError || !data ? (
-              <h2 className="text-lg font-semibold text-foreground">Applicant Context</h2>
-            ) : (
-              <>
-                <h2 className="text-lg font-semibold text-foreground">
-                  {data.application.applicant.firstName} {data.application.applicant.lastName}
-                </h2>
-                <p className="text-xs text-muted-foreground">
-                  {data.domainApplication.domain?.name ?? ""}
-                  {data.decisions?.length > 0 && (
-                    <>
-                      {" · "}
-                      <span
-                        className={`inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold ${
-                          DECISION_COLORS[data.decisions[0].type] ?? "bg-muted text-foreground/80"
-                        }`}
-                      >
-                        {data.decisions[0].type} ({STAGE_LABELS[data.decisions[0].stage] ?? data.decisions[0].stage})
-                      </span>
-                    </>
-                  )}
-                </p>
-              </>
-            )}
-          </div>
-          <button
-            onClick={onClose}
-            aria-label="Close"
-            className="text-muted-foreground/70 hover:text-muted-foreground"
-          >
-            <X className="w-5 h-5" />
-          </button>
+      <div className="px-6 py-4 border-b border-border flex items-center justify-between bg-card rounded-t-xl flex-shrink-0">
+        <div>
+          {isLoading || isError || !data ? (
+            <h2 id="applicant-context-title" className="text-lg font-semibold text-foreground">
+              Applicant Context
+            </h2>
+          ) : (
+            <>
+              <h2 id="applicant-context-title" className="text-lg font-semibold text-foreground">
+                {data.application.applicant.firstName} {data.application.applicant.lastName}
+              </h2>
+              <p className="text-xs text-muted-foreground">
+                {data.domainApplication.domain?.name ?? ""}
+                {data.decisions?.length > 0 && (
+                  <>
+                    {" · "}
+                    <span
+                      className={`inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold ${
+                        DECISION_COLORS[data.decisions[0].type] ?? "bg-muted text-foreground/80"
+                      }`}
+                    >
+                      {data.decisions[0].type} ({STAGE_LABELS[data.decisions[0].stage] ?? data.decisions[0].stage})
+                    </span>
+                  </>
+                )}
+              </p>
+            </>
+          )}
         </div>
+      </div>
 
-        <div className="flex-1 min-h-0 overflow-y-auto lg:overflow-hidden flex flex-col p-6 gap-6">
+      <div className="flex-1 min-h-0 overflow-y-auto lg:overflow-hidden flex flex-col p-6 gap-6">
           <InterviewPrepNoteSection
             domainApplicationId={domainApplicationId}
             editable={editable}
@@ -157,8 +127,7 @@ export function ApplicantContextModal({
             </div>
           )}
         </div>
-      </div>
-    </div>
+    </Modal>
   );
 }
 

--- a/dali-api/app/hiring/lib/__tests__/api.decisions.lineage.test.ts
+++ b/dali-api/app/hiring/lib/__tests__/api.decisions.lineage.test.ts
@@ -3,12 +3,26 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 vi.mock("~/lib/db");
 vi.mock("~/lib/auth", () => ({
   requireAuth: vi.fn(),
+  requireCore: vi.fn(),
+  requireCoreOrDomainLead: vi.fn(),
+  requireMemberSession: vi.fn(),
+  forbidden: vi.fn((_req: Request) =>
+    Response.json({ error: "Forbidden" }, { status: 403 }),
+  ),
+  unauthorized: vi.fn((_req: Request) =>
+    Response.json({ error: "Unauthorized" }, { status: 401 }),
+  ),
+  redirectApplicantToPortal: vi.fn(() => null),
 }));
 vi.mock("~/lib/roles");
 vi.mock("~/lib/gmail");
 
 import { prisma } from "~/lib/db";
-import { requireAuth } from "~/lib/auth";
+import {
+  requireAuth,
+  requireCoreOrDomainLead,
+  requireMemberSession,
+} from "~/lib/auth";
 import { isCore, isDomainLead, hasCycleAccess } from "~/lib/roles";
 import { sendEmail } from "~/lib/gmail";
 import { action as finalizeAction } from "~/hiring/routes/api.decisions.$id.finalize";
@@ -52,6 +66,16 @@ beforeEach(() => {
   (mockPrisma as any).$transaction = vi.fn(async (fn: any) => fn(mockPrisma));
   vi.mocked(sendEmail).mockResolvedValue(undefined as any);
   vi.mocked(requireAuth).mockResolvedValue({ ok: true, user: { sub: USER_ID } } as any);
+  const okGate = {
+    ok: true as const,
+    auth: {
+      ok: true as const,
+      user: { sub: USER_ID, email: "u@x.com", type: "member" },
+      sessionId: "sid",
+    },
+  };
+  vi.mocked(requireCoreOrDomainLead).mockResolvedValue(okGate as any);
+  vi.mocked(requireMemberSession).mockResolvedValue(okGate as any);
   mockPrisma.dALIMember.findUnique.mockResolvedValue({ id: MEMBER_ID, userId: USER_ID });
 });
 

--- a/dali-api/app/hiring/lib/__tests__/api.delibs.close.test.ts
+++ b/dali-api/app/hiring/lib/__tests__/api.delibs.close.test.ts
@@ -3,11 +3,21 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 vi.mock("~/lib/db");
 vi.mock("~/lib/auth", () => ({
   requireAuth: vi.fn(),
+  requireCore: vi.fn(),
+  requireCoreOrDomainLead: vi.fn(),
+  requireMemberSession: vi.fn(),
+  forbidden: vi.fn((_req: Request) =>
+    Response.json({ error: "Forbidden" }, { status: 403 }),
+  ),
+  unauthorized: vi.fn((_req: Request) =>
+    Response.json({ error: "Unauthorized" }, { status: 401 }),
+  ),
+  redirectApplicantToPortal: vi.fn(() => null),
 }));
 vi.mock("~/lib/roles");
 
 import { prisma } from "~/lib/db";
-import { requireAuth } from "~/lib/auth";
+import { requireAuth, requireCoreOrDomainLead } from "~/lib/auth";
 import { isCore, isDomainLead } from "~/lib/roles";
 import { action } from "~/hiring/routes/api.delibs.$id";
 
@@ -40,6 +50,14 @@ beforeEach(() => {
   (mockPrisma as any).$transaction = vi.fn(async (cb: any) => cb(mockTx));
 
   vi.mocked(requireAuth).mockResolvedValue({ ok: true, user: { sub: USER_ID } } as any);
+  vi.mocked(requireCoreOrDomainLead).mockResolvedValue({
+    ok: true,
+    auth: {
+      ok: true,
+      user: { sub: USER_ID, email: "u@x.com", type: "member" },
+      sessionId: "sid",
+    },
+  } as any);
   vi.mocked(isCore).mockResolvedValue(true);
   vi.mocked(isDomainLead).mockResolvedValue(false);
   mockPrisma.dALIMember.findUnique.mockResolvedValue({ id: MEMBER_ID, userId: USER_ID });

--- a/dali-api/app/hiring/lib/__tests__/api.delibs.id.moves.test.ts
+++ b/dali-api/app/hiring/lib/__tests__/api.delibs.id.moves.test.ts
@@ -3,11 +3,21 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 vi.mock("~/lib/db");
 vi.mock("~/lib/auth", () => ({
   requireAuth: vi.fn(),
+  requireCore: vi.fn(),
+  requireCoreOrDomainLead: vi.fn(),
+  requireMemberSession: vi.fn(),
+  forbidden: vi.fn((_req: Request) =>
+    Response.json({ error: "Forbidden" }, { status: 403 }),
+  ),
+  unauthorized: vi.fn((_req: Request) =>
+    Response.json({ error: "Unauthorized" }, { status: 401 }),
+  ),
+  redirectApplicantToPortal: vi.fn(() => null),
 }));
 vi.mock("~/lib/roles");
 
 import { prisma } from "~/lib/db";
-import { requireAuth } from "~/lib/auth";
+import { requireAuth, requireCoreOrDomainLead } from "~/lib/auth";
 import { isCore, isDomainLead, hasCycleAccess } from "~/lib/roles";
 import { action } from "~/hiring/routes/api.delibs.$id.moves";
 
@@ -49,6 +59,14 @@ beforeEach(() => {
   vi.mocked(requireAuth).mockResolvedValue({
     ok: true,
     user: { sub: USER_ID },
+  } as any);
+  vi.mocked(requireCoreOrDomainLead).mockResolvedValue({
+    ok: true,
+    auth: {
+      ok: true,
+      user: { sub: USER_ID, email: "u@x.com", type: "member" },
+      sessionId: "sid",
+    },
   } as any);
   vi.mocked(isCore).mockResolvedValue(false);
   vi.mocked(isDomainLead).mockResolvedValue(true);
@@ -168,6 +186,10 @@ describe("POST /api/hiring/delibs/:id/moves", () => {
   it("returns 403 when caller is neither hiring lead nor domain lead", async () => {
     vi.mocked(isCore).mockResolvedValue(false);
     vi.mocked(isDomainLead).mockResolvedValue(false);
+    vi.mocked(requireCoreOrDomainLead).mockResolvedValueOnce({
+      ok: false,
+      response: Response.json({ error: "Forbidden" }, { status: 403 }),
+    });
 
     const res = await action({
       request: makeRequest({ cardId: "card-a", toColumn: "Interview" }),

--- a/dali-api/app/hiring/lib/extension-notice.ts
+++ b/dali-api/app/hiring/lib/extension-notice.ts
@@ -17,23 +17,20 @@
 import { prisma } from "~/lib/db";
 import { sendEmail } from "~/lib/gmail";
 import { getApplicationsGmailRefreshToken } from "~/lib/gmail-integration";
+import { APPLICATION_TZ, APPLICATION_TZ_LABEL } from "~/lib/timezone";
 import { renderForSlot, notificationSlot } from "./email-variables";
 import { logAuditEvent } from "~/lib/audit";
 
 function formatCloseInstant(d: Date): string {
   return `${d.toLocaleString("en-US", {
-    timeZone: "America/New_York",
+    timeZone: APPLICATION_TZ,
     weekday: "long",
     month: "long",
     day: "numeric",
     year: "numeric",
     hour: "numeric",
     minute: "2-digit",
-  })} ET`;
-}
-
-async function getGmailRefreshToken(): Promise<string | null> {
-  return getApplicationsGmailRefreshToken();
+  })} ${APPLICATION_TZ_LABEL}`;
 }
 
 interface DraftRecipient {
@@ -189,7 +186,7 @@ async function preflight(cycleId: string): Promise<{
   refreshToken: string;
   binding: { emailTemplateVersion: { subject: string; body: string } };
 } | null> {
-  const refreshToken = await getGmailRefreshToken();
+  const refreshToken = await getApplicationsGmailRefreshToken();
   if (!refreshToken) return null;
   const binding = await prisma.cycleNotificationEmail.findUnique({
     where: {

--- a/dali-api/app/hiring/lib/intern-eligibility.ts
+++ b/dali-api/app/hiring/lib/intern-eligibility.ts
@@ -1,17 +1,12 @@
 import { prisma } from "~/lib/db";
+import { currentTermStrict } from "~/lib/roles";
 
 // A user is eligible to apply to an InternToFull cycle iff they currently
 // hold a ProjectAssignment in the active term where the project's domain is
-// flagged as an intern program. We require the term to be live (now is
-// between startDate and endDate inclusive); we deliberately do NOT fall back
-// to the next upcoming term, so the window between intern terms fails closed.
+// flagged as an intern program. `currentTermStrict` ensures the window
+// between intern terms fails closed (no roll-forward to the next term).
 export async function isInternToFullEligible(userId: string): Promise<boolean> {
-  const now = new Date();
-  const activeTerm = await prisma.term.findFirst({
-    where: { startDate: { lte: now }, endDate: { gte: now } },
-    orderBy: { sortKey: "desc" },
-    select: { id: true },
-  });
+  const activeTerm = await currentTermStrict();
   if (!activeTerm) return false;
 
   const assignment = await prisma.projectAssignment.findFirst({
@@ -30,12 +25,7 @@ export async function isInternToFullEligible(userId: string): Promise<boolean> {
 // is flagged as an intern program. Used to fan out the "cycle is open"
 // notification. Returns [] when no term is currently active.
 export async function eligibleInternUserIds(): Promise<string[]> {
-  const now = new Date();
-  const activeTerm = await prisma.term.findFirst({
-    where: { startDate: { lte: now }, endDate: { gte: now } },
-    orderBy: { sortKey: "desc" },
-    select: { id: true },
-  });
+  const activeTerm = await currentTermStrict();
   if (!activeTerm) return [];
 
   const rows = await prisma.projectAssignment.findMany({
@@ -53,12 +43,7 @@ export async function eligibleInternUserIds(): Promise<string[]> {
 // Used to surface "you're converting from <X>" hints in the applicant UI
 // and reviewer view. Empty when the user is not a current-term intern.
 export async function currentInternDomains(userId: string) {
-  const now = new Date();
-  const activeTerm = await prisma.term.findFirst({
-    where: { startDate: { lte: now }, endDate: { gte: now } },
-    orderBy: { sortKey: "desc" },
-    select: { id: true },
-  });
+  const activeTerm = await currentTermStrict();
   if (!activeTerm) return [];
 
   const assignments = await prisma.projectAssignment.findMany({

--- a/dali-api/app/hiring/lib/interview-emails.ts
+++ b/dali-api/app/hiring/lib/interview-emails.ts
@@ -7,6 +7,7 @@ import { prisma } from "~/lib/db";
 import { sendEmail } from "~/lib/gmail";
 import { type InterpolationVars } from "~/lib/email";
 import { getApplicationsGmailRefreshToken } from "~/lib/gmail-integration";
+import { APPLICATION_TZ, APPLICATION_TZ_LABEL } from "~/lib/timezone";
 import { renderForSlot, notificationSlot } from "./email-variables";
 import { buildInviteIcs, buildCancelIcs, type IcsAttendee } from "./interview-ics";
 
@@ -28,12 +29,8 @@ function formatTime(d: Date): string {
     day: "numeric",
     hour: "numeric",
     minute: "2-digit",
-    timeZone: "America/New_York",
-  }) + " ET";
-}
-
-async function getGmailRefreshToken(): Promise<string | null> {
-  return getApplicationsGmailRefreshToken();
+    timeZone: APPLICATION_TZ,
+  }) + ` ${APPLICATION_TZ_LABEL}`;
 }
 
 interface Recipient {
@@ -119,7 +116,7 @@ export async function sendInterviewInviteEmails(
   domainApplicationId: string,
 ): Promise<void> {
   try {
-    const refreshToken = await getGmailRefreshToken();
+    const refreshToken = await getApplicationsGmailRefreshToken();
     if (!refreshToken) return;
 
     const interview = await prisma.interview.findUnique({ where: { id: interviewId } });
@@ -217,7 +214,7 @@ export async function sendInterviewCancelEmails(
   domainApplicationId: string,
 ): Promise<void> {
   try {
-    const refreshToken = await getGmailRefreshToken();
+    const refreshToken = await getApplicationsGmailRefreshToken();
     if (!refreshToken) return;
 
     const interview = await prisma.interview.findUnique({ where: { id: interviewId } });
@@ -315,7 +312,7 @@ export async function sendReassignmentEmails(
   newCycleInterviewerId: string,
 ): Promise<void> {
   try {
-    const refreshToken = await getGmailRefreshToken();
+    const refreshToken = await getApplicationsGmailRefreshToken();
     if (!refreshToken) return;
 
     const interview = await prisma.interview.findUnique({ where: { id: interviewId } });
@@ -453,7 +450,7 @@ export async function sendLocationChangeEmails(
   domainApplicationId: string,
 ): Promise<void> {
   try {
-    const refreshToken = await getGmailRefreshToken();
+    const refreshToken = await getApplicationsGmailRefreshToken();
     if (!refreshToken) return;
 
     const interview = await prisma.interview.findUnique({ where: { id: interviewId } });

--- a/dali-api/app/hiring/lib/interview-notifications.ts
+++ b/dali-api/app/hiring/lib/interview-notifications.ts
@@ -1,4 +1,5 @@
 import { prisma } from "~/lib/db";
+import { APPLICATION_TZ } from "~/lib/timezone";
 
 // Emit an in-app Notification to each newly-assigned interviewer so the
 // assignment shows up in the bell + Home tasks banner. The notification
@@ -29,7 +30,7 @@ function formatStart(d: Date): string {
     day: "numeric",
     hour: "numeric",
     minute: "2-digit",
-    timeZone: "America/New_York",
+    timeZone: APPLICATION_TZ,
   });
 }
 

--- a/dali-api/app/hiring/lib/interview-time.ts
+++ b/dali-api/app/hiring/lib/interview-time.ts
@@ -3,7 +3,8 @@
 // at Dartmouth. Centralizing the formatter (and the timezone label) here keeps
 // every applicant view consistent and protects against host-TZ regressions.
 
-const EASTERN_TZ = "America/New_York";
+import { APPLICATION_TZ as EASTERN_TZ } from "~/lib/timezone";
+
 export const INTERVIEW_TIMEZONE_LABEL = "ET";
 
 function formatTime(iso: string | Date): string {

--- a/dali-api/app/hiring/lib/labels.ts
+++ b/dali-api/app/hiring/lib/labels.ts
@@ -1,0 +1,79 @@
+// Shared color + label maps for hiring status/decision/stage pills.
+// Source of truth for adoption (wave 2); see callers in app/hiring/routes
+// and app/hiring/components. Plain (border-less) variants chosen as the
+// majority across sites; bordered/dark-mode variants stay local where used.
+
+// Cycle / Application cycle status pills.
+// Matches lead.tsx, CycleSelector.tsx, lead.cycle.$id.tsx.
+export const STATUS_COLORS: Record<string, string> = {
+  Draft: "bg-muted text-foreground/80",
+  Open: "bg-green-100 text-green-700",
+  UnderReview: "bg-yellow-100 text-yellow-700",
+  Completed: "bg-blue-100 text-blue-700",
+};
+
+// Display labels for the cycle status enum.
+export const STATUS_LABELS: Record<string, string> = {
+  Draft: "Draft",
+  Open: "Open",
+  UnderReview: "Under Review",
+  Completed: "Completed",
+};
+
+// Decision pill colors. Plain (border-less) majority variant.
+// InvitedToInterview is bg-blue-100 (majority); fixes purple drift at
+// domain-lead.application.$id.tsx:44.
+export const DECISION_COLORS: Record<string, string> = {
+  InvitedToInterview: "bg-blue-100 text-blue-700",
+  Accepted: "bg-green-100 text-green-700",
+  Waitlisted: "bg-yellow-100 text-yellow-700",
+  Rejected: "bg-red-100 text-red-700",
+};
+
+// Short decision labels used on action buttons / compact pills.
+// Source: domain-lead.tsx:2049.
+export const DECISION_LABELS: Record<string, string> = {
+  InvitedToInterview: "Interview",
+  Accepted: "Accept",
+  Waitlisted: "Waitlist",
+  Rejected: "Reject",
+};
+
+// Interview status colors. Keys match the InterviewStatus enum used in
+// applications.$domainApplicationId.tsx:13 and interviewer.interview.$interviewId.tsx:38.
+export const INTERVIEW_STATUS_COLORS: Record<string, string> = {
+  Scheduled: "bg-blue-100 text-blue-700",
+  Completed: "bg-green-100 text-green-700",
+  CancelledByApplicant: "bg-red-100 text-red-700",
+  CancelledByAdmin: "bg-muted text-foreground/80",
+};
+
+// Display overrides for interview status. Scheduled/Completed render as-is.
+// Source: applications.$domainApplicationId.tsx:20.
+export const INTERVIEW_STATUS_LABELS: Record<string, string> = {
+  CancelledByApplicant: "Cancelled (applicant)",
+  CancelledByAdmin: "Cancelled (admin)",
+};
+
+// Decision lifecycle stages (Draft -> Final -> Released). Final renders as
+// "Finalized" for users.
+export const STAGE_LABELS: Record<string, string> = {
+  Draft: "Draft",
+  Final: "Finalized",
+  Released: "Released",
+};
+
+// Reviewer overall-recommendation pills. Source: ApplicantContextModal.tsx:6
+// and domain-lead.application.$id.tsx:19.
+export const RECOMMENDATION_COLORS: Record<string, string> = {
+  "Strong Hire": "bg-green-100 text-green-800",
+  Hire: "bg-green-50 text-green-700",
+  "Lean Hire": "bg-yellow-50 text-yellow-700",
+  "Lean No Hire": "bg-orange-50 text-orange-700",
+  "No Hire": "bg-red-100 text-red-700",
+};
+
+// Shared base classes for the common pill shape. Compose with one of the
+// *_COLORS maps above: `${STATUS_PILL_BASE} ${STATUS_COLORS[s]}`.
+export const STATUS_PILL_BASE =
+  "inline-flex items-center px-2 py-0.5 rounded-full text-xs font-bold";

--- a/dali-api/app/hiring/lib/note-schemas.ts
+++ b/dali-api/app/hiring/lib/note-schemas.ts
@@ -1,0 +1,4 @@
+import { z } from "zod";
+
+export const NoteVersionSchema = z.object({ content: z.string().max(100_000) });
+export type NoteVersion = z.infer<typeof NoteVersionSchema>;

--- a/dali-api/app/hiring/lib/review.ts
+++ b/dali-api/app/hiring/lib/review.ts
@@ -1,0 +1,70 @@
+import { z } from "zod";
+
+export const VALID_RECOMMENDATIONS = [
+  "Strong Hire",
+  "Hire",
+  "Lean Hire",
+  "Lean No Hire",
+  "No Hire",
+] as const;
+
+export type Recommendation = (typeof VALID_RECOMMENDATIONS)[number];
+
+export const MAX_SCORE_KEYS = 50;
+export const MAX_SCORE_KEY_LENGTH = 100;
+export const MIN_SCORE_VALUE = 0;
+export const MAX_SCORE_VALUE = 10;
+export const MAX_FEEDBACK_LENGTH = 10_000;
+export const MAX_REJECTION_RATIONALE_LENGTH = 5_000;
+export const MAX_ANNOTATIONS = 500;
+export const MAX_ANNOTATION_COMMENT_LENGTH = 2_000;
+export const MAX_ANNOTATION_FIELD_LENGTH = 200;
+
+const finiteNumber = z.number().refine((n) => Number.isFinite(n), {
+  message: "must be a finite number",
+});
+
+const ScoresSchema = z
+  .record(
+    z.string().max(MAX_SCORE_KEY_LENGTH),
+    finiteNumber.min(MIN_SCORE_VALUE).max(MAX_SCORE_VALUE),
+  )
+  .refine((obj) => Object.keys(obj).length <= MAX_SCORE_KEYS, {
+    message: `scores cannot have more than ${MAX_SCORE_KEYS} keys`,
+  });
+
+const AnnotationSchema = z.object({
+  id: z.string().min(1).max(MAX_ANNOTATION_FIELD_LENGTH),
+  fieldKey: z.string().min(1).max(MAX_ANNOTATION_FIELD_LENGTH),
+  start: finiteNumber.min(0),
+  end: finiteNumber.min(0),
+  comment: z.string().max(MAX_ANNOTATION_COMMENT_LENGTH),
+  color: z.string().max(MAX_ANNOTATION_FIELD_LENGTH),
+});
+
+export const ReviewPatchSchema = z.object({
+  scores: ScoresSchema.optional(),
+  feedback: z.string().max(MAX_FEEDBACK_LENGTH).optional(),
+  rejectionRationale: z.string().max(MAX_REJECTION_RATIONALE_LENGTH).optional(),
+  // nullable + optional: allows clearing the recommendation explicitly with null
+  overallRecommendation: z.enum(VALID_RECOMMENDATIONS).nullable().optional(),
+  annotations: z.array(AnnotationSchema).max(MAX_ANNOTATIONS).optional(),
+});
+
+export type ReviewPatch = z.infer<typeof ReviewPatchSchema>;
+
+// Back-compat adapter for tests that import this validator directly.
+// Returns the same {ok, data} | {ok: false, error} shape the old imperative
+// validator did; the route handler itself uses `parseJson(ReviewPatchSchema)`.
+export function validateReviewPatch(
+  body: unknown,
+): { ok: true; data: ReviewPatch } | { ok: false; error: string } {
+  const result = ReviewPatchSchema.safeParse(body);
+  if (!result.success) {
+    const first = result.error.issues[0];
+    const path = first?.path.join(".") ?? "";
+    const msg = first?.message ?? "Invalid request body";
+    return { ok: false, error: path ? `${path}: ${msg}` : msg };
+  }
+  return { ok: true, data: result.data };
+}

--- a/dali-api/app/hiring/lib/scheduling.ts
+++ b/dali-api/app/hiring/lib/scheduling.ts
@@ -2,6 +2,7 @@ import type { Prisma } from "~/generated/prisma/client";
 import { prisma } from "~/lib/db";
 import { notifyInterviewAssigned } from "~/hiring/lib/interview-notifications";
 import { sendReassignmentEmails } from "~/hiring/lib/interview-emails";
+import { zonedWallTimeUtc } from "~/lib/timezone";
 
 // New-assignee notifications fire outside transactions (best-effort), so
 // scheduling.ts hands callers the cycleInterviewerIds that need notifying
@@ -543,7 +544,8 @@ export function generateCandidateSlots(
 
     for (let hour = dayStartHour; hour < dayEndHour; hour++) {
       for (let minute = 0; minute < 60; minute += 15) {
-        const slotStart = parseTzDateTime(dayStr, hour, minute, timezone);
+        const [y, mo, d] = dayStr.split("-").map(Number);
+        const slotStart = zonedWallTimeUtc(y, mo, d, hour, minute, timezone);
         const slotEnd = new Date(slotStart.getTime() + slotDurationMinutes * 60_000);
 
         const slotEndLocal = new Date(slotEnd.toLocaleString("en-US", { timeZone: timezone }));
@@ -566,29 +568,3 @@ export function generateCandidateSlots(
   return slots;
 }
 
-/** Parse a date + hour + minute in a specific timezone into a UTC Date */
-function parseTzDateTime(dateStr: string, hour: number, minute: number, timezone: string): Date {
-  const pad = (n: number) => String(n).padStart(2, "0");
-  const fakeLocal = `${dateStr}T${pad(hour)}:${pad(minute)}:00`;
-
-  const formatter = new Intl.DateTimeFormat("en-US", {
-    timeZone: timezone,
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-    second: "2-digit",
-    hour12: false,
-  });
-
-  const utcGuess = new Date(fakeLocal + "Z");
-  const parts = formatter.formatToParts(utcGuess);
-  const get = (type: string) => parseInt(parts.find((p) => p.type === type)?.value ?? "0");
-  // Use Date.UTC so the comparison is timezone-independent (new Date(y,m,d,...)
-  // uses the system timezone, which breaks when it matches the target timezone).
-  const localAtUtcMs = Date.UTC(get("year"), get("month") - 1, get("day"), get("hour"), get("minute"), get("second"));
-  const offsetMs = localAtUtcMs - utcGuess.getTime();
-
-  return new Date(utcGuess.getTime() - offsetMs);
-}

--- a/dali-api/app/hiring/routes/__tests__/api.cycles.interviewers.delete.test.ts
+++ b/dali-api/app/hiring/routes/__tests__/api.cycles.interviewers.delete.test.ts
@@ -3,11 +3,21 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 vi.mock("~/lib/db");
 vi.mock("~/lib/auth", () => ({
   requireAuth: vi.fn(),
+  requireCore: vi.fn(),
+  requireCoreOrDomainLead: vi.fn(),
+  requireMemberSession: vi.fn(),
+  forbidden: vi.fn((_req: Request) =>
+    Response.json({ error: "Forbidden" }, { status: 403 }),
+  ),
+  unauthorized: vi.fn((_req: Request) =>
+    Response.json({ error: "Unauthorized" }, { status: 401 }),
+  ),
+  redirectApplicantToPortal: vi.fn(() => null),
 }));
 vi.mock("~/lib/roles");
 
 import { prisma } from "~/lib/db";
-import { requireAuth } from "~/lib/auth";
+import { requireAuth, requireCoreOrDomainLead } from "~/lib/auth";
 import { isCore, isDomainLead } from "~/lib/roles";
 import { action } from "~/hiring/routes/api.cycles.$cycleId.interviewers";
 
@@ -46,6 +56,14 @@ beforeEach(() => {
     ok: true,
     user: { sub: USER_ID, email: "u@x.com", type: "user" },
   } as any);
+  vi.mocked(requireCoreOrDomainLead).mockResolvedValue({
+    ok: true,
+    auth: {
+      ok: true,
+      user: { sub: USER_ID, email: "u@x.com", type: "user" },
+      sessionId: "sid",
+    },
+  } as any);
   vi.mocked(isCore).mockResolvedValue(true);
   vi.mocked(isDomainLead).mockResolvedValue(false);
 });
@@ -54,6 +72,10 @@ describe("DELETE /api/hiring/cycles/:cycleId/interviewers", () => {
   it("returns 403 when caller is not a hiring or domain lead", async () => {
     vi.mocked(isCore).mockResolvedValueOnce(false);
     vi.mocked(isDomainLead).mockResolvedValueOnce(false);
+    vi.mocked(requireCoreOrDomainLead).mockResolvedValueOnce({
+      ok: false,
+      response: Response.json({ error: "Forbidden" }, { status: 403 }),
+    });
     const res = await action({
       request: makeDeleteRequest(),
       params: { cycleId: CYCLE_ID },

--- a/dali-api/app/hiring/routes/__tests__/api.cycles.reviewers.delete.test.ts
+++ b/dali-api/app/hiring/routes/__tests__/api.cycles.reviewers.delete.test.ts
@@ -3,6 +3,16 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 vi.mock("~/lib/db");
 vi.mock("~/lib/auth", () => ({
   requireAuth: vi.fn(),
+  requireCore: vi.fn(),
+  requireCoreOrDomainLead: vi.fn(),
+  requireMemberSession: vi.fn(),
+  forbidden: vi.fn((_req: Request) =>
+    Response.json({ error: "Forbidden" }, { status: 403 }),
+  ),
+  unauthorized: vi.fn((_req: Request) =>
+    Response.json({ error: "Unauthorized" }, { status: 401 }),
+  ),
+  redirectApplicantToPortal: vi.fn(() => null),
 }));
 vi.mock("~/lib/cors", () => ({
   handlePreflight: () => null,
@@ -11,7 +21,7 @@ vi.mock("~/lib/cors", () => ({
 vi.mock("~/lib/roles");
 
 import { prisma } from "~/lib/db";
-import { requireAuth } from "~/lib/auth";
+import { requireAuth, requireCoreOrDomainLead } from "~/lib/auth";
 import { isCore, isDomainLead } from "~/lib/roles";
 import { action } from "~/hiring/routes/api.cycles.$cycleId.reviewers.$reviewerId";
 
@@ -44,6 +54,14 @@ beforeEach(() => {
     ok: true,
     user: { sub: USER_ID, email: "u@x.com", type: "user" },
   } as any);
+  vi.mocked(requireCoreOrDomainLead).mockResolvedValue({
+    ok: true,
+    auth: {
+      ok: true,
+      user: { sub: USER_ID, email: "u@x.com", type: "user" },
+      sessionId: "sid",
+    },
+  } as any);
   vi.mocked(isCore).mockResolvedValue(true);
   vi.mocked(isDomainLead).mockResolvedValue(false);
 });
@@ -52,6 +70,10 @@ describe("DELETE /api/hiring/cycles/:cycleId/reviewers/:reviewerId", () => {
   it("returns 403 when caller is not a hiring or domain lead", async () => {
     vi.mocked(isCore).mockResolvedValueOnce(false);
     vi.mocked(isDomainLead).mockResolvedValueOnce(false);
+    vi.mocked(requireCoreOrDomainLead).mockResolvedValueOnce({
+      ok: false,
+      response: Response.json({ error: "Forbidden" }, { status: 403 }),
+    });
     const res = await action({
       request: makeRequest(),
       params: { cycleId: CYCLE_ID, reviewerId: REVIEWER_ID },

--- a/dali-api/app/hiring/routes/__tests__/lead.intern-to-full-cycle.$id.test.ts
+++ b/dali-api/app/hiring/routes/__tests__/lead.intern-to-full-cycle.$id.test.ts
@@ -3,6 +3,8 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 vi.mock("~/lib/db");
 vi.mock("~/lib/auth", () => ({
   requireAuth: vi.fn(),
+  forbidden: vi.fn((_req: Request) => Response.json({ error: "Forbidden" }, { status: 403 })),
+  unauthorized: vi.fn((_req: Request) => Response.json({ error: "Unauthorized" }, { status: 401 })),
 }));
 vi.mock("~/lib/roles");
 

--- a/dali-api/app/hiring/routes/api.cycles.$cycleId.coverage.ts
+++ b/dali-api/app/hiring/routes/api.cycles.$cycleId.coverage.ts
@@ -3,6 +3,7 @@ import { prisma } from "~/lib/db";
 import { requireAuth } from "~/lib/auth";
 import { hasCycleAccess } from "~/lib/roles";
 import { generateCandidateSlots, isInterviewerFree } from "~/hiring/lib/scheduling";
+import { APPLICATION_TZ } from "~/lib/timezone";
 
 export async function loader({ request, params }: Route.LoaderArgs) {
   const auth = await requireAuth(request);
@@ -19,7 +20,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
       configured: false,
       slots: [],
       slotDurationMinutes: 30,
-      timezone: "America/New_York",
+      timezone: APPLICATION_TZ,
     });
   }
 

--- a/dali-api/app/hiring/routes/api.cycles.$cycleId.delibs.ts
+++ b/dali-api/app/hiring/routes/api.cycles.$cycleId.delibs.ts
@@ -1,13 +1,13 @@
 import type { Route } from "./+types/api.cycles.$cycleId.delibs";
 import { z } from "zod";
 import { prisma } from "~/lib/db";
-import { requireAuth } from "~/lib/auth";
-import { isCore, isDomainLead, hasCycleAccess } from "~/lib/roles";
-import { parseJson } from "~/lib/validate";
+import { requireAuth, requireCoreOrDomainLead, forbidden } from "~/lib/auth";
+import { hasCycleAccess } from "~/lib/roles";
+import { idSchema, parseJson } from "~/lib/validate";
 import { requireApiSignedOrForbidden } from "~/hiring/lib/confidentiality";
 
 const CreateDelibsSchema = z.object({
-  domainId: z.string().min(1).max(100),
+  domainId: idSchema,
   type: z.enum(["Initial", "Final"]),
 });
 
@@ -16,7 +16,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   if (!auth.ok) return auth.response;
 
   if (!(await hasCycleAccess(auth.user.sub, params.cycleId!)))
-    return Response.json({ error: "Forbidden" }, { status: 403 });
+    return forbidden(request);
 
   const gate = await requireApiSignedOrForbidden(auth.user.sub, params.cycleId!);
   if (gate) return gate;
@@ -30,17 +30,12 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const auth = await requireAuth(request);
-  if (!auth.ok) return auth.response;
+  const roleGate = await requireCoreOrDomainLead(request);
+  if (!roleGate.ok) return roleGate.response;
+  const auth = roleGate.auth;
 
   if (request.method !== "POST") {
     return Response.json({ error: "Method not allowed" }, { status: 405 });
-  }
-
-  const hiringLead = await isCore(auth.user.sub);
-  const domainLead = await isDomainLead(auth.user.sub);
-  if (!hiringLead && !domainLead) {
-    return Response.json({ error: "Forbidden" }, { status: 403 });
   }
 
   const gate = await requireApiSignedOrForbidden(auth.user.sub, params.cycleId!);

--- a/dali-api/app/hiring/routes/api.cycles.$cycleId.interview-config.ts
+++ b/dali-api/app/hiring/routes/api.cycles.$cycleId.interview-config.ts
@@ -1,11 +1,11 @@
 import type { Route } from "./+types/api.cycles.$cycleId.interview-config";
 import { z } from "zod";
 import { prisma } from "~/lib/db";
-import { requireAuth } from "~/lib/auth";
+import { requireAuth, forbidden } from "~/lib/auth";
 import { isCore, hasCycleAccess } from "~/lib/roles";
 import { withCors, handlePreflight } from "~/lib/cors";
-import { parseJson } from "~/lib/validate";
-import { isValidTimezone } from "~/lib/timezone";
+import { idSchema, parseJson } from "~/lib/validate";
+import { APPLICATION_TZ, isValidTimezone } from "~/lib/timezone";
 
 const InterviewConfigSchema = z
   .object({
@@ -15,7 +15,7 @@ const InterviewConfigSchema = z
     dayEndHour: z.number().int().min(0).max(23).optional(),
     interviewStartDate: z.string().datetime({ offset: true }),
     interviewEndDate: z.string().datetime({ offset: true }),
-    timezone: z.string().min(1).max(100).optional(),
+    timezone: idSchema.optional(),
     rescheduleNoticeHours: z.number().int().min(0).max(168).optional(),
     cancelNoticeHours: z.number().int().min(0).max(168).optional(),
     bookingNoticeHours: z.number().int().min(0).max(168).optional(),
@@ -40,7 +40,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   if (!auth.ok) return withCors(request, auth.response);
 
   if (!(await hasCycleAccess(auth.user.sub, params.cycleId!)))
-    return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
+    return forbidden(request);
 
   const config = await prisma.interviewConfig.findUnique({
     where: { applicationCycleId: params.cycleId },
@@ -55,7 +55,7 @@ export async function action({ request, params }: Route.ActionArgs) {
 
   const auth = await requireAuth(request);
   if (!auth.ok) return withCors(request, auth.response);
-  if (!(await isCore(auth.user.sub))) return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
+  if (!(await isCore(auth.user.sub))) return forbidden(request);
 
   if (request.method !== "POST") {
     return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));
@@ -80,7 +80,7 @@ export async function action({ request, params }: Route.ActionArgs) {
       rescheduleNoticeHours: body.rescheduleNoticeHours ?? 12,
       cancelNoticeHours: body.cancelNoticeHours ?? 0,
       bookingNoticeHours: body.bookingNoticeHours ?? 12,
-      timezone: body.timezone ?? "America/New_York",
+      timezone: body.timezone ?? APPLICATION_TZ,
     },
     create: {
       applicationCycleId: params.cycleId,
@@ -93,7 +93,7 @@ export async function action({ request, params }: Route.ActionArgs) {
       rescheduleNoticeHours: body.rescheduleNoticeHours ?? 12,
       cancelNoticeHours: body.cancelNoticeHours ?? 0,
       bookingNoticeHours: body.bookingNoticeHours ?? 12,
-      timezone: body.timezone ?? "America/New_York",
+      timezone: body.timezone ?? APPLICATION_TZ,
     },
   });
 

--- a/dali-api/app/hiring/routes/api.cycles.$cycleId.interviewers.ts
+++ b/dali-api/app/hiring/routes/api.cycles.$cycleId.interviewers.ts
@@ -1,17 +1,17 @@
 import type { Route } from "./+types/api.cycles.$cycleId.interviewers";
 import { z } from "zod";
 import { prisma } from "~/lib/db";
-import { requireAuth } from "~/lib/auth";
-import { isCore, isDomainLead, hasCycleAccess } from "~/lib/roles";
-import { parseJson } from "~/lib/validate";
+import { requireAuth, requireCoreOrDomainLead, forbidden } from "~/lib/auth";
+import { hasCycleAccess } from "~/lib/roles";
+import { idSchema, parseJson } from "~/lib/validate";
 
 const CreateInterviewerSchema = z.object({
-  userId: z.string().min(1).max(100),
-  domainId: z.string().min(1).max(100),
+  userId: idSchema,
+  domainId: idSchema,
 });
 
 const DeleteInterviewerSchema = z.object({
-  interviewerId: z.string().min(1).max(100),
+  interviewerId: idSchema,
 });
 
 export async function loader({ request, params }: Route.LoaderArgs) {
@@ -19,7 +19,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   if (!auth.ok) return auth.response;
 
   if (!(await hasCycleAccess(auth.user.sub, params.cycleId!)))
-    return Response.json({ error: "Forbidden" }, { status: 403 });
+    return forbidden(request);
 
   const interviewers = await prisma.cycleInterviewer.findMany({
     where: { applicationCycleId: params.cycleId },
@@ -51,14 +51,8 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const auth = await requireAuth(request);
-  if (!auth.ok) return auth.response;
-
-  const hiringLead = await isCore(auth.user.sub);
-  const domainLead = await isDomainLead(auth.user.sub);
-  if (!hiringLead && !domainLead) {
-    return Response.json({ error: "Forbidden" }, { status: 403 });
-  }
+  const gate = await requireCoreOrDomainLead(request);
+  if (!gate.ok) return gate.response;
 
   if (request.method === "POST") {
     const body = await parseJson(request, CreateInterviewerSchema);

--- a/dali-api/app/hiring/routes/api.cycles.$cycleId.my-interviews.$interviewId.notes.ts
+++ b/dali-api/app/hiring/routes/api.cycles.$cycleId.my-interviews.$interviewId.notes.ts
@@ -1,14 +1,10 @@
 import type { Route } from "./+types/api.cycles.$cycleId.my-interviews.$interviewId.notes";
-import { z } from "zod";
 import { prisma } from "~/lib/db";
 import { requireAuth } from "~/lib/auth";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { parseJson } from "~/lib/validate";
 import { requireApiSignedOrForbidden } from "~/hiring/lib/confidentiality";
-
-const NoteVersionSchema = z.object({
-  content: z.string().max(100_000),
-});
+import { NoteVersionSchema } from "~/hiring/lib/note-schemas";
 
 async function getAssignment(userId: string, cycleId: string, interviewId: string) {
   const member = await prisma.dALIMember.findUnique({ where: { userId } });

--- a/dali-api/app/hiring/routes/api.cycles.$cycleId.reviewers.$reviewerId.ts
+++ b/dali-api/app/hiring/routes/api.cycles.$cycleId.reviewers.$reviewerId.ts
@@ -1,22 +1,20 @@
 import type { Route } from "./+types/api.cycles.$cycleId.reviewers.$reviewerId";
 import { z } from "zod";
 import { prisma } from "~/lib/db";
-import { requireAuth } from "~/lib/auth";
-import { isCore, isDomainLead } from "~/lib/roles";
+import { requireCoreOrDomainLead } from "~/lib/auth";
 import { withCors, handlePreflight } from "~/lib/cors";
-import { parseJson } from "~/lib/validate";
+import { idSchema, parseJson } from "~/lib/validate";
 
 const PatchReviewerSchema = z.object({
-  domainId: z.string().min(1).max(100).optional(),
+  domainId: idSchema.optional(),
 });
 
 export async function action({ request, params }: Route.ActionArgs) {
   const preflight = handlePreflight(request);
   if (preflight) return preflight;
 
-  const auth = await requireAuth(request);
-  if (!auth.ok) return withCors(request, auth.response);
-  if (!(await isCore(auth.user.sub)) && !(await isDomainLead(auth.user.sub))) return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
+  const gate = await requireCoreOrDomainLead(request);
+  if (!gate.ok) return gate.response;
 
   if (request.method === "PATCH") {
     const body = await parseJson(request, PatchReviewerSchema);

--- a/dali-api/app/hiring/routes/api.cycles.$cycleId.reviewers.ts
+++ b/dali-api/app/hiring/routes/api.cycles.$cycleId.reviewers.ts
@@ -1,14 +1,14 @@
 import type { Route } from "./+types/api.cycles.$cycleId.reviewers";
 import { z } from "zod";
 import { prisma } from "~/lib/db";
-import { requireAuth } from "~/lib/auth";
-import { isCore, isDomainLead, hasCycleAccess } from "~/lib/roles";
+import { requireAuth, requireCoreOrDomainLead, forbidden } from "~/lib/auth";
+import { hasCycleAccess } from "~/lib/roles";
 import { withCors, handlePreflight } from "~/lib/cors";
-import { parseJson } from "~/lib/validate";
+import { idSchema, parseJson } from "~/lib/validate";
 
 const CreateReviewerSchema = z.object({
-  userId: z.string().min(1).max(100),
-  domainId: z.string().min(1).max(100),
+  userId: idSchema,
+  domainId: idSchema,
 });
 
 export async function loader({ request, params }: Route.LoaderArgs) {
@@ -19,7 +19,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   if (!auth.ok) return withCors(request, auth.response);
 
   if (!(await hasCycleAccess(auth.user.sub, params.cycleId!)))
-    return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
+    return forbidden(request);
 
   const reviewers = await prisma.cycleReviewer.findMany({
     where: { applicationCycleId: params.cycleId },
@@ -36,9 +36,8 @@ export async function action({ request, params }: Route.ActionArgs) {
   const preflight = handlePreflight(request);
   if (preflight) return preflight;
 
-  const auth = await requireAuth(request);
-  if (!auth.ok) return withCors(request, auth.response);
-  if (!(await isCore(auth.user.sub)) && !(await isDomainLead(auth.user.sub))) return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
+  const gate = await requireCoreOrDomainLead(request);
+  if (!gate.ok) return gate.response;
 
   if (request.method !== "POST") {
     return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));

--- a/dali-api/app/hiring/routes/api.decisions.$id.finalize.ts
+++ b/dali-api/app/hiring/routes/api.decisions.$id.finalize.ts
@@ -1,7 +1,6 @@
 import type { Route } from "./+types/api.decisions.$id.finalize";
 import { prisma } from "~/lib/db";
-import { requireAuth } from "~/lib/auth";
-import { isCore, isDomainLead } from "~/lib/roles";
+import { requireCoreOrDomainLead, requireMemberSession } from "~/lib/auth";
 import { logAuditEvent } from "~/lib/audit";
 import { requireApiSignedOrForbidden } from "~/hiring/lib/confidentiality";
 
@@ -10,23 +9,16 @@ import { requireApiSignedOrForbidden } from "~/hiring/lib/confidentiality";
 class AlreadyFinalizedError extends Error {}
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const auth = await requireAuth(request);
-  if (!auth.ok) return auth.response;
+  const roleGate = await requireCoreOrDomainLead(request);
+  if (!roleGate.ok) return roleGate.response;
 
   if (request.method !== "POST") {
     return Response.json({ error: "Method not allowed" }, { status: 405 });
   }
 
-  const hiringLead = await isCore(auth.user.sub);
-  const domainLead = await isDomainLead(auth.user.sub);
-  if (!hiringLead && !domainLead) {
-    return Response.json({ error: "Forbidden" }, { status: 403 });
-  }
-
-  const member = await prisma.dALIMember.findUnique({ where: { userId: auth.user.sub } });
-  if (!member) {
-    return Response.json({ error: "Not a DALI member" }, { status: 403 });
-  }
+  const memberGate = await requireMemberSession(request);
+  if (!memberGate.ok) return memberGate.response;
+  const auth = memberGate.auth;
 
   const decision = await prisma.decision.findUnique({
     where: { id: params.id },

--- a/dali-api/app/hiring/routes/api.delibs.$id.moves.ts
+++ b/dali-api/app/hiring/routes/api.delibs.$id.moves.ts
@@ -1,30 +1,25 @@
 import type { Route } from "./+types/api.delibs.$id.moves";
 import { z } from "zod";
 import { prisma } from "~/lib/db";
-import { requireAuth } from "~/lib/auth";
-import { isCore, isDomainLead, hasCycleAccess } from "~/lib/roles";
+import { requireCoreOrDomainLead, forbidden } from "~/lib/auth";
+import { hasCycleAccess } from "~/lib/roles";
 import { INITIAL_COLUMNS, FINAL_COLUMNS } from "~/hiring/lib/delibs";
-import { parseJson } from "~/lib/validate";
+import { idSchema, parseJson } from "~/lib/validate";
 import { requireApiSignedOrForbidden } from "~/hiring/lib/confidentiality";
 
 const MoveSchema = z.object({
-  cardId: z.string().min(1).max(100),
-  toColumn: z.string().min(1).max(100),
+  cardId: idSchema,
+  toColumn: idSchema,
   position: z.number().int().min(0).max(10_000).optional(),
 });
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const auth = await requireAuth(request);
-  if (!auth.ok) return auth.response;
+  const gate = await requireCoreOrDomainLead(request);
+  if (!gate.ok) return gate.response;
+  const auth = gate.auth;
 
   if (request.method !== "POST") {
     return Response.json({ error: "Method not allowed" }, { status: 405 });
-  }
-
-  const hiringLead = await isCore(auth.user.sub);
-  const domainLead = await isDomainLead(auth.user.sub);
-  if (!hiringLead && !domainLead) {
-    return Response.json({ error: "Forbidden" }, { status: 403 });
   }
 
 
@@ -36,14 +31,14 @@ export async function action({ request, params }: Route.ActionArgs) {
     return Response.json({ error: "Not found" }, { status: 404 });
   }
   if (!(await hasCycleAccess(auth.user.sub, sessionForAuth.applicationCycleId))) {
-    return Response.json({ error: "Forbidden" }, { status: 403 });
+    return forbidden(request);
   }
 
-  const gate = await requireApiSignedOrForbidden(
+  const confidentialityGate = await requireApiSignedOrForbidden(
     auth.user.sub,
     sessionForAuth.applicationCycleId,
   );
-  if (gate) return gate;
+  if (confidentialityGate) return confidentialityGate;
 
   const body = await parseJson(request, MoveSchema);
   if (body instanceof Response) return body;
@@ -115,3 +110,4 @@ export async function action({ request, params }: Route.ActionArgs) {
     throw err;
   }
 }
+

--- a/dali-api/app/hiring/routes/api.delibs.$id.ts
+++ b/dali-api/app/hiring/routes/api.delibs.$id.ts
@@ -1,8 +1,8 @@
 import type { Route } from "./+types/api.delibs.$id";
 import { z } from "zod";
 import { prisma } from "~/lib/db";
-import { requireAuth } from "~/lib/auth";
-import { isCore, isDomainLead, hasCycleAccess } from "~/lib/roles";
+import { requireAuth, requireCoreOrDomainLead, requireMemberSession, forbidden } from "~/lib/auth";
+import { hasCycleAccess } from "~/lib/roles";
 import { parseJson } from "~/lib/validate";
 import { requireApiSignedOrForbidden } from "~/hiring/lib/confidentiality";
 
@@ -23,7 +23,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   }
 
   if (!(await hasCycleAccess(auth.user.sub, session.applicationCycleId)))
-    return Response.json({ error: "Forbidden" }, { status: 403 });
+    return forbidden(request);
 
   const gate = await requireApiSignedOrForbidden(
     auth.user.sub,
@@ -35,14 +35,9 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const auth = await requireAuth(request);
-  if (!auth.ok) return auth.response;
-
-  const hiringLead = await isCore(auth.user.sub);
-  const domainLead = await isDomainLead(auth.user.sub);
-  if (!hiringLead && !domainLead) {
-    return Response.json({ error: "Forbidden" }, { status: 403 });
-  }
+  const roleGate = await requireCoreOrDomainLead(request);
+  if (!roleGate.ok) return roleGate.response;
+  const auth = roleGate.auth;
 
   const sessionForGate = await prisma.delibsSession.findUnique({
     where: { id: params.id },

--- a/dali-api/app/hiring/routes/api.domain-applications.$id.decisions.ts
+++ b/dali-api/app/hiring/routes/api.domain-applications.$id.decisions.ts
@@ -1,7 +1,7 @@
 import type { Route } from "./+types/api.domain-applications.$id.decisions";
 import { z } from "zod";
 import { prisma } from "~/lib/db";
-import { requireAuth } from "~/lib/auth";
+import { requireAuth, forbidden } from "~/lib/auth";
 import { isCore, isDomainLead, hasCycleAccess } from "~/lib/roles";
 import { parseJson } from "~/lib/validate";
 import { requireApiSignedOrForbidden } from "~/hiring/lib/confidentiality";
@@ -23,7 +23,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   });
   if (!domainApp) return Response.json({ error: "Not found" }, { status: 404 });
   if (!(await hasCycleAccess(auth.user.sub, domainApp.application.applicationCycleId)))
-    return Response.json({ error: "Forbidden" }, { status: 403 });
+    return forbidden(request);
 
   const gate = await requireApiSignedOrForbidden(
     auth.user.sub,
@@ -86,7 +86,7 @@ export async function action({ request, params }: Route.ActionArgs) {
     const hiringLead = await isCore(auth.user.sub);
     const domainLead = await isDomainLead(auth.user.sub);
     if (!hiringLead && !domainLead) {
-      return Response.json({ error: "Forbidden" }, { status: 403 });
+      return forbidden(request);
     }
   }
 

--- a/dali-api/app/hiring/routes/api.domain-applications.$id.reviews.ts
+++ b/dali-api/app/hiring/routes/api.domain-applications.$id.reviews.ts
@@ -3,11 +3,11 @@ import { z } from "zod";
 import { prisma } from "~/lib/db";
 import { requireAuth } from "~/lib/auth";
 import { isCore, hasCycleAccess } from "~/lib/roles";
-import { parseJson } from "~/lib/validate";
+import { parseJson, idSchema } from "~/lib/validate";
 import { requireApiSignedOrForbidden } from "~/hiring/lib/confidentiality";
 
 const CreateReviewSchema = z.object({
-  cycleReviewerId: z.string().min(1).max(100),
+  cycleReviewerId: idSchema,
 });
 
 export async function loader({ request, params }: Route.LoaderArgs) {

--- a/dali-api/app/hiring/routes/api.interview-assignments.$id.notes.ts
+++ b/dali-api/app/hiring/routes/api.interview-assignments.$id.notes.ts
@@ -1,14 +1,10 @@
 import type { Route } from "./+types/api.interview-assignments.$id.notes";
-import { z } from "zod";
 import { prisma } from "~/lib/db";
 import { requireAuth } from "~/lib/auth";
 import { hasCycleAccess } from "~/lib/roles";
 import { parseJson } from "~/lib/validate";
 import { requireApiSignedOrForbidden } from "~/hiring/lib/confidentiality";
-
-const NoteVersionSchema = z.object({
-  content: z.string().max(100_000),
-});
+import { NoteVersionSchema } from "~/hiring/lib/note-schemas";
 
 export async function loader({ request, params }: Route.LoaderArgs) {
   const auth = await requireAuth(request);

--- a/dali-api/app/hiring/routes/api.interviews.$id.complete.ts
+++ b/dali-api/app/hiring/routes/api.interviews.$id.complete.ts
@@ -6,8 +6,7 @@ import { parseJson } from "~/lib/validate";
 import { requireApiSignedOrForbidden } from "~/hiring/lib/confidentiality";
 import { isCore } from "~/lib/roles";
 import { logAuditEvent } from "~/lib/audit";
-
-const VALID_RECOMMENDATIONS = ["Strong Hire", "Hire", "Lean Hire", "Lean No Hire", "No Hire"] as const;
+import { VALID_RECOMMENDATIONS } from "~/hiring/lib/review";
 
 const CompleteSchema = z.object({
   recommendation: z.enum(VALID_RECOMMENDATIONS),

--- a/dali-api/app/hiring/routes/api.interviews.$id.complete.ts
+++ b/dali-api/app/hiring/routes/api.interviews.$id.complete.ts
@@ -1,7 +1,7 @@
 import type { Route } from "./+types/api.interviews.$id.complete";
 import { z } from "zod";
 import { prisma } from "~/lib/db";
-import { requireAuth } from "~/lib/auth";
+import { requireMemberSession } from "~/lib/auth";
 import { parseJson } from "~/lib/validate";
 import { requireApiSignedOrForbidden } from "~/hiring/lib/confidentiality";
 import { isCore } from "~/lib/roles";
@@ -15,16 +15,12 @@ const CompleteSchema = z.object({
 });
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const auth = await requireAuth(request);
-  if (!auth.ok) return auth.response;
+  const memberGate = await requireMemberSession(request);
+  if (!memberGate.ok) return memberGate.response;
+  const auth = memberGate.auth;
 
   if (request.method !== "POST" && request.method !== "DELETE") {
     return Response.json({ error: "Method not allowed" }, { status: 405 });
-  }
-
-  const member = await prisma.dALIMember.findUnique({ where: { userId: auth.user.sub } });
-  if (!member) {
-    return Response.json({ error: "Not a DALI member" }, { status: 403 });
   }
 
   // Verify the caller is an active interviewer on this interview

--- a/dali-api/app/hiring/routes/api.interviews.$id.reassign.ts
+++ b/dali-api/app/hiring/routes/api.interviews.$id.reassign.ts
@@ -3,15 +3,15 @@ import { z } from "zod";
 import { prisma } from "~/lib/db";
 import { requireAuth } from "~/lib/auth";
 import { isCore } from "~/lib/roles";
-import { parseJson } from "~/lib/validate";
+import { parseJson, idSchema } from "~/lib/validate";
 import { requireApiSignedOrForbidden } from "~/hiring/lib/confidentiality";
 import { sendReassignmentEmails } from "~/hiring/lib/interview-emails";
 import { notifyInterviewAssigned } from "~/hiring/lib/interview-notifications";
 import { logAuditEvent } from "~/lib/audit";
 
 const ReassignSchema = z.object({
-  assignmentId: z.string().min(1).max(100),
-  newCycleInterviewerId: z.string().min(1).max(100),
+  assignmentId: idSchema,
+  newCycleInterviewerId: idSchema,
 });
 
 export async function action({ request, params }: Route.ActionArgs) {

--- a/dali-api/app/hiring/routes/api.my-interview.cancel.ts
+++ b/dali-api/app/hiring/routes/api.my-interview.cancel.ts
@@ -3,12 +3,12 @@ import { z } from "zod";
 import { prisma } from "~/lib/db";
 import { requireAuth } from "~/lib/auth";
 import { withCors, handlePreflight } from "~/lib/cors";
-import { parseJson } from "~/lib/validate";
+import { idSchema, parseJson } from "~/lib/validate";
 // import { deprovisionZoomMeeting } from "~/lib/zoom"; // S2S Zoom not configured yet
 import { sendInterviewCancelEmails } from "~/hiring/lib/interview-emails";
 
 const CancelSchema = z.object({
-  domainApplicationId: z.string().min(1).max(100),
+  domainApplicationId: idSchema,
 });
 
 export async function action({ request }: Route.ActionArgs) {

--- a/dali-api/app/hiring/routes/api.my-interview.reschedule.ts
+++ b/dali-api/app/hiring/routes/api.my-interview.reschedule.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { prisma } from "~/lib/db";
 import { requireAuth } from "~/lib/auth";
 import { withCors, handlePreflight } from "~/lib/cors";
-import { parseJson } from "~/lib/validate";
+import { parseJson, idSchema } from "~/lib/validate";
 import { assignInterviewers } from "~/hiring/lib/scheduling";
 // import { provisionZoomMeeting, deprovisionZoomMeeting } from "~/lib/zoom"; // S2S Zoom not configured yet
 import { sendInterviewCancelEmails, sendInterviewInviteEmails } from "~/hiring/lib/interview-emails";
@@ -13,7 +13,7 @@ const RescheduleSchema = z
   .object({
     newStart: z.string().datetime({ offset: true }),
     newEnd: z.string().datetime({ offset: true }),
-    domainApplicationId: z.string().min(1).max(100),
+    domainApplicationId: idSchema,
     mode: z.enum(["in-person", "online"]).optional(),
   })
   .refine((v) => new Date(v.newEnd) > new Date(v.newStart), {

--- a/dali-api/app/hiring/routes/api.reviews.$id.submit.ts
+++ b/dali-api/app/hiring/routes/api.reviews.$id.submit.ts
@@ -1,23 +1,17 @@
 import type { Route } from "./+types/api.reviews.$id.submit";
 import { prisma } from "~/lib/db";
-import { requireAuth } from "~/lib/auth";
+import { requireMemberSession } from "~/lib/auth";
 import { isCore, isDomainLead } from "~/lib/roles";
 import { requireApiSignedOrForbidden } from "~/hiring/lib/confidentiality";
 import { logAuditEvent } from "~/lib/audit";
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const auth = await requireAuth(request);
-  if (!auth.ok) return auth.response;
+  const memberGate = await requireMemberSession(request);
+  if (!memberGate.ok) return memberGate.response;
+  const auth = memberGate.auth;
 
   if (request.method !== "POST") {
     return Response.json({ error: "Method not allowed" }, { status: 405 });
-  }
-
-  const member = await prisma.dALIMember.findUnique({
-    where: { userId: auth.user.sub },
-  });
-  if (!member) {
-    return Response.json({ error: "Not a DALI member" }, { status: 403 });
   }
 
   const review = await prisma.applicationReview.findUnique({

--- a/dali-api/app/hiring/routes/api.reviews.$id.ts
+++ b/dali-api/app/hiring/routes/api.reviews.$id.ts
@@ -2,147 +2,12 @@ import type { Route } from "./+types/api.reviews.$id";
 import { prisma } from "~/lib/db";
 import { requireAuth } from "~/lib/auth";
 import { isCore, isDomainLead } from "~/lib/roles";
-import { safeJson } from "~/lib/safe-json";
+import { parseJson } from "~/lib/validate";
 import { requireApiSignedOrForbidden } from "~/hiring/lib/confidentiality";
+import { ReviewPatchSchema } from "~/hiring/lib/review";
 
-const VALID_RECOMMENDATIONS = ["Strong Hire", "Hire", "Lean Hire", "Lean No Hire", "No Hire"];
-
-const MAX_SCORE_KEYS = 50;
-const MAX_SCORE_KEY_LENGTH = 100;
-const MIN_SCORE_VALUE = 0;
-const MAX_SCORE_VALUE = 10;
-const MAX_FEEDBACK_LENGTH = 10_000;
-const MAX_REJECTION_RATIONALE_LENGTH = 5_000;
-const MAX_ANNOTATIONS = 500;
-const MAX_ANNOTATION_COMMENT_LENGTH = 2_000;
-const MAX_ANNOTATION_FIELD_LENGTH = 200;
-
-type ValidatedPatch = {
-  scores?: Record<string, number>;
-  feedback?: string;
-  rejectionRationale?: string;
-  overallRecommendation?: string | null;
-  annotations?: Array<{
-    id: string;
-    fieldKey: string;
-    start: number;
-    end: number;
-    comment: string;
-    color: string;
-  }>;
-};
-
-function isPlainObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-export function validateReviewPatch(body: unknown): { ok: true; data: ValidatedPatch } | { ok: false; error: string } {
-  if (!isPlainObject(body)) {
-    return { ok: false, error: "Request body must be a JSON object" };
-  }
-
-  const out: ValidatedPatch = {};
-
-  if (body.scores !== undefined) {
-    if (!isPlainObject(body.scores)) {
-      return { ok: false, error: "scores must be a plain object" };
-    }
-    const keys = Object.keys(body.scores);
-    if (keys.length > MAX_SCORE_KEYS) {
-      return { ok: false, error: `scores cannot have more than ${MAX_SCORE_KEYS} keys` };
-    }
-    const scores: Record<string, number> = {};
-    for (const key of keys) {
-      if (key.length > MAX_SCORE_KEY_LENGTH) {
-        return { ok: false, error: `scores key exceeds ${MAX_SCORE_KEY_LENGTH} characters` };
-      }
-      const value = (body.scores as Record<string, unknown>)[key];
-      if (typeof value !== "number" || !Number.isFinite(value)) {
-        return { ok: false, error: `scores.${key} must be a finite number` };
-      }
-      if (value < MIN_SCORE_VALUE || value > MAX_SCORE_VALUE) {
-        return { ok: false, error: `scores.${key} must be between ${MIN_SCORE_VALUE} and ${MAX_SCORE_VALUE}` };
-      }
-      scores[key] = value;
-    }
-    out.scores = scores;
-  }
-
-  if (body.feedback !== undefined) {
-    if (typeof body.feedback !== "string") {
-      return { ok: false, error: "feedback must be a string" };
-    }
-    if (body.feedback.length > MAX_FEEDBACK_LENGTH) {
-      return { ok: false, error: `feedback cannot exceed ${MAX_FEEDBACK_LENGTH} characters` };
-    }
-    out.feedback = body.feedback;
-  }
-
-  if (body.rejectionRationale !== undefined) {
-    if (typeof body.rejectionRationale !== "string") {
-      return { ok: false, error: "rejectionRationale must be a string" };
-    }
-    if (body.rejectionRationale.length > MAX_REJECTION_RATIONALE_LENGTH) {
-      return { ok: false, error: `rejectionRationale cannot exceed ${MAX_REJECTION_RATIONALE_LENGTH} characters` };
-    }
-    out.rejectionRationale = body.rejectionRationale;
-  }
-
-  if (body.overallRecommendation !== undefined) {
-    if (body.overallRecommendation === null) {
-      out.overallRecommendation = null;
-    } else if (typeof body.overallRecommendation !== "string" || !VALID_RECOMMENDATIONS.includes(body.overallRecommendation)) {
-      return {
-        ok: false,
-        error: `overallRecommendation must be null or one of: ${VALID_RECOMMENDATIONS.join(", ")}`,
-      };
-    } else {
-      out.overallRecommendation = body.overallRecommendation;
-    }
-  }
-
-  if (body.annotations !== undefined) {
-    if (!Array.isArray(body.annotations)) {
-      return { ok: false, error: "annotations must be an array" };
-    }
-    if (body.annotations.length > MAX_ANNOTATIONS) {
-      return { ok: false, error: `annotations cannot have more than ${MAX_ANNOTATIONS} entries` };
-    }
-    const annotations: ValidatedPatch["annotations"] = [];
-    for (let i = 0; i < body.annotations.length; i++) {
-      const a = body.annotations[i];
-      if (!isPlainObject(a)) {
-        return { ok: false, error: `annotations[${i}] must be an object` };
-      }
-      const { id, fieldKey, start, end, comment, color } = a;
-      if (typeof id !== "string" || id.length === 0 || id.length > MAX_ANNOTATION_FIELD_LENGTH) {
-        return { ok: false, error: `annotations[${i}].id must be a string up to ${MAX_ANNOTATION_FIELD_LENGTH} chars` };
-      }
-      if (typeof fieldKey !== "string" || fieldKey.length === 0 || fieldKey.length > MAX_ANNOTATION_FIELD_LENGTH) {
-        return { ok: false, error: `annotations[${i}].fieldKey must be a string up to ${MAX_ANNOTATION_FIELD_LENGTH} chars` };
-      }
-      if (typeof start !== "number" || !Number.isFinite(start) || start < 0) {
-        return { ok: false, error: `annotations[${i}].start must be a non-negative finite number` };
-      }
-      if (typeof end !== "number" || !Number.isFinite(end) || end < 0) {
-        return { ok: false, error: `annotations[${i}].end must be a non-negative finite number` };
-      }
-      if (typeof comment !== "string" || comment.length > MAX_ANNOTATION_COMMENT_LENGTH) {
-        return {
-          ok: false,
-          error: `annotations[${i}].comment must be a string up to ${MAX_ANNOTATION_COMMENT_LENGTH} chars`,
-        };
-      }
-      if (typeof color !== "string" || color.length > MAX_ANNOTATION_FIELD_LENGTH) {
-        return { ok: false, error: `annotations[${i}].color must be a string up to ${MAX_ANNOTATION_FIELD_LENGTH} chars` };
-      }
-      annotations.push({ id, fieldKey, start, end, comment, color });
-    }
-    out.annotations = annotations;
-  }
-
-  return { ok: true, data: out };
-}
+// Re-exported so existing tests can import it from this route module.
+export { validateReviewPatch } from "~/hiring/lib/review";
 
 export async function action({ request, params }: Route.ActionArgs) {
   const auth = await requireAuth(request);
@@ -183,27 +48,16 @@ export async function action({ request, params }: Route.ActionArgs) {
       return Response.json({ error: "Forbidden" }, { status: 403 });
     }
 
-    const body = await safeJson<Record<string, unknown>>(request);
-    if (body instanceof Response) return body;
-    const data: Record<string, unknown> = {};
-    if (body.scores !== undefined) data.scores = body.scores;
-    if (body.feedback !== undefined) data.feedback = body.feedback;
-    if (body.rejectionRationale !== undefined) data.rejectionRationale = body.rejectionRationale;
-    if (body.overallRecommendation !== undefined) data.overallRecommendation = body.overallRecommendation;
-    if (body.annotations !== undefined) data.annotations = body.annotations;
-
-    const result = validateReviewPatch(body);
-    if (!result.ok) {
-      return Response.json({ error: result.error }, { status: 400 });
-    }
+    const parsed = await parseJson(request, ReviewPatchSchema);
+    if (parsed instanceof Response) return parsed;
 
     // When scores are written, pin the domain rubric version those keys belong
     // to so a later rubric edit can't orphan them at render time. Only the
     // domain rubric is pinned (its criteria are the crit-<ts> keys that drift);
     // the general-form rubric is resolved separately by consumers.
-    const patch: typeof result.data & { rubricVersionId?: string } = { ...result.data };
+    const patch: typeof parsed & { rubricVersionId?: string } = { ...parsed };
     const da = review.domainApplication;
-    if (result.data.scores !== undefined && !review.rubricVersionId && da) {
+    if (parsed.scores !== undefined && !review.rubricVersionId && da) {
       const domainId = da.domainId ?? da.challengeVersion?.domainId ?? null;
       const applicationCycleId = da.application?.applicationCycleId ?? null;
       if (domainId && applicationCycleId) {

--- a/dali-api/app/hiring/routes/applications.$domainApplicationId.tsx
+++ b/dali-api/app/hiring/routes/applications.$domainApplicationId.tsx
@@ -9,31 +9,12 @@ import { presignAnswers } from "~/hiring/lib/presign";
 import { ApplicationViewer } from "~/hiring/components/ApplicationViewer";
 import { ReviewSummary } from "~/hiring/components/ReviewSummary";
 import type { Question, RubricCriterion } from "~/types";
-
-const INTERVIEW_STATUS_COLORS: Record<string, string> = {
-  Scheduled: "bg-blue-100 text-blue-700",
-  Completed: "bg-green-100 text-green-700",
-  CancelledByApplicant: "bg-red-100 text-red-700",
-  CancelledByAdmin: "bg-muted text-foreground/80",
-};
-
-const INTERVIEW_STATUS_LABELS: Record<string, string> = {
-  CancelledByApplicant: "Cancelled (applicant)",
-  CancelledByAdmin: "Cancelled (admin)",
-};
-
-const DECISION_COLORS: Record<string, string> = {
-  Rejected: "bg-red-100 text-red-700",
-  InvitedToInterview: "bg-blue-100 text-blue-700",
-  Accepted: "bg-green-100 text-green-700",
-  Waitlisted: "bg-yellow-100 text-yellow-700",
-};
-
-const STAGE_LABELS: Record<string, string> = {
-  Draft: "Draft",
-  Final: "Finalized",
-  Released: "Released",
-};
+import {
+  INTERVIEW_STATUS_COLORS,
+  INTERVIEW_STATUS_LABELS,
+  DECISION_COLORS,
+  STAGE_LABELS,
+} from "~/hiring/lib/labels";
 
 const LOCATION_LABELS: Record<string, string> = {
   PodAppa: "Pod Appa",

--- a/dali-api/app/hiring/routes/challenges.$id.tsx
+++ b/dali-api/app/hiring/routes/challenges.$id.tsx
@@ -1,8 +1,7 @@
 import { redirect } from "react-router";
 import type { Route } from "./+types/challenges.$id";
 import { prisma } from "~/lib/db";
-import { requireAuth } from "~/lib/auth";
-import { isCore, isDomainLead, isAdmin } from "~/lib/roles";
+import { requireCoreOrDomainLead } from "~/lib/auth";
 import { ChallengeDetail } from "~/hiring/components/ChallengeDetail";
 
 export const meta: Route.MetaFunction = ({ data }) => {
@@ -11,9 +10,8 @@ export const meta: Route.MetaFunction = ({ data }) => {
 };
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const auth = await requireAuth(request);
-  if (!auth.ok) return redirect("/login");
-  if (!(await isCore(auth.user.sub)) && !(await isDomainLead(auth.user.sub)) && !(await isAdmin(auth.user.sub))) return redirect("/");
+  const gate = await requireCoreOrDomainLead(request);
+  if (!gate.ok) return gate.response;
   const [challenge, domains] = await Promise.all([
     prisma.challenge.findUniqueOrThrow({
       where: { id: params.id },
@@ -34,9 +32,9 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const auth = await requireAuth(request);
-  if (!auth.ok) return auth.response;
-  if (!(await isCore(auth.user.sub)) && !(await isDomainLead(auth.user.sub)) && !(await isAdmin(auth.user.sub))) return new Response(JSON.stringify({ error: "Forbidden" }), { status: 403, headers: { "Content-Type": "application/json" } });
+  const gate = await requireCoreOrDomainLead(request);
+  if (!gate.ok) return gate.response;
+  const auth = gate.auth;
 
   const user = await prisma.user.findUnique({ where: { id: auth.user.sub } });
   if (!user) return new Response(JSON.stringify({ error: "User not found" }), { status: 401 });

--- a/dali-api/app/hiring/routes/domain-lead.application.$id.tsx
+++ b/dali-api/app/hiring/routes/domain-lead.application.$id.tsx
@@ -15,14 +15,11 @@ import {
 } from "~/hiring/lib/domain-application-status";
 import type { ApplicationCycleStatus } from "~/generated/prisma/enums";
 import type { Question } from "~/types";
-
-const RECOMMENDATION_COLORS: Record<string, string> = {
-  "Strong Hire": "bg-green-100 text-green-800",
-  Hire: "bg-green-50 text-green-700",
-  "Lean Hire": "bg-yellow-50 text-yellow-700",
-  "Lean No Hire": "bg-orange-50 text-orange-700",
-  "No Hire": "bg-red-100 text-red-700",
-};
+import {
+  RECOMMENDATION_COLORS,
+  DECISION_COLORS,
+  STAGE_LABELS,
+} from "~/hiring/lib/labels";
 
 // bg + text + an explicit same-hue border (e.g. red pill → red border), so the
 // outline always matches the pill and never falls back to the neutral gray
@@ -37,19 +34,6 @@ const STATUS_BADGE: Record<string, { bg: string; label: string }> = {
   PostInterviewPending: { bg: "bg-purple-100 text-purple-700 border-purple-300 dark:bg-purple-900/30 dark:text-purple-400 dark:border-purple-700", label: "Post-Interview" },
   Accepted: { bg: "bg-green-100 text-green-700 border-green-300 dark:bg-green-900/30 dark:text-green-400 dark:border-green-700", label: "Accepted" },
   Waitlisted: { bg: "bg-yellow-100 text-yellow-700 border-yellow-300 dark:bg-yellow-900/30 dark:text-yellow-400 dark:border-yellow-700", label: "Waitlisted" },
-};
-
-const DECISION_COLORS: Record<string, string> = {
-  Rejected: "bg-red-100 text-red-700 border-red-300 dark:bg-red-900/30 dark:text-red-400 dark:border-red-700",
-  InvitedToInterview: "bg-purple-100 text-purple-700 border-purple-300 dark:bg-purple-900/30 dark:text-purple-400 dark:border-purple-700",
-  Accepted: "bg-green-100 text-green-700 border-green-300 dark:bg-green-900/30 dark:text-green-400 dark:border-green-700",
-  Waitlisted: "bg-yellow-100 text-yellow-700 border-yellow-300 dark:bg-yellow-900/30 dark:text-yellow-400 dark:border-yellow-700",
-};
-
-const STAGE_LABELS: Record<string, string> = {
-  Draft: "Draft",
-  Final: "Finalized",
-  Released: "Released",
 };
 
 export const meta: Route.MetaFunction = ({ data }) => {

--- a/dali-api/app/hiring/routes/domain-lead.tsx
+++ b/dali-api/app/hiring/routes/domain-lead.tsx
@@ -27,13 +27,7 @@ import type { ApplicationCycleStatus } from "~/generated/prisma/enums";
 import type { DecisionType } from "~/types";
 import { formatVersionLabel, buildVersionNumberMap } from "~/lib/formatVersion";
 import { selectActiveCycleForDomainLead } from "~/hiring/lib/cycle-picker";
-
-const STATUS_LABELS: Record<string, string> = {
-  Draft: "Draft",
-  Open: "Open",
-  UnderReview: "Under Review",
-  Completed: "Completed",
-};
+import { STATUS_LABELS, DECISION_LABELS } from "~/hiring/lib/labels";
 
 // Every status/decision pill carries a border in its OWN hue (never a neutral
 // black/gray line on a colored pill) so the whole page reads consistently.
@@ -2044,13 +2038,6 @@ const DECISION_COLORS: Record<string, string> = {
   InvitedToInterview: "bg-purple-100 text-purple-700 border-purple-300 dark:bg-purple-900/30 dark:text-purple-400 dark:border-purple-700",
   Accepted: "bg-green-100 text-green-700 border-green-300 dark:bg-green-900/30 dark:text-green-400 dark:border-green-700",
   Waitlisted: "bg-yellow-100 text-yellow-700 border-yellow-300 dark:bg-yellow-900/30 dark:text-yellow-400 dark:border-yellow-700",
-};
-
-const DECISION_LABELS: Record<string, string> = {
-  Rejected: "Reject",
-  InvitedToInterview: "Interview",
-  Accepted: "Accept",
-  Waitlisted: "Waitlist",
 };
 
 // Stage treatment composes on top of the `border border-current/40` the badge

--- a/dali-api/app/hiring/routes/interviewer.interview.$interviewId.tsx
+++ b/dali-api/app/hiring/routes/interviewer.interview.$interviewId.tsx
@@ -26,6 +26,7 @@ import { ReviewSummary } from '~/hiring/components/ReviewSummary'
 import { buildCriteriaLabelMap } from '~/hiring/lib/rubric-criteria'
 import type { Route } from './+types/interviewer.interview.$interviewId'
 import type { Question } from '~/types'
+import { INTERVIEW_STATUS_COLORS } from '~/hiring/lib/labels'
 
 const RECOMMENDATION_OPTIONS = [
   'Strong Hire',
@@ -34,13 +35,6 @@ const RECOMMENDATION_OPTIONS = [
   'Lean No Hire',
   'No Hire',
 ]
-
-const STATUS_COLORS: Record<string, string> = {
-  Scheduled: 'bg-blue-100 text-blue-700',
-  Completed: 'bg-green-100 text-green-700',
-  CancelledByApplicant: 'bg-red-100 text-red-700',
-  CancelledByAdmin: 'bg-muted text-foreground/80',
-}
 
 const ROLE_LABELS: Record<string, string> = {
   InDomain: 'In-domain',
@@ -388,7 +382,7 @@ export default function InterviewDetailPage() {
                 className={`px-2 py-0.5 rounded text-xs font-medium ${
                   isCompleted
                     ? 'bg-green-100 text-green-700'
-                    : STATUS_COLORS[interview.status] ??
+                    : INTERVIEW_STATUS_COLORS[interview.status] ??
                       'bg-muted text-foreground/80'
                 }`}
               >

--- a/dali-api/app/hiring/routes/lead.cycle.$id.tsx
+++ b/dali-api/app/hiring/routes/lead.cycle.$id.tsx
@@ -1178,7 +1178,7 @@ export default function HiringLeadCycleDetails() {
     rescheduleNoticeHours: 12,
     cancelNoticeHours: 0,
     bookingNoticeHours: 12,
-    timezone: 'America/New_York',
+    timezone: APPLICATION_TZ,
   })
   const [configSaved, setConfigSaved] = useState(false)
   const [configSaving, setConfigSaving] = useState(false)

--- a/dali-api/app/hiring/routes/lead.cycle.$id.tsx
+++ b/dali-api/app/hiring/routes/lead.cycle.$id.tsx
@@ -26,6 +26,7 @@ import { formatVersionLabel, buildVersionNumberMap } from "~/lib/formatVersion";
 import { getCycleConfidentialityState } from "~/hiring/lib/confidentiality";
 import { sendExtensionNoticeIfDue, resendExtensionNotice } from "~/hiring/lib/extension-notice";
 import { ConfidentialityGate } from "~/hiring/components/ConfidentialityGate";
+import { STATUS_COLORS, STATUS_LABELS } from "~/hiring/lib/labels";
 import {
   zonedDayStartUtc,
   zonedDayEndUtc,
@@ -1232,13 +1233,6 @@ export default function HiringLeadCycleDetails() {
   const [showOpenConfirm, setShowOpenConfirm] = useState(false)
 
   const STATUS_FLOW = ['Draft', 'Open', 'UnderReview', 'Completed'] as const
-  const STATUS_LABELS: Record<string, string> = {
-    Draft: 'Draft', Open: 'Open', UnderReview: 'Under Review', Completed: 'Completed',
-  }
-  const STATUS_COLORS: Record<string, string> = {
-    Draft: 'bg-muted text-muted-foreground', Open: 'bg-green-100 text-green-700',
-    UnderReview: 'bg-yellow-100 text-yellow-700', Completed: 'bg-blue-100 text-blue-700',
-  }
 
   // ── Active tab (URL-synced: deep-links, reload, and back/forward all work) ──
   const [searchParams, setSearchParams] = useSearchParams()

--- a/dali-api/app/hiring/routes/lead.intern-to-full-cycle.$id.tsx
+++ b/dali-api/app/hiring/routes/lead.intern-to-full-cycle.$id.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { Form, redirect, useLoaderData, useFetcher, Link } from "react-router";
 import type { Route } from "./+types/lead.intern-to-full-cycle.$id";
 import { prisma } from "~/lib/db";
-import { requireAuth } from "~/lib/auth";
+import { requireAuth, forbidden } from "~/lib/auth";
 import { isCore } from "~/lib/roles";
 import type { Question } from "~/types";
 import type { Prisma } from "~/generated/prisma/client";
@@ -213,7 +213,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 export async function action({ request, params }: Route.ActionArgs) {
   const auth = await requireAuth(request);
   if (!auth.ok) return auth.response;
-  if (!(await isCore(auth.user.sub))) return new Response("Forbidden", { status: 403 });
+  if (!(await isCore(auth.user.sub))) return forbidden(request);
 
   const cycleId = params.id!;
   const formData = await request.formData();

--- a/dali-api/app/hiring/routes/lead.tsx
+++ b/dali-api/app/hiring/routes/lead.tsx
@@ -5,20 +5,7 @@ import { prisma } from "~/lib/db";
 import { requireAuth } from "~/lib/auth";
 import { isCore } from "~/lib/roles";
 import { ChevronRight, ChevronDown, Plus, X } from "lucide-react";
-
-const STATUS_LABELS: Record<string, string> = {
-  Draft: "Draft",
-  Open: "Open",
-  UnderReview: "Under Review",
-  Completed: "Completed",
-};
-
-const STATUS_COLORS: Record<string, string> = {
-  Draft: "bg-muted text-foreground/80",
-  Open: "bg-green-100 text-green-700",
-  UnderReview: "bg-yellow-100 text-yellow-700",
-  Completed: "bg-blue-100 text-blue-700",
-};
+import { STATUS_COLORS, STATUS_LABELS } from "~/hiring/lib/labels";
 
 export const meta: Route.MetaFunction = () => [{ title: "Hiring lead · DALI OS" }];
 

--- a/dali-api/app/hiring/routes/library.tsx
+++ b/dali-api/app/hiring/routes/library.tsx
@@ -1,8 +1,7 @@
 import { redirect } from "react-router";
 import type { Route } from "./+types/library";
 import { prisma } from "~/lib/db";
-import { requireAuth } from "~/lib/auth";
-import { isCore, isDomainLead, isAdmin } from "~/lib/roles";
+import { requireCoreOrDomainLead } from "~/lib/auth";
 import Library from "~/hiring/components/Library";
 
 export const meta: Route.MetaFunction = () => [{ title: "Library · Hiring · DALI OS" }];
@@ -12,15 +11,8 @@ export const meta: Route.MetaFunction = () => [{ title: "Library · Hiring · DA
 // they share the same audience and CRUD shape, so they live behind one route
 // and one loader/action keyed by an `entity` discriminator.
 export async function loader({ request }: Route.LoaderArgs) {
-  const auth = await requireAuth(request);
-  if (!auth.ok) return redirect("/login");
-
-  const [hiringLead, domainLead, admin] = await Promise.all([
-    isCore(auth.user.sub),
-    isDomainLead(auth.user.sub),
-    isAdmin(auth.user.sub),
-  ]);
-  if (!hiringLead && !domainLead && !admin) return redirect("/");
+  const gate = await requireCoreOrDomainLead(request);
+  if (!gate.ok) return gate.response;
 
   const [domains, challenges, rubrics, agreements] = await Promise.all([
     prisma.domain.findMany({ orderBy: { name: "asc" } }),
@@ -58,19 +50,13 @@ export async function loader({ request }: Route.LoaderArgs) {
     challenges,
     rubrics,
     agreements,
-    canEdit: hiringLead || domainLead || admin,
+    canEdit: true,
   };
 }
 
 export async function action({ request }: Route.ActionArgs) {
-  const auth = await requireAuth(request);
-  if (!auth.ok) return redirect("/login");
-  const [hiringLead, domainLead, admin] = await Promise.all([
-    isCore(auth.user.sub),
-    isDomainLead(auth.user.sub),
-    isAdmin(auth.user.sub),
-  ]);
-  if (!hiringLead && !domainLead && !admin) return redirect("/");
+  const gate = await requireCoreOrDomainLead(request);
+  if (!gate.ok) return gate.response;
 
   const formData = await request.formData();
   const entity = formData.get("entity") as string;

--- a/dali-api/app/hiring/routes/rubrics.$id.tsx
+++ b/dali-api/app/hiring/routes/rubrics.$id.tsx
@@ -1,8 +1,7 @@
 import { redirect } from 'react-router'
 import type { Route } from './+types/rubrics.$id'
 import { prisma } from '~/lib/db'
-import { requireAuth } from "~/lib/auth";
-import { isCore, isDomainLead, isAdmin } from '~/lib/roles'
+import { requireCoreOrDomainLead } from "~/lib/auth";
 import { RubricDetail } from '~/hiring/components/RubricDetail'
 
 export const meta: Route.MetaFunction = ({ data }) => {
@@ -11,9 +10,8 @@ export const meta: Route.MetaFunction = ({ data }) => {
 }
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const auth = await requireAuth(request)
-  if (!auth.ok) return redirect('/login')
-  if (!(await isCore(auth.user.sub)) && !(await isDomainLead(auth.user.sub)) && !(await isAdmin(auth.user.sub))) return redirect('/')
+  const gate = await requireCoreOrDomainLead(request)
+  if (!gate.ok) return gate.response
 
   const rubric = await prisma.rubric.findUniqueOrThrow({
     where: { id: params.id },
@@ -29,9 +27,9 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const auth = await requireAuth(request)
-  if (!auth.ok) return redirect('/login')
-  if (!(await isCore(auth.user.sub)) && !(await isDomainLead(auth.user.sub)) && !(await isAdmin(auth.user.sub))) return redirect('/')
+  const gate = await requireCoreOrDomainLead(request)
+  if (!gate.ok) return gate.response
+  const auth = gate.auth
 
   const user = await prisma.user.findUnique({ where: { id: auth.user.sub } })
   if (!user) return redirect('/login')

--- a/dali-api/app/internal-processes/routes/__tests__/internal-processes.onboarding.test.ts
+++ b/dali-api/app/internal-processes/routes/__tests__/internal-processes.onboarding.test.ts
@@ -1,7 +1,19 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 
 vi.mock("~/lib/db");
-vi.mock("~/lib/auth", () => ({ requireAuth: vi.fn() }));
+vi.mock("~/lib/auth", () => ({
+  requireAuth: vi.fn(),
+  requireCore: vi.fn(),
+  requireCoreOrDomainLead: vi.fn(),
+  requireMemberSession: vi.fn(),
+  forbidden: vi.fn((_req: Request) =>
+    Response.json({ error: "Forbidden" }, { status: 403 }),
+  ),
+  unauthorized: vi.fn((_req: Request) =>
+    Response.json({ error: "Unauthorized" }, { status: 401 }),
+  ),
+  redirectApplicantToPortal: vi.fn(() => null),
+}));
 vi.mock("~/lib/roles", () => ({ isCore: vi.fn() }));
 
 import { prisma } from "~/lib/db";

--- a/dali-api/app/internal-processes/routes/internal-processes.jobx.tsx
+++ b/dali-api/app/internal-processes/routes/internal-processes.jobx.tsx
@@ -1,6 +1,6 @@
 import { redirect } from "react-router";
 import type { Route } from "./+types/internal-processes.jobx";
-import { requireAuth } from "~/lib/auth";
+import { requireAuth, redirectApplicantToPortal } from "~/lib/auth";
 import { ComingSoon } from "~/components/ComingSoon";
 
 export const meta: Route.MetaFunction = () => [
@@ -10,7 +10,8 @@ export const meta: Route.MetaFunction = () => [
 export async function loader({ request }: Route.LoaderArgs) {
   const auth = await requireAuth(request);
   if (!auth.ok) return redirect("/login");
-  if (auth.user.type === "applicant") return redirect("/portal");
+  const portalRedirect = redirectApplicantToPortal(auth);
+  if (portalRedirect) return portalRedirect;
   return null;
 }
 

--- a/dali-api/app/internal-processes/routes/internal-processes.onboarding.tsx
+++ b/dali-api/app/internal-processes/routes/internal-processes.onboarding.tsx
@@ -1,6 +1,6 @@
 import { redirect, useFetcher, useLoaderData, useNavigate, useSearchParams } from "react-router";
 import type { Route } from "./+types/internal-processes.onboarding";
-import { requireAuth } from "~/lib/auth";
+import { requireAuth, unauthorized, forbidden } from "~/lib/auth";
 import { isCore } from "~/lib/roles";
 import { prisma } from "~/lib/db";
 
@@ -131,9 +131,9 @@ export async function loader({ request }: Route.LoaderArgs) {
 // checking, or null when unchecking.
 export async function action({ request }: Route.ActionArgs) {
   const auth = await requireAuth(request);
-  if (!auth.ok) return Response.json({ error: "Unauthorized" }, { status: 401 });
+  if (!auth.ok) return unauthorized(request);
   if (!(await isCore(auth.user.sub))) {
-    return Response.json({ error: "Forbidden" }, { status: 403 });
+    return forbidden(request);
   }
 
   const form = await request.formData();

--- a/dali-api/app/internal-processes/routes/internal-processes.transfer.tsx
+++ b/dali-api/app/internal-processes/routes/internal-processes.transfer.tsx
@@ -1,6 +1,6 @@
 import { redirect } from "react-router";
 import type { Route } from "./+types/internal-processes.transfer";
-import { requireAuth } from "~/lib/auth";
+import { requireAuth, redirectApplicantToPortal } from "~/lib/auth";
 import { ComingSoon } from "~/components/ComingSoon";
 
 export const meta: Route.MetaFunction = () => [
@@ -10,7 +10,8 @@ export const meta: Route.MetaFunction = () => [
 export async function loader({ request }: Route.LoaderArgs) {
   const auth = await requireAuth(request);
   if (!auth.ok) return redirect("/login");
-  if (auth.user.type === "applicant") return redirect("/portal");
+  const portalRedirect = redirectApplicantToPortal(auth);
+  if (portalRedirect) return portalRedirect;
   return null;
 }
 

--- a/dali-api/app/lib/__mocks__/db.ts
+++ b/dali-api/app/lib/__mocks__/db.ts
@@ -185,6 +185,7 @@ export const prisma = {
   },
   term: {
     findFirst: vi.fn().mockResolvedValue(null),
+    findMany: vi.fn().mockResolvedValue([]),
   },
   adminMembership: {
     findUnique: vi.fn(),
@@ -193,6 +194,9 @@ export const prisma = {
     findFirst: vi.fn(),
   },
   domainLeadAssignment: {
+    findFirst: vi.fn(),
+  },
+  instructorAssignment: {
     findFirst: vi.fn(),
   },
   $transaction: vi.fn(),

--- a/dali-api/app/lib/app-env.ts
+++ b/dali-api/app/lib/app-env.ts
@@ -17,8 +17,11 @@ export function getAppEnv(): AppEnv {
 
 export const DARTMOUTH_EMAIL_DOMAIN = 'dartmouth.edu'
 
-// NOTE: google-workspace.ts duplicate; new canonical home, adoption later
-export const WORKSPACE_DOMAIN = process.env.GOOGLE_WORKSPACE_DOMAIN ?? 'dali.dartmouth.edu'
+// NOTE: google-workspace.ts duplicate; new canonical home, adoption later.
+// Hardcoded (no env override) so this module stays safe to import from client
+// components — top-level `process.env` reads crash the browser bundle. If we
+// ever need the env override, move it into a function or a server-only file.
+export const WORKSPACE_DOMAIN = 'dali.dartmouth.edu'
 
 export const APPLICATIONS_FROM_EMAIL = 'applications@dali.dartmouth.edu'
 

--- a/dali-api/app/lib/app-env.ts
+++ b/dali-api/app/lib/app-env.ts
@@ -14,3 +14,24 @@ export function getAppEnv(): AppEnv {
       return 'dev'
   }
 }
+
+export const DARTMOUTH_EMAIL_DOMAIN = 'dartmouth.edu'
+
+// NOTE: google-workspace.ts duplicate; new canonical home, adoption later
+export const WORKSPACE_DOMAIN = process.env.GOOGLE_WORKSPACE_DOMAIN ?? 'dali.dartmouth.edu'
+
+export const APPLICATIONS_FROM_EMAIL = 'applications@dali.dartmouth.edu'
+
+export const APPLICATIONS_FROM_NAME = 'DALI Lab'
+
+export function getApiBaseUrl(): string {
+  return process.env.API_BASE_URL ?? 'http://localhost:3001'
+}
+
+export function getFrontendUrl(): string {
+  return process.env.FRONTEND_URL ?? 'http://localhost:5173'
+}
+
+export function getCasBaseUrl(): string {
+  return process.env.CAS_BASE_URL ?? 'https://login.dartmouth.edu/cas'
+}

--- a/dali-api/app/lib/app-env.ts
+++ b/dali-api/app/lib/app-env.ts
@@ -1,5 +1,9 @@
 export type AppEnv = 'dev' | 'staging' | 'prod'
 
+// Two parallel "environment" axes exist on purpose:
+//  - NODE_ENV === "production" → Node/runtime gate (cookie Secure, CSP, dev routes).
+//  - getAppEnv() → app-level intent (Fly app name → 'dev'|'staging'|'prod').
+// On Fly.io, staging is NODE_ENV=production AND getAppEnv()==='staging'.
 export function getAppEnv(): AppEnv {
   const override = process.env.DALI_APP_ENV
   if (override === 'dev' || override === 'staging' || override === 'prod') {

--- a/dali-api/app/lib/auth.ts
+++ b/dali-api/app/lib/auth.ts
@@ -1,3 +1,4 @@
+import { redirect } from "react-router";
 import {
   clearSessionCookie,
   parseSessionIdWithSource,
@@ -5,6 +6,10 @@ import {
 } from "~/lib/cookies";
 import { logAuditEvent } from "~/lib/audit";
 import { lookupSession, rollSession, hashSessionId } from "~/lib/session";
+import { withCors } from "~/lib/cors";
+import { isCore, isDomainLead } from "~/lib/roles";
+import { prisma } from "~/lib/db";
+import { displayEmail } from "~/lib/display";
 
 // Session-backed auth middleware. See SESSION_AUTH_PLAN.md for design.
 // The `user.sub` shape is preserved from the legacy JWT payload so existing
@@ -19,7 +24,7 @@ export type AuthUser = {
   lastName?: string;
 };
 
-type AuthSuccess = {
+export type AuthSuccess = {
   ok: true;
   user: AuthUser;
   sessionId: string; // hashed PK; not the raw credential
@@ -39,7 +44,7 @@ type AuthFailure = {
 
 export type AuthResult = AuthSuccess | AuthFailure;
 
-function unauthorized(): Response {
+function unauthorizedJson(): Response {
   return new Response(JSON.stringify({ error: "Unauthorized" }), {
     status: 401,
     headers: { "Content-Type": "application/json" },
@@ -74,8 +79,7 @@ function buildAuthUser(user: {
 }): AuthUser {
   return {
     sub: user.id,
-    email:
-      user.daliEmail ?? user.dartmouthEmail ?? `${user.netId}@dartmouth.edu`,
+    email: displayEmail(user),
     type: deriveAuthType(user),
     firstName: user.firstName,
     lastName: user.lastName,
@@ -85,7 +89,7 @@ function buildAuthUser(user: {
 export async function requireAuth(request: Request): Promise<AuthResult> {
   const credential = parseSessionIdWithSource(request);
   if (!credential) {
-    return { ok: false, response: unauthorized(), reason: "no_session" };
+    return { ok: false, response: unauthorizedJson(), reason: "no_session" };
   }
 
   const session = await lookupSession(credential.raw);
@@ -157,4 +161,60 @@ export async function validateCasTicket(ticket: string, serviceUrl: string) {
   const lastName = nameParts.length > 1 ? nameParts.slice(-1)[0] : "";
 
   return { netId, firstName, lastName };
+}
+
+export function unauthorized(request: Request): Response {
+  return withCors(request, Response.json({ error: "Unauthorized" }, { status: 401 }));
+}
+
+export function forbidden(request: Request): Response {
+  return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
+}
+
+export async function requireCore(
+  request: Request,
+): Promise<{ ok: true; auth: AuthSuccess } | { ok: false; response: Response }> {
+  const auth = await requireAuth(request);
+  if (!auth.ok) return { ok: false, response: auth.response };
+  const core = await isCore(auth.user.sub);
+  if (!core) return { ok: false, response: forbidden(request) };
+  return { ok: true, auth };
+}
+
+export async function requireCoreOrDomainLead(
+  request: Request,
+): Promise<{ ok: true; auth: AuthSuccess } | { ok: false; response: Response }> {
+  const auth = await requireAuth(request);
+  if (!auth.ok) return { ok: false, response: auth.response };
+  const [core, domainLead] = await Promise.all([
+    isCore(auth.user.sub),
+    isDomainLead(auth.user.sub),
+  ]);
+  if (!core && !domainLead) return { ok: false, response: forbidden(request) };
+  return { ok: true, auth };
+}
+
+export async function requireMemberSession(
+  request: Request,
+): Promise<{ ok: true; auth: AuthSuccess } | { ok: false; response: Response }> {
+  const auth = await requireAuth(request);
+  if (!auth.ok) return { ok: false, response: auth.response };
+  const member = await prisma.dALIMember.findUnique({
+    where: { userId: auth.user.sub },
+  });
+  if (!member) {
+    return {
+      ok: false,
+      response: withCors(
+        request,
+        Response.json({ error: "Not a DALI member" }, { status: 403 }),
+      ),
+    };
+  }
+  return { ok: true, auth };
+}
+
+export function redirectApplicantToPortal(auth: AuthSuccess): Response | null {
+  if (auth.user.type === "applicant") return redirect("/portal");
+  return null;
 }

--- a/dali-api/app/lib/auth.ts
+++ b/dali-api/app/lib/auth.ts
@@ -7,7 +7,7 @@ import {
 import { logAuditEvent } from "~/lib/audit";
 import { lookupSession, rollSession, hashSessionId } from "~/lib/session";
 import { withCors } from "~/lib/cors";
-import { isCore, isDomainLead } from "~/lib/roles";
+import { isCore, isDomainLead, isProjectMember } from "~/lib/roles";
 import { prisma } from "~/lib/db";
 import { displayEmail } from "~/lib/display";
 
@@ -211,6 +211,23 @@ export async function requireMemberSession(
       ),
     };
   }
+  return { ok: true, auth };
+}
+
+// Matches the loader's canEdit predicate at projects.$id.tsx — Core OR
+// a current/historical assignee of the project may edit project content
+// (tasks, epics, stories, sprints, documents, files).
+export async function requireProjectEditAccess(
+  request: Request,
+  projectId: string,
+): Promise<{ ok: true; auth: AuthSuccess } | { ok: false; response: Response }> {
+  const auth = await requireAuth(request);
+  if (!auth.ok) return { ok: false, response: auth.response };
+  const [core, member] = await Promise.all([
+    isCore(auth.user.sub),
+    isProjectMember(auth.user.sub, projectId),
+  ]);
+  if (!core && !member) return { ok: false, response: forbidden(request) };
   return { ok: true, auth };
 }
 

--- a/dali-api/app/lib/availability.ts
+++ b/dali-api/app/lib/availability.ts
@@ -2,7 +2,7 @@ import rrulePkg from "rrule";
 import type { RRule as RRuleType } from "rrule";
 import { prisma } from "~/lib/db";
 import { fetchBusyEvents } from "~/lib/google-calendar";
-import { getZonedYMD, zonedDayStartUtc } from "~/lib/timezone";
+import { APPLICATION_TZ as DEFAULT_TIMEZONE, getZonedYMD, zonedDayStartUtc } from "~/lib/timezone";
 
 const { RRule, rrulestr } = rrulePkg as unknown as {
   RRule: typeof import("rrule").RRule;
@@ -241,7 +241,6 @@ function formatDtstart(d: Date): string {
 // per-day grid bucketing; this module owns the cross-user math.
 
 const DEFAULT_BUFFER_MIN = 15;
-const DEFAULT_TIMEZONE = "America/New_York";
 
 /**
  * Load + compute free/busy for a single user across the given window.

--- a/dali-api/app/lib/cookies.ts
+++ b/dali-api/app/lib/cookies.ts
@@ -2,12 +2,8 @@
 
 export const COOKIE_SID = "__dali_sid";
 
-// 30 days in seconds — same horizon as ROLLING_TTL_MS in `lib/session.ts`,
-// kept local so this module doesn't transitively import the Prisma client.
-// The cookie Max-Age and the DB rolling TTL are independently enforced:
-// the server is the source of truth, and an expired DB session 302s to
-// /login on the next request regardless of the cookie's lifetime.
-const SESSION_COOKIE_MAX_AGE_SECONDS = 30 * 24 * 60 * 60;
+export const SESSION_TTL_SECONDS = 30 * 24 * 60 * 60;
+export const SESSION_COOKIE_MAX_AGE_SECONDS = SESSION_TTL_SECONDS;
 
 const isProduction = process.env.NODE_ENV === "production";
 

--- a/dali-api/app/lib/core-cycle.ts
+++ b/dali-api/app/lib/core-cycle.ts
@@ -1,0 +1,39 @@
+import { prisma } from "~/lib/db";
+
+// Core is elected in Spring (election cycle) and the lab's Core cohort stays
+// the same through the following Winter. We materialize one CoreAssignment row
+// per term in that window so every reader can just query by termId without
+// re-deriving cycle math.
+//
+// Cycle math (mirrors lib/roles.ts):
+//   Season digits — W=1, S=2, X=3, F=4. Cycle starts at the Spring of the
+//   given term's cycle and spans [Spring N, Spring N+1) in sortKey space,
+//   i.e. 10 consecutive sortKeys → 4 terms (S, X, F, W).
+//
+// This helper is intentionally parameterizable (any term, not just current)
+// so add/remove writers can fan out across the cycle of whichever term they
+// were handed.
+
+function cycleStartSortKey(sk: number): number {
+  const seasonDigit = sk % 10;
+  return seasonDigit === 1 ? sk - 9 : sk - seasonDigit + 2;
+}
+
+export function cycleSortKeyRange(termSortKey: number): { gte: number; lt: number } {
+  const start = cycleStartSortKey(termSortKey);
+  return { gte: start, lt: start + 10 };
+}
+
+export async function coreCycleTermIds(termId: string): Promise<string[]> {
+  const term = await prisma.term.findUnique({
+    where: { id: termId },
+    select: { sortKey: true },
+  });
+  if (!term) return [];
+  const range = cycleSortKeyRange(term.sortKey);
+  const terms = await prisma.term.findMany({
+    where: { sortKey: { gte: range.gte, lt: range.lt } },
+    select: { id: true },
+  });
+  return terms.map((t) => t.id);
+}

--- a/dali-api/app/lib/core-titles.ts
+++ b/dali-api/app/lib/core-titles.ts
@@ -1,0 +1,14 @@
+// Distinct Core lead titles for a member's Roles column. Title-less Core
+// assignments collapse to a single "Core" pill so a Core member without a
+// specific title still shows up (rather than contributing no pill at all).
+export function deriveCoreTitles(
+  assignments: { leadTitle: string | null }[],
+): string[] {
+  if (assignments.length === 0) return [];
+  const titles = new Set(
+    assignments.map((a) => a.leadTitle).filter((t): t is string => !!t),
+  );
+  const hasUntitled = assignments.some((a) => !a.leadTitle);
+  if (hasUntitled) titles.add("Core");
+  return Array.from(titles);
+}

--- a/dali-api/app/lib/csv.ts
+++ b/dali-api/app/lib/csv.ts
@@ -1,0 +1,23 @@
+function escapeCell(raw: unknown): string {
+  if (raw === null || raw === undefined) return "";
+  const s = String(raw);
+  if (/[",\r\n]/.test(s)) {
+    return `"${s.replace(/"/g, '""')}"`;
+  }
+  return s;
+}
+
+export const csvCell = escapeCell;
+
+export function rowsToCsv(rows: ReadonlyArray<ReadonlyArray<unknown>>): string {
+  if (rows.length === 0) return "";
+  return rows.map((r) => r.map(csvCell).join(",")).join("\r\n") + "\r\n";
+}
+
+export function csvResponse(body: string, filename: string, init: { status?: number; headers?: HeadersInit } = {}): Response {
+  const safeName = filename.replace(/[\r\n"]/g, "_");
+  const headers = new Headers(init.headers);
+  headers.set("Content-Type", "text/csv; charset=utf-8");
+  headers.set("Content-Disposition", `attachment; filename="${safeName}"`);
+  return new Response(body, { status: init.status ?? 200, headers });
+}

--- a/dali-api/app/lib/display.ts
+++ b/dali-api/app/lib/display.ts
@@ -19,3 +19,44 @@ export function userInitials(user: {
   const localPart = user.email.split("@")[0] ?? user.email;
   return initialsFromName(localPart);
 }
+
+export const UNKNOWN_LABEL = "Unknown";
+export const EMPTY_DISPLAY = "—";
+
+// TODO: import from app-env.ts once available
+const DARTMOUTH_EMAIL_DOMAIN_FALLBACK = "dartmouth.edu";
+
+export function fullName(user: { firstName?: string | null; lastName?: string | null }): string {
+  return `${user.firstName ?? ""} ${user.lastName ?? ""}`.trim();
+}
+
+export function primaryEmail(user: {
+  daliEmail?: string | null;
+  dartmouthEmail?: string | null;
+  personalEmail?: string | null;
+}): string | null {
+  return user.daliEmail || user.dartmouthEmail || user.personalEmail || null;
+}
+
+export function displayEmail(user: {
+  daliEmail?: string | null;
+  dartmouthEmail?: string | null;
+  netId?: string | null;
+  personalEmail?: string | null;
+}): string {
+  const primary = user.daliEmail || user.dartmouthEmail || user.personalEmail;
+  if (primary) return primary;
+  if (user.netId) return `${user.netId}@${DARTMOUTH_EMAIL_DOMAIN_FALLBACK}`;
+  return "";
+}
+
+export function formatDateTime(iso: string | Date): string {
+  const d = new Date(iso);
+  return d.toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" })
+    + " at " + d.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" });
+}
+
+export function formatDateShort(iso: string | Date): string {
+  const d = new Date(iso);
+  return d.toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" });
+}

--- a/dali-api/app/lib/display.ts
+++ b/dali-api/app/lib/display.ts
@@ -20,6 +20,9 @@ export function userInitials(user: {
   return initialsFromName(localPart);
 }
 
+// Sentinel-string policy:
+//   UNKNOWN_LABEL ("Unknown") → human prose ("Created by Unknown")
+//   EMPTY_DISPLAY ("—")       → table cells / structured data
 export const UNKNOWN_LABEL = "Unknown";
 export const EMPTY_DISPLAY = "—";
 

--- a/dali-api/app/lib/general-calendar.ts
+++ b/dali-api/app/lib/general-calendar.ts
@@ -11,6 +11,7 @@
 
 import rrulePkg from "rrule";
 import type { RRule as RRuleType } from "rrule";
+import { zonedWallTimeUtc } from "~/lib/timezone";
 
 const { RRule, rrulestr } = rrulePkg as unknown as {
   RRule: typeof import("rrule").RRule;
@@ -221,37 +222,15 @@ function parseIcsDate(namePart: string, value: string): { date: Date; allDay: bo
   // Floating or TZID local time. Resolve the named zone's UTC offset at that
   // wall-clock instant; fall back to UTC if the tz is missing/invalid.
   const tzid = /TZID=([^;:]+)/.exec(namePart)?.[1];
-  const utcGuess = Date.UTC(y, mon - 1, day, hour, min, sec);
-  if (!tzid) return { date: new Date(utcGuess), allDay: false };
-  const offsetMs = tzOffsetMs(tzid, new Date(utcGuess));
-  return { date: new Date(utcGuess - offsetMs), allDay: false };
-}
-
-// How far the named timezone is ahead of UTC at `instant`, in ms.
-function tzOffsetMs(timeZone: string, instant: Date): number {
+  if (!tzid) {
+    return { date: new Date(Date.UTC(y, mon - 1, day, hour, min, sec)), allDay: false };
+  }
   try {
-    const dtf = new Intl.DateTimeFormat("en-US", {
-      timeZone,
-      year: "numeric",
-      month: "2-digit",
-      day: "2-digit",
-      hour: "2-digit",
-      minute: "2-digit",
-      second: "2-digit",
-      hour12: false,
-    });
-    const parts = dtf.formatToParts(instant);
-    const get = (t: string) => +(parts.find((p) => p.type === t)?.value ?? "0");
-    const asUtc = Date.UTC(
-      get("year"),
-      get("month") - 1,
-      get("day"),
-      get("hour") % 24,
-      get("minute"),
-      get("second"),
-    );
-    return asUtc - instant.getTime();
+    // zonedWallTimeUtc handles minute-precision wall clocks; carry seconds
+    // separately since DST offsets never change mid-minute.
+    const minuteUtc = zonedWallTimeUtc(y, mon, day, hour, min, tzid);
+    return { date: new Date(minuteUtc.getTime() + sec * 1000), allDay: false };
   } catch {
-    return 0;
+    return { date: new Date(Date.UTC(y, mon - 1, day, hour, min, sec)), allDay: false };
   }
 }

--- a/dali-api/app/lib/gmail-integration.ts
+++ b/dali-api/app/lib/gmail-integration.ts
@@ -1,10 +1,9 @@
 import { prisma } from "~/lib/db";
+import { APPLICATIONS_FROM_EMAIL as GMAIL_USER } from "~/lib/app-env";
 
 // Phase 2: Gmail send-as credentials moved from User.google* to the
 // GmailIntegration model. This helper is the single read path for callers
 // that previously looked up `User.googleRefreshToken` by daliEmail.
-
-const GMAIL_USER = "applications@dali.dartmouth.edu";
 
 /**
  * Returns the refresh token for the Gmail send-as integration tied to the

--- a/dali-api/app/lib/gmail.ts
+++ b/dali-api/app/lib/gmail.ts
@@ -1,27 +1,20 @@
 // Gmail sending via OAuth refresh token stored on the applications@ user row.
 // All outbound email comes from applications@dali.dartmouth.edu.
 
-import { getAppEnv } from './app-env'
+import { getAppEnv, APPLICATIONS_FROM_EMAIL as GMAIL_USER, APPLICATIONS_FROM_NAME } from './app-env'
+import { refreshGoogleToken } from '~/lib/google-oauth'
 
-const GMAIL_USER = 'applications@dali.dartmouth.edu'
 const STAGING_REDIRECT = 'systems@dali.dartmouth.edu'
 const CLIENT_ID = process.env.GMAIL_CLIENT_ID ?? process.env.GOOGLE_CLIENT_ID!
 const CLIENT_SECRET = process.env.GMAIL_CLIENT_SECRET ?? process.env.GOOGLE_CLIENT_SECRET!
 
 async function getAccessToken(refreshToken: string): Promise<string> {
-  const res = await fetch('https://oauth2.googleapis.com/token', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: new URLSearchParams({
-      client_id: CLIENT_ID,
-      client_secret: CLIENT_SECRET,
-      refresh_token: refreshToken,
-      grant_type: 'refresh_token',
-    }),
+  const tokens = await refreshGoogleToken({
+    refreshToken,
+    clientId: CLIENT_ID,
+    clientSecret: CLIENT_SECRET,
   })
-  if (!res.ok) throw new Error(`Failed to refresh Gmail token: ${await res.text()}`)
-  const data = await res.json()
-  return data.access_token as string
+  return tokens.access_token
 }
 
 function sanitizeHeader(value: string): string {
@@ -68,7 +61,7 @@ function htmlToPlainText(html: string): string {
 
 function makeRawEmail(to: string, subject: string, htmlBody: string, ics?: string): string {
   const headers = [
-    `From: DALI Lab <${GMAIL_USER}>`,
+    `From: ${APPLICATIONS_FROM_NAME} <${GMAIL_USER}>`,
     `To: ${sanitizeHeader(to)}`,
     `Subject: ${sanitizeHeader(subject)}`,
     'MIME-Version: 1.0',

--- a/dali-api/app/lib/google-calendar.ts
+++ b/dali-api/app/lib/google-calendar.ts
@@ -1,5 +1,6 @@
 import { prisma } from "~/lib/db";
 import { decrypt, encrypt } from "~/lib/calendar-crypto";
+import { GoogleOAuthError, refreshGoogleToken } from "~/lib/google-oauth";
 
 interface BusyEvent {
   start: string; // ISO
@@ -43,20 +44,19 @@ function serializeStoredTokens(t: StoredTokens): string {
 }
 
 async function refreshAndPersist(linkId: string, refreshToken: string): Promise<string> {
-  const res = await fetch("https://oauth2.googleapis.com/token", {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: new URLSearchParams({
-      client_id: process.env.GOOGLE_CLIENT_ID!,
-      client_secret: process.env.GOOGLE_CLIENT_SECRET!,
-      refresh_token: refreshToken,
-      grant_type: "refresh_token",
-    }),
-  });
-  if (!res.ok) {
-    throw new Error(`Google token refresh failed (${res.status})`);
+  let data;
+  try {
+    data = await refreshGoogleToken({
+      refreshToken,
+      clientId: process.env.GOOGLE_CLIENT_ID!,
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+    });
+  } catch (err) {
+    if (err instanceof GoogleOAuthError) {
+      throw new Error(`Google token refresh failed (${err.upstreamStatus ?? "?"})`);
+    }
+    throw err;
   }
-  const data = (await res.json()) as { access_token: string; expires_in: number };
   const expiresAt = new Date(Date.now() + data.expires_in * 1000).toISOString();
   const stored: StoredTokens = {
     accessToken: data.access_token,

--- a/dali-api/app/lib/google-oauth.ts
+++ b/dali-api/app/lib/google-oauth.ts
@@ -1,0 +1,98 @@
+const GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
+const GOOGLE_AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth";
+
+export interface GoogleTokenResponse {
+  access_token: string;
+  refresh_token?: string;
+  expires_in: number;
+  scope?: string;
+  token_type?: string;
+  id_token?: string;
+}
+
+export class GoogleOAuthError extends Error {
+  constructor(
+    message: string,
+    public readonly upstreamStatus?: number,
+    public readonly upstreamBody?: string,
+  ) {
+    super(message);
+    this.name = "GoogleOAuthError";
+  }
+}
+
+async function postToken(params: URLSearchParams): Promise<GoogleTokenResponse> {
+  const response = await fetch(GOOGLE_TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: params,
+  });
+  if (!response.ok) {
+    const body = await response.text();
+    const truncatedBody = body.length > 500 ? `${body.slice(0, 500)}…` : body;
+    throw new GoogleOAuthError(
+      `Google token request failed (${response.status}): ${truncatedBody}`,
+      response.status,
+      body,
+    );
+  }
+  return (await response.json()) as GoogleTokenResponse;
+}
+
+// clientId/clientSecret are explicit so callers can use scoped env vars
+// (e.g. GMAIL_CLIENT_ID fallback to GOOGLE_CLIENT_ID) instead of one global pair.
+export async function refreshGoogleToken(opts: {
+  refreshToken: string;
+  clientId: string;
+  clientSecret: string;
+}): Promise<GoogleTokenResponse> {
+  return postToken(
+    new URLSearchParams({
+      client_id: opts.clientId,
+      client_secret: opts.clientSecret,
+      refresh_token: opts.refreshToken,
+      grant_type: "refresh_token",
+    }),
+  );
+}
+
+export async function exchangeGoogleCode(opts: {
+  code: string;
+  redirectUri: string;
+  clientId: string;
+  clientSecret: string;
+}): Promise<GoogleTokenResponse> {
+  return postToken(
+    new URLSearchParams({
+      code: opts.code,
+      client_id: opts.clientId,
+      client_secret: opts.clientSecret,
+      redirect_uri: opts.redirectUri,
+      grant_type: "authorization_code",
+    }),
+  );
+}
+
+export function buildGoogleAuthUrl(opts: {
+  clientId: string;
+  redirectUri: string;
+  scopes: string[];
+  state: string;
+  accessType?: "offline" | "online";
+  prompt?: "consent" | "select_account" | "none";
+  loginHint?: string;
+  includeGrantedScopes?: boolean;
+}): string {
+  const params = new URLSearchParams({
+    client_id: opts.clientId,
+    redirect_uri: opts.redirectUri,
+    response_type: "code",
+    scope: opts.scopes.join(" "),
+    state: opts.state,
+  });
+  if (opts.accessType) params.set("access_type", opts.accessType);
+  if (opts.prompt) params.set("prompt", opts.prompt);
+  if (opts.loginHint) params.set("login_hint", opts.loginHint);
+  if (opts.includeGrantedScopes) params.set("include_granted_scopes", "true");
+  return `${GOOGLE_AUTH_URL}?${params.toString()}`;
+}

--- a/dali-api/app/lib/google-workspace.ts
+++ b/dali-api/app/lib/google-workspace.ts
@@ -1,4 +1,5 @@
 import { JWT } from "google-auth-library";
+import { retry } from "./retry";
 
 // Google Workspace account provisioning via the Admin SDK Directory API. Used
 // to create a member's @dali.dartmouth.edu account when they're accepted.
@@ -249,42 +250,52 @@ export async function addGroupMember(args: {
 }): Promise<GroupMemberResult> {
   // ~0.5 + 1 + 2 + 4 + 8 = 15.5s of total backoff across the retries — enough to
   // cover typical group-propagation lag without hanging the finalize for long.
-  const backoffsMs = [500, 1000, 2000, 4000, 8000];
   try {
     const token = await getAccessToken();
-    for (let attempt = 0; ; attempt++) {
-      const res = await fetch(
-        `${DIRECTORY_GROUPS_URL}/${encodeURIComponent(args.groupEmail)}/members`,
-        {
-          method: "POST",
-          headers: {
-            Authorization: `Bearer ${token}`,
-            "Content-Type": "application/json",
+    return await retry(
+      async (): Promise<GroupMemberResult> => {
+        const res = await fetch(
+          `${DIRECTORY_GROUPS_URL}/${encodeURIComponent(args.groupEmail)}/members`,
+          {
+            method: "POST",
+            headers: {
+              Authorization: `Bearer ${token}`,
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({ email: args.memberEmail, role: "MEMBER" }),
           },
-          body: JSON.stringify({ email: args.memberEmail, role: "MEMBER" }),
-        },
-      );
-      if (res.status === 409) {
-        return { status: "ok", added: false };
-      }
-      if (res.ok) {
-        return { status: "ok", added: true };
-      }
-      const body = await res.text();
-      // Retry only the group-not-yet-propagated 404 (groupKey), and only while
-      // we have backoff budget left.
-      const isGroupKeyNotFound =
-        res.status === 404 && /groupKey/i.test(body);
-      if (isGroupKeyNotFound && attempt < backoffsMs.length) {
-        await new Promise((r) => setTimeout(r, backoffsMs[attempt]));
-        continue;
-      }
-      return { status: "error", message: `Directory API ${res.status}: ${body.slice(0, 200)}` };
-    }
+        );
+        if (res.status === 409) {
+          return { status: "ok", added: false };
+        }
+        if (res.ok) {
+          return { status: "ok", added: true };
+        }
+        const body = await res.text();
+        // Throw the group-not-yet-propagated 404 so retry() can ride out propagation lag.
+        if (res.status === 404 && /groupKey/i.test(body)) {
+          throw new GroupPropagation404(body);
+        }
+        return { status: "error", message: `Directory API ${res.status}: ${body.slice(0, 200)}` };
+      },
+      {
+        backoffsMs: [500, 1000, 2000, 4000, 8000],
+        shouldRetry: (err) => err instanceof GroupPropagation404,
+      },
+    );
   } catch (err) {
+    if (err instanceof GroupPropagation404) {
+      return { status: "error", message: `Directory API 404: ${err.body.slice(0, 200)}` };
+    }
     return {
       status: "error",
       message: err instanceof Error ? err.message : String(err),
     };
+  }
+}
+
+class GroupPropagation404 extends Error {
+  constructor(public body: string) {
+    super("group propagation 404");
   }
 }

--- a/dali-api/app/lib/groups.ts
+++ b/dali-api/app/lib/groups.ts
@@ -84,19 +84,6 @@ async function resolveCoreMembers(): Promise<string[]> {
   return rows.map((r) => r.userId);
 }
 
-// Current term = the Term whose [startDate, endDate] window contains now.
-// If multiple windows overlap (rare seed edge case), prefer the largest
-// sortKey. Returns null if no term covers today.
-export async function getCurrentTermId(): Promise<string | null> {
-  const now = new Date();
-  const term = await prisma.term.findFirst({
-    where: { startDate: { lte: now }, endDate: { gte: now } },
-    orderBy: { sortKey: "desc" },
-    select: { id: true },
-  });
-  return term?.id ?? null;
-}
-
 // Every current lab member's userId. "Lab member" = a User with a DALIMember
 // marker row who is also placed in at least one domain (has a DomainEligibility
 // row). Members not yet assigned to any domain are excluded from the "whole

--- a/dali-api/app/lib/level.ts
+++ b/dali-api/app/lib/level.ts
@@ -1,0 +1,7 @@
+export type Level = "P1" | "P2" | "P3";
+
+export const ALL_LEVELS: readonly Level[] = ["P1", "P2", "P3"] as const;
+
+export function isLevel(value: unknown): value is Level {
+  return value === "P1" || value === "P2" || value === "P3";
+}

--- a/dali-api/app/lib/oauth.ts
+++ b/dali-api/app/lib/oauth.ts
@@ -1,6 +1,11 @@
 import { createHash, randomBytes } from "node:crypto";
 import { OAuth2Client } from "google-auth-library";
 import { prisma } from "~/lib/db";
+import { displayEmail } from "~/lib/display";
+import {
+  exchangeGoogleCode as exchangeGoogleCodeImpl,
+  GoogleOAuthError,
+} from "~/lib/google-oauth";
 import type { OAuthProvider, OAuthAccountType } from "~/generated/prisma/enums";
 import type { OAuthClient } from "~/generated/prisma/client";
 
@@ -108,8 +113,7 @@ export function buildUserInfo(
   const resolvedType = authType ?? deriveAuthType(user);
   return {
     id: user.id,
-    email:
-      user.daliEmail ?? user.dartmouthEmail ?? `${user.netId}@dartmouth.edu`,
+    email: displayEmail(user),
     firstName: user.firstName,
     lastName: user.lastName,
     type: resolvedType,
@@ -236,27 +240,24 @@ export async function exchangeAuthorizationCode(params: {
 // google OAuth
 
 export async function exchangeGoogleCode(code: string, callbackUrl: string) {
-  const res = await fetch("https://oauth2.googleapis.com/token", {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: new URLSearchParams({
+  let data;
+  try {
+    data = await exchangeGoogleCodeImpl({
       code,
-      client_id: process.env.GOOGLE_CLIENT_ID!,
-      client_secret: process.env.GOOGLE_CLIENT_SECRET!,
-      redirect_uri: callbackUrl,
-      grant_type: "authorization_code",
-    }),
-  });
-
-  if (!res.ok) {
-    const err = await res.text();
-    throw new OAuthError(
-      "server_error",
-      `Google token exchange failed: ${err}`,
-    );
+      redirectUri: callbackUrl,
+      clientId: process.env.GOOGLE_CLIENT_ID!,
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+    });
+  } catch (err) {
+    if (err instanceof GoogleOAuthError) {
+      throw new OAuthError(
+        "server_error",
+        `Google token exchange failed: ${err.upstreamBody ?? err.message}`,
+      );
+    }
+    throw err;
   }
 
-  const data = await res.json();
   const idToken = data.id_token as string;
 
   const client = new OAuth2Client(process.env.GOOGLE_CLIENT_ID);

--- a/dali-api/app/lib/presence-user.ts
+++ b/dali-api/app/lib/presence-user.ts
@@ -1,5 +1,6 @@
 import { prisma } from "./db";
 import { resolvePhotoUrl } from "./photo";
+import { primaryEmail } from "~/lib/display";
 
 export interface PresenceUser {
   userId: string;
@@ -17,7 +18,7 @@ function buildSubtitle(args: {
   personalEmail: string | null;
   classYear: number | null;
 }): string | null {
-  const email = args.daliEmail ?? args.dartmouthEmail ?? args.personalEmail ?? null;
+  const email = primaryEmail(args) ?? null;
   const yearTail = args.classYear ? `'${String(args.classYear).slice(-2)}` : null;
   if (email && yearTail) return `${email} · ${yearTail}`;
   return email ?? yearTail ?? null;

--- a/dali-api/app/lib/prisma-shapes.ts
+++ b/dali-api/app/lib/prisma-shapes.ts
@@ -1,0 +1,52 @@
+import type { Prisma } from "~/generated/prisma/client";
+
+// Minimal "name card" — user:{ select:{ id, firstName, lastName }}
+export const USER_NAME_SELECT = {
+  id: true,
+  firstName: true,
+  lastName: true,
+} satisfies Prisma.UserSelect;
+
+// Name + both Dartmouth emails
+export const USER_NAME_AND_EMAIL_SELECT = {
+  id: true,
+  firstName: true,
+  lastName: true,
+  daliEmail: true,
+  dartmouthEmail: true,
+} satisfies Prisma.UserSelect;
+
+// "Is a DALI lab member" predicate
+export const LAB_MEMBER_WHERE = {
+  daliMember: { isNot: null },
+} satisfies Prisma.UserWhereInput;
+
+// Canonical sort for any list of members
+export const MEMBER_LIST_ORDER_BY = [
+  { lastName: "asc" },
+  { firstName: "asc" },
+] satisfies Prisma.UserOrderByWithRelationInput[];
+
+// Nested domain pill shape
+export const DOMAIN_DISPLAY_SELECT = {
+  id: true,
+  displayName: true,
+} satisfies Prisma.DomainSelect;
+
+// Lab member with role badges + domain eligibilities
+export const STAFFING_MEMBER_SELECT = {
+  id: true,
+  firstName: true,
+  lastName: true,
+  daliEmail: true,
+  dartmouthEmail: true,
+  photoUrl: true,
+  adminMembership: { select: { id: true } },
+  coreAssignments: { select: { leadTitle: true } },
+  domainEligibilities: {
+    select: {
+      level: true,
+      domain: { select: { id: true, displayName: true } },
+    },
+  },
+} satisfies Prisma.UserSelect;

--- a/dali-api/app/lib/retry.ts
+++ b/dali-api/app/lib/retry.ts
@@ -1,0 +1,26 @@
+export interface RetryOptions {
+  // Backoff intervals in milliseconds. retry() runs the fn up to (backoffsMs.length + 1)
+  // times — the initial call plus one retry per backoff.
+  backoffsMs: number[];
+  // If provided, retry only when this returns true for the thrown error.
+  // Default: retry on every thrown error.
+  shouldRetry?: (err: unknown) => boolean;
+}
+
+export async function retry<T>(
+  fn: () => Promise<T>,
+  opts: RetryOptions,
+): Promise<T> {
+  let lastErr: unknown;
+  for (let i = 0; i <= opts.backoffsMs.length; i++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastErr = err;
+      if (opts.shouldRetry && !opts.shouldRetry(err)) throw err;
+      if (i === opts.backoffsMs.length) throw err;
+      await new Promise((r) => setTimeout(r, opts.backoffsMs[i]!));
+    }
+  }
+  throw lastErr;
+}

--- a/dali-api/app/lib/roles.ts
+++ b/dali-api/app/lib/roles.ts
@@ -5,6 +5,13 @@ function getAdminUserIdsFromEnv(): string[] {
   return (process.env.ADMIN_USER_IDS ?? "").split(",").filter(Boolean);
 }
 
+// True if the userId is in ADMIN_USER_IDS env. Exported so list-view loaders
+// can OR this into their per-row isAdmin/isCore derivation without paying
+// per-row getUserRoles() round-trips.
+export function isAdminViaEnv(userId: string): boolean {
+  return getAdminUserIdsFromEnv().includes(userId);
+}
+
 // Phase 2 rewrite: role flags derived from the new typed assignment tables
 // (AdminMembership, CoreAssignment, DomainLeadAssignment) rather than the
 // dropped DALIMember.roles[] enum. See V0_PLAN.md §"Identity model".
@@ -192,6 +199,20 @@ export async function currentTerm() {
   return prisma.term.findFirst({
     where: { startDate: { gt: now } },
     orderBy: { sortKey: "asc" },
+  });
+}
+
+/**
+ * Strict variant of `currentTerm()`: returns the Term whose
+ * [startDate, endDate] window contains now, or null if now falls in the
+ * inter-term gap. No roll-forward to the next upcoming term. Use this when
+ * the call site must fail closed between terms (e.g. intern eligibility).
+ */
+export async function currentTermStrict() {
+  const now = new Date();
+  return prisma.term.findFirst({
+    where: { startDate: { lte: now }, endDate: { gte: now } },
+    orderBy: { sortKey: "desc" },
   });
 }
 

--- a/dali-api/app/lib/roles.ts
+++ b/dali-api/app/lib/roles.ts
@@ -1,6 +1,10 @@
 import { prisma } from "~/lib/db";
 import { cycleSortKeyRange } from "~/lib/core-cycle";
 
+function getAdminUserIdsFromEnv(): string[] {
+  return (process.env.ADMIN_USER_IDS ?? "").split(",").filter(Boolean);
+}
+
 // Phase 2 rewrite: role flags derived from the new typed assignment tables
 // (AdminMembership, CoreAssignment, DomainLeadAssignment) rather than the
 // dropped DALIMember.roles[] enum. See V0_PLAN.md §"Identity model".
@@ -31,9 +35,7 @@ export interface UserRoles {
  * Use this in layout loaders instead of calling individual checks separately.
  */
 export async function getUserRoles(userId: string): Promise<UserRoles> {
-  const envIds = (process.env.ADMIN_USER_IDS ?? "")
-    .split(",")
-    .filter(Boolean);
+  const envIds = getAdminUserIdsFromEnv();
 
   const cycleTermIds = await getActiveCoreCycleTermIds();
 
@@ -82,9 +84,7 @@ export async function getUserRoles(userId: string): Promise<UserRoles> {
  * (e.g. seed hasn't run), Admin is the only path that passes.
  */
 export async function isCore(userId: string): Promise<boolean> {
-  const envIds = (process.env.ADMIN_USER_IDS ?? "")
-    .split(",")
-    .filter(Boolean);
+  const envIds = getAdminUserIdsFromEnv();
   if (envIds.includes(userId)) return true;
   const admin = await prisma.adminMembership.findUnique({
     where: { userId },
@@ -102,9 +102,7 @@ export async function isCore(userId: string): Promise<boolean> {
 
 /** Admin: full-time staff. */
 export async function isAdmin(userId: string): Promise<boolean> {
-  const envIds = (process.env.ADMIN_USER_IDS ?? "")
-    .split(",")
-    .filter(Boolean);
+  const envIds = getAdminUserIdsFromEnv();
   if (envIds.includes(userId)) return true;
   const row = await prisma.adminMembership.findUnique({
     where: { userId },

--- a/dali-api/app/lib/roles.ts
+++ b/dali-api/app/lib/roles.ts
@@ -1,4 +1,5 @@
 import { prisma } from "~/lib/db";
+import { cycleSortKeyRange } from "~/lib/core-cycle";
 
 // Phase 2 rewrite: role flags derived from the new typed assignment tables
 // (AdminMembership, CoreAssignment, DomainLeadAssignment) rather than the
@@ -220,35 +221,27 @@ export async function currentTermMemberWhere() {
 }
 
 /**
- * Spring sortKey at or before `sk`. A Core "cycle" runs from one Spring
- * election (W=1, S=2, X=3, F=4) through the following Winter, so the
- * cycle that contains a term is anchored by its preceding Spring. Winter
- * (digit 1) belongs to the previous calendar year's Spring cycle.
- */
-function cycleStartSortKey(sk: number): number {
-  const seasonDigit = sk % 10;
-  return seasonDigit === 1 ? sk - 9 : sk - seasonDigit + 2;
-}
-
-/**
  * Term IDs that constitute the active Core cycle. Core is elected in
- * Spring and auto-rolls over through the following Winter; the cycle
- * window spans `[Spring N, Spring N+1)` in sortKey space.
+ * Spring and the cycle window spans `[Spring N, Spring N+1)` in sortKey
+ * space.
  *
  * During a Spring term, the previous cycle is also active so an outgoing
- * Core keeps access through the election handoff (until they're either
- * re-elected, or replaced — at which point the new cycle's assignments
- * become the active set the following Summer).
+ * Core keeps access through the election handoff (until the new cycle's
+ * assignments take over the following Summer). Outside of Spring, the
+ * helper just returns the current cycle's term ids — same set the
+ * cycle-aware fan-out writes to CoreAssignment.
+ *
+ * Cycle math lives in `~/lib/core-cycle.ts` and is shared with the
+ * add/remove writers so reads + writes can't drift.
  */
 export async function getActiveCoreCycleTermIds(): Promise<string[]> {
   const term = await currentTerm();
   if (!term) return [];
-  const cycleStart = cycleStartSortKey(term.sortKey);
+  const currentRange = cycleSortKeyRange(term.sortKey);
   // Spring (digit 2) extends the window back one cycle for the handoff.
-  const lowerBound = term.sortKey % 10 === 2 ? cycleStart - 10 : cycleStart;
-  const upperBound = cycleStart + 10;
+  const lowerBound = term.sortKey % 10 === 2 ? currentRange.gte - 10 : currentRange.gte;
   const terms = await prisma.term.findMany({
-    where: { sortKey: { gte: lowerBound, lt: upperBound } },
+    where: { sortKey: { gte: lowerBound, lt: currentRange.lt } },
     select: { id: true },
   });
   return terms.map((t) => t.id);

--- a/dali-api/app/lib/safe-json.ts
+++ b/dali-api/app/lib/safe-json.ts
@@ -59,3 +59,16 @@ export async function safeJson<T>(
     });
   }
 }
+
+/**
+ * Parses a FormData entry as JSON. Returns null when the entry is absent,
+ * not a string (e.g. a File), or invalid JSON.
+ */
+export function parseFormDataJson(v: FormDataEntryValue | null): unknown {
+  if (typeof v !== "string") return null;
+  try {
+    return JSON.parse(v);
+  } catch {
+    return null;
+  }
+}

--- a/dali-api/app/lib/scheduled-meeting.ts
+++ b/dali-api/app/lib/scheduled-meeting.ts
@@ -6,6 +6,7 @@
 import { prisma } from "~/lib/db";
 import { resolveGroupMembers } from "~/lib/groups";
 import { createGoogleCalendarEvent, type GoogleAttendee } from "~/lib/google-calendar";
+import { primaryEmail } from "~/lib/display";
 import type { ScheduledMeeting } from "~/generated/prisma/client";
 
 export type ScheduledMeetingScope =
@@ -94,7 +95,7 @@ export async function createScheduledMeeting(
     });
     const attendees: GoogleAttendee[] = [];
     for (const u of attendeeUsers) {
-      const email = u.daliEmail ?? u.dartmouthEmail;
+      const email = primaryEmail(u);
       if (!email) continue;
       attendees.push({
         email,

--- a/dali-api/app/lib/session.ts
+++ b/dali-api/app/lib/session.ts
@@ -1,11 +1,12 @@
 import { createHash, randomBytes } from "node:crypto";
 import { prisma } from "~/lib/db";
+import { SESSION_TTL_SECONDS } from "./cookies";
 
 // 30 days rolling expiry; same value as the absolute cap so a session
 // can be extended for up to 30 days from creation. Matches the prior
 // `RefreshToken.familyCreatedAt + SESSION_MAX_AGE_MS` behavior.
-export const ROLLING_TTL_MS = 30 * 24 * 60 * 60 * 1000;
-export const ABSOLUTE_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+export const ROLLING_TTL_MS = SESSION_TTL_SECONDS * 1000;
+export const ABSOLUTE_TTL_MS = SESSION_TTL_SECONDS * 1000;
 
 export function hashSessionId(raw: string): string {
   return createHash("sha256").update(raw).digest("base64url");

--- a/dali-api/app/lib/user-provisioning.ts
+++ b/dali-api/app/lib/user-provisioning.ts
@@ -1,5 +1,6 @@
 import { prisma } from "~/lib/db";
 import { linkCasToGoogleUser } from "~/lib/linking";
+import { DARTMOUTH_EMAIL_DOMAIN } from "~/lib/app-env";
 
 // Shared user-provisioning helpers used by /auth/callback/{google,cas} and
 // /oauth/callback/{google,cas}.
@@ -88,7 +89,7 @@ export async function upsertUserFromCas(
     return { user };
   }
 
-  const dartmouthEmail = `${cas.netId}@dartmouth.edu`;
+  const dartmouthEmail = `${cas.netId}@${DARTMOUTH_EMAIL_DOMAIN}`;
   const user = await prisma.user.upsert({
     where: { netId: cas.netId },
     update: {

--- a/dali-api/app/lib/validate.ts
+++ b/dali-api/app/lib/validate.ts
@@ -1,5 +1,12 @@
-import type { ZodType } from "zod";
+import { z, type ZodType } from "zod";
 import { safeJson } from "~/lib/safe-json";
+
+export const idSchema = z.string().min(1).max(100);
+
+export const nullableTrimmed = z.preprocess(
+  (v) => (typeof v === "string" ? (v.trim() === "" ? null : v.trim()) : v),
+  z.string().nullable(),
+);
 
 /**
  * Read and validate a JSON request body against a Zod schema.
@@ -22,6 +29,41 @@ export async function parseJson<T>(
   if (!result.success) {
     return Response.json(
       { error: "Invalid request body", details: result.error.flatten() },
+      { status: 400 },
+    );
+  }
+  return result.data;
+}
+
+export async function parseForm<T extends z.ZodType>(
+  request: Request,
+  schema: T,
+): Promise<z.infer<T> | Response> {
+  const contentType = request.headers.get("content-type") ?? "";
+  if (
+    !contentType.includes("application/x-www-form-urlencoded") &&
+    !contentType.includes("multipart/form-data")
+  ) {
+    return Response.json(
+      { error: "Invalid form data", details: "Unsupported content type" },
+      { status: 400 },
+    );
+  }
+
+  let form: FormData;
+  try {
+    form = await request.formData();
+  } catch {
+    return Response.json(
+      { error: "Invalid form data", details: "Malformed form body" },
+      { status: 400 },
+    );
+  }
+
+  const result = schema.safeParse(Object.fromEntries(form));
+  if (!result.success) {
+    return Response.json(
+      { error: "Invalid form data", details: result.error.flatten() },
       { status: 400 },
     );
   }

--- a/dali-api/app/mcp/resources/project-backlog.ts
+++ b/dali-api/app/mcp/resources/project-backlog.ts
@@ -4,6 +4,7 @@
 // large and a client may only need it when planning the next sprint.
 
 import { prisma } from "~/lib/db";
+import { fullName } from "~/lib/display";
 
 export const PROJECT_BACKLOG_RESOURCE = {
   uriTemplate: "dali://projects/{projectId}/backlog",
@@ -71,7 +72,7 @@ export async function readProjectBacklogResource(projectId: string): Promise<str
         dueAt: t.dueAt?.toISOString() ?? null,
         assignees: t.assignees.map((a) => ({
           id: a.user.id,
-          name: `${a.user.firstName} ${a.user.lastName}`.trim(),
+          name: fullName(a.user),
         })),
       })),
     },

--- a/dali-api/app/mcp/resources/project-board.ts
+++ b/dali-api/app/mcp/resources/project-board.ts
@@ -5,6 +5,7 @@
 
 import { prisma } from "~/lib/db";
 import { TASK_STATUSES, type TaskStatus } from "~/projects/lib/task-board";
+import { fullName } from "~/lib/display";
 
 export const PROJECT_BOARD_RESOURCE = {
   uriTemplate: "dali://projects/{projectId}/board",
@@ -102,7 +103,7 @@ export async function readProjectBoardResource(projectId: string): Promise<strin
       dueAt: t.dueAt?.toISOString() ?? null,
       assignees: t.assignees.map((a) => ({
         id: a.user.id,
-        name: `${a.user.firstName} ${a.user.lastName}`.trim(),
+        name: fullName(a.user),
       })),
     };
     if (t.sprintId) {

--- a/dali-api/app/mcp/tools/get-member-profile.ts
+++ b/dali-api/app/mcp/tools/get-member-profile.ts
@@ -4,7 +4,7 @@
 // own profile. Requires the `mcp:read` scope.
 
 import { prisma } from "~/lib/db";
-import { currentTerm } from "~/lib/roles";
+import { currentTerm, isAdminViaEnv } from "~/lib/roles";
 
 export const GET_MEMBER_PROFILE_TOOL = {
   name: "get_member_profile",
@@ -88,8 +88,8 @@ export async function runGetMemberProfile(callerId: string, input: Input) {
     throw new MemberNotFoundError(input.memberId);
   }
 
-  const isAdminUser = user.adminMembership !== null;
-  const isCoreUser = user.coreAssignments.length > 0;
+  const isAdminUser = user.adminMembership !== null || isAdminViaEnv(user.id);
+  const isCoreUser = isAdminUser || user.coreAssignments.length > 0;
   const isDomainLeadUser = user.domainLeadAssignmentsAsUser.length > 0;
   const tier: "admin" | "core" | "domain-lead" | "member" = isAdminUser
     ? "admin"

--- a/dali-api/app/mcp/tools/get-project-overview.ts
+++ b/dali-api/app/mcp/tools/get-project-overview.ts
@@ -6,6 +6,7 @@
 
 import { prisma } from "~/lib/db";
 import { currentTerm } from "~/lib/roles";
+import { fullName } from "~/lib/display";
 
 export const GET_PROJECT_OVERVIEW_TOOL = {
   name: "get_project_overview",
@@ -121,7 +122,7 @@ export async function runGetProjectOverview(input: Input) {
     })),
     currentTermRoster: currentAssignments.map((a) => ({
       userId: a.user.id,
-      name: `${a.user.firstName} ${a.user.lastName}`.trim(),
+      name: fullName(a.user),
       domain: a.domain.displayName,
       level: a.level,
     })),

--- a/dali-api/app/mcp/tools/rsvp-to-notification.ts
+++ b/dali-api/app/mcp/tools/rsvp-to-notification.ts
@@ -5,6 +5,7 @@
 
 import { prisma } from "~/lib/db";
 import { updateGoogleAttendeeRsvp } from "~/lib/google-calendar";
+import { primaryEmail } from "~/lib/display";
 
 export const RSVP_TO_NOTIFICATION_TOOL = {
   name: "rsvp_to_notification",
@@ -66,7 +67,7 @@ export async function runRsvpToNotification(
     throw new RsvpError("Notification has no associated meeting", 400);
   }
 
-  const attendeeEmail = caller.daliEmail ?? caller.dartmouthEmail;
+  const attendeeEmail = primaryEmail(caller);
 
   let gcalError: string | null = null;
   if (

--- a/dali-api/app/mcp/tools/search-directory.ts
+++ b/dali-api/app/mcp/tools/search-directory.ts
@@ -3,7 +3,7 @@
 // names, and current-term role titles. Requires the `mcp:read` scope.
 
 import { prisma } from "~/lib/db";
-import { currentTerm } from "~/lib/roles";
+import { currentTerm, isAdminViaEnv } from "~/lib/roles";
 
 export const SEARCH_DIRECTORY_TOOL = {
   name: "search_directory",
@@ -104,8 +104,8 @@ export async function runSearchDirectory(input: Input): Promise<{ results: Direc
   });
 
   const results: DirectoryRow[] = users.map((u) => {
-    const isAdminUser = u.adminMembership !== null;
-    const isCoreUser = u.coreAssignments.length > 0;
+    const isAdminUser = u.adminMembership !== null || isAdminViaEnv(u.id);
+    const isCoreUser = isAdminUser || u.coreAssignments.length > 0;
     const isDomainLeadUser = u.domainLeadAssignmentsAsUser.length > 0;
     const tier: DirectoryRow["tier"] = isAdminUser
       ? "admin"

--- a/dali-api/app/members/lib/profile-page.server.ts
+++ b/dali-api/app/members/lib/profile-page.server.ts
@@ -5,7 +5,7 @@
 
 import { redirect } from "react-router";
 import { prisma } from "~/lib/db";
-import { requireAuth } from "~/lib/auth";
+import { requireAuth, redirectApplicantToPortal } from "~/lib/auth";
 import { resolvePhotoUrl } from "~/lib/photo";
 import { parseSessionCookie } from "~/lib/cookies";
 import { getPresenceUser } from "~/lib/presence-user";
@@ -107,7 +107,8 @@ export async function loadProfilePage({
 }): Promise<ProfilePageData> {
   const auth = await requireAuth(request);
   if (!auth.ok) throw redirect("/login");
-  if (auth.user.type === "applicant") throw redirect("/portal");
+  const portalRedirect = redirectApplicantToPortal(auth);
+  if (portalRedirect) throw portalRedirect;
 
   const isSelf = auth.user.sub === targetId;
 
@@ -257,7 +258,8 @@ export async function runProfileAction({
 }): Promise<ProfileActionResult | Response> {
   const auth = await requireAuth(request);
   if (!auth.ok) throw redirect("/login");
-  if (auth.user.type === "applicant") throw redirect("/portal");
+  const portalRedirect = redirectApplicantToPortal(auth);
+  if (portalRedirect) throw portalRedirect;
 
   const form = await request.formData();
   const intent = String(form.get("intent") ?? "profile");

--- a/dali-api/app/members/routes/members.groups.tsx
+++ b/dali-api/app/members/routes/members.groups.tsx
@@ -3,10 +3,12 @@ import { Link, redirect, useLoaderData, useFetcher } from "react-router";
 import type { Route } from "./+types/members.groups";
 import { prisma } from "~/lib/db";
 import { listAllGroups } from "~/lib/groups";
-import { requireAuth } from "~/lib/auth";
+import { requireAuth, forbidden } from "~/lib/auth";
 import { canViewForms, currentTermMemberWhere } from "~/lib/roles";
+import { MEMBER_LIST_ORDER_BY } from "~/lib/prisma-shapes";
 import { resolvePhotoUrl } from "~/lib/photo";
 import { initialsFromName } from "~/lib/display";
+import { deriveCoreTitles } from "~/lib/core-titles";
 import { Modal } from "~/components/Modal";
 import {
   Users,
@@ -86,7 +88,7 @@ export async function loader({ request }: Route.LoaderArgs) {
         select: { level: true, domain: { select: { displayName: true } } },
       },
     },
-    orderBy: [{ lastName: "asc" }, { firstName: "asc" }],
+    orderBy: MEMBER_LIST_ORDER_BY,
   });
 
   const termCodeById = new Map(terms.map((t) => [t.id, t.code]));
@@ -123,22 +125,11 @@ export async function loader({ request }: Route.LoaderArgs) {
   return { groups, members, terms };
 }
 
-// Distinct Core lead titles, with title-less Core assignments collapsing to a
-// single "Core" pill. Mirrors the Members directory derivation.
-function deriveCoreTitles(assignments: { leadTitle: string | null }[]): string[] {
-  if (assignments.length === 0) return [];
-  const titles = new Set(
-    assignments.map((a) => a.leadTitle).filter((t): t is string => !!t),
-  );
-  if (assignments.some((a) => !a.leadTitle)) titles.add("Core");
-  return Array.from(titles);
-}
-
 export async function action({ request }: Route.ActionArgs) {
   const auth = await requireAuth(request);
   if (!auth.ok) return auth.response;
   if (!(await canViewForms(auth.user.sub)))
-    return Response.json({ error: "Forbidden" }, { status: 403 });
+    return forbidden(request);
 
   const formData = await request.formData();
   const intent = String(formData.get("intent") ?? "");

--- a/dali-api/app/members/routes/members.groups.tsx
+++ b/dali-api/app/members/routes/members.groups.tsx
@@ -7,7 +7,8 @@ import { requireAuth, forbidden } from "~/lib/auth";
 import { canViewForms, currentTermMemberWhere } from "~/lib/roles";
 import { MEMBER_LIST_ORDER_BY } from "~/lib/prisma-shapes";
 import { resolvePhotoUrl } from "~/lib/photo";
-import { initialsFromName } from "~/lib/display";
+import { Avatar } from "~/components/ui/Avatar";
+import { RolePills } from "~/components/ui/RolePills";
 import { deriveCoreTitles } from "~/lib/core-titles";
 import { Modal } from "~/components/Modal";
 import {
@@ -806,11 +807,20 @@ function ExpandedMemberCard({
   return (
     <div className="relative border border-border rounded-md p-2 bg-background flex items-start gap-2 hover:bg-muted/10 transition-colors">
       <Link to={`/members/${member.id}`} className="flex items-start gap-2 min-w-0 flex-1">
-        <Avatar photoUrl={member.photoUrl} name={fullName} />
+        <Avatar photoUrl={member.photoUrl} name={fullName} size="sm" className="flex-shrink-0" />
         <div className="min-w-0 flex-1">
           <div className="text-sm font-medium text-foreground truncate">{fullName}</div>
           <div className="mt-1">
-            <RolePills coreTitles={member.coreTitles} domainRoles={member.domainRoles} />
+            {member.coreTitles.length === 0 && member.domainRoles.length === 0 ? (
+              <span className="text-muted-foreground text-xs">—</span>
+            ) : (
+              <RolePills
+                coreTitles={member.coreTitles}
+                domainRoles={member.domainRoles}
+                size="sm"
+                showLevel
+              />
+            )}
           </div>
         </div>
       </Link>
@@ -828,55 +838,6 @@ function ExpandedMemberCard({
           </button>
         </fetcher.Form>
       )}
-    </div>
-  );
-}
-
-function Avatar({ photoUrl, name }: { photoUrl: string | null; name: string }) {
-  if (photoUrl) {
-    return (
-      <img
-        src={photoUrl}
-        alt=""
-        className="w-8 h-8 rounded-full object-cover flex-shrink-0"
-      />
-    );
-  }
-  return (
-    <div className="w-8 h-8 rounded-full bg-accent-coral/15 text-accent-coral flex items-center justify-center font-bold text-[11px] flex-shrink-0">
-      {initialsFromName(name)}
-    </div>
-  );
-}
-
-function RolePills({
-  coreTitles,
-  domainRoles,
-}: {
-  coreTitles: string[];
-  domainRoles: { domainName: string; level: string }[];
-}) {
-  if (coreTitles.length === 0 && domainRoles.length === 0) {
-    return <span className="text-muted-foreground text-xs">—</span>;
-  }
-  return (
-    <div className="flex flex-wrap gap-1">
-      {coreTitles.map((title) => (
-        <span
-          key={title}
-          className="inline-flex items-center px-1.5 py-0.5 text-[11px] font-medium rounded bg-muted text-foreground"
-        >
-          {title}
-        </span>
-      ))}
-      {domainRoles.map((d) => (
-        <span
-          key={`${d.domainName}-${d.level}`}
-          className="inline-flex items-center px-1.5 py-0.5 text-[11px] font-medium rounded bg-blue-50 text-blue-700 border border-blue-100"
-        >
-          {d.domainName} · {d.level}
-        </span>
-      ))}
     </div>
   );
 }

--- a/dali-api/app/members/routes/members.tsx
+++ b/dali-api/app/members/routes/members.tsx
@@ -9,16 +9,18 @@ import {
   useSearchParams,
 } from "react-router";
 import type { Route } from "./+types/members";
-import { requireAuth } from "~/lib/auth";
+import { requireAuth, redirectApplicantToPortal } from "~/lib/auth";
 import { isCore } from "~/lib/roles";
 import { requestOpenTabIfEmbedded } from "~/components/workspace-link";
 import { prisma } from "~/lib/db";
 import { promoteToMember } from "~/members/lib/membership.server";
-import { initialsFromName } from "~/lib/display";
+import { initialsFromName, fullName, primaryEmail } from "~/lib/display";
+import { LAB_MEMBER_WHERE, MEMBER_LIST_ORDER_BY } from "~/lib/prisma-shapes";
 import { resolvePhotoUrl } from "~/lib/photo";
 import { ViewToggle, useViewPreference } from "~/components/ViewToggle";
 import { TermFilter } from "~/components/TermFilter";
 import { resolveTermFilter } from "~/lib/terms";
+import { deriveCoreTitles } from "~/lib/core-titles";
 
 export const meta: Route.MetaFunction = () => [{ title: "Members · DALI OS" }];
 
@@ -39,7 +41,8 @@ type MemberRow = {
 export async function loader({ request }: Route.LoaderArgs) {
   const auth = await requireAuth(request);
   if (!auth.ok) return redirect("/login");
-  if (auth.user.type === "applicant") return redirect("/portal");
+  const portalRedirect = redirectApplicantToPortal(auth);
+  if (portalRedirect) return portalRedirect;
 
   const { terms, selected, termId, isAll } = await resolveTermFilter(request);
 
@@ -76,8 +79,8 @@ export async function loader({ request }: Route.LoaderArgs) {
   // AdminMembership + CoreAssignment per the Phase 2 identity model — see
   // app/admin-console/routes/api.members.ts for the canonical shape.
   const users = await prisma.user.findMany({
-    where: { daliMember: { isNot: null }, ...activeInTerm, ...inDomain },
-    orderBy: [{ lastName: "asc" }, { firstName: "asc" }],
+    where: { ...LAB_MEMBER_WHERE, ...activeInTerm, ...inDomain },
+    orderBy: MEMBER_LIST_ORDER_BY,
     select: {
       id: true,
       firstName: true,
@@ -101,7 +104,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     id: u.id,
     firstName: u.firstName,
     lastName: u.lastName,
-    email: u.daliEmail ?? u.dartmouthEmail,
+    email: primaryEmail(u),
     pronouns: u.pronouns,
     classYear: u.classYear,
     photoUrl: await resolvePhotoUrl(u.photoUrl),
@@ -128,21 +131,6 @@ export async function loader({ request }: Route.LoaderArgs) {
   };
 }
 
-// Distinct Core lead titles for a member's Roles column. Title-less Core
-// assignments collapse to a single "Core" pill so a Core member without a
-// specific title still shows up (rather than contributing no pill at all).
-function deriveCoreTitles(
-  assignments: { leadTitle: string | null }[],
-): string[] {
-  if (assignments.length === 0) return [];
-  const titles = new Set(
-    assignments.map((a) => a.leadTitle).filter((t): t is string => !!t),
-  );
-  const hasUntitled = assignments.some((a) => !a.leadTitle);
-  if (hasUntitled) titles.add("Core");
-  return Array.from(titles);
-}
-
 // Profile fields offered on the create form. Mirrors the editable text fields
 // on members/$id so a member can be filled in fully at creation time; all are
 // optional except first/last name. classYear is handled separately (numeric).
@@ -157,7 +145,8 @@ const PROFILE_TEXT_FIELDS = [
 export async function action({ request }: Route.ActionArgs) {
   const auth = await requireAuth(request);
   if (!auth.ok) return redirect("/login");
-  if (auth.user.type === "applicant") return redirect("/portal");
+  const portalRedirect = redirectApplicantToPortal(auth);
+  if (portalRedirect) return portalRedirect;
   if (!(await isCore(auth.user.sub))) {
     return { error: "You don't have permission to add members." };
   }
@@ -449,7 +438,7 @@ function MembersTable({ rows }: { rows: MemberRow[] }) {
               key={m.id}
               onClick={() => {
                 const url = `/members/${m.id}`;
-                const label = `${m.firstName ?? ""} ${m.lastName ?? ""}`.trim() || "Member";
+                const label = fullName(m) || "Member";
                 if (!requestOpenTabIfEmbedded(url, label)) navigate(url);
               }}
               className="border-t border-border hover:bg-muted/20 cursor-pointer"

--- a/dali-api/app/members/routes/members.tsx
+++ b/dali-api/app/members/routes/members.tsx
@@ -14,7 +14,9 @@ import { isCore } from "~/lib/roles";
 import { requestOpenTabIfEmbedded } from "~/components/workspace-link";
 import { prisma } from "~/lib/db";
 import { promoteToMember } from "~/members/lib/membership.server";
-import { initialsFromName, fullName, primaryEmail } from "~/lib/display";
+import { fullName, primaryEmail } from "~/lib/display";
+import { Avatar } from "~/components/ui/Avatar";
+import { RolePills } from "~/components/ui/RolePills";
 import { LAB_MEMBER_WHERE, MEMBER_LIST_ORDER_BY } from "~/lib/prisma-shapes";
 import { resolvePhotoUrl } from "~/lib/photo";
 import { ViewToggle, useViewPreference } from "~/components/ViewToggle";
@@ -448,10 +450,15 @@ function MembersTable({ rows }: { rows: MemberRow[] }) {
               </td>
               <td className="px-4 py-2 text-muted-foreground">{m.email ?? "—"}</td>
               <td className="px-4 py-2">
-                <RolePills
-                  coreTitles={m.coreTitles}
-                  domainRoles={m.domainRoles}
-                />
+                {m.coreTitles.length === 0 && m.domainRoles.length === 0 ? (
+                  <span className="text-muted-foreground text-xs">—</span>
+                ) : (
+                  <RolePills
+                    coreTitles={m.coreTitles}
+                    domainRoles={m.domainRoles}
+                    size="md"
+                  />
+                )}
               </td>
             </tr>
           ))}
@@ -478,7 +485,7 @@ function MemberCard({ member }: { member: MemberRow }) {
       to={`/members/${member.id}`}
       className="border border-border rounded-md p-3 bg-background flex items-start gap-3 hover:bg-muted/10 transition-colors"
     >
-      <Avatar photoUrl={member.photoUrl} name={fullName} />
+      <Avatar photoUrl={member.photoUrl} name={fullName} size="md" className="flex-shrink-0" />
       <div className="min-w-0 flex-1">
         <div className="flex items-baseline gap-2 flex-wrap">
           <span className="font-semibold text-foreground truncate">{fullName}</span>
@@ -493,61 +500,18 @@ function MemberCard({ member }: { member: MemberRow }) {
           <div className="text-xs text-muted-foreground truncate mt-0.5">{member.email}</div>
         )}
         <div className="mt-2">
-          <RolePills
-            coreTitles={member.coreTitles}
-            domainRoles={member.domainRoles}
-          />
+          {member.coreTitles.length === 0 && member.domainRoles.length === 0 ? (
+            <span className="text-muted-foreground text-xs">—</span>
+          ) : (
+            <RolePills
+              coreTitles={member.coreTitles}
+              domainRoles={member.domainRoles}
+              size="md"
+            />
+          )}
         </div>
       </div>
     </Link>
   );
 }
 
-function Avatar({ photoUrl, name }: { photoUrl: string | null; name: string }) {
-  if (photoUrl) {
-    return (
-      <img
-        src={photoUrl}
-        alt=""
-        className="w-10 h-10 rounded-full object-cover flex-shrink-0"
-      />
-    );
-  }
-  return (
-    <div className="w-10 h-10 rounded-full bg-accent-coral/15 text-accent-coral flex items-center justify-center font-bold text-sm flex-shrink-0">
-      {initialsFromName(name)}
-    </div>
-  );
-}
-
-function RolePills({
-  coreTitles,
-  domainRoles,
-}: {
-  coreTitles: string[];
-  domainRoles: { domainName: string; level: string }[];
-}) {
-  if (coreTitles.length === 0 && domainRoles.length === 0) {
-    return <span className="text-muted-foreground text-xs">—</span>;
-  }
-  return (
-    <div className="flex flex-wrap gap-1.5">
-      {coreTitles.map((title) => (
-        <span
-          key={title}
-          className="inline-flex items-center px-2 py-0.5 text-xs font-medium rounded bg-muted text-foreground"
-        >
-          {title}
-        </span>
-      ))}
-      {domainRoles.map((d) => (
-        <span
-          key={d.domainName}
-          className="inline-flex items-center px-2 py-0.5 text-xs font-medium rounded bg-blue-50 text-blue-700 border border-blue-100"
-        >
-          {d.domainName}
-        </span>
-      ))}
-    </div>
-  );
-}

--- a/dali-api/app/members/routes/users.$id.ts
+++ b/dali-api/app/members/routes/users.$id.ts
@@ -1,6 +1,6 @@
 import type { Route } from "./+types/users.$id";
 import { prisma } from "~/lib/db";
-import { requireAuth } from "~/lib/auth";
+import { requireAuth, forbidden } from "~/lib/auth";
 import { withCors, handlePreflight } from "~/lib/cors";
 
 
@@ -13,7 +13,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 
   // users can only access their own data
   if (auth.user.sub !== params.id) {
-    return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
+    return forbidden(request);
   }
 
   const user = await prisma.user.findUnique({

--- a/dali-api/app/partners/routes/api.partner-application-domains.$id.ts
+++ b/dali-api/app/partners/routes/api.partner-application-domains.$id.ts
@@ -1,7 +1,7 @@
 import type { Route } from "./+types/api.partner-application-domains.$id";
 import { Prisma } from "~/generated/prisma/client";
 import { prisma } from "~/lib/db";
-import { requireAuth } from "~/lib/auth";
+import { requireAuth, forbidden } from "~/lib/auth";
 import { isCore } from "~/lib/roles";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { isEmptyDoc } from "~/components/RichTextViewer";
@@ -48,10 +48,7 @@ export async function action({ request, params }: Route.ActionArgs) {
     );
   }
   if (!(await isCore(auth.user.sub))) {
-    return withCors(
-      request,
-      Response.json({ error: "Forbidden" }, { status: 403 }),
-    );
+    return forbidden(request);
   }
 
   const id = params.id!;

--- a/dali-api/app/partners/routes/api.partner-applications.$id.domains.ts
+++ b/dali-api/app/partners/routes/api.partner-applications.$id.domains.ts
@@ -1,6 +1,6 @@
 import type { Route } from "./+types/api.partner-applications.$id.domains";
 import { prisma } from "~/lib/db";
-import { requireAuth } from "~/lib/auth";
+import { requireAuth, forbidden } from "~/lib/auth";
 import { isCore } from "~/lib/roles";
 import { withCors, handlePreflight } from "~/lib/cors";
 
@@ -37,10 +37,7 @@ export async function action({ request, params }: Route.ActionArgs) {
     );
   }
   if (!(await isCore(auth.user.sub))) {
-    return withCors(
-      request,
-      Response.json({ error: "Forbidden" }, { status: 403 }),
-    );
+    return forbidden(request);
   }
 
   let body: unknown;

--- a/dali-api/app/partners/routes/api.partner-applications.$id.status.ts
+++ b/dali-api/app/partners/routes/api.partner-applications.$id.status.ts
@@ -1,6 +1,6 @@
 import type { Route } from "./+types/api.partner-applications.$id.status";
 import { prisma } from "~/lib/db";
-import { requireAuth } from "~/lib/auth";
+import { requireAuth, forbidden } from "~/lib/auth";
 import { isCore } from "~/lib/roles";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { isPartnerApplicationStatus } from "../lib/partner-application";
@@ -25,10 +25,7 @@ export async function action({ request, params }: Route.ActionArgs) {
     );
   }
   if (!(await isCore(auth.user.sub))) {
-    return withCors(
-      request,
-      Response.json({ error: "Forbidden" }, { status: 403 }),
-    );
+    return forbidden(request);
   }
 
   let body: unknown;

--- a/dali-api/app/projects/components/EpicSprintManager.tsx
+++ b/dali-api/app/projects/components/EpicSprintManager.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useRevalidator } from "react-router";
 import { Modal } from "~/components/Modal";
+import { Button } from "~/components/ui/Button";
 import { CollaborativeEditor } from "~/components/CollaborativeEditor";
 import { PresenceProvider } from "~/components/collab/PresenceProvider";
 import { EpicsTimeline, type TimelineEpic } from "./EpicsTimeline";
@@ -842,13 +843,14 @@ function EpicForm({
       </div>
 
       <div className="flex gap-1.5">
-        <button
+        <Button
           type="submit"
+          variant="primary"
+          size="sm"
           disabled={busy}
-          className="px-3 py-1.5 text-xs font-medium rounded-md bg-accent-coral text-white hover:bg-accent-coral/90 disabled:opacity-60 transition-colors"
         >
           Save
-        </button>
+        </Button>
         <button
           type="button"
           onClick={onCancel}
@@ -945,13 +947,14 @@ function SprintForm({
         </select>
       </label>
       <div className="flex gap-1.5">
-        <button
+        <Button
           type="submit"
+          variant="primary"
+          size="sm"
           disabled={busy}
-          className="px-3 py-1.5 text-xs font-medium rounded-md bg-accent-coral text-white hover:bg-accent-coral/90 disabled:opacity-60 transition-colors"
         >
           Save
-        </button>
+        </Button>
         <button
           type="button"
           onClick={onCancel}
@@ -1035,13 +1038,14 @@ function StoryForm({
         />
       </label>
       <div className="flex gap-1.5">
-        <button
+        <Button
           type="submit"
+          variant="primary"
+          size="sm"
           disabled={busy}
-          className="px-3 py-1.5 text-xs font-medium rounded-md bg-accent-coral text-white hover:bg-accent-coral/90 disabled:opacity-60 transition-colors"
         >
           Save
-        </button>
+        </Button>
         <button
           type="button"
           onClick={onCancel}

--- a/dali-api/app/projects/components/FinalizeModal.tsx
+++ b/dali-api/app/projects/components/FinalizeModal.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useRevalidator } from "react-router";
 import { Modal } from "~/components/Modal";
+import { Button } from "~/components/ui/Button";
 
 type Automation = "assignments" | "slack" | "gmail" | "github";
 
@@ -333,14 +334,14 @@ export function FinalizeModal({
           >
             {running ? "Running…" : "Run selected"}
           </button>
-          <button
-            type="button"
+          <Button
+            variant="primary"
+            size="sm"
             disabled={running || savingFields}
             onClick={() => run(AUTOMATIONS.filter((a) => a.configured).map((a) => a.id))}
-            className="px-3 py-1.5 text-sm font-medium rounded-md bg-accent-coral text-white hover:bg-accent-coral/90 disabled:opacity-60 transition-colors"
           >
             {running ? "Running…" : "Run all"}
-          </button>
+          </Button>
         </div>
       </div>
     </Modal>

--- a/dali-api/app/projects/components/MemberCard.tsx
+++ b/dali-api/app/projects/components/MemberCard.tsx
@@ -1,6 +1,8 @@
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { initialsFromName, fullName as buildFullName } from "~/lib/display";
+import { fullName as buildFullName } from "~/lib/display";
+import { Avatar } from "~/components/ui/Avatar";
+import { RolePills } from "~/components/ui/RolePills";
 import type { MemberCardModel, Level } from "../lib/staffing-board";
 
 const LEVEL_BADGE: Record<Level, { label: string; cls: string }> = {
@@ -98,7 +100,7 @@ function MemberCardBody({
   return (
     <>
       <div className="flex items-start gap-2">
-        <Avatar photoUrl={card.photoUrl} name={fullName} />
+        <Avatar photoUrl={card.photoUrl} name={fullName} size="sm" />
         <div className="min-w-0 flex-1">
           <div className="flex items-baseline gap-1.5 flex-wrap">
             <span className="text-sm font-semibold text-foreground truncate text-left">
@@ -121,7 +123,12 @@ function MemberCardBody({
               </span>
             )}
           </div>
-          <RoleStrip card={card} />
+          <RolePills
+            isAdmin={card.isAdmin}
+            coreTitles={card.coreTitles}
+            size="sm"
+            className="mt-0.5"
+          />
         </div>
         {onRemove && card.manuallyAdded && (
           <button
@@ -187,38 +194,6 @@ function DomainLevelStrip({ card }: { card: MemberCardModel }) {
           <span className={`px-1 rounded font-bold ${LEVEL_BADGE[d.level].cls}`}>
             {LEVEL_BADGE[d.level].label}
           </span>
-        </span>
-      ))}
-    </div>
-  );
-}
-
-function Avatar({ photoUrl, name }: { photoUrl: string | null; name: string }) {
-  if (photoUrl) {
-    return <img src={photoUrl} alt="" className="w-8 h-8 rounded-full object-cover flex-shrink-0" />;
-  }
-  return (
-    <div className="w-8 h-8 rounded-full bg-accent-coral/15 text-accent-coral flex items-center justify-center font-bold text-[11px] flex-shrink-0">
-      {initialsFromName(name)}
-    </div>
-  );
-}
-
-function RoleStrip({ card }: { card: MemberCardModel }) {
-  if (!card.isAdmin && card.coreTitles.length === 0) return null;
-  return (
-    <div className="flex flex-wrap gap-1 mt-0.5">
-      {card.isAdmin && (
-        <span className="inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium rounded bg-accent-coral/15 text-accent-coral">
-          Admin
-        </span>
-      )}
-      {card.coreTitles.map((t) => (
-        <span
-          key={t}
-          className="inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium rounded bg-muted text-foreground"
-        >
-          {t}
         </span>
       ))}
     </div>

--- a/dali-api/app/projects/components/MemberCard.tsx
+++ b/dali-api/app/projects/components/MemberCard.tsx
@@ -1,6 +1,6 @@
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { initialsFromName } from "~/lib/display";
+import { initialsFromName, fullName as buildFullName } from "~/lib/display";
 import type { MemberCardModel, Level } from "../lib/staffing-board";
 
 const LEVEL_BADGE: Record<Level, { label: string; cls: string }> = {
@@ -31,7 +31,7 @@ export function MemberCard({ card, columnId, projectNames, domainNames, onOpenBi
       disabled: !draggable,
     });
 
-  const fullName = `${card.firstName} ${card.lastName}`.trim();
+  const fullName = buildFullName(card);
 
   // Only wire dnd listeners + grab cursor when draggable. Read-only viewers
   // still see the card and can click it to open the bid modal.
@@ -158,7 +158,7 @@ export function MemberCardPreview({
   projectNames: Record<string, string>;
   domainNames: Record<string, string>;
 }) {
-  const fullName = `${card.firstName} ${card.lastName}`.trim();
+  const fullName = buildFullName(card);
   return (
     <div className="bg-card border border-border rounded-md p-2.5 flex flex-col gap-1.5 select-none shadow-lg cursor-grabbing">
       <MemberCardBody

--- a/dali-api/app/projects/components/SlotColumnMapper.tsx
+++ b/dali-api/app/projects/components/SlotColumnMapper.tsx
@@ -15,6 +15,7 @@
 // not a component change.
 import { useMemo, useRef, useState } from "react";
 import { useFetcher } from "react-router";
+import { Button } from "~/components/ui/Button";
 import {
   SLOT_ROLES,
   BUILTIN_SOURCES,
@@ -591,14 +592,15 @@ export function SlotColumnMapper({
           >
             + Extra column
           </button>
-          <button
-            type="button"
+          <Button
+            variant="primary"
+            size="sm"
             onClick={save}
             disabled={saving || !dirty || missing.length > 0}
-            className="ml-auto px-3 py-1.5 text-sm font-medium rounded-md bg-accent-coral text-white hover:bg-accent-coral/90 transition-colors disabled:opacity-60"
+            className="ml-auto"
           >
             {saving ? "Saving…" : "Save columns"}
-          </button>
+          </Button>
         </div>
       )}
     </div>

--- a/dali-api/app/projects/components/SlotFormPicker.tsx
+++ b/dali-api/app/projects/components/SlotFormPicker.tsx
@@ -5,6 +5,7 @@
 // — this only controls which form is surfaced to members.
 import { useState } from "react";
 import { useFetcher } from "react-router";
+import { Button } from "~/components/ui/Button";
 
 type SelectableForm = { id: string; name: string; published: boolean };
 
@@ -73,13 +74,14 @@ export function SlotFormPicker({
                 </option>
               ))}
             </select>
-            <button
+            <Button
               type="submit"
+              variant="primary"
+              size="sm"
               disabled={saving || !dirty}
-              className="px-3 py-1.5 text-sm font-medium rounded-md bg-accent-coral text-white hover:bg-accent-coral/90 transition-colors disabled:opacity-60"
             >
               {saving ? "Saving…" : "Save"}
-            </button>
+            </Button>
           </fetcher.Form>
         ) : (
           <div className="flex-1 text-sm text-foreground">

--- a/dali-api/app/projects/components/StaffingBoard.tsx
+++ b/dali-api/app/projects/components/StaffingBoard.tsx
@@ -22,6 +22,7 @@ import {
   type Preference,
 } from "../lib/staffing-board";
 import { CheckCircle2 } from "lucide-react";
+import { Button } from "~/components/ui/Button";
 import { MemberCard, MemberCardPreview } from "./MemberCard";
 import { BidModal } from "./BidModal";
 import { FinalizeModal } from "./FinalizeModal";
@@ -509,14 +510,15 @@ function TermChannelBanner({ termId, termCode }: { termId: string; termCode: str
           aria-label="Term channel name"
           className="w-32 px-2 py-1 text-sm border border-border rounded-md bg-background text-foreground disabled:opacity-60 focus:outline-none focus:ring-2 focus:ring-accent-coral/30"
         />
-        <button
-          type="button"
+        <Button
+          variant="primary"
+          size="sm"
           disabled={running || !channel.trim()}
           onClick={run}
-          className="px-3 py-1.5 text-sm font-medium rounded-md bg-accent-coral text-white hover:bg-accent-coral/90 disabled:opacity-60 transition-colors whitespace-nowrap"
+          className="whitespace-nowrap"
         >
           {running ? "Creating…" : "Create + invite"}
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/dali-api/app/projects/components/StaffingBoard.tsx
+++ b/dali-api/app/projects/components/StaffingBoard.tsx
@@ -27,6 +27,7 @@ import { BidModal } from "./BidModal";
 import { FinalizeModal } from "./FinalizeModal";
 import { AddMemberControl } from "./AddMemberControl";
 import { DomainFilter } from "./DomainFilter";
+import { sanitizeChannelName } from "~/slack/lib/channel-name";
 
 type ProjectMeta = {
   id: string;
@@ -36,18 +37,6 @@ type ProjectMeta = {
   githubTeamSlug?: string | null;
   slackChannelName?: string | null;
 };
-
-// Slack channel names: lowercase, hyphens for spaces, no other punctuation, ≤80.
-// Mirrors the server's sanitizeChannelName so the modal's default matches what
-// ensureChannel would derive from the project name.
-function deriveChannelName(name: string): string {
-  return name
-    .toLowerCase()
-    .replace(/[^a-z0-9-_\s]/g, "")
-    .trim()
-    .replace(/\s+/g, "-")
-    .slice(0, 80);
-}
 
 // Expected headcount per (project, domain) for this term — already summed
 // across levels and sorted by domain name in the loader. Keyed by projectId.
@@ -443,7 +432,7 @@ export function StaffingBoard({
           projectName={projectNames[finalizeProjectId] ?? "project"}
           defaultSlackChannel={
             projects.find((p) => p.id === finalizeProjectId)?.slackChannelName ??
-            deriveChannelName(projectNames[finalizeProjectId] ?? "")
+            sanitizeChannelName(projectNames[finalizeProjectId] ?? "")
           }
           defaultGithubSlug={
             projects.find((p) => p.id === finalizeProjectId)?.githubTeamSlug ?? ""
@@ -458,21 +447,13 @@ export function StaffingBoard({
 // invite all current-term Core + Admin/staff + everyone assigned to a project
 // this term. The channel name is editable, defaulting to the term code.
 function TermChannelBanner({ termId, termCode }: { termId: string; termCode: string }) {
-  const deriveTermChannel = (code: string) =>
-    code
-      .toLowerCase()
-      .replace(/[^a-z0-9-_\s]/g, "")
-      .trim()
-      .replace(/\s+/g, "-")
-      .slice(0, 80);
-
-  const [channel, setChannel] = useState(deriveTermChannel(termCode));
+  const [channel, setChannel] = useState(sanitizeChannelName(termCode));
   const [running, setRunning] = useState(false);
   const [result, setResult] = useState<{ ok: boolean; message: string } | null>(null);
 
   // Keep the field in sync when the selected term changes.
   useEffect(() => {
-    setChannel(deriveTermChannel(termCode));
+    setChannel(sanitizeChannelName(termCode));
     setResult(null);
   }, [termCode]);
 

--- a/dali-api/app/projects/components/TaskBoard.tsx
+++ b/dali-api/app/projects/components/TaskBoard.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo, useState } from "react";
 import { useSearchParams } from "react-router";
+import { Button } from "~/components/ui/Button";
 import { DndContext, useDraggable, useDroppable, type DragEndEvent } from "@dnd-kit/core";
 import { GripVertical } from "lucide-react";
 import {
@@ -189,13 +190,13 @@ export function TaskBoard({ projectId, initialTasks, options, canManage }: Props
 
       {canManage && (
         <div>
-          <button
-            type="button"
+          <Button
+            variant="primary"
+            size="sm"
             onClick={() => setIsCreating(true)}
-            className="px-3 py-1.5 text-xs font-medium rounded-md bg-accent-coral text-white hover:bg-accent-coral/90 transition-colors"
           >
             + Add task
-          </button>
+          </Button>
         </div>
       )}
 

--- a/dali-api/app/projects/components/TaskModal.tsx
+++ b/dali-api/app/projects/components/TaskModal.tsx
@@ -6,6 +6,7 @@
 
 import { useEffect, useState } from "react";
 import { Modal } from "~/components/Modal";
+import { Button } from "~/components/ui/Button";
 import type { TaskBoardOptions, TaskCardModel, Priority } from "../lib/task-board";
 
 const PRIORITIES: Priority[] = ["Low", "Normal", "High", "Urgent"];
@@ -256,22 +257,22 @@ export function TaskModal({
           </button>
           {canManage &&
             (isCreate ? (
-              <button
-                type="button"
+              <Button
+                variant="primary"
+                size="sm"
                 onClick={() => void handleCreate()}
                 disabled={!title.trim() || saving}
-                className="px-3 py-1.5 text-sm font-medium rounded-md bg-accent-coral text-white hover:bg-accent-coral/90 disabled:opacity-50 transition-colors"
               >
                 {saving ? "Creating…" : "Create task"}
-              </button>
+              </Button>
             ) : (
-              <button
-                type="button"
+              <Button
+                variant="primary"
+                size="sm"
                 onClick={() => void handleSave()}
-                className="px-3 py-1.5 text-sm font-medium rounded-md bg-accent-coral text-white hover:bg-accent-coral/90 transition-colors"
               >
                 Save
-              </button>
+              </Button>
             ))}
         </div>
       </div>

--- a/dali-api/app/projects/components/UserSubmissionShell.tsx
+++ b/dali-api/app/projects/components/UserSubmissionShell.tsx
@@ -1,0 +1,73 @@
+import type { ReactNode } from "react";
+import { cn } from "~/lib/cn";
+
+interface UserSubmissionRow {
+  key: string;
+  label: string;
+  value: ReactNode;
+  // When false, label is annotated "(not in table)" — matches the staffing
+  // submission detail pages where managers need to see which form fields
+  // aren't surfaced in the board table.
+  mapped?: boolean;
+}
+
+interface UserSubmissionShellProps {
+  title?: string;
+  subtitle?: string;
+  rows: UserSubmissionRow[];
+  emptyMessage?: string;
+  className?: string;
+}
+
+export function UserSubmissionShell({
+  title,
+  subtitle,
+  rows,
+  emptyMessage = "This submission is empty.",
+  className,
+}: UserSubmissionShellProps) {
+  return (
+    <div className={cn("flex flex-col gap-6", className)}>
+      {(title || subtitle) && (
+        <div>
+          {title && (
+            <h1 className="font-heading text-2xl font-bold text-foreground">
+              {title}
+            </h1>
+          )}
+          {subtitle && (
+            <p className="text-sm text-muted-foreground">{subtitle}</p>
+          )}
+        </div>
+      )}
+      {rows.length === 0 ? (
+        <p className="text-sm text-muted-foreground">{emptyMessage}</p>
+      ) : (
+        <dl className="bg-card border border-border rounded-lg divide-y divide-border">
+          {rows.map((row) => (
+            <div
+              key={row.key}
+              className="px-4 py-3 flex flex-col sm:flex-row sm:gap-4"
+            >
+              <dt className="sm:w-56 shrink-0 text-sm font-medium text-foreground">
+                {row.label}
+                {row.mapped === false && (
+                  <span className="ml-2 text-[11px] text-muted-foreground">
+                    (not in table)
+                  </span>
+                )}
+              </dt>
+              <dd className="text-sm text-foreground mt-1 sm:mt-0 whitespace-pre-wrap break-words">
+                {row.value === "" || row.value == null ? (
+                  <span className="text-muted-foreground">—</span>
+                ) : (
+                  row.value
+                )}
+              </dd>
+            </div>
+          ))}
+        </dl>
+      )}
+    </div>
+  );
+}

--- a/dali-api/app/projects/lib/bid-validation.ts
+++ b/dali-api/app/projects/lib/bid-validation.ts
@@ -12,10 +12,10 @@
 // (ProjectRoleRequest is headcount display only; it never gates bids.)
 
 import { prisma } from "~/lib/db";
+import type { Level } from "~/lib/level";
 
-// Level is the Prisma enum; kept as a string union to avoid importing the
-// generated enum into pure call sites.
-export type BidLevel = "P1" | "P2" | "P3";
+// Re-export under the legacy name for callers that still import `BidLevel`.
+export type BidLevel = Level;
 
 export type RawBid = {
   projectId: string;

--- a/dali-api/app/projects/lib/staffing-board.ts
+++ b/dali-api/app/projects/lib/staffing-board.ts
@@ -2,7 +2,8 @@
 // means the route loader/action stay thin and we can iterate on board shape
 // without dragging Prisma + React in.
 
-export type Level = "P1" | "P2" | "P3";
+import type { Level } from "~/lib/level";
+export type { Level };
 
 export type Preference = {
   projectId: string;

--- a/dali-api/app/projects/routes/api.documents.$id.ts
+++ b/dali-api/app/projects/routes/api.documents.$id.ts
@@ -1,6 +1,6 @@
 import type { Route } from "./+types/api.documents.$id";
 import { prisma } from "~/lib/db";
-import { requireCore } from "~/lib/auth";
+import { requireProjectEditAccess } from "~/lib/auth";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { logAuditEvent } from "~/lib/audit";
 
@@ -25,18 +25,17 @@ export async function action({ request, params }: Route.ActionArgs) {
   if (request.method !== "POST" && request.method !== "DELETE") {
     return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));
   }
-  const gate = await requireCore(request);
-  if (!gate.ok) return gate.response;
-  const auth = gate.auth;
-
   const pageId = params.id!;
   const page = await prisma.page.findUnique({
     where: { id: pageId },
-    select: { id: true, workspaceType: true },
+    select: { id: true, workspaceType: true, workspaceId: true },
   });
-  if (!page || page.workspaceType !== "Project") {
+  if (!page || page.workspaceType !== "Project" || !page.workspaceId) {
     return withCors(request, Response.json({ error: "Document not found" }, { status: 404 }));
   }
+  const gate = await requireProjectEditAccess(request, page.workspaceId);
+  if (!gate.ok) return gate.response;
+  const auth = gate.auth;
 
   if (request.method === "DELETE") {
     await prisma.page.update({

--- a/dali-api/app/projects/routes/api.documents.$id.ts
+++ b/dali-api/app/projects/routes/api.documents.$id.ts
@@ -1,7 +1,6 @@
 import type { Route } from "./+types/api.documents.$id";
 import { prisma } from "~/lib/db";
-import { requireAuth } from "~/lib/auth";
-import { isCore } from "~/lib/roles";
+import { requireCore } from "~/lib/auth";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { logAuditEvent } from "~/lib/audit";
 
@@ -23,15 +22,12 @@ export async function action({ request, params }: Route.ActionArgs) {
   const preflight = handlePreflight(request);
   if (preflight) return preflight;
 
-  const auth = await requireAuth(request);
-  if (!auth.ok) return withCors(request, auth.response);
-
   if (request.method !== "POST" && request.method !== "DELETE") {
     return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));
   }
-  if (!(await isCore(auth.user.sub))) {
-    return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
-  }
+  const gate = await requireCore(request);
+  if (!gate.ok) return gate.response;
+  const auth = gate.auth;
 
   const pageId = params.id!;
   const page = await prisma.page.findUnique({

--- a/dali-api/app/projects/routes/api.epics.$id.description-doc.ts
+++ b/dali-api/app/projects/routes/api.epics.$id.description-doc.ts
@@ -1,7 +1,7 @@
 import type { Route } from "./+types/api.epics.$id.description-doc";
 import { randomUUID } from "node:crypto";
 import { prisma } from "~/lib/db";
-import { requireCore } from "~/lib/auth";
+import { requireProjectEditAccess } from "~/lib/auth";
 import { withCors, handlePreflight } from "~/lib/cors";
 
 // POST /api/epics/:id/description-doc
@@ -28,17 +28,16 @@ export async function action({ request, params }: Route.ActionArgs) {
       Response.json({ error: "Method not allowed" }, { status: 405 }),
     );
   }
-  const gate = await requireCore(request);
-  if (!gate.ok) return gate.response;
-
   const epicId = params.id!;
   const epic = await prisma.epic.findUnique({
     where: { id: epicId },
-    select: { descriptionDocId: true },
+    select: { descriptionDocId: true, projectId: true },
   });
   if (!epic) {
     return withCors(request, Response.json({ error: "Epic not found" }, { status: 404 }));
   }
+  const gate = await requireProjectEditAccess(request, epic.projectId);
+  if (!gate.ok) return gate.response;
 
   if (epic.descriptionDocId) {
     return withCors(

--- a/dali-api/app/projects/routes/api.epics.$id.description-doc.ts
+++ b/dali-api/app/projects/routes/api.epics.$id.description-doc.ts
@@ -1,8 +1,7 @@
 import type { Route } from "./+types/api.epics.$id.description-doc";
 import { randomUUID } from "node:crypto";
 import { prisma } from "~/lib/db";
-import { requireAuth } from "~/lib/auth";
-import { isCore } from "~/lib/roles";
+import { requireCore } from "~/lib/auth";
 import { withCors, handlePreflight } from "~/lib/cors";
 
 // POST /api/epics/:id/description-doc
@@ -23,17 +22,14 @@ export async function action({ request, params }: Route.ActionArgs) {
   const preflight = handlePreflight(request);
   if (preflight) return preflight;
 
-  const auth = await requireAuth(request);
-  if (!auth.ok) return withCors(request, auth.response);
   if (request.method !== "POST") {
     return withCors(
       request,
       Response.json({ error: "Method not allowed" }, { status: 405 }),
     );
   }
-  if (!(await isCore(auth.user.sub))) {
-    return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
-  }
+  const gate = await requireCore(request);
+  if (!gate.ok) return gate.response;
 
   const epicId = params.id!;
   const epic = await prisma.epic.findUnique({

--- a/dali-api/app/projects/routes/api.epics.$id.stories.ts
+++ b/dali-api/app/projects/routes/api.epics.$id.stories.ts
@@ -1,7 +1,6 @@
 import type { Route } from "./+types/api.epics.$id.stories";
 import { prisma } from "~/lib/db";
-import { requireAuth } from "~/lib/auth";
-import { isCore } from "~/lib/roles";
+import { requireCore } from "~/lib/auth";
 import { withCors, handlePreflight } from "~/lib/cors";
 
 // POST /api/epics/:id/stories
@@ -35,15 +34,11 @@ export async function action({ request, params }: Route.ActionArgs) {
   const preflight = handlePreflight(request);
   if (preflight) return preflight;
 
-  const auth = await requireAuth(request);
-  if (!auth.ok) return withCors(request, auth.response);
-
   if (request.method !== "POST") {
     return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));
   }
-  if (!(await isCore(auth.user.sub))) {
-    return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
-  }
+  const gate = await requireCore(request);
+  if (!gate.ok) return gate.response;
 
   let body: unknown;
   try {

--- a/dali-api/app/projects/routes/api.epics.$id.stories.ts
+++ b/dali-api/app/projects/routes/api.epics.$id.stories.ts
@@ -1,6 +1,6 @@
 import type { Route } from "./+types/api.epics.$id.stories";
 import { prisma } from "~/lib/db";
-import { requireCore } from "~/lib/auth";
+import { requireProjectEditAccess } from "~/lib/auth";
 import { withCors, handlePreflight } from "~/lib/cors";
 
 // POST /api/epics/:id/stories
@@ -37,7 +37,15 @@ export async function action({ request, params }: Route.ActionArgs) {
   if (request.method !== "POST") {
     return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));
   }
-  const gate = await requireCore(request);
+  const epicId = params.id!;
+  const epic = await prisma.epic.findUnique({
+    where: { id: epicId },
+    select: { id: true, projectId: true },
+  });
+  if (!epic) {
+    return withCors(request, Response.json({ error: "Epic not found" }, { status: 404 }));
+  }
+  const gate = await requireProjectEditAccess(request, epic.projectId);
   if (!gate.ok) return gate.response;
 
   let body: unknown;
@@ -58,15 +66,6 @@ export async function action({ request, params }: Route.ActionArgs) {
   const status = body.status ?? "Todo";
   if (!isStoryStatus(status)) {
     return withCors(request, Response.json({ error: "Invalid status" }, { status: 400 }));
-  }
-
-  const epicId = params.id!;
-  const epic = await prisma.epic.findUnique({
-    where: { id: epicId },
-    select: { id: true },
-  });
-  if (!epic) {
-    return withCors(request, Response.json({ error: "Epic not found" }, { status: 404 }));
   }
 
   const last = await prisma.userStory.findFirst({

--- a/dali-api/app/projects/routes/api.epics.$id.ts
+++ b/dali-api/app/projects/routes/api.epics.$id.ts
@@ -1,7 +1,6 @@
 import type { Route } from "./+types/api.epics.$id";
 import { prisma } from "~/lib/db";
-import { requireAuth } from "~/lib/auth";
-import { isCore } from "~/lib/roles";
+import { requireCore } from "~/lib/auth";
 import { withCors, handlePreflight } from "~/lib/cors";
 
 // POST   /api/epics/:id  — edit. Body: { title?, status?, targetTermId? }
@@ -46,15 +45,11 @@ export async function action({ request, params }: Route.ActionArgs) {
   const preflight = handlePreflight(request);
   if (preflight) return preflight;
 
-  const auth = await requireAuth(request);
-  if (!auth.ok) return withCors(request, auth.response);
-
   if (request.method !== "POST" && request.method !== "DELETE") {
     return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));
   }
-  if (!(await isCore(auth.user.sub))) {
-    return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
-  }
+  const gate = await requireCore(request);
+  if (!gate.ok) return gate.response;
 
   const epicId = params.id!;
   const epic = await prisma.epic.findUnique({

--- a/dali-api/app/projects/routes/api.epics.$id.ts
+++ b/dali-api/app/projects/routes/api.epics.$id.ts
@@ -1,6 +1,6 @@
 import type { Route } from "./+types/api.epics.$id";
 import { prisma } from "~/lib/db";
-import { requireCore } from "~/lib/auth";
+import { requireProjectEditAccess } from "~/lib/auth";
 import { withCors, handlePreflight } from "~/lib/cors";
 
 // POST   /api/epics/:id  — edit. Body: { title?, status?, targetTermId? }
@@ -48,17 +48,16 @@ export async function action({ request, params }: Route.ActionArgs) {
   if (request.method !== "POST" && request.method !== "DELETE") {
     return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));
   }
-  const gate = await requireCore(request);
-  if (!gate.ok) return gate.response;
-
   const epicId = params.id!;
   const epic = await prisma.epic.findUnique({
     where: { id: epicId },
-    select: { id: true, startsAt: true, endsAt: true },
+    select: { id: true, startsAt: true, endsAt: true, projectId: true },
   });
   if (!epic) {
     return withCors(request, Response.json({ error: "Epic not found" }, { status: 404 }));
   }
+  const gate = await requireProjectEditAccess(request, epic.projectId);
+  if (!gate.ok) return gate.response;
 
   if (request.method === "DELETE") {
     await prisma.$transaction([

--- a/dali-api/app/projects/routes/api.files.$id.ts
+++ b/dali-api/app/projects/routes/api.files.$id.ts
@@ -1,8 +1,8 @@
 import type { Route } from "./+types/api.files.$id";
 import { z } from "zod";
 import { prisma } from "~/lib/db";
-import { requireAuth } from "~/lib/auth";
-import { isCore } from "~/lib/roles";
+import { requireAuth, requireCore } from "~/lib/auth";
+import { UNKNOWN_LABEL } from "~/lib/display";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { logAuditEvent } from "~/lib/audit";
 import { getDownloadUrl } from "~/lib/s3";
@@ -75,7 +75,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
       fileName: v.fileName,
       contentType: v.contentType,
       sizeBytes: v.sizeBytes,
-      uploadedBy: nameById.get(v.uploadedById) ?? "Unknown",
+      uploadedBy: nameById.get(v.uploadedById) ?? UNKNOWN_LABEL,
       createdAt: v.createdAt.toISOString(),
       isCurrent: v.id === file.currentVersionId,
       downloadUrl: await getDownloadUrl(v.s3Key),
@@ -89,14 +89,12 @@ export async function action({ request, params }: Route.ActionArgs) {
   const preflight = handlePreflight(request);
   if (preflight) return preflight;
 
-  const auth = await requireAuth(request);
-  if (!auth.ok) return withCors(request, auth.response);
   if (request.method !== "POST" && request.method !== "DELETE") {
     return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));
   }
-  if (!(await isCore(auth.user.sub))) {
-    return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
-  }
+  const gate = await requireCore(request);
+  if (!gate.ok) return gate.response;
+  const auth = gate.auth;
 
   const file = await prisma.projectFile.findUnique({
     where: { id: params.id },

--- a/dali-api/app/projects/routes/api.files.$id.ts
+++ b/dali-api/app/projects/routes/api.files.$id.ts
@@ -1,7 +1,7 @@
 import type { Route } from "./+types/api.files.$id";
 import { z } from "zod";
 import { prisma } from "~/lib/db";
-import { requireAuth, requireCore } from "~/lib/auth";
+import { requireAuth, requireProjectEditAccess } from "~/lib/auth";
 import { UNKNOWN_LABEL } from "~/lib/display";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { logAuditEvent } from "~/lib/audit";
@@ -92,17 +92,16 @@ export async function action({ request, params }: Route.ActionArgs) {
   if (request.method !== "POST" && request.method !== "DELETE") {
     return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));
   }
-  const gate = await requireCore(request);
-  if (!gate.ok) return gate.response;
-  const auth = gate.auth;
-
   const file = await prisma.projectFile.findUnique({
     where: { id: params.id },
-    select: { id: true, archivedAt: true },
+    select: { id: true, archivedAt: true, projectId: true },
   });
   if (!file || file.archivedAt !== null) {
     return withCors(request, Response.json({ error: "File not found" }, { status: 404 }));
   }
+  const gate = await requireProjectEditAccess(request, file.projectId);
+  if (!gate.ok) return gate.response;
+  const auth = gate.auth;
 
   if (request.method === "DELETE") {
     await prisma.projectFile.update({

--- a/dali-api/app/projects/routes/api.projects.$id.documents.ts
+++ b/dali-api/app/projects/routes/api.projects.$id.documents.ts
@@ -1,7 +1,6 @@
 import type { Route } from "./+types/api.projects.$id.documents";
 import { prisma } from "~/lib/db";
-import { requireAuth } from "~/lib/auth";
-import { isCore } from "~/lib/roles";
+import { requireCore } from "~/lib/auth";
 import { withCors, handlePreflight } from "~/lib/cors";
 
 // POST /api/projects/:id/documents
@@ -24,15 +23,12 @@ export async function action({ request, params }: Route.ActionArgs) {
   const preflight = handlePreflight(request);
   if (preflight) return preflight;
 
-  const auth = await requireAuth(request);
-  if (!auth.ok) return withCors(request, auth.response);
-
   if (request.method !== "POST") {
     return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));
   }
-  if (!(await isCore(auth.user.sub))) {
-    return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
-  }
+  const gate = await requireCore(request);
+  if (!gate.ok) return gate.response;
+  const auth = gate.auth;
 
   let body: unknown;
   try {

--- a/dali-api/app/projects/routes/api.projects.$id.documents.ts
+++ b/dali-api/app/projects/routes/api.projects.$id.documents.ts
@@ -1,6 +1,6 @@
 import type { Route } from "./+types/api.projects.$id.documents";
 import { prisma } from "~/lib/db";
-import { requireCore } from "~/lib/auth";
+import { requireProjectEditAccess } from "~/lib/auth";
 import { withCors, handlePreflight } from "~/lib/cors";
 
 // POST /api/projects/:id/documents
@@ -26,7 +26,7 @@ export async function action({ request, params }: Route.ActionArgs) {
   if (request.method !== "POST") {
     return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));
   }
-  const gate = await requireCore(request);
+  const gate = await requireProjectEditAccess(request, params.id!);
   if (!gate.ok) return gate.response;
   const auth = gate.auth;
 

--- a/dali-api/app/projects/routes/api.projects.$id.epics.ts
+++ b/dali-api/app/projects/routes/api.projects.$id.epics.ts
@@ -1,6 +1,6 @@
 import type { Route } from "./+types/api.projects.$id.epics";
 import { prisma } from "~/lib/db";
-import { requireCore } from "~/lib/auth";
+import { requireProjectEditAccess } from "~/lib/auth";
 import { withCors, handlePreflight } from "~/lib/cors";
 
 // POST /api/projects/:id/epics
@@ -52,7 +52,7 @@ export async function action({ request, params }: Route.ActionArgs) {
   if (request.method !== "POST") {
     return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));
   }
-  const gate = await requireCore(request);
+  const gate = await requireProjectEditAccess(request, params.id!);
   if (!gate.ok) return gate.response;
 
   let body: unknown;

--- a/dali-api/app/projects/routes/api.projects.$id.epics.ts
+++ b/dali-api/app/projects/routes/api.projects.$id.epics.ts
@@ -1,7 +1,6 @@
 import type { Route } from "./+types/api.projects.$id.epics";
 import { prisma } from "~/lib/db";
-import { requireAuth } from "~/lib/auth";
-import { isCore } from "~/lib/roles";
+import { requireCore } from "~/lib/auth";
 import { withCors, handlePreflight } from "~/lib/cors";
 
 // POST /api/projects/:id/epics
@@ -50,15 +49,11 @@ export async function action({ request, params }: Route.ActionArgs) {
   const preflight = handlePreflight(request);
   if (preflight) return preflight;
 
-  const auth = await requireAuth(request);
-  if (!auth.ok) return withCors(request, auth.response);
-
   if (request.method !== "POST") {
     return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));
   }
-  if (!(await isCore(auth.user.sub))) {
-    return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
-  }
+  const gate = await requireCore(request);
+  if (!gate.ok) return gate.response;
 
   let body: unknown;
   try {

--- a/dali-api/app/projects/routes/api.projects.$id.files.ts
+++ b/dali-api/app/projects/routes/api.projects.$id.files.ts
@@ -1,7 +1,7 @@
 import type { Route } from "./+types/api.projects.$id.files";
 import { z } from "zod";
 import { prisma } from "~/lib/db";
-import { requireCore } from "~/lib/auth";
+import { requireProjectEditAccess } from "~/lib/auth";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { parseJson } from "~/lib/validate";
 import { logAuditEvent } from "~/lib/audit";
@@ -29,7 +29,7 @@ export async function action({ request, params }: Route.ActionArgs) {
   if (request.method !== "POST") {
     return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));
   }
-  const gate = await requireCore(request);
+  const gate = await requireProjectEditAccess(request, params.id!);
   if (!gate.ok) return gate.response;
   const auth = gate.auth;
 

--- a/dali-api/app/projects/routes/api.projects.$id.files.ts
+++ b/dali-api/app/projects/routes/api.projects.$id.files.ts
@@ -1,8 +1,7 @@
 import type { Route } from "./+types/api.projects.$id.files";
 import { z } from "zod";
 import { prisma } from "~/lib/db";
-import { requireAuth } from "~/lib/auth";
-import { isCore } from "~/lib/roles";
+import { requireCore } from "~/lib/auth";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { parseJson } from "~/lib/validate";
 import { logAuditEvent } from "~/lib/audit";
@@ -27,14 +26,12 @@ export async function action({ request, params }: Route.ActionArgs) {
   const preflight = handlePreflight(request);
   if (preflight) return preflight;
 
-  const auth = await requireAuth(request);
-  if (!auth.ok) return withCors(request, auth.response);
   if (request.method !== "POST") {
     return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));
   }
-  if (!(await isCore(auth.user.sub))) {
-    return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
-  }
+  const gate = await requireCore(request);
+  if (!gate.ok) return gate.response;
+  const auth = gate.auth;
 
   const body = await parseJson(request, CreateFileSchema);
   if (body instanceof Response) return withCors(request, body);

--- a/dali-api/app/projects/routes/api.projects.$id.sprints.ts
+++ b/dali-api/app/projects/routes/api.projects.$id.sprints.ts
@@ -1,7 +1,6 @@
 import type { Route } from "./+types/api.projects.$id.sprints";
 import { prisma } from "~/lib/db";
-import { requireAuth } from "~/lib/auth";
-import { isCore } from "~/lib/roles";
+import { requireCore } from "~/lib/auth";
 import { withCors, handlePreflight } from "~/lib/cors";
 
 // POST /api/projects/:id/sprints
@@ -39,15 +38,11 @@ export async function action({ request, params }: Route.ActionArgs) {
   const preflight = handlePreflight(request);
   if (preflight) return preflight;
 
-  const auth = await requireAuth(request);
-  if (!auth.ok) return withCors(request, auth.response);
-
   if (request.method !== "POST") {
     return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));
   }
-  if (!(await isCore(auth.user.sub))) {
-    return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
-  }
+  const gate = await requireCore(request);
+  if (!gate.ok) return gate.response;
 
   let body: unknown;
   try {

--- a/dali-api/app/projects/routes/api.projects.$id.sprints.ts
+++ b/dali-api/app/projects/routes/api.projects.$id.sprints.ts
@@ -1,6 +1,6 @@
 import type { Route } from "./+types/api.projects.$id.sprints";
 import { prisma } from "~/lib/db";
-import { requireCore } from "~/lib/auth";
+import { requireProjectEditAccess } from "~/lib/auth";
 import { withCors, handlePreflight } from "~/lib/cors";
 
 // POST /api/projects/:id/sprints
@@ -41,7 +41,7 @@ export async function action({ request, params }: Route.ActionArgs) {
   if (request.method !== "POST") {
     return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));
   }
-  const gate = await requireCore(request);
+  const gate = await requireProjectEditAccess(request, params.id!);
   if (!gate.ok) return gate.response;
 
   let body: unknown;

--- a/dali-api/app/projects/routes/api.projects.$id.tasks.ts
+++ b/dali-api/app/projects/routes/api.projects.$id.tasks.ts
@@ -1,6 +1,6 @@
 import type { Route } from "./+types/api.projects.$id.tasks";
 import { prisma } from "~/lib/db";
-import { requireCore } from "~/lib/auth";
+import { requireProjectEditAccess } from "~/lib/auth";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { isTaskStatus } from "../lib/task-board";
 import { createIssueForTask, normalizeRepo } from "../lib/github-task-sync";
@@ -54,7 +54,7 @@ export async function action({ request, params }: Route.ActionArgs) {
   if (request.method !== "POST") {
     return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));
   }
-  const gate = await requireCore(request);
+  const gate = await requireProjectEditAccess(request, params.id!);
   if (!gate.ok) return gate.response;
   const auth = gate.auth;
 

--- a/dali-api/app/projects/routes/api.projects.$id.tasks.ts
+++ b/dali-api/app/projects/routes/api.projects.$id.tasks.ts
@@ -1,7 +1,6 @@
 import type { Route } from "./+types/api.projects.$id.tasks";
 import { prisma } from "~/lib/db";
-import { requireAuth } from "~/lib/auth";
-import { isCore } from "~/lib/roles";
+import { requireCore } from "~/lib/auth";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { isTaskStatus } from "../lib/task-board";
 import { createIssueForTask, normalizeRepo } from "../lib/github-task-sync";
@@ -52,15 +51,12 @@ export async function action({ request, params }: Route.ActionArgs) {
   const preflight = handlePreflight(request);
   if (preflight) return preflight;
 
-  const auth = await requireAuth(request);
-  if (!auth.ok) return withCors(request, auth.response);
-
   if (request.method !== "POST") {
     return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));
   }
-  if (!(await isCore(auth.user.sub))) {
-    return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
-  }
+  const gate = await requireCore(request);
+  if (!gate.ok) return gate.response;
+  const auth = gate.auth;
 
   let body: unknown;
   try {

--- a/dali-api/app/projects/routes/api.sprints.$id.ts
+++ b/dali-api/app/projects/routes/api.sprints.$id.ts
@@ -1,7 +1,6 @@
 import type { Route } from "./+types/api.sprints.$id";
 import { prisma } from "~/lib/db";
-import { requireAuth } from "~/lib/auth";
-import { isCore } from "~/lib/roles";
+import { requireCore } from "~/lib/auth";
 import { withCors, handlePreflight } from "~/lib/cors";
 
 // POST   /api/sprints/:id — edit. Body: { name?, startsAt?, endsAt?, status?, epicId? }
@@ -40,15 +39,11 @@ export async function action({ request, params }: Route.ActionArgs) {
   const preflight = handlePreflight(request);
   if (preflight) return preflight;
 
-  const auth = await requireAuth(request);
-  if (!auth.ok) return withCors(request, auth.response);
-
   if (request.method !== "POST" && request.method !== "DELETE") {
     return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));
   }
-  if (!(await isCore(auth.user.sub))) {
-    return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
-  }
+  const gate = await requireCore(request);
+  if (!gate.ok) return gate.response;
 
   const sprintId = params.id!;
   const sprint = await prisma.sprint.findUnique({

--- a/dali-api/app/projects/routes/api.sprints.$id.ts
+++ b/dali-api/app/projects/routes/api.sprints.$id.ts
@@ -1,6 +1,6 @@
 import type { Route } from "./+types/api.sprints.$id";
 import { prisma } from "~/lib/db";
-import { requireCore } from "~/lib/auth";
+import { requireProjectEditAccess } from "~/lib/auth";
 import { withCors, handlePreflight } from "~/lib/cors";
 
 // POST   /api/sprints/:id — edit. Body: { name?, startsAt?, endsAt?, status?, epicId? }
@@ -42,17 +42,16 @@ export async function action({ request, params }: Route.ActionArgs) {
   if (request.method !== "POST" && request.method !== "DELETE") {
     return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));
   }
-  const gate = await requireCore(request);
-  if (!gate.ok) return gate.response;
-
   const sprintId = params.id!;
   const sprint = await prisma.sprint.findUnique({
     where: { id: sprintId },
-    select: { id: true, startsAt: true, endsAt: true },
+    select: { id: true, startsAt: true, endsAt: true, projectId: true },
   });
   if (!sprint) {
     return withCors(request, Response.json({ error: "Sprint not found" }, { status: 404 }));
   }
+  const gate = await requireProjectEditAccess(request, sprint.projectId);
+  if (!gate.ok) return gate.response;
 
   if (request.method === "DELETE") {
     await prisma.$transaction([

--- a/dali-api/app/projects/routes/api.staffing.assign.ts
+++ b/dali-api/app/projects/routes/api.staffing.assign.ts
@@ -4,6 +4,7 @@ import { requireAuth, forbidden } from "~/lib/auth";
 import { canManageStaffing } from "~/lib/roles";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { logAuditEvent } from "~/lib/audit";
+import { isLevel, type Level } from "~/lib/level";
 import { publishCycleChange } from "../lib/staffing-events.server";
 
 // POST /api/staffing/assign
@@ -25,7 +26,7 @@ type Body = {
   cycleId: string;
   projectId: string | null;
   domainId?: string;
-  level?: "P1" | "P2" | "P3";
+  level?: Level;
 };
 
 function isBody(x: unknown): x is Body {
@@ -36,7 +37,7 @@ function isBody(x: unknown): x is Body {
   if (o.projectId !== null && typeof o.projectId !== "string") return false;
   if (o.projectId !== null) {
     if (typeof o.domainId !== "string") return false;
-    if (o.level !== "P1" && o.level !== "P2" && o.level !== "P3") return false;
+    if (!isLevel(o.level)) return false;
   }
   return true;
 }

--- a/dali-api/app/projects/routes/api.staffing.assign.ts
+++ b/dali-api/app/projects/routes/api.staffing.assign.ts
@@ -1,6 +1,6 @@
 import type { Route } from "./+types/api.staffing.assign";
 import { prisma } from "~/lib/db";
-import { requireAuth } from "~/lib/auth";
+import { requireAuth, forbidden } from "~/lib/auth";
 import { canManageStaffing } from "~/lib/roles";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { logAuditEvent } from "~/lib/audit";
@@ -53,7 +53,7 @@ export async function action({ request }: Route.ActionArgs) {
   }
 
   if (!(await canManageStaffing(auth.user.sub))) {
-    return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
+    return forbidden(request);
   }
 
   let body: unknown;

--- a/dali-api/app/projects/routes/api.staffing.board-member.ts
+++ b/dali-api/app/projects/routes/api.staffing.board-member.ts
@@ -1,6 +1,7 @@
 import type { Route } from "./+types/api.staffing.board-member";
 import { prisma } from "~/lib/db";
-import { requireAuth } from "~/lib/auth";
+import { requireAuth, forbidden } from "~/lib/auth";
+import { primaryEmail } from "~/lib/display";
 import { canManageStaffing } from "~/lib/roles";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { logAuditEvent } from "~/lib/audit";
@@ -30,7 +31,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   const auth = await requireAuth(request);
   if (!auth.ok) return withCors(request, auth.response);
   if (!(await canManageStaffing(auth.user.sub))) {
-    return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
+    return forbidden(request);
   }
 
   const url = new URL(request.url);
@@ -99,7 +100,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     .map((u) => ({
       userId: u.id,
       name: `${u.firstName} ${u.lastName}`.trim(),
-      email: u.daliEmail ?? u.dartmouthEmail,
+      email: primaryEmail(u) ?? null,
     }));
 
   return withCors(request, Response.json({ results }));
@@ -120,7 +121,7 @@ export async function action({ request }: Route.ActionArgs) {
   const auth = await requireAuth(request);
   if (!auth.ok) return withCors(request, auth.response);
   if (!(await canManageStaffing(auth.user.sub))) {
-    return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
+    return forbidden(request);
   }
   if (request.method !== "POST" && request.method !== "DELETE") {
     return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));

--- a/dali-api/app/projects/routes/api.staffing.events.ts
+++ b/dali-api/app/projects/routes/api.staffing.events.ts
@@ -1,5 +1,5 @@
 import type { Route } from "./+types/api.staffing.events";
-import { requireAuth } from "~/lib/auth";
+import { requireAuth, forbidden } from "~/lib/auth";
 import { canViewStaffing } from "~/lib/roles";
 import { subscribeToCycle } from "../lib/staffing-events.server";
 
@@ -22,7 +22,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   // the client's onerror handles by backing off.
   if (!auth.ok) return new Response("Unauthorized", { status: 401 });
   if (!(await canViewStaffing(auth.user.sub))) {
-    return new Response("Forbidden", { status: 403 });
+    return forbidden(request);
   }
 
   const cycleId = new URL(request.url).searchParams.get("cycleId");

--- a/dali-api/app/projects/routes/api.staffing.finalize.ts
+++ b/dali-api/app/projects/routes/api.staffing.finalize.ts
@@ -8,6 +8,8 @@ import {
   ensureChannel,
   inviteUsersToChannel,
   slackErrorMessage,
+  slackConfigured,
+  SLACK_NOT_CONFIGURED_MESSAGE,
 } from "~/slack/lib/slack-client";
 import { resolveSlackIdsForInvite } from "~/members/lib/slack-sync.server";
 import { ensureTeam, addTeamMember } from "~/lib/github";
@@ -290,8 +292,8 @@ export async function action({ request }: Route.ActionArgs) {
   // announcement (each member's domain + level, plus the project's repos). The
   // channel id is reused across runs (stored on Project.slackChannelId).
   if (selected.has("slack")) {
-    if (!process.env.SLACK_BOT_TOKEN) {
-      results.slack = { status: "skipped", message: "SLACK_BOT_TOKEN not set." };
+    if (!slackConfigured()) {
+      results.slack = { status: "skipped" as const, message: SLACK_NOT_CONFIGURED_MESSAGE };
     } else {
       try {
         // Confirmed roster with level + slack id, regardless of whether the

--- a/dali-api/app/projects/routes/api.staffing.finalize.ts
+++ b/dali-api/app/projects/routes/api.staffing.finalize.ts
@@ -1,13 +1,13 @@
 import type { Route } from "./+types/api.staffing.finalize";
 import { prisma } from "~/lib/db";
-import { requireAuth } from "~/lib/auth";
+import { requireAuth, forbidden } from "~/lib/auth";
 import { canManageStaffing } from "~/lib/roles";
 import { withCors, handlePreflight } from "~/lib/cors";
 import {
   postMessage,
   ensureChannel,
   inviteUsersToChannel,
-  slackMissingScopeMsg,
+  slackErrorMessage,
 } from "~/slack/lib/slack-client";
 import { resolveSlackIdsForInvite } from "~/members/lib/slack-sync.server";
 import { ensureTeam, addTeamMember } from "~/lib/github";
@@ -97,7 +97,7 @@ export async function action({ request }: Route.ActionArgs) {
     return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));
   }
   if (!(await canManageStaffing(auth.user.sub))) {
-    return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
+    return forbidden(request);
   }
 
   let body: unknown;
@@ -280,7 +280,7 @@ export async function action({ request }: Route.ActionArgs) {
           skipNote,
       };
     } catch (err) {
-      results.assignments = { status: "error", message: errMsg(err) };
+      results.assignments = { status: "error", message: slackErrorMessage(err) };
     }
   }
 
@@ -391,7 +391,7 @@ export async function action({ request }: Route.ActionArgs) {
         }
         results.slack = { status: "ok", message: `${parts.join("; ")}.` };
       } catch (err) {
-        results.slack = { status: "error", message: errMsg(err) };
+        results.slack = { status: "error", message: slackErrorMessage(err) };
       }
     }
   }
@@ -485,7 +485,7 @@ export async function action({ request }: Route.ActionArgs) {
           }
         }
       } catch (err) {
-        results.gmail = { status: "error", message: errMsg(err) };
+        results.gmail = { status: "error", message: slackErrorMessage(err) };
       }
     }
   }
@@ -548,7 +548,7 @@ export async function action({ request }: Route.ActionArgs) {
         }
         results.github = { status: "ok", message: `${parts.join("; ")}.` };
       } catch (err) {
-        results.github = { status: "error", message: errMsg(err) };
+        results.github = { status: "error", message: slackErrorMessage(err) };
       }
     }
   }
@@ -571,20 +571,4 @@ export async function action({ request }: Route.ActionArgs) {
   publishCycleChange(cycle.id);
 
   return withCors(request, Response.json({ results }));
-}
-
-function errMsg(err: unknown): string {
-  const raw = err instanceof Error ? err.message : String(err);
-  // Append an actionable hint for the common integration-config failures so a
-  // lead can self-diagnose without reading API docs.
-  if (/missing_scope/i.test(raw)) {
-    return slackMissingScopeMsg(err, raw);
-  }
-  if (/not_in_channel|channel_not_found/i.test(raw)) {
-    return `${raw} — the Slack bot isn't a member of that channel. Invite the bot to it, or let finalize create the channel.`;
-  }
-  if (/\bNot Found\b/.test(raw) && /teams\/members/.test(raw)) {
-    return `${raw} — couldn't add a GitHub team member. Check that the GitHub App is installed on GITHUB_ORG with the "Members: read & write" org permission, and that each member's githubUsername is a real GitHub login.`;
-  }
-  return raw;
 }

--- a/dali-api/app/projects/routes/api.staffing.reorder.ts
+++ b/dali-api/app/projects/routes/api.staffing.reorder.ts
@@ -1,6 +1,6 @@
 import type { Route } from "./+types/api.staffing.reorder";
 import { prisma } from "~/lib/db";
-import { requireAuth } from "~/lib/auth";
+import { requireAuth, forbidden } from "~/lib/auth";
 import { canManageStaffing } from "~/lib/roles";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { logAuditEvent } from "~/lib/audit";
@@ -40,7 +40,7 @@ export async function action({ request }: Route.ActionArgs) {
     return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));
   }
   if (!(await canManageStaffing(auth.user.sub))) {
-    return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
+    return forbidden(request);
   }
 
   let body: unknown;

--- a/dali-api/app/projects/routes/api.staffing.term-channel.ts
+++ b/dali-api/app/projects/routes/api.staffing.term-channel.ts
@@ -3,7 +3,13 @@ import { prisma } from "~/lib/db";
 import { requireAuth, forbidden } from "~/lib/auth";
 import { canManageStaffing } from "~/lib/roles";
 import { withCors, handlePreflight } from "~/lib/cors";
-import { ensureChannel, inviteUsersToChannel, slackErrorMessage } from "~/slack/lib/slack-client";
+import {
+  ensureChannel,
+  inviteUsersToChannel,
+  slackErrorMessage,
+  slackConfigured,
+  SLACK_NOT_CONFIGURED_MESSAGE,
+} from "~/slack/lib/slack-client";
 import { resolveSlackIdsForInvite } from "~/members/lib/slack-sync.server";
 import { logAuditEvent } from "~/lib/audit";
 
@@ -49,8 +55,8 @@ export async function action({ request }: Route.ActionArgs) {
     return withCors(request, Response.json({ error: "Invalid body" }, { status: 400 }));
   }
 
-  if (!process.env.SLACK_BOT_TOKEN) {
-    return withCors(request, Response.json({ error: "SLACK_BOT_TOKEN not set." }, { status: 400 }));
+  if (!slackConfigured()) {
+    return withCors(request, Response.json({ error: SLACK_NOT_CONFIGURED_MESSAGE }, { status: 400 }));
   }
 
   const term = await prisma.term.findUnique({

--- a/dali-api/app/projects/routes/api.staffing.term-channel.ts
+++ b/dali-api/app/projects/routes/api.staffing.term-channel.ts
@@ -1,9 +1,9 @@
 import type { Route } from "./+types/api.staffing.term-channel";
 import { prisma } from "~/lib/db";
-import { requireAuth } from "~/lib/auth";
+import { requireAuth, forbidden } from "~/lib/auth";
 import { canManageStaffing } from "~/lib/roles";
 import { withCors, handlePreflight } from "~/lib/cors";
-import { ensureChannel, inviteUsersToChannel, slackMissingScopeMsg } from "~/slack/lib/slack-client";
+import { ensureChannel, inviteUsersToChannel, slackErrorMessage } from "~/slack/lib/slack-client";
 import { resolveSlackIdsForInvite } from "~/members/lib/slack-sync.server";
 import { logAuditEvent } from "~/lib/audit";
 
@@ -26,17 +26,6 @@ function isBody(x: unknown): x is Body {
   );
 }
 
-function errMsg(err: unknown): string {
-  const raw = err instanceof Error ? err.message : String(err);
-  if (/missing_scope/i.test(raw)) {
-    return slackMissingScopeMsg(err, raw);
-  }
-  if (/not_in_channel|channel_not_found/i.test(raw)) {
-    return `${raw} — the Slack bot isn't a member of that channel.`;
-  }
-  return raw;
-}
-
 export async function action({ request }: Route.ActionArgs) {
   const preflight = handlePreflight(request);
   if (preflight) return preflight;
@@ -47,7 +36,7 @@ export async function action({ request }: Route.ActionArgs) {
     return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));
   }
   if (!(await canManageStaffing(auth.user.sub))) {
-    return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
+    return forbidden(request);
   }
 
   let body: unknown;
@@ -127,6 +116,6 @@ export async function action({ request }: Route.ActionArgs) {
       Response.json({ ok: true, channel: ch.name, message: `${parts.join("; ")}.` }),
     );
   } catch (err) {
-    return withCors(request, Response.json({ error: errMsg(err) }, { status: 500 }));
+    return withCors(request, Response.json({ error: slackErrorMessage(err) }, { status: 500 }));
   }
 }

--- a/dali-api/app/projects/routes/api.stories.$id.ts
+++ b/dali-api/app/projects/routes/api.stories.$id.ts
@@ -1,7 +1,6 @@
 import type { Route } from "./+types/api.stories.$id";
 import { prisma } from "~/lib/db";
-import { requireAuth } from "~/lib/auth";
-import { isCore } from "~/lib/roles";
+import { requireCore } from "~/lib/auth";
 import { withCors, handlePreflight } from "~/lib/cors";
 
 // POST   /api/stories/:id  — edit. Body: { title?, notes?, status? }
@@ -34,15 +33,11 @@ export async function action({ request, params }: Route.ActionArgs) {
   const preflight = handlePreflight(request);
   if (preflight) return preflight;
 
-  const auth = await requireAuth(request);
-  if (!auth.ok) return withCors(request, auth.response);
-
   if (request.method !== "POST" && request.method !== "DELETE") {
     return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));
   }
-  if (!(await isCore(auth.user.sub))) {
-    return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
-  }
+  const gate = await requireCore(request);
+  if (!gate.ok) return gate.response;
 
   const storyId = params.id!;
   const story = await prisma.userStory.findUnique({

--- a/dali-api/app/projects/routes/api.stories.$id.ts
+++ b/dali-api/app/projects/routes/api.stories.$id.ts
@@ -1,6 +1,6 @@
 import type { Route } from "./+types/api.stories.$id";
 import { prisma } from "~/lib/db";
-import { requireCore } from "~/lib/auth";
+import { requireProjectEditAccess } from "~/lib/auth";
 import { withCors, handlePreflight } from "~/lib/cors";
 
 // POST   /api/stories/:id  — edit. Body: { title?, notes?, status? }
@@ -36,17 +36,16 @@ export async function action({ request, params }: Route.ActionArgs) {
   if (request.method !== "POST" && request.method !== "DELETE") {
     return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));
   }
-  const gate = await requireCore(request);
-  if (!gate.ok) return gate.response;
-
   const storyId = params.id!;
   const story = await prisma.userStory.findUnique({
     where: { id: storyId },
-    select: { id: true },
+    select: { id: true, epic: { select: { projectId: true } } },
   });
   if (!story) {
     return withCors(request, Response.json({ error: "Story not found" }, { status: 404 }));
   }
+  const gate = await requireProjectEditAccess(request, story.epic.projectId);
+  if (!gate.ok) return gate.response;
 
   if (request.method === "DELETE") {
     await prisma.userStory.delete({ where: { id: storyId } });

--- a/dali-api/app/projects/routes/api.tasks.$id.move.ts
+++ b/dali-api/app/projects/routes/api.tasks.$id.move.ts
@@ -1,7 +1,6 @@
 import type { Route } from "./+types/api.tasks.$id.move";
 import { prisma } from "~/lib/db";
-import { requireAuth } from "~/lib/auth";
-import { isCore } from "~/lib/roles";
+import { requireCore } from "~/lib/auth";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { isTaskStatus } from "../lib/task-board";
 import { closeIssueForTask, syncIssueForTask } from "../lib/github-task-sync";
@@ -27,15 +26,11 @@ export async function action({ request, params }: Route.ActionArgs) {
   const preflight = handlePreflight(request);
   if (preflight) return preflight;
 
-  const auth = await requireAuth(request);
-  if (!auth.ok) return withCors(request, auth.response);
-
   if (request.method !== "POST") {
     return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));
   }
-  if (!(await isCore(auth.user.sub))) {
-    return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
-  }
+  const gate = await requireCore(request);
+  if (!gate.ok) return gate.response;
 
   let body: unknown;
   try {

--- a/dali-api/app/projects/routes/api.tasks.$id.move.ts
+++ b/dali-api/app/projects/routes/api.tasks.$id.move.ts
@@ -1,6 +1,6 @@
 import type { Route } from "./+types/api.tasks.$id.move";
 import { prisma } from "~/lib/db";
-import { requireCore } from "~/lib/auth";
+import { requireProjectEditAccess } from "~/lib/auth";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { isTaskStatus } from "../lib/task-board";
 import { closeIssueForTask, syncIssueForTask } from "../lib/github-task-sync";
@@ -29,7 +29,14 @@ export async function action({ request, params }: Route.ActionArgs) {
   if (request.method !== "POST") {
     return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));
   }
-  const gate = await requireCore(request);
+  const task = await prisma.task.findUnique({
+    where: { id: params.id },
+    select: { id: true, githubIssueNumber: true, projectId: true },
+  });
+  if (!task) {
+    return withCors(request, Response.json({ error: "Task not found" }, { status: 404 }));
+  }
+  const gate = await requireProjectEditAccess(request, task.projectId);
   if (!gate.ok) return gate.response;
 
   let body: unknown;
@@ -43,14 +50,6 @@ export async function action({ request, params }: Route.ActionArgs) {
   }
   if (!isTaskStatus(body.status)) {
     return withCors(request, Response.json({ error: "Invalid status" }, { status: 400 }));
-  }
-
-  const task = await prisma.task.findUnique({
-    where: { id: params.id },
-    select: { id: true, githubIssueNumber: true },
-  });
-  if (!task) {
-    return withCors(request, Response.json({ error: "Task not found" }, { status: 404 }));
   }
 
   await prisma.task.update({

--- a/dali-api/app/projects/routes/api.tasks.$id.ts
+++ b/dali-api/app/projects/routes/api.tasks.$id.ts
@@ -1,7 +1,6 @@
 import type { Route } from "./+types/api.tasks.$id";
 import { prisma } from "~/lib/db";
-import { requireAuth } from "~/lib/auth";
-import { isCore } from "~/lib/roles";
+import { requireCore } from "~/lib/auth";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { syncIssueForTask } from "../lib/github-task-sync";
 
@@ -66,18 +65,14 @@ export async function action({ request, params }: Route.ActionArgs) {
   const preflight = handlePreflight(request);
   if (preflight) return preflight;
 
-  const auth = await requireAuth(request);
-  if (!auth.ok) return withCors(request, auth.response);
-
   if (request.method !== "PATCH") {
     return withCors(
       request,
       Response.json({ error: "Method not allowed" }, { status: 405 }),
     );
   }
-  if (!(await isCore(auth.user.sub))) {
-    return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
-  }
+  const gate = await requireCore(request);
+  if (!gate.ok) return gate.response;
 
   let body: unknown;
   try {

--- a/dali-api/app/projects/routes/api.tasks.$id.ts
+++ b/dali-api/app/projects/routes/api.tasks.$id.ts
@@ -1,6 +1,6 @@
 import type { Route } from "./+types/api.tasks.$id";
 import { prisma } from "~/lib/db";
-import { requireCore } from "~/lib/auth";
+import { requireProjectEditAccess } from "~/lib/auth";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { syncIssueForTask } from "../lib/github-task-sync";
 
@@ -71,7 +71,14 @@ export async function action({ request, params }: Route.ActionArgs) {
       Response.json({ error: "Method not allowed" }, { status: 405 }),
     );
   }
-  const gate = await requireCore(request);
+  const task = await prisma.task.findUnique({
+    where: { id: params.id },
+    select: { id: true, githubIssueNumber: true, projectId: true },
+  });
+  if (!task) {
+    return withCors(request, Response.json({ error: "Task not found" }, { status: 404 }));
+  }
+  const gate = await requireProjectEditAccess(request, task.projectId);
   if (!gate.ok) return gate.response;
 
   let body: unknown;
@@ -82,14 +89,6 @@ export async function action({ request, params }: Route.ActionArgs) {
   }
   if (!isBody(body)) {
     return withCors(request, Response.json({ error: "Invalid body" }, { status: 400 }));
-  }
-
-  const task = await prisma.task.findUnique({
-    where: { id: params.id },
-    select: { id: true, githubIssueNumber: true },
-  });
-  if (!task) {
-    return withCors(request, Response.json({ error: "Task not found" }, { status: 404 }));
   }
 
   // Build a partial update: a key being present (even null) is a write; an

--- a/dali-api/app/projects/routes/projects.$id.tsx
+++ b/dali-api/app/projects/routes/projects.$id.tsx
@@ -20,7 +20,9 @@ import { uploadFileToS3, formatBytes } from "~/lib/upload-client";
 import type { Route } from "./+types/projects.$id";
 import { prisma } from "~/lib/db";
 import { ensureProjectGroup } from "~/lib/groups";
-import { requireAuth } from "~/lib/auth";
+import { requireAuth, redirectApplicantToPortal } from "~/lib/auth";
+import { fullName } from "~/lib/display";
+import { USER_NAME_SELECT } from "~/lib/prisma-shapes";
 import { resolvePhotoUrl } from "~/lib/photo";
 import { ProjectImageBanner } from "../components/ProjectImageBanner";
 import { Markdown } from "~/components/Markdown";
@@ -82,7 +84,8 @@ const TAB_LABELS: Record<Tab, string> = {
 export async function loader({ request, params }: Route.LoaderArgs) {
   const auth = await requireAuth(request);
   if (!auth.ok) return redirect("/login");
-  if (auth.user.type === "applicant") return redirect("/portal");
+  const portalRedirect = redirectApplicantToPortal(auth);
+  if (portalRedirect) return portalRedirect;
 
   const project = await prisma.project.findUnique({
     where: { id: params.id },
@@ -124,7 +127,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
           userId: true,
           termId: true,
           domainId: true,
-          user: { select: { id: true, firstName: true, lastName: true } },
+          user: { select: USER_NAME_SELECT },
           term: { select: { code: true, sortKey: true } },
           domain: { select: { id: true, name: true } },
         },
@@ -172,7 +175,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
           domain: { select: { id: true, displayName: true } },
           assignees: {
             select: {
-              user: { select: { id: true, firstName: true, lastName: true } },
+              user: { select: USER_NAME_SELECT },
             },
           },
         },
@@ -321,7 +324,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     sprintId: t.sprintId,
     assignees: t.assignees.map((a) => ({
       id: a.user.id,
-      name: `${a.user.firstName} ${a.user.lastName}`.trim(),
+      name: fullName(a.user),
     })),
     domain: t.domain
       ? { id: t.domain.id, name: t.domain.displayName }
@@ -337,7 +340,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   for (const a of project.assignments) {
     const id = a.user.id;
     if (!memberMap.has(id)) {
-      memberMap.set(id, `${a.user.firstName} ${a.user.lastName}`.trim());
+      memberMap.set(id, fullName(a.user));
     }
   }
   const boardOptions: TaskBoardOptions = {
@@ -415,7 +418,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     teamByTerm.get(key)!.members.push({
       assignmentId: a.id,
       userId: a.userId,
-      name: `${a.user.firstName} ${a.user.lastName}`.trim(),
+      name: fullName(a.user),
       domain: a.domain.name,
       domainId: a.domainId,
       level: a.level,
@@ -575,7 +578,8 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 export async function action({ request, params }: Route.ActionArgs) {
   const auth = await requireAuth(request);
   if (!auth.ok) return redirect("/login");
-  if (auth.user.type === "applicant") return redirect("/portal");
+  const portalRedirect = redirectApplicantToPortal(auth);
+  if (portalRedirect) return portalRedirect;
 
   // Content edits are open to Core/Admin or anyone staffed on the project;
   // scope/domain settings (scopesBulk, domains, terms) stay Core/Admin only.

--- a/dali-api/app/projects/routes/projects.intent-to-work.$userId.tsx
+++ b/dali-api/app/projects/routes/projects.intent-to-work.$userId.tsx
@@ -7,6 +7,7 @@ import { ensureStaffingCycle } from "../lib/staffing-cycle";
 import { getSlotBinding } from "../lib/form-slots";
 import { resolveTermFilter } from "~/lib/terms";
 import { buildSubmissionView } from "../lib/submission-view.server";
+import { UserSubmissionShell } from "../components/UserSubmissionShell";
 
 const SLOT = "intent-to-work" as const;
 
@@ -68,44 +69,15 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 export default function IntentSubmissionDetail() {
   const data = useLoaderData<typeof loader>();
   return (
-    <div className="flex flex-col gap-6">
-      <div>
-        <h1 className="font-heading text-2xl font-bold text-foreground">
-          {data.record.name}
-        </h1>
-        <p className="text-sm text-muted-foreground">{data.cycleName}</p>
-      </div>
-
-      {data.fields.length === 0 ? (
-        <p className="text-sm text-muted-foreground">
-          This submission is empty.
-        </p>
-      ) : (
-        <dl className="bg-card border border-border rounded-lg divide-y divide-border">
-          {data.fields.map((f) => (
-            <div
-              key={f.key}
-              className="px-4 py-3 flex flex-col sm:flex-row sm:gap-4"
-            >
-              <dt className="sm:w-56 shrink-0 text-sm font-medium text-foreground">
-                {f.label}
-                {!f.mapped && (
-                  <span className="ml-2 text-[11px] text-muted-foreground">
-                    (not in table)
-                  </span>
-                )}
-              </dt>
-              <dd className="text-sm text-foreground mt-1 sm:mt-0 whitespace-pre-wrap break-words">
-                {f.value === "" ? (
-                  <span className="text-muted-foreground">—</span>
-                ) : (
-                  f.value
-                )}
-              </dd>
-            </div>
-          ))}
-        </dl>
-      )}
-    </div>
+    <UserSubmissionShell
+      title={data.record.name}
+      subtitle={data.cycleName}
+      rows={data.fields.map((f) => ({
+        key: f.key,
+        label: f.label,
+        value: f.value,
+        mapped: f.mapped,
+      }))}
+    />
   );
 }

--- a/dali-api/app/projects/routes/projects.intent-to-work.$userId.tsx
+++ b/dali-api/app/projects/routes/projects.intent-to-work.$userId.tsx
@@ -1,6 +1,6 @@
 import { redirect, useLoaderData } from "react-router";
 import type { Route } from "./+types/projects.intent-to-work.$userId";
-import { requireAuth } from "~/lib/auth";
+import { requireAuth, redirectApplicantToPortal } from "~/lib/auth";
 import { canViewStaffing, currentTerm } from "~/lib/roles";
 import { prisma } from "~/lib/db";
 import { ensureStaffingCycle } from "../lib/staffing-cycle";
@@ -24,7 +24,8 @@ export const meta: Route.MetaFunction = ({ data }) => [
 export async function loader({ request, params }: Route.LoaderArgs) {
   const auth = await requireAuth(request);
   if (!auth.ok) return redirect("/login");
-  if (auth.user.type === "applicant") return redirect("/portal");
+  const portalRedirect = redirectApplicantToPortal(auth);
+  if (portalRedirect) return portalRedirect;
   if (!(await canViewStaffing(auth.user.sub))) return redirect("/");
 
   const { termId: filterTermId, isAll } = await resolveTermFilter(request);

--- a/dali-api/app/projects/routes/projects.intent-to-work.tsx
+++ b/dali-api/app/projects/routes/projects.intent-to-work.tsx
@@ -1,7 +1,8 @@
 import { useMemo, useState } from "react";
 import { redirect, useLoaderData } from "react-router";
 import type { Route } from "./+types/projects.intent-to-work";
-import { requireAuth } from "~/lib/auth";
+import { requireAuth, redirectApplicantToPortal } from "~/lib/auth";
+import { parseFormDataJson } from "~/lib/safe-json";
 import { canManageStaffing, canViewStaffing, currentTerm } from "~/lib/roles";
 import { prisma } from "~/lib/db";
 import { ensureStaffingCycle } from "../lib/staffing-cycle";
@@ -37,7 +38,8 @@ export const meta: Route.MetaFunction = () => [
 export async function loader({ request }: Route.LoaderArgs) {
   const auth = await requireAuth(request);
   if (!auth.ok) return redirect("/login");
-  if (auth.user.type === "applicant") return redirect("/portal");
+  const portalRedirect = redirectApplicantToPortal(auth);
+  if (portalRedirect) return portalRedirect;
   if (!(await canViewStaffing(auth.user.sub))) return redirect("/");
 
   const {
@@ -208,7 +210,7 @@ export async function action({ request }: Route.ActionArgs) {
         { error: "Bind a form before mapping its columns." },
         { status: 400 },
       );
-    const mapping = parseColumnMapping(safeJsonParse(form.get("mapping")));
+    const mapping = parseColumnMapping(parseFormDataJson(form.get("mapping")));
     if (!mapping)
       return Response.json({ error: "Invalid mapping." }, { status: 400 });
     const latest = await prisma.formVersion.findFirst({
@@ -232,15 +234,6 @@ export async function action({ request }: Route.ActionArgs) {
   }
 
   return Response.json({ error: "Unknown intent" }, { status: 400 });
-}
-
-function safeJsonParse(v: FormDataEntryValue | null): unknown {
-  if (typeof v !== "string") return null;
-  try {
-    return JSON.parse(v);
-  } catch {
-    return null;
-  }
 }
 
 export default function IntentToWorkDatabase() {

--- a/dali-api/app/projects/routes/projects.level-up.$userId.tsx
+++ b/dali-api/app/projects/routes/projects.level-up.$userId.tsx
@@ -1,6 +1,6 @@
 import { redirect, useLoaderData } from "react-router";
 import type { Route } from "./+types/projects.level-up.$userId";
-import { requireAuth } from "~/lib/auth";
+import { requireAuth, redirectApplicantToPortal } from "~/lib/auth";
 import { canViewStaffing, currentTerm } from "~/lib/roles";
 import { prisma } from "~/lib/db";
 import { ensureStaffingCycle } from "../lib/staffing-cycle";
@@ -22,7 +22,8 @@ export const meta: Route.MetaFunction = ({ data }) => [
 export async function loader({ request, params }: Route.LoaderArgs) {
   const auth = await requireAuth(request);
   if (!auth.ok) return redirect("/login");
-  if (auth.user.type === "applicant") return redirect("/portal");
+  const portalRedirect = redirectApplicantToPortal(auth);
+  if (portalRedirect) return portalRedirect;
   if (!(await canViewStaffing(auth.user.sub))) return redirect("/");
 
   const { termId: filterTermId, isAll } = await resolveTermFilter(request);

--- a/dali-api/app/projects/routes/projects.level-up.$userId.tsx
+++ b/dali-api/app/projects/routes/projects.level-up.$userId.tsx
@@ -7,6 +7,7 @@ import { ensureStaffingCycle } from "../lib/staffing-cycle";
 import { getSlotBinding } from "../lib/form-slots";
 import { resolveTermFilter } from "~/lib/terms";
 import { buildSubmissionView } from "../lib/submission-view.server";
+import { UserSubmissionShell } from "../components/UserSubmissionShell";
 
 const SLOT = "level-up" as const;
 
@@ -63,42 +64,15 @@ export default function LevelUpSubmissionDetail() {
   const data = useLoaderData<typeof loader>();
 
   return (
-    <div className="flex flex-col gap-6">
-      <div>
-        <h1 className="font-heading text-2xl font-bold text-foreground">
-          {data.record.name}
-        </h1>
-        <p className="text-sm text-muted-foreground">{data.cycleName}</p>
-      </div>
-
-      {data.fields.length === 0 ? (
-        <p className="text-sm text-muted-foreground">This submission is empty.</p>
-      ) : (
-        <dl className="bg-card border border-border rounded-lg divide-y divide-border">
-          {data.fields.map((f) => (
-            <div
-              key={f.key}
-              className="px-4 py-3 flex flex-col sm:flex-row sm:gap-4"
-            >
-              <dt className="sm:w-56 shrink-0 text-sm font-medium text-foreground">
-                {f.label}
-                {!f.mapped && (
-                  <span className="ml-2 text-[11px] text-muted-foreground">
-                    (not in table)
-                  </span>
-                )}
-              </dt>
-              <dd className="text-sm text-foreground mt-1 sm:mt-0 whitespace-pre-wrap break-words">
-                {f.value === "" ? (
-                  <span className="text-muted-foreground">—</span>
-                ) : (
-                  f.value
-                )}
-              </dd>
-            </div>
-          ))}
-        </dl>
-      )}
-    </div>
+    <UserSubmissionShell
+      title={data.record.name}
+      subtitle={data.cycleName}
+      rows={data.fields.map((f) => ({
+        key: f.key,
+        label: f.label,
+        value: f.value,
+        mapped: f.mapped,
+      }))}
+    />
   );
 }

--- a/dali-api/app/projects/routes/projects.level-up.tsx
+++ b/dali-api/app/projects/routes/projects.level-up.tsx
@@ -1,7 +1,8 @@
 import { useMemo, useState, useEffect } from "react";
 import { redirect, useLoaderData, useFetcher } from "react-router";
 import type { Route } from "./+types/projects.level-up";
-import { requireAuth } from "~/lib/auth";
+import { requireAuth, redirectApplicantToPortal } from "~/lib/auth";
+import { parseFormDataJson } from "~/lib/safe-json";
 import { canManageStaffing, canViewStaffing, currentTerm } from "~/lib/roles";
 import { prisma } from "~/lib/db";
 import { ensureStaffingCycle } from "../lib/staffing-cycle";
@@ -44,7 +45,8 @@ function parseLevel(raw: string): Level | null {
 export async function loader({ request }: Route.LoaderArgs) {
   const auth = await requireAuth(request);
   if (!auth.ok) return redirect("/login");
-  if (auth.user.type === "applicant") return redirect("/portal");
+  const portalRedirect = redirectApplicantToPortal(auth);
+  if (portalRedirect) return portalRedirect;
   if (!(await canViewStaffing(auth.user.sub))) return redirect("/");
 
   const {
@@ -322,7 +324,7 @@ export async function action({ request }: Route.ActionArgs) {
           { error: "Bind a form before mapping its columns." },
           { status: 400 },
         );
-      const mapping = parseColumnMapping(safeJsonParse(form.get("mapping")));
+      const mapping = parseColumnMapping(parseFormDataJson(form.get("mapping")));
       if (!mapping)
         return Response.json({ error: "Invalid mapping." }, { status: 400 });
       const latest = await prisma.formVersion.findFirst({
@@ -376,15 +378,6 @@ export async function action({ request }: Route.ActionArgs) {
   }
 
   return Response.json({ error: "Unknown intent" }, { status: 400 });
-}
-
-function safeJsonParse(v: FormDataEntryValue | null): unknown {
-  if (typeof v !== "string") return null;
-  try {
-    return JSON.parse(v);
-  } catch {
-    return null;
-  }
 }
 
 // ─── Component ────────────────────────────────────────────────────────────────

--- a/dali-api/app/projects/routes/projects.level-up.tsx
+++ b/dali-api/app/projects/routes/projects.level-up.tsx
@@ -24,7 +24,7 @@ import {
 } from "../lib/slot-roles";
 import { buildSubmissionView } from "../lib/submission-view.server";
 import type { Question } from "~/types";
-import type { Level } from "~/generated/prisma/enums";
+import { isLevel, type Level } from "~/lib/level";
 
 const SLOT = "level-up" as const;
 
@@ -355,8 +355,8 @@ export async function action({ request }: Route.ActionArgs) {
       return Response.json({ error: "Forbidden" }, { status: 403 });
     const targetUserId = String(form.get("userId") ?? "");
     const domainId = String(form.get("domainId") ?? "");
-    const targetLevel = String(form.get("targetLevel") ?? "") as Level;
-    if (!targetUserId || !domainId || !["P1", "P2", "P3"].includes(targetLevel))
+    const targetLevel = String(form.get("targetLevel") ?? "");
+    if (!targetUserId || !domainId || !isLevel(targetLevel))
       return Response.json({ error: "Invalid parameters." }, { status: 400 });
 
     await prisma.domainEligibility.upsert({

--- a/dali-api/app/projects/routes/projects.list.tsx
+++ b/dali-api/app/projects/routes/projects.list.tsx
@@ -8,7 +8,7 @@ import {
   useNavigate,
 } from "react-router";
 import type { Route } from "./+types/projects.list";
-import { requireAuth } from "~/lib/auth";
+import { requireAuth, redirectApplicantToPortal } from "~/lib/auth";
 import { isCore } from "~/lib/roles";
 import { requestOpenTabIfEmbedded } from "~/components/workspace-link";
 import { prisma } from "~/lib/db";
@@ -38,7 +38,8 @@ type ProjectRow = {
 export async function loader({ request }: Route.LoaderArgs) {
   const auth = await requireAuth(request);
   if (!auth.ok) return redirect("/login");
-  if (auth.user.type === "applicant") return redirect("/portal");
+  const portalRedirect = redirectApplicantToPortal(auth);
+  if (portalRedirect) return portalRedirect;
 
   const { terms, selected, termId, isAll } = await resolveTermFilter(request);
 
@@ -99,7 +100,8 @@ export async function loader({ request }: Route.LoaderArgs) {
 export async function action({ request }: Route.ActionArgs) {
   const auth = await requireAuth(request);
   if (!auth.ok) return redirect("/login");
-  if (auth.user.type === "applicant") return redirect("/portal");
+  const portalRedirect = redirectApplicantToPortal(auth);
+  if (portalRedirect) return portalRedirect;
   if (!(await isCore(auth.user.sub))) {
     return { error: "You don't have permission to create projects." };
   }

--- a/dali-api/app/projects/routes/projects.project-bids.$userId.tsx
+++ b/dali-api/app/projects/routes/projects.project-bids.$userId.tsx
@@ -1,6 +1,6 @@
 import { redirect, useLoaderData } from "react-router";
 import type { Route } from "./+types/projects.project-bids.$userId";
-import { requireAuth } from "~/lib/auth";
+import { requireAuth, redirectApplicantToPortal } from "~/lib/auth";
 import { canViewStaffing, currentTerm } from "~/lib/roles";
 import { prisma } from "~/lib/db";
 import { ensureStaffingCycle } from "../lib/staffing-cycle";
@@ -25,7 +25,8 @@ export const meta: Route.MetaFunction = ({ data }) => [
 export async function loader({ request, params }: Route.LoaderArgs) {
   const auth = await requireAuth(request);
   if (!auth.ok) return redirect("/login");
-  if (auth.user.type === "applicant") return redirect("/portal");
+  const portalRedirect = redirectApplicantToPortal(auth);
+  if (portalRedirect) return portalRedirect;
   if (!(await canViewStaffing(auth.user.sub))) return redirect("/");
 
   const { termId: filterTermId, isAll } = await resolveTermFilter(request);

--- a/dali-api/app/projects/routes/projects.project-bids.$userId.tsx
+++ b/dali-api/app/projects/routes/projects.project-bids.$userId.tsx
@@ -7,6 +7,7 @@ import { ensureStaffingCycle } from "../lib/staffing-cycle";
 import { getSlotBinding } from "../lib/form-slots";
 import { resolveTermFilter } from "~/lib/terms";
 import { buildSubmissionView } from "../lib/submission-view.server";
+import { UserSubmissionShell } from "../components/UserSubmissionShell";
 
 const SLOT = "project-bids" as const;
 
@@ -71,44 +72,15 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 export default function ProjectBidSubmissionDetail() {
   const data = useLoaderData<typeof loader>();
   return (
-    <div className="flex flex-col gap-6">
-      <div>
-        <h1 className="font-heading text-2xl font-bold text-foreground">
-          {data.record.name}
-        </h1>
-        <p className="text-sm text-muted-foreground">{data.cycleName}</p>
-      </div>
-
-      {data.fields.length === 0 ? (
-        <p className="text-sm text-muted-foreground">
-          This submission is empty.
-        </p>
-      ) : (
-        <dl className="bg-card border border-border rounded-lg divide-y divide-border">
-          {data.fields.map((f) => (
-            <div
-              key={f.key}
-              className="px-4 py-3 flex flex-col sm:flex-row sm:gap-4"
-            >
-              <dt className="sm:w-56 shrink-0 text-sm font-medium text-foreground">
-                {f.label}
-                {!f.mapped && (
-                  <span className="ml-2 text-[11px] text-muted-foreground">
-                    (not in table)
-                  </span>
-                )}
-              </dt>
-              <dd className="text-sm text-foreground mt-1 sm:mt-0 whitespace-pre-wrap break-words">
-                {f.value === "" ? (
-                  <span className="text-muted-foreground">—</span>
-                ) : (
-                  f.value
-                )}
-              </dd>
-            </div>
-          ))}
-        </dl>
-      )}
-    </div>
+    <UserSubmissionShell
+      title={data.record.name}
+      subtitle={data.cycleName}
+      rows={data.fields.map((f) => ({
+        key: f.key,
+        label: f.label,
+        value: f.value,
+        mapped: f.mapped,
+      }))}
+    />
   );
 }

--- a/dali-api/app/projects/routes/projects.project-bids.tsx
+++ b/dali-api/app/projects/routes/projects.project-bids.tsx
@@ -1,7 +1,8 @@
 import { useMemo, useState } from "react";
 import { redirect, useLoaderData } from "react-router";
 import type { Route } from "./+types/projects.project-bids";
-import { requireAuth } from "~/lib/auth";
+import { requireAuth, redirectApplicantToPortal } from "~/lib/auth";
+import { parseFormDataJson } from "~/lib/safe-json";
 import { canManageStaffing, canViewStaffing, currentTerm } from "~/lib/roles";
 import { prisma } from "~/lib/db";
 import { ensureStaffingCycle } from "../lib/staffing-cycle";
@@ -37,7 +38,8 @@ export const meta: Route.MetaFunction = () => [
 export async function loader({ request }: Route.LoaderArgs) {
   const auth = await requireAuth(request);
   if (!auth.ok) return redirect("/login");
-  if (auth.user.type === "applicant") return redirect("/portal");
+  const portalRedirect = redirectApplicantToPortal(auth);
+  if (portalRedirect) return portalRedirect;
   if (!(await canViewStaffing(auth.user.sub))) return redirect("/");
 
   const {
@@ -206,7 +208,7 @@ export async function action({ request }: Route.ActionArgs) {
         { error: "Bind a form before mapping its columns." },
         { status: 400 },
       );
-    const mapping = parseColumnMapping(safeJsonParse(form.get("mapping")));
+    const mapping = parseColumnMapping(parseFormDataJson(form.get("mapping")));
     if (!mapping)
       return Response.json({ error: "Invalid mapping." }, { status: 400 });
     // Validate against the bound form's current questions before saving.
@@ -231,15 +233,6 @@ export async function action({ request }: Route.ActionArgs) {
   }
 
   return Response.json({ error: "Unknown intent" }, { status: 400 });
-}
-
-function safeJsonParse(v: FormDataEntryValue | null): unknown {
-  if (typeof v !== "string") return null;
-  try {
-    return JSON.parse(v);
-  } catch {
-    return null;
-  }
 }
 
 export default function ProjectBidsDatabase() {

--- a/dali-api/app/projects/routes/projects.staffing.tsx
+++ b/dali-api/app/projects/routes/projects.staffing.tsx
@@ -1,6 +1,8 @@
 import { redirect, useLoaderData } from "react-router";
 import type { Route } from "./+types/projects.staffing";
-import { requireAuth } from "~/lib/auth";
+import { requireAuth, redirectApplicantToPortal } from "~/lib/auth";
+import { STAFFING_MEMBER_SELECT } from "~/lib/prisma-shapes";
+import { primaryEmail } from "~/lib/display";
 import { canManageStaffing, canViewStaffing } from "~/lib/roles";
 import { prisma } from "~/lib/db";
 import { resolvePhotoUrl } from "~/lib/photo";
@@ -26,7 +28,8 @@ export const meta: Route.MetaFunction = () => [{ title: "Staffing · DALI OS" }]
 export async function loader({ request }: Route.LoaderArgs) {
   const auth = await requireAuth(request);
   if (!auth.ok) return redirect("/login");
-  if (auth.user.type === "applicant") return redirect("/portal");
+  const portalRedirect = redirectApplicantToPortal(auth);
+  if (portalRedirect) return portalRedirect;
   // Viewing and managing the board are both Core/Admin (canViewStaffing and
   // canManageStaffing are the same membership set); the UI still hides drag
   // affordances when canManage is false (e.g. a future read-only tier).
@@ -121,22 +124,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     await Promise.all([
     prisma.user.findMany({
       where: { id: { in: memberUserIds } },
-      select: {
-        id: true,
-        firstName: true,
-        lastName: true,
-        daliEmail: true,
-        dartmouthEmail: true,
-        photoUrl: true,
-        adminMembership: { select: { id: true } },
-        coreAssignments: { select: { leadTitle: true } },
-        domainEligibilities: {
-          select: {
-            level: true,
-            domain: { select: { id: true, displayName: true } },
-          },
-        },
-      },
+      select: STAFFING_MEMBER_SELECT,
     }),
     // Both in-progress (Proposed) and finalized (Confirmed) assignments — a
     // confirmed roster must stay on the board after finalize, not vanish.
@@ -252,7 +240,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     userId: u.id,
     firstName: u.firstName,
     lastName: u.lastName,
-    email: u.daliEmail ?? u.dartmouthEmail,
+    email: primaryEmail(u) ?? null,
     photoUrl: await resolvePhotoUrl(u.photoUrl),
     isAdmin: u.adminMembership !== null,
     coreTitles: Array.from(
@@ -292,19 +280,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   if (bidSubmitterIds.length > 0) {
     const flaggedUsers = await prisma.user.findMany({
       where: { id: { in: bidSubmitterIds } },
-      select: {
-        id: true,
-        firstName: true,
-        lastName: true,
-        daliEmail: true,
-        dartmouthEmail: true,
-        photoUrl: true,
-        adminMembership: { select: { id: true } },
-        coreAssignments: { select: { leadTitle: true } },
-        domainEligibilities: {
-          select: { level: true, domain: { select: { id: true, displayName: true } } },
-        },
-      },
+      select: STAFFING_MEMBER_SELECT,
     });
     const flagged = await Promise.all(
       flaggedUsers.map((u) => toMemberInput(u, [], true)),
@@ -328,19 +304,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   if (boardMemberIds.length > 0) {
     const manualUsers = await prisma.user.findMany({
       where: { id: { in: boardMemberIds } },
-      select: {
-        id: true,
-        firstName: true,
-        lastName: true,
-        daliEmail: true,
-        dartmouthEmail: true,
-        photoUrl: true,
-        adminMembership: { select: { id: true } },
-        coreAssignments: { select: { leadTitle: true } },
-        domainEligibilities: {
-          select: { level: true, domain: { select: { id: true, displayName: true } } },
-        },
-      },
+      select: STAFFING_MEMBER_SELECT,
     });
     const manual = await Promise.all(
       manualUsers.map(async (u) => ({

--- a/dali-api/app/routes/admin.authorize-gmail.callback.ts
+++ b/dali-api/app/routes/admin.authorize-gmail.callback.ts
@@ -5,6 +5,8 @@
 import { requireAuth } from "~/lib/auth";
 import { isCore } from '~/lib/roles'
 import { prisma } from '~/lib/db'
+import { getApiBaseUrl } from '~/lib/app-env'
+import { exchangeGoogleCode, GoogleOAuthError } from '~/lib/google-oauth'
 
 const GMAIL_STATE_COOKIE = '__dali_gmail_oauth_state'
 const GMAIL_USER = 'applications@dali.dartmouth.edu'
@@ -30,7 +32,7 @@ export async function loader({ request }: { request: Request }) {
   }
 
   const url = new URL(request.url)
-  const apiBase = process.env.API_BASE_URL ?? 'http://localhost:3001'
+  const apiBase = getApiBaseUrl()
   const clientId = process.env.GMAIL_CLIENT_ID ?? process.env.GOOGLE_CLIENT_ID!
   const clientSecret = process.env.GMAIL_CLIENT_SECRET ?? process.env.GOOGLE_CLIENT_SECRET!
 
@@ -57,27 +59,25 @@ export async function loader({ request }: { request: Request }) {
   }
 
   // Exchange code for tokens
-  const tokenRes = await fetch('https://oauth2.googleapis.com/token', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: new URLSearchParams({
+  let tokens
+  try {
+    tokens = await exchangeGoogleCode({
       code,
-      client_id: clientId,
-      client_secret: clientSecret,
-      redirect_uri: `${apiBase}/admin/authorize-gmail/callback`,
-      grant_type: 'authorization_code',
-    }),
-  })
-
-  if (!tokenRes.ok) {
-    console.error('Gmail token exchange failed:', await tokenRes.text())
-    return new Response(null, {
-          status: 302,
-          headers: { 'Set-Cookie': clearCookie, Location: '/hiring/emails?gmail_error=token_exchange_failed' },
-        })
+      redirectUri: `${apiBase}/admin/authorize-gmail/callback`,
+      clientId,
+      clientSecret,
+    })
+  } catch (err) {
+    if (err instanceof GoogleOAuthError) {
+      console.error('Gmail token exchange failed:', err.upstreamBody ?? err.message)
+      return new Response(null, {
+            status: 302,
+            headers: { 'Set-Cookie': clearCookie, Location: '/hiring/emails?gmail_error=token_exchange_failed' },
+          })
+    }
+    throw err
   }
 
-  const tokens = await tokenRes.json()
   const refreshToken = tokens.refresh_token as string | undefined
 
   if (!refreshToken) {

--- a/dali-api/app/routes/admin.authorize-gmail.ts
+++ b/dali-api/app/routes/admin.authorize-gmail.ts
@@ -5,6 +5,8 @@
 
 import { requireAuth } from "~/lib/auth";
 import { isCore } from '~/lib/roles'
+import { getApiBaseUrl, APPLICATIONS_FROM_EMAIL } from '~/lib/app-env'
+import { buildGoogleAuthUrl } from '~/lib/google-oauth'
 import { randomBytes } from 'node:crypto'
 
 const GMAIL_STATE_COOKIE = '__dali_gmail_oauth_state'
@@ -14,7 +16,7 @@ const SCOPES = [
   'https://www.googleapis.com/auth/calendar',
   'openid',
   'email',
-].join(' ')
+]
 
 export async function loader({ request }: { request: Request }) {
   const auth = await requireAuth(request)
@@ -26,19 +28,18 @@ export async function loader({ request }: { request: Request }) {
     return new Response(null, { status: 302, headers: { Location: '/' } })
   }
 
-  const apiBase = process.env.API_BASE_URL ?? 'http://localhost:3001'
+  const apiBase = getApiBaseUrl()
   const clientId = process.env.GMAIL_CLIENT_ID ?? process.env.GOOGLE_CLIENT_ID!
 
   const state = randomBytes(16).toString('hex')
-  const params = new URLSearchParams({
-    client_id: clientId,
-    redirect_uri: `${apiBase}/admin/authorize-gmail/callback`,
-    response_type: 'code',
-    scope: SCOPES,
-    access_type: 'offline',
-    prompt: 'consent',
+  const authUrl = buildGoogleAuthUrl({
+    clientId,
+    redirectUri: `${apiBase}/admin/authorize-gmail/callback`,
+    scopes: SCOPES,
     state,
-    login_hint: 'applications@dali.dartmouth.edu',
+    accessType: 'offline',
+    prompt: 'consent',
+    loginHint: APPLICATIONS_FROM_EMAIL,
   })
 
   const stateCookie = `${GMAIL_STATE_COOKIE}=${state}; Path=/admin/authorize-gmail; Max-Age=600; HttpOnly; SameSite=Lax`
@@ -47,7 +48,7 @@ export async function loader({ request }: { request: Request }) {
       status: 302,
       headers: {
         'Set-Cookie': stateCookie,
-        Location: `https://accounts.google.com/o/oauth2/v2/auth?${params}`,
+        Location: authUrl,
       },
     })
 }

--- a/dali-api/app/routes/api.collab.versions.$id.ts
+++ b/dali-api/app/routes/api.collab.versions.$id.ts
@@ -1,7 +1,7 @@
 import type { Route } from "./+types/api.collab.versions.$id";
 import { z } from "zod";
 import { prisma } from "~/lib/db";
-import { requireAuth } from "~/lib/auth";
+import { requireAuth, forbidden } from "~/lib/auth";
 import { authorizeCollabDoc, hydrateAuthors } from "~/lib/collabAuth";
 import { getCollabServer } from "~/collab/server";
 import { restoreVersion } from "~/collab/persistence";
@@ -30,7 +30,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   if (!version) return Response.json({ error: "Not found" }, { status: 404 });
 
   const allowed = await authorizeCollabDoc(auth.user.sub, version.name);
-  if (!allowed) return Response.json({ error: "Forbidden" }, { status: 403 });
+  if (!allowed) return forbidden(request);
 
   return Response.json({
       id: version.id,
@@ -61,7 +61,7 @@ export async function action({ request, params }: Route.ActionArgs) {
   if (!version) return Response.json({ error: "Not found" }, { status: 404 });
 
   const allowed = await authorizeCollabDoc(auth.user.sub, version.name);
-  if (!allowed) return Response.json({ error: "Forbidden" }, { status: 403 });
+  if (!allowed) return forbidden(request);
 
   const server = getCollabServer();
   if (!server) {

--- a/dali-api/app/routes/api.collab.versions.ts
+++ b/dali-api/app/routes/api.collab.versions.ts
@@ -1,6 +1,6 @@
 import type { Route } from "./+types/api.collab.versions";
 import { prisma } from "~/lib/db";
-import { requireAuth } from "~/lib/auth";
+import { requireAuth, forbidden } from "~/lib/auth";
 import { authorizeCollabDoc, hydrateAuthors } from "~/lib/collabAuth";
 
 const PREVIEW_CHARS = 200;
@@ -19,7 +19,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   }
 
   const allowed = await authorizeCollabDoc(auth.user.sub, name);
-  if (!allowed) return Response.json({ error: "Forbidden" }, { status: 403 });
+  if (!allowed) return forbidden(request);
 
   const versions = await prisma.collabDocumentVersion.findMany({
     where: { name },

--- a/dali-api/app/routes/api.comments.$id.ts
+++ b/dali-api/app/routes/api.comments.$id.ts
@@ -1,6 +1,6 @@
 import type { Route } from "./+types/api.comments.$id";
 import { prisma } from "~/lib/db";
-import { requireAuth } from "~/lib/auth";
+import { requireAuth, forbidden } from "~/lib/auth";
 import { isCore } from "~/lib/roles";
 import { withCors, handlePreflight } from "~/lib/cors";
 
@@ -20,7 +20,7 @@ export async function action({ request, params }: Route.ActionArgs) {
     return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));
   }
   if (!(await isCore(auth.user.sub))) {
-    return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
+    return forbidden(request);
   }
 
   const comment = await prisma.docComment.findUnique({

--- a/dali-api/app/routes/api.comments.ts
+++ b/dali-api/app/routes/api.comments.ts
@@ -1,7 +1,7 @@
 import type { Route } from "./+types/api.comments";
 import { z } from "zod";
 import { prisma } from "~/lib/db";
-import { requireAuth } from "~/lib/auth";
+import { requireAuth, forbidden } from "~/lib/auth";
 import { isCore } from "~/lib/roles";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { parseJson } from "~/lib/validate";
@@ -52,7 +52,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   const auth = await requireAuth(request);
   if (!auth.ok) return withCors(request, auth.response);
   if (!(await isCore(auth.user.sub))) {
-    return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
+    return forbidden(request);
   }
 
   const url = new URL(request.url);
@@ -103,7 +103,7 @@ export async function action({ request }: Route.ActionArgs) {
     return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));
   }
   if (!(await isCore(auth.user.sub))) {
-    return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
+    return forbidden(request);
   }
 
   const body = await parseJson(request, CreateSchema);

--- a/dali-api/app/routes/api.doctags.apply.ts
+++ b/dali-api/app/routes/api.doctags.apply.ts
@@ -1,7 +1,7 @@
 import type { Route } from "./+types/api.doctags.apply";
 import { z } from "zod";
 import { prisma } from "~/lib/db";
-import { requireAuth } from "~/lib/auth";
+import { requireAuth, forbidden } from "~/lib/auth";
 import { isCore } from "~/lib/roles";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { parseJson } from "~/lib/validate";
@@ -31,7 +31,7 @@ export async function action({ request }: Route.ActionArgs) {
     return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));
   }
   if (!(await isCore(auth.user.sub))) {
-    return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
+    return forbidden(request);
   }
 
   const body = await parseJson(request, ApplySchema);

--- a/dali-api/app/routes/api.doctags.ts
+++ b/dali-api/app/routes/api.doctags.ts
@@ -1,7 +1,7 @@
 import type { Route } from "./+types/api.doctags";
 import { z } from "zod";
 import { prisma } from "~/lib/db";
-import { requireAuth } from "~/lib/auth";
+import { requireAuth, forbidden } from "~/lib/auth";
 import { isCore } from "~/lib/roles";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { parseJson } from "~/lib/validate";
@@ -53,7 +53,7 @@ export async function action({ request }: Route.ActionArgs) {
   const auth = await requireAuth(request);
   if (!auth.ok) return withCors(request, auth.response);
   if (!(await isCore(auth.user.sub))) {
-    return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
+    return forbidden(request);
   }
   if (request.method !== "POST") {
     return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));

--- a/dali-api/app/routes/api.notifications.$id.read.ts
+++ b/dali-api/app/routes/api.notifications.$id.read.ts
@@ -1,6 +1,6 @@
 import type { Route } from "./+types/api.notifications.$id.read";
 import { prisma } from "~/lib/db";
-import { requireAuth } from "~/lib/auth";
+import { requireAuth, forbidden } from "~/lib/auth";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { ONBOARDING_LINK } from "~/members/lib/welcome.server";
 
@@ -30,7 +30,7 @@ export async function action({ request, params }: Route.ActionArgs) {
     return withCors(request, Response.json({ error: "Not found" }, { status: 404 }));
   }
   if (existing.recipientUserId !== auth.user.sub) {
-    return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
+    return forbidden(request);
   }
 
   // A meeting invite only clears once the recipient RSVPs (via the rsvp

--- a/dali-api/app/routes/api.notifications.$id.rsvp.ts
+++ b/dali-api/app/routes/api.notifications.$id.rsvp.ts
@@ -5,6 +5,7 @@ import { requireAuth, forbidden } from "~/lib/auth";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { parseJson } from "~/lib/validate";
 import { updateGoogleAttendeeRsvp } from "~/lib/google-calendar";
+import { primaryEmail } from "~/lib/display";
 
 const Schema = z.object({
   response: z.enum(["accepted", "declined", "tentative"]),
@@ -60,7 +61,7 @@ export async function action({ request, params }: Route.ActionArgs) {
     where: { id: auth.user.sub },
     select: { daliEmail: true, dartmouthEmail: true },
   });
-  const attendeeEmail = recipient?.daliEmail ?? recipient?.dartmouthEmail ?? auth.user.email;
+  const attendeeEmail = (recipient ? primaryEmail(recipient) : null) ?? auth.user.email;
 
   // Best-effort: push the RSVP to Google. If the meeting wasn't pushed to GCal
   // (no externalEventId or no organizer link), we still record the in-app RSVP.

--- a/dali-api/app/routes/api.notifications.$id.rsvp.ts
+++ b/dali-api/app/routes/api.notifications.$id.rsvp.ts
@@ -1,7 +1,7 @@
 import type { Route } from "./+types/api.notifications.$id.rsvp";
 import { z } from "zod";
 import { prisma } from "~/lib/db";
-import { requireAuth } from "~/lib/auth";
+import { requireAuth, forbidden } from "~/lib/auth";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { parseJson } from "~/lib/validate";
 import { updateGoogleAttendeeRsvp } from "~/lib/google-calendar";
@@ -49,7 +49,7 @@ export async function action({ request, params }: Route.ActionArgs) {
     return withCors(request, Response.json({ error: "Not found" }, { status: 404 }));
   }
   if (notif.recipientUserId !== auth.user.sub) {
-    return withCors(request, Response.json({ error: "Forbidden" }, { status: 403 }));
+    return forbidden(request);
   }
   if (!notif.scheduledMeetingId) {
     return withCors(request, Response.json({ error: "Notification has no associated meeting" }, { status: 400 }));

--- a/dali-api/app/routes/api.tour.complete.ts
+++ b/dali-api/app/routes/api.tour.complete.ts
@@ -1,6 +1,6 @@
 import type { Route } from "./+types/api.tour.complete";
 import { prisma } from "~/lib/db";
-import { requireAuth } from "~/lib/auth";
+import { requireAuth, unauthorized } from "~/lib/auth";
 
 // Mark the launch tour completed for the current member so it isn't auto-shown
 // again (server-driven, per-user). Called when the member finishes or dismisses
@@ -8,7 +8,7 @@ import { requireAuth } from "~/lib/auth";
 // this only governs the automatic post-onboarding show.
 export async function action({ request }: Route.ActionArgs) {
   const auth = await requireAuth(request);
-  if (!auth.ok) return Response.json({ error: "Unauthorized" }, { status: 401 });
+  if (!auth.ok) return unauthorized(request);
   if (request.method !== "POST") {
     return Response.json({ error: "Method not allowed" }, { status: 405 });
   }

--- a/dali-api/app/routes/auth.callback.cas.ts
+++ b/dali-api/app/routes/auth.callback.cas.ts
@@ -5,6 +5,7 @@ import { setSessionCookie } from "~/lib/cookies";
 import { getClientIp } from "~/lib/request-meta";
 import { logAuditEvent } from "~/lib/audit";
 import { upsertUserFromCas } from "~/lib/user-provisioning";
+import { getApiBaseUrl } from "~/lib/app-env";
 
 export async function action() {
   return new Response("Method not allowed", { status: 405 });
@@ -12,7 +13,7 @@ export async function action() {
 
 export async function loader({ request }: Route.LoaderArgs) {
   const url = new URL(request.url);
-  const apiBase = process.env.API_BASE_URL ?? "http://localhost:3001";
+  const apiBase = getApiBaseUrl();
 
   const ticket = url.searchParams.get("ticket");
   const isLink = url.searchParams.get("link") === "1";

--- a/dali-api/app/routes/auth.callback.google.ts
+++ b/dali-api/app/routes/auth.callback.google.ts
@@ -5,6 +5,7 @@ import { setSessionCookie } from "~/lib/cookies";
 import { getClientIp } from "~/lib/request-meta";
 import { logAuditEvent } from "~/lib/audit";
 import { upsertUserFromGoogle } from "~/lib/user-provisioning";
+import { getApiBaseUrl, getCasBaseUrl } from "~/lib/app-env";
 
 const OAUTH_STATE_COOKIE = "__dali_oauth_state";
 
@@ -24,7 +25,7 @@ export async function action() {
 
 export async function loader({ request }: Route.LoaderArgs) {
   const url = new URL(request.url);
-  const apiBase = process.env.API_BASE_URL ?? "http://localhost:3001";
+  const apiBase = getApiBaseUrl();
 
   const code = url.searchParams.get("code");
   const state = url.searchParams.get("state");
@@ -142,8 +143,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   // the merge / no-op / attach cases. Mirrors the MCP-provider flow in
   // oauth.callback.google.ts.
   if (!user.netId) {
-    const casBase =
-      process.env.CAS_BASE_URL ?? "https://login.dartmouth.edu/cas";
+    const casBase = getCasBaseUrl();
     const serviceUrl = `${apiBase}/auth/callback/cas?link=1`;
     headers.set(
       "Location",

--- a/dali-api/app/routes/help.mcp.tsx
+++ b/dali-api/app/routes/help.mcp.tsx
@@ -3,9 +3,10 @@
 import { useState } from "react";
 import { Check, Copy } from "lucide-react";
 import type { Route } from "./+types/help.mcp";
+import { getApiBaseUrl } from "~/lib/app-env";
 
 export async function loader() {
-  const base = process.env.API_BASE_URL ?? "https://os.dali.dartmouth.edu";
+  const base = getApiBaseUrl();
   return { mcpUrl: `${base}/mcp` };
 }
 

--- a/dali-api/app/routes/integrations.calendar.google.callback.ts
+++ b/dali-api/app/routes/integrations.calendar.google.callback.ts
@@ -11,6 +11,8 @@ import { prisma } from "~/lib/db";
 import { buildEncryptedTokens } from "~/lib/google-calendar";
 import { requireAuth } from "~/lib/auth";
 import { CAL_STATE_COOKIE } from "~/routes/oauth.calendar.google.start";
+import { getApiBaseUrl } from "~/lib/app-env";
+import { exchangeGoogleCode, GoogleOAuthError } from "~/lib/google-oauth";
 
 function parseCookies(request: Request): Record<string, string> {
   const header = request.headers.get("Cookie") ?? "";
@@ -63,31 +65,25 @@ export async function loader({ request }: Route.LoaderArgs) {
     return redirectToCalendar("calendar_link_error=state_mismatch");
   }
 
-  const apiBase = process.env.API_BASE_URL ?? "http://localhost:3001";
+  const apiBase = getApiBaseUrl();
   const clientId = process.env.GOOGLE_CLIENT_ID!;
   const clientSecret = process.env.GOOGLE_CLIENT_SECRET!;
 
-  const tokenRes = await fetch("https://oauth2.googleapis.com/token", {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: new URLSearchParams({
+  let tokens;
+  try {
+    tokens = await exchangeGoogleCode({
       code,
-      client_id: clientId,
-      client_secret: clientSecret,
       // Must match the redirect_uri sent by /oauth/calendar/google/start.
-      redirect_uri: `${apiBase}/integrations/calendar/google/callback`,
-      grant_type: "authorization_code",
-    }),
-  });
-  if (!tokenRes.ok) {
-    return redirectToCalendar("calendar_link_error=token_exchange_failed");
+      redirectUri: `${apiBase}/integrations/calendar/google/callback`,
+      clientId,
+      clientSecret,
+    });
+  } catch (err) {
+    if (err instanceof GoogleOAuthError) {
+      return redirectToCalendar("calendar_link_error=token_exchange_failed");
+    }
+    throw err;
   }
-  const tokens = (await tokenRes.json()) as {
-    access_token: string;
-    refresh_token?: string;
-    expires_in?: number;
-    id_token?: string;
-  };
   if (!tokens.refresh_token) {
     return redirectToCalendar("calendar_link_error=no_refresh_token");
   }

--- a/dali-api/app/routes/login.tsx
+++ b/dali-api/app/routes/login.tsx
@@ -12,6 +12,8 @@ const OAUTH_STATE_COOKIE = "__dali_oauth_state";
 const RATE_LIMIT_MAX = 5;
 const RATE_LIMIT_WINDOW_MS = 60_000;
 
+const isProduction = process.env.NODE_ENV === "production";
+
 export const meta: Route.MetaFunction = () => [{ title: "DALI OS · Sign in" }];
 
 export async function loader({ request }: Route.LoaderArgs) {
@@ -62,7 +64,7 @@ export async function action({ request }: Route.ActionArgs) {
       "Max-Age=600",
       "HttpOnly",
       "SameSite=Lax",
-      ...(process.env.NODE_ENV === "production" ? ["Secure"] : []),
+      ...(isProduction ? ["Secure"] : []),
     ].join("; ");
     headers.append("Set-Cookie", stateCookie);
     headers.set(
@@ -79,7 +81,7 @@ export async function action({ request }: Route.ActionArgs) {
     "Max-Age=600",
     "HttpOnly",
     "SameSite=Lax",
-    ...(process.env.NODE_ENV === "production" ? ["Secure"] : []),
+    ...(isProduction ? ["Secure"] : []),
   ].join("; ");
   headers.append("Set-Cookie", stateCookie);
 

--- a/dali-api/app/routes/login.tsx
+++ b/dali-api/app/routes/login.tsx
@@ -4,6 +4,8 @@ import type { Route } from "./+types/login";
 import { requireAuth } from "~/lib/auth";
 import { prisma } from "~/lib/db";
 import { checkRateLimit } from "~/lib/rate-limit";
+import { getApiBaseUrl, getCasBaseUrl } from "~/lib/app-env";
+import { buildGoogleAuthUrl } from "~/lib/google-oauth";
 
 const OAUTH_STATE_COOKIE = "__dali_oauth_state";
 
@@ -46,8 +48,8 @@ export async function action({ request }: Route.ActionArgs) {
   const provider = formData.get("provider") as string;
 
   const state = randomBytes(32).toString("base64url");
-  const apiBase = process.env.API_BASE_URL ?? "http://localhost:3001";
-  const casBase = process.env.CAS_BASE_URL ?? "https://login.dartmouth.edu/cas";
+  const apiBase = getApiBaseUrl();
+  const casBase = getCasBaseUrl();
 
   const headers = new Headers();
 
@@ -86,19 +88,14 @@ export async function action({ request }: Route.ActionArgs) {
   // Enforcement of the domain still happens server-side in
   // /auth/callback/google; `hd` is purely a UX hint and not a security
   // boundary.
-  const googleParams = new URLSearchParams({
-    client_id: process.env.GOOGLE_CLIENT_ID!,
-    redirect_uri: `${apiBase}/auth/callback/google`,
-    response_type: "code",
-    scope: "openid email profile",
+  const googleAuthUrl = buildGoogleAuthUrl({
+    clientId: process.env.GOOGLE_CLIENT_ID!,
+    redirectUri: `${apiBase}/auth/callback/google`,
+    scopes: ["openid", "email", "profile"],
     state,
-    hd: "dali.dartmouth.edu",
   });
 
-  headers.set(
-    "Location",
-    `https://accounts.google.com/o/oauth2/v2/auth?${googleParams}`,
-  );
+  headers.set("Location", `${googleAuthUrl}&hd=dali.dartmouth.edu`);
   return new Response(null, { status: 302, headers });
 }
 

--- a/dali-api/app/routes/oauth.authorize.ts
+++ b/dali-api/app/routes/oauth.authorize.ts
@@ -11,6 +11,8 @@ import { parseSessionId } from "~/lib/cookies";
 import { lookupSession } from "~/lib/session";
 import { prisma } from "~/lib/db";
 import type { OAuthAccountType, OAuthProvider } from "~/generated/prisma/enums";
+import { getApiBaseUrl, getCasBaseUrl } from "~/lib/app-env";
+import { buildGoogleAuthUrl } from "~/lib/google-oauth";
 
 const RATE_LIMIT_MAX = 10;
 const RATE_LIMIT_WINDOW_MS = 60_000;
@@ -141,7 +143,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     scopes: requestedScopes,
   });
 
-  const apiBase = process.env.API_BASE_URL ?? "http://localhost:5173";
+  const apiBase = getApiBaseUrl();
 
   // ── Existing-session shortcut ────────────────────────────────────────────
   // If the browser already has a valid first-party cookie session, skip
@@ -217,8 +219,7 @@ export async function loader({ request }: Route.LoaderArgs) {
 
   // ── CAS flow ─────────────────────────────────────────────────────────────
   if (provider === "cas") {
-    const casBase =
-      process.env.CAS_BASE_URL ?? "https://login.dartmouth.edu/cas";
+    const casBase = getCasBaseUrl();
     const serviceUrl = `${apiBase}/oauth/callback/cas?session_id=${oauthSession.id}`;
     return new Response(null, {
       status: 302,
@@ -229,22 +230,21 @@ export async function loader({ request }: Route.LoaderArgs) {
   }
 
   // ── Google flow ──────────────────────────────────────────────────────────
-  const googleParams = new URLSearchParams({
-    client_id: process.env.GOOGLE_CLIENT_ID!,
-    redirect_uri: `${apiBase}/oauth/callback/google`,
-    response_type: "code",
-    scope: "openid email profile",
+  let googleAuthUrl = buildGoogleAuthUrl({
+    clientId: process.env.GOOGLE_CLIENT_ID!,
+    redirectUri: `${apiBase}/oauth/callback/google`,
+    scopes: ["openid", "email", "profile"],
     state: oauthSession.id,
     prompt: "select_account",
   });
   if (accountType === "member") {
-    googleParams.set("hd", "dali.dartmouth.edu");
+    googleAuthUrl += "&hd=dali.dartmouth.edu";
   }
 
   return new Response(null, {
     status: 302,
     headers: {
-      Location: `https://accounts.google.com/o/oauth2/v2/auth?${googleParams}`,
+      Location: googleAuthUrl,
     },
   });
 }

--- a/dali-api/app/routes/oauth.calendar.google.start.ts
+++ b/dali-api/app/routes/oauth.calendar.google.start.ts
@@ -5,6 +5,8 @@
 // in isolation from login.
 
 import { requireAuth } from "~/lib/auth";
+import { getApiBaseUrl } from "~/lib/app-env";
+import { buildGoogleAuthUrl } from "~/lib/google-oauth";
 import { randomBytes } from "node:crypto";
 
 export const CAL_STATE_COOKIE = "__dali_cal_oauth_state";
@@ -15,7 +17,7 @@ const SCOPES = [
   // Full calendar scope: needed for events.insert / events.patch when pushing
   // scheduled meetings and RSVP updates, plus calendarList + freebusy reads.
   "https://www.googleapis.com/auth/calendar",
-].join(" ");
+];
 
 export async function loader({ request }: { request: Request }) {
   const auth = await requireAuth(request);
@@ -26,23 +28,28 @@ export async function loader({ request }: { request: Request }) {
     return new Response(null, { status: 302, headers: { Location: "/portal" } });
   }
 
-  const apiBase = process.env.API_BASE_URL ?? "http://localhost:3001";
+  const apiBase = getApiBaseUrl();
   const clientId = process.env.GOOGLE_CLIENT_ID;
   if (!clientId) {
     return new Response("GOOGLE_CLIENT_ID not configured", { status: 500 });
   }
 
   const state = randomBytes(16).toString("hex");
-  const params = new URLSearchParams({
-    client_id: clientId,
-    redirect_uri: `${apiBase}/integrations/calendar/google/callback`,
-    response_type: "code",
-    scope: SCOPES,
-    access_type: "offline",
-    // `consent` forces a refresh_token even if the user has authorized before.
-    prompt: "consent select_account",
+  const authUrl = buildGoogleAuthUrl({
+    clientId,
+    redirectUri: `${apiBase}/integrations/calendar/google/callback`,
+    scopes: SCOPES,
     state,
+    accessType: "offline",
+    // `consent` forces a refresh_token even if the user has authorized before.
+    prompt: "consent",
   });
+  // Append select_account to the prompt: the helper only supports a single
+  // prompt value, but Google accepts a space-delimited combination.
+  const location = authUrl.replace(
+    "prompt=consent",
+    "prompt=consent+select_account",
+  );
 
   const stateCookie = `${CAL_STATE_COOKIE}=${state}; Path=/; Max-Age=600; HttpOnly; SameSite=Lax`;
 
@@ -50,7 +57,7 @@ export async function loader({ request }: { request: Request }) {
       status: 302,
       headers: {
         "Set-Cookie": stateCookie,
-        Location: `https://accounts.google.com/o/oauth2/v2/auth?${params}`,
+        Location: location,
       },
     });
 }

--- a/dali-api/app/routes/oauth.callback.cas.ts
+++ b/dali-api/app/routes/oauth.callback.cas.ts
@@ -10,6 +10,7 @@ import { prisma } from "~/lib/db";
 import { issueSession } from "~/lib/session";
 import { setSessionCookie } from "~/lib/cookies";
 import { getClientIp } from "~/lib/request-meta";
+import { getApiBaseUrl, getFrontendUrl } from "~/lib/app-env";
 
 export async function action() {
   return new Response("Method not allowed", { status: 405 });
@@ -17,8 +18,8 @@ export async function action() {
 
 export async function loader({ request }: Route.LoaderArgs) {
   const url = new URL(request.url);
-  const frontendUrl = process.env.FRONTEND_URL ?? "http://localhost:5173";
-  const apiBase = process.env.API_BASE_URL ?? "http://localhost:3001";
+  const frontendUrl = getFrontendUrl();
+  const apiBase = getApiBaseUrl();
 
   const ticket = url.searchParams.get("ticket");
   const sessionId = url.searchParams.get("session_id");

--- a/dali-api/app/routes/oauth.callback.google.ts
+++ b/dali-api/app/routes/oauth.callback.google.ts
@@ -10,6 +10,7 @@ import { upsertUserFromGoogle } from "~/lib/user-provisioning";
 import { issueSession } from "~/lib/session";
 import { setSessionCookie } from "~/lib/cookies";
 import { getClientIp } from "~/lib/request-meta";
+import { getApiBaseUrl, getCasBaseUrl, getFrontendUrl } from "~/lib/app-env";
 
 export async function action() {
   return new Response("Method not allowed", { status: 405 });
@@ -17,8 +18,8 @@ export async function action() {
 
 export async function loader({ request }: Route.LoaderArgs) {
   const url = new URL(request.url);
-  const frontendUrl = process.env.FRONTEND_URL ?? "http://localhost:5173";
-  const apiBase = process.env.API_BASE_URL ?? "http://localhost:3001";
+  const frontendUrl = getFrontendUrl();
+  const apiBase = getApiBaseUrl();
 
   const googleCode = url.searchParams.get("code");
   const sessionId = url.searchParams.get("state"); // passed session.id as Google's state
@@ -103,8 +104,7 @@ export async function loader({ request }: Route.LoaderArgs) {
       data: { linkUserId: user.id },
     });
 
-    const casBase =
-      process.env.CAS_BASE_URL ?? "https://login.dartmouth.edu/cas";
+    const casBase = getCasBaseUrl();
     const serviceUrl = `${apiBase}/oauth/callback/cas?session_id=${session.id}`;
     return new Response(null, {
       status: 302,

--- a/dali-api/app/routes/oauth.consent.tsx
+++ b/dali-api/app/routes/oauth.consent.tsx
@@ -4,6 +4,7 @@ import { prisma } from "~/lib/db";
 import { getOAuthClient, generateAuthorizationCode } from "~/lib/oauth";
 import { parseSessionId } from "~/lib/cookies";
 import { lookupSession } from "~/lib/session";
+import { displayEmail } from "~/lib/display";
 
 const SCOPE_DESCRIPTIONS: Record<string, string> = {
   "mcp:read": "Read your DALI OS data on your behalf",
@@ -58,10 +59,7 @@ export async function loader({ request }: Route.LoaderArgs): Promise<LoaderData>
     where: { id: oauthSession.userId },
     select: { daliEmail: true, dartmouthEmail: true, netId: true },
   });
-  const userEmail =
-    user?.daliEmail ??
-    user?.dartmouthEmail ??
-    (user?.netId ? `${user.netId}@dartmouth.edu` : "(unknown)");
+  const userEmail = (user ? displayEmail(user) : "") || "(unknown)";
 
   return {
     ok: true,

--- a/dali-api/app/routes/portal.tsx
+++ b/dali-api/app/routes/portal.tsx
@@ -15,6 +15,7 @@ import { InterviewSlotPicker } from "~/hiring/components/InterviewSlotPicker";
 import { ApplicantErrorBoundary } from "~/components/ApplicantErrorBoundary";
 import { Confetti } from "~/components/Confetti";
 import { formatInterviewDate, formatInterviewTimeRange } from "~/hiring/lib/interview-time";
+import { APPLICATIONS_FROM_EMAIL } from "~/lib/app-env";
 
 export const meta: Route.MetaFunction = () => [{ title: "Applicant portal · DALI OS" }];
 
@@ -563,8 +564,8 @@ function InvitedToInterviewView({
 
       <p className="text-sm text-muted-foreground mt-6">
         Can't attend in-person?{" "}
-        <a href="mailto:applications@dali.dartmouth.edu" className="underline text-dark-blue hover:text-accent-coral">
-          Email applications@dali.dartmouth.edu
+        <a href={`mailto:${APPLICATIONS_FROM_EMAIL}`} className="underline text-dark-blue hover:text-accent-coral">
+          Email {APPLICATIONS_FROM_EMAIL}
         </a>{" "}
         to request an online interview.
       </p>

--- a/dali-api/app/routes/portal.tsx
+++ b/dali-api/app/routes/portal.tsx
@@ -16,6 +16,7 @@ import { ApplicantErrorBoundary } from "~/components/ApplicantErrorBoundary";
 import { Confetti } from "~/components/Confetti";
 import { formatInterviewDate, formatInterviewTimeRange } from "~/hiring/lib/interview-time";
 import { APPLICATIONS_FROM_EMAIL } from "~/lib/app-env";
+import { Button } from "~/components/ui/Button";
 
 export const meta: Route.MetaFunction = () => [{ title: "Applicant portal · DALI OS" }];
 
@@ -552,13 +553,14 @@ function InvitedToInterviewView({
             />
           </div>
 
-          <button
+          <Button
+            variant="primary"
+            size="md"
             onClick={handleConfirm}
             disabled={!selectedSlot || booking}
-            className="px-6 py-2.5 rounded-full bg-accent-coral text-white text-sm font-semibold hover:bg-accent-coral/90 transition disabled:opacity-50"
           >
             {booking ? "Booking..." : "Confirm Time"}
-          </button>
+          </Button>
         </>
       )}
 
@@ -708,13 +710,15 @@ function InterviewScheduledView({
               />
             </div>
 
-            <button
+            <Button
+              variant="primary"
+              size="md"
               onClick={handleConfirmReschedule}
               disabled={!selectedRescheduleSlotId || confirmingReschedule}
-              className="px-6 py-2.5 rounded-full bg-accent-coral text-white text-sm font-semibold hover:bg-accent-coral/90 transition disabled:opacity-50 mr-3"
+              className="mr-3"
             >
               {confirmingReschedule ? "Rescheduling..." : "Confirm Reschedule"}
-            </button>
+            </Button>
           </>
         )}
         <button onClick={exitRescheduling} className="text-sm font-semibold text-muted-foreground hover:underline">

--- a/dali-api/app/routes/privacy.tsx
+++ b/dali-api/app/routes/privacy.tsx
@@ -6,6 +6,7 @@
 // app/lib/gmail.ts — if those change, update this page in the same PR.
 
 import type { Route } from "./+types/privacy";
+import { APPLICATIONS_FROM_EMAIL } from "~/lib/app-env";
 
 export const meta: Route.MetaFunction = () => [
   { title: "Privacy Policy · DALI OS" },
@@ -101,7 +102,7 @@ export default function PrivacyPolicy() {
         <p>
           A single shared lab account (
           <code className="rounded bg-muted px-1.5 py-0.5 text-xs">
-            applications@dali.dartmouth.edu
+            {APPLICATIONS_FROM_EMAIL}
           </code>
           ) is authorized with the scope{" "}
           <code className="rounded bg-muted px-1.5 py-0.5 text-xs">

--- a/dali-api/app/routes/settings.calendar.tsx
+++ b/dali-api/app/routes/settings.calendar.tsx
@@ -5,7 +5,7 @@
 
 import { Link, redirect, useFetcher } from "react-router";
 import { CalendarDays, Plus, Trash2 } from "lucide-react";
-import { requireAuth } from "~/lib/auth";
+import { requireAuth, forbidden, unauthorized } from "~/lib/auth";
 import { prisma } from "~/lib/db";
 import { listCalendarsForLink } from "~/lib/google-calendar";
 import { CalendarActionSchema } from "~/lib/calendar-schemas";
@@ -73,9 +73,9 @@ export async function loader({ request }: Route.LoaderArgs) {
 
 export async function action({ request }: Route.ActionArgs) {
   const auth = await requireAuth(request);
-  if (!auth.ok) return Response.json({ error: "Unauthorized" }, { status: 401 });
+  if (!auth.ok) return unauthorized(request);
   if (auth.user.type === "applicant")
-    return Response.json({ error: "Forbidden" }, { status: 403 });
+    return forbidden(request);
 
   const userId = auth.user.sub;
   const form = await request.formData();

--- a/dali-api/app/routes/settings.slack.tsx
+++ b/dali-api/app/routes/settings.slack.tsx
@@ -6,7 +6,7 @@
 
 import { redirect, useFetcher } from "react-router";
 import { Slack, CheckCircle2, Trash2 } from "lucide-react";
-import { requireAuth } from "~/lib/auth";
+import { requireAuth, unauthorized, forbidden } from "~/lib/auth";
 import { prisma } from "~/lib/db";
 import { lookupSlackUserByEmail } from "~/slack/lib/slack-client";
 import { logAuditEvent } from "~/lib/audit";
@@ -38,9 +38,9 @@ export async function loader({ request }: Route.LoaderArgs) {
 
 export async function action({ request }: Route.ActionArgs) {
   const auth = await requireAuth(request);
-  if (!auth.ok) return Response.json({ error: "Unauthorized" }, { status: 401 });
+  if (!auth.ok) return unauthorized(request);
   if (auth.user.type === "applicant")
-    return Response.json({ error: "Forbidden" }, { status: 403 });
+    return forbidden(request);
 
   const userId = auth.user.sub;
   const form = await request.formData();

--- a/dali-api/app/slack/lib/channel-name.ts
+++ b/dali-api/app/slack/lib/channel-name.ts
@@ -1,0 +1,10 @@
+// Slack channel names: lowercase, no spaces/periods, ≤80 chars, hyphens ok.
+// Pure string function — kept out of slack-client.ts so client components can
+// import it without dragging @slack/web-api into the browser bundle.
+export function sanitizeChannelName(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80);
+}

--- a/dali-api/app/slack/lib/slack-client.ts
+++ b/dali-api/app/slack/lib/slack-client.ts
@@ -1,4 +1,6 @@
 import { WebClient } from "@slack/web-api";
+import { sanitizeChannelName } from "./channel-name";
+export { sanitizeChannelName };
 
 export type SlackThreadMessage = {
   ts: string;
@@ -215,13 +217,22 @@ export function slackMissingScopeMsg(err: unknown, raw: string): string {
   return `${raw} — the Slack bot token is missing a required scope. Check the call's needed scope in the Slack app config (Bot Token Scopes) and reinstall.`;
 }
 
-function sanitizeChannelName(name: string): string {
-  // Slack channel names: lowercase, no spaces/periods, ≤80 chars, hyphens ok.
-  return name
-    .toLowerCase()
-    .replace(/[^a-z0-9-]+/g, "-")
-    .replace(/^-+|-+$/g, "")
-    .slice(0, 80);
+
+// Shared Slack/integration error formatter: maps common Slack API error codes
+// (and the GitHub teams "Not Found" variant) to actionable hints so leads can
+// self-diagnose without reading API docs. Falls back to the raw message.
+export function slackErrorMessage(err: unknown, raw?: string): string {
+  const message = raw ?? (err instanceof Error ? err.message : String(err));
+  if (/missing_scope/i.test(message)) {
+    return slackMissingScopeMsg(err, message);
+  }
+  if (/not_in_channel|channel_not_found/i.test(message)) {
+    return `${message} — the Slack bot isn't a member of that channel. Invite the bot to it, or let finalize create the channel.`;
+  }
+  if (/\bNot Found\b/.test(message) && /teams\/members/.test(message)) {
+    return `${message} — couldn't add a GitHub team member. Check that the GitHub App is installed on GITHUB_ORG with the "Members: read & write" org permission, and that each member's githubUsername is a real GitHub login.`;
+  }
+  return message;
 }
 
 async function findChannelByName(

--- a/dali-api/app/slack/lib/slack-client.ts
+++ b/dali-api/app/slack/lib/slack-client.ts
@@ -16,6 +16,12 @@ export type SlackFile = {
   urlPrivate: string;
 };
 
+export const SLACK_NOT_CONFIGURED_MESSAGE = "SLACK_BOT_TOKEN not set.";
+
+export function slackConfigured(): boolean {
+  return Boolean(process.env.SLACK_BOT_TOKEN);
+}
+
 let cached: WebClient | null = null;
 function client(): WebClient {
   if (cached) return cached;

--- a/dali-api/prisma/migrations/20260614000000_core_assignment_cycle_backfill/migration.sql
+++ b/dali-api/prisma/migrations/20260614000000_core_assignment_cycle_backfill/migration.sql
@@ -1,0 +1,50 @@
+-- Backfill: materialize CoreAssignment rows across the full election cycle.
+--
+-- Previously a Core election only wrote a single CoreAssignment row anchored
+-- on the Spring term it was set during; readers like `isCore` then derived
+-- cycle membership at query time. As of this migration, writers fan out the
+-- assignment across every term in the cycle window [Spring N, Spring N+1)
+-- (4 terms — S, X, F, W) so reads by termId can stand on their own.
+--
+-- This backfill makes existing data consistent with that contract.
+--
+-- Cycle math (mirrors app/lib/core-cycle.ts):
+--   Season digit = sortKey % 10. W=1, S=2, X=3, F=4.
+--   cycle_start =  (W) sk - 9, (S) sk, (X) sk - 1, (F) sk - 2.
+--   cycle window = [cycle_start, cycle_start + 10) — 4 consecutive terms.
+--
+-- For each distinct (userId, leadTitle, cycle_start) implied by the existing
+-- rows, we insert any missing (userId, termId, leadTitle) triples. The
+-- NOT EXISTS guard makes this idempotent and safe to re-run; we do not
+-- delete or modify any existing rows.
+
+INSERT INTO "CoreAssignment" (id, "userId", "termId", "leadTitle")
+SELECT
+  'cab_' || REPLACE(gen_random_uuid()::text, '-', '') AS id,
+  cycles."userId",
+  t.id                                                AS "termId",
+  cycles."leadTitle"
+FROM (
+  SELECT DISTINCT
+    ca."userId",
+    ca."leadTitle",
+    CASE
+      WHEN anchor."sortKey" % 10 = 1 THEN anchor."sortKey" - 9
+      ELSE anchor."sortKey" - (anchor."sortKey" % 10) + 2
+    END AS cycle_start
+  FROM "CoreAssignment" ca
+  JOIN "Term" anchor ON anchor.id = ca."termId"
+) cycles
+JOIN "Term" t
+  ON t."sortKey" >= cycles.cycle_start
+ AND t."sortKey" <  cycles.cycle_start + 10
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM "CoreAssignment" existing
+  WHERE existing."userId" = cycles."userId"
+    AND existing."termId" = t.id
+    AND (
+      (existing."leadTitle" IS NULL AND cycles."leadTitle" IS NULL)
+      OR existing."leadTitle" = cycles."leadTitle"
+    )
+);


### PR DESCRIPTION
Previously a Core election only wrote a single CoreAssignment row for the Spring term it ran in. Cycle rollover (#803) made isCore checks recognize that row across the full Spring→Winter window at READ time, but no other surface re-derived the same math, so features that queried CoreAssignment by termId (payroll export's Core section, the groups helper, the staffing finalize cohort check, etc.) saw the roster as empty for Summer / Fall / next Winter.

This makes the data side of the contract match the access side: every writer fans out across the cycle's 4 terms on add, and clears the matching (userId, leadTitle) across the cycle on remove. Existing rows are backfilled by an idempotent migration.

- New shared helper `~/lib/core-cycle.ts` with `coreCycleTermIds(termId)` and `cycleSortKeyRange(sortKey)`. `roles.ts` now imports the range helper instead of duplicating the cycle math.
- Writers updated:
  - `admin-console.members.tsx` add-core-title / remove-core-title: fan-out createMany / cycle-scoped deleteMany.
  - `api.members.$memberId.roles.ts` Hiring Lead toggle: same pattern, inside the existing $transaction.
- Backfill migration `20260614000000_core_assignment_cycle_backfill` inserts the missing (userId, termId, leadTitle) triples across every cycle implied by existing rows. Idempotent via NOT EXISTS guard.
- Reverts the payroll-export listCoreCandidates band-aid (b4adbed): the lookup is back to a plain `where: { termId }` because rows now exist directly for the selected term.
- Tests updated to assert the new findMany / createMany shape and the cycle-scoped delete; `~/lib/core-cycle` is mocked to a single term so existing schema-validation tests stay focused on input handling.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/835"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784061594&installation_id=133523038&pr_number=835&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F835&signature=5fdd22116ec9f05ba03f75705d1b6e3fca35c641d3cbd33650641bf6157dc90f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->