### PR TITLE
DRY refactor: UI primitive adoption, label dedup, Zod schemas, retry …

### DIFF
--- a/dali-api/app/admin-console/lib/eligibility.ts
+++ b/dali-api/app/admin-console/lib/eligibility.ts
@@ -3,11 +3,11 @@
 // client bundle; pure values stay here so route components can render the
 // level picker without pulling a "*.server" file into the browser.
 
-export type Level = "P1" | "P2" | "P3";
+import { ALL_LEVELS, isLevel, type Level } from "~/lib/level";
 
-export const ALLOWED_LEVELS: Level[] = ["P1", "P2", "P3"];
+export { type Level };
+export const ALLOWED_LEVELS = ALL_LEVELS;
 
 export function parseLevel(raw: unknown): Level | null {
-  if (typeof raw !== "string") return null;
-  return (ALLOWED_LEVELS as string[]).includes(raw) ? (raw as Level) : null;
+  return isLevel(raw) ? raw : null;
 }

--- a/dali-api/app/admin-console/routes/admin-console.announcements.tsx
+++ b/dali-api/app/admin-console/routes/admin-console.announcements.tsx
@@ -16,6 +16,7 @@ import {
   Paperclip,
   CheckCircle2,
 } from "lucide-react";
+import { SearchInput } from "~/components/ui/SearchInput";
 
 export const meta: Route.MetaFunction = () => [
   { title: "Announcements · Operations · DALI OS" },
@@ -373,16 +374,11 @@ export default function AnnouncementsPage() {
                 </span>
               ) : (
                 <>
-                  <div className="relative">
-                    <Search className="absolute left-2 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground" />
-                    <input
-                      type="text"
-                      placeholder="Search groups…"
-                      value={groupSearch}
-                      onChange={(e) => setGroupSearch(e.target.value)}
-                      className="w-full pl-7 pr-2 py-1.5 text-sm border border-border rounded-md bg-card text-foreground"
-                    />
-                  </div>
+                  <SearchInput
+                    value={groupSearch}
+                    onChange={(e) => setGroupSearch(e.target.value)}
+                    placeholder="Search groups…"
+                  />
                   {filteredGroups.length === 0 ? (
                     <span className="text-xs text-muted-foreground">
                       No matching groups.
@@ -425,16 +421,11 @@ export default function AnnouncementsPage() {
                   </span>
                 )}
               </div>
-              <div className="relative">
-                <Search className="absolute left-2 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground" />
-                <input
-                  type="text"
-                  placeholder="Search people…"
-                  value={search}
-                  onChange={(e) => setSearch(e.target.value)}
-                  className="w-full pl-7 pr-2 py-1.5 text-sm border border-border rounded-md bg-card text-foreground"
-                />
-              </div>
+              <SearchInput
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder="Search people…"
+              />
               <div className="max-h-64 overflow-y-auto border border-border rounded-md divide-y divide-border bg-card">
                 {filteredMembers.map((m) => (
                   <label

--- a/dali-api/app/admin-console/routes/admin-console.domains.tsx
+++ b/dali-api/app/admin-console/routes/admin-console.domains.tsx
@@ -7,7 +7,7 @@ import { requireAuth, forbidden } from "~/lib/auth";
 import { isAdmin, isCore, isAdminViaEnv, currentTerm } from "~/lib/roles";
 import { LAB_MEMBER_WHERE, MEMBER_LIST_ORDER_BY } from "~/lib/prisma-shapes";
 import { describeDomainUsage, DOMAIN_USAGE_COUNT_SELECT } from "./api.domains.$domainId";
-import { ALLOWED_LEVELS, parseLevel } from "~/admin-console/lib/eligibility";
+import { ALLOWED_LEVELS, parseLevel, type Level } from "~/admin-console/lib/eligibility";
 import {
   addOrUpdateEligibility,
   removeEligibility,
@@ -102,7 +102,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     })),
     eligibilities: d.eligibilities.map((e) => ({
       id: e.id,
-      level: e.level as "P1" | "P2" | "P3",
+      level: e.level as Level,
       user: {
         id: e.user.id,
         firstName: e.user.firstName,
@@ -312,7 +312,7 @@ function DomainLeadsForDomain({ domain, members }: { domain: DomainWithCounts; m
 // the level menu, while the styled badge underneath renders the current value.
 // Transparent background — distinguished by text color only (P1 muted, P2 teal,
 // P3 coral).
-const LEVEL_BADGE: Record<"P1" | "P2" | "P3", string> = {
+const LEVEL_BADGE: Record<Level, string> = {
   P1: "text-muted-foreground",
   P2: "text-accent-teal",
   P3: "text-accent-coral",
@@ -325,12 +325,12 @@ function EligibilityLevelSelect({
 }: {
   domainId: string;
   userId: string;
-  level: "P1" | "P2" | "P3";
+  level: Level;
 }) {
   const fetcher = useFetcher();
   // Optimistic: reflect the just-submitted level while the request is in flight.
   const pending = fetcher.formData?.get("level");
-  const shown = (typeof pending === "string" ? pending : level) as "P1" | "P2" | "P3";
+  const shown = (typeof pending === "string" ? pending : level) as Level;
   return (
     <fetcher.Form method="post" className="relative inline-flex">
       <input type="hidden" name="intent" value="set-eligibility-level" />

--- a/dali-api/app/admin-console/routes/admin-console.payroll-export.csv.ts
+++ b/dali-api/app/admin-console/routes/admin-console.payroll-export.csv.ts
@@ -1,7 +1,7 @@
 import type { Route } from "./+types/admin-console.payroll-export.csv";
 import { redirect } from "react-router";
 import { prisma } from "~/lib/db";
-import { requireAuth } from "~/lib/auth";
+import { requireAuth, forbidden } from "~/lib/auth";
 import { csvResponse } from "~/lib/csv";
 import { isAdmin } from "~/lib/roles";
 import {
@@ -29,7 +29,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   const auth = await requireAuth(request);
   if (!auth.ok) return redirect("/login");
   if (!(await isAdmin(auth.user.sub))) {
-    return new Response("Forbidden", { status: 403 });
+    return forbidden(request);
   }
 
   const url = new URL(request.url);

--- a/dali-api/app/components/ApplicantErrorBoundary.tsx
+++ b/dali-api/app/components/ApplicantErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import { isRouteErrorResponse, Link, useRevalidator } from "react-router";
+import { Button } from "~/components/ui/Button";
 
 type SecondaryAction =
   | { kind: "back-to-portal" }
@@ -59,14 +60,14 @@ export function ApplicantErrorBoundary({
           {description}
         </p>
         <div className="flex flex-wrap items-center justify-center gap-3">
-          <button
-            type="button"
+          <Button
+            variant="primary"
+            size="md"
             onClick={() => revalidator.revalidate()}
             disabled={trying}
-            className="px-6 py-2.5 rounded-full bg-accent-coral text-white text-sm font-semibold hover:bg-accent-coral/90 transition disabled:opacity-50"
           >
             {trying ? "Trying..." : "Try again"}
-          </button>
+          </Button>
           {secondaryAction.kind === "back-to-portal" && (
             <Link
               to="/portal"

--- a/dali-api/app/components/ui/Avatar.tsx
+++ b/dali-api/app/components/ui/Avatar.tsx
@@ -1,0 +1,41 @@
+import { cn } from "~/lib/cn";
+import { initialsFromName } from "~/lib/display";
+
+export type AvatarSize = "sm" | "md" | "lg";
+
+export interface AvatarProps {
+  photoUrl?: string | null;
+  name: string;
+  size?: AvatarSize;
+  className?: string;
+}
+
+const SIZES: Record<AvatarSize, string> = {
+  sm: "w-8 h-8 text-[11px]",
+  md: "w-10 h-10 text-sm",
+  lg: "w-12 h-12 text-base",
+};
+
+export function Avatar({ photoUrl, name, size = "md", className }: AvatarProps) {
+  if (photoUrl) {
+    return (
+      <img
+        src={photoUrl}
+        alt={name}
+        className={cn("rounded-full object-cover", SIZES[size], className)}
+      />
+    );
+  }
+  return (
+    <div
+      className={cn(
+        "bg-accent-coral/15 text-accent-coral font-medium rounded-full flex items-center justify-center",
+        SIZES[size],
+        className,
+      )}
+      aria-label={name}
+    >
+      {initialsFromName(name)}
+    </div>
+  );
+}

--- a/dali-api/app/components/ui/RolePills.tsx
+++ b/dali-api/app/components/ui/RolePills.tsx
@@ -1,0 +1,59 @@
+import { cn } from "~/lib/cn";
+
+export type RolePillSize = "sm" | "md";
+
+export interface RolePillsProps {
+  isAdmin?: boolean;
+  isCore?: boolean;
+  coreTitles?: string[];
+  domainRoles?: Array<{ domainName: string; level?: string }>;
+  size?: RolePillSize;
+  showLevel?: boolean;
+  className?: string;
+}
+
+const SIZES: Record<RolePillSize, string> = {
+  sm: "text-[11px] px-1.5 py-0.5",
+  md: "text-xs px-2 py-0.5",
+};
+
+const PILL_BASE = "inline-flex items-center rounded-full font-medium";
+const ADMIN_TONE = "bg-accent-coral/15 text-accent-coral";
+const DEFAULT_TONE = "bg-muted text-foreground";
+
+export function RolePills({
+  isAdmin,
+  isCore,
+  coreTitles,
+  domainRoles,
+  size = "md",
+  showLevel = false,
+  className,
+}: RolePillsProps) {
+  const sizeClass = SIZES[size];
+  return (
+    <span className={cn("inline-flex flex-wrap gap-1", className)}>
+      {isAdmin && (
+        <span className={cn(PILL_BASE, ADMIN_TONE, sizeClass)}>Admin</span>
+      )}
+      {isCore && (
+        <span className={cn(PILL_BASE, DEFAULT_TONE, sizeClass)}>Core</span>
+      )}
+      {coreTitles?.map((title) => (
+        <span key={`core-${title}`} className={cn(PILL_BASE, DEFAULT_TONE, sizeClass)}>
+          {title}
+        </span>
+      ))}
+      {domainRoles?.map((role, i) => (
+        <span
+          key={`domain-${role.domainName}-${i}`}
+          className={cn(PILL_BASE, DEFAULT_TONE, sizeClass)}
+        >
+          {showLevel && role.level
+            ? `${role.domainName} · ${role.level}`
+            : role.domainName}
+        </span>
+      ))}
+    </span>
+  );
+}

--- a/dali-api/app/components/ui/SearchInput.tsx
+++ b/dali-api/app/components/ui/SearchInput.tsx
@@ -1,0 +1,37 @@
+import type { InputHTMLAttributes, ChangeEvent } from "react";
+import { Search } from "lucide-react";
+import { cn } from "~/lib/cn";
+
+export interface SearchInputProps
+  extends Omit<InputHTMLAttributes<HTMLInputElement>, "size"> {
+  value: string;
+  onChange: (e: ChangeEvent<HTMLInputElement>) => void;
+  placeholder?: string;
+  containerClassName?: string;
+}
+
+const INPUT_BASE =
+  "w-full pl-7 pr-2 py-1.5 text-sm border border-border rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-accent-coral/30";
+
+export function SearchInput({
+  value,
+  onChange,
+  placeholder,
+  className,
+  containerClassName,
+  ...props
+}: SearchInputProps) {
+  return (
+    <div className={cn("relative", containerClassName)}>
+      <Search className="absolute left-2 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground pointer-events-none" />
+      <input
+        type="search"
+        value={value}
+        onChange={onChange}
+        placeholder={placeholder}
+        className={cn(INPUT_BASE, className)}
+        {...props}
+      />
+    </div>
+  );
+}

--- a/dali-api/app/forms/components/FormDetail.tsx
+++ b/dali-api/app/forms/components/FormDetail.tsx
@@ -13,6 +13,7 @@ import {
 } from "lucide-react";
 import { FormBuilderTab } from "~/hiring/components/ChallengeBuilder";
 import { RichTextViewer, isEmptyDoc } from "~/components/RichTextViewer";
+import { Button } from "~/components/ui/Button";
 import type { Question } from "~/types";
 import type { loader } from "~/forms/routes/forms.edit.$formId";
 
@@ -199,13 +200,14 @@ export function FormDetail() {
             </p>
           </div>
           {!isEditing && (
-            <button
+            <Button
+              variant="primary"
+              size="sm"
               onClick={() => startEditing()}
-              className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-lg text-white bg-accent-coral hover:bg-accent-coral/90 shadow-sm"
             >
-              <Plus className="w-4 h-4 mr-2" />
+              <Plus className="w-4 h-4" />
               {hasDraft ? "Continue editing draft" : "New version"}
-            </button>
+            </Button>
           )}
         </div>
 
@@ -435,13 +437,14 @@ export function FormDetail() {
                 Get started by building this form.
               </p>
               <div className="mt-6">
-                <button
+                <Button
+                  variant="primary"
+                  size="sm"
                   onClick={() => startEditing()}
-                  className="inline-flex items-center px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-accent-coral hover:bg-accent-coral/90"
                 >
-                  <Plus className="w-4 h-4 mr-2" />
+                  <Plus className="w-4 h-4" />
                   Build form
-                </button>
+                </Button>
               </div>
             </div>
           )}

--- a/dali-api/app/forms/components/FormsBrowser.tsx
+++ b/dali-api/app/forms/components/FormsBrowser.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { Link, useFetcher } from "react-router";
 import { Folder, FileText, MoreVertical } from "lucide-react";
+import { Button } from "~/components/ui/Button";
 import type { FormCard, FolderCard } from "~/forms/lib/forms-data";
 
 function errorOf(data: unknown): string | null {
@@ -153,14 +154,15 @@ export function FormsBrowser({
         >
           + New folder
         </button>
-        <button
+        <Button
           type="button"
+          variant="primary"
+          size="sm"
           disabled={busy}
           onClick={createForm}
-          className="px-3 py-1.5 text-sm font-medium rounded-md bg-accent-coral text-white hover:bg-accent-coral/90 transition-colors disabled:opacity-60"
         >
           + New form
-        </button>
+        </Button>
         </div>
       </div>
 

--- a/dali-api/app/forms/components/MemberFormFillView.tsx
+++ b/dali-api/app/forms/components/MemberFormFillView.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { ChallengeQuestionField } from "~/hiring/components/ChallengeQuestionField";
 import { RichTextViewer, isEmptyDoc } from "~/components/RichTextViewer";
+import { Button } from "~/components/ui/Button";
 import type { Question } from "~/types";
 
 // The shared authenticated form-fill UI. Rendered both by /forms/fill/:token
@@ -125,13 +126,15 @@ export function MemberFormFillView({
           </div>
         ))}
 
-        <button
+        <Button
           type="submit"
+          variant="primary"
+          size="sm"
           disabled={state === "submitting"}
-          className="self-start px-4 py-2 text-sm font-medium rounded-lg bg-accent-coral text-white hover:bg-accent-coral/90 disabled:opacity-60 transition-colors"
+          className="self-start"
         >
           {state === "submitting" ? "Submitting…" : "Submit"}
-        </button>
+        </Button>
       </form>
     </>
   );

--- a/dali-api/app/forms/lib/forms-data.ts
+++ b/dali-api/app/forms/lib/forms-data.ts
@@ -117,13 +117,13 @@ export async function loadFormForEdit(
       createdByName: `${v.createdBy.firstName} ${v.createdBy.lastName}`.trim(),
       questions: (v.questions as unknown as Question[]) ?? [],
       // intro holds serialized ProseMirror JSON (see module note).
-      description: v.intro ? safeParse(v.intro) : null,
+      description: v.intro ? safeParseJsonString(v.intro) : null,
     })),
     draft: draftQuestions
       ? {
           questions: draftQuestions,
           // draftIntro mirrors FormVersion.intro (serialized ProseMirror JSON).
-          description: form.draftIntro ? safeParse(form.draftIntro) : null,
+          description: safeParseJsonString(form.draftIntro),
         }
       : null,
   };
@@ -196,7 +196,7 @@ export async function loadFormsLevel(folderId: string | null) {
               id: v.id,
               questions: (v.questions as unknown as Question[]) ?? [],
               // intro holds serialized ProseMirror JSON (see module note).
-              description: v.intro ? safeParse(v.intro) : null,
+              description: v.intro ? safeParseJsonString(v.intro) : null,
             }
           : null,
       };
@@ -208,7 +208,8 @@ export async function loadFormsLevel(folderId: string | null) {
   };
 }
 
-function safeParse(s: string): unknown {
+export function safeParseJsonString(s: string | null | undefined): unknown {
+  if (!s) return null;
   try {
     return JSON.parse(s);
   } catch {

--- a/dali-api/app/forms/lib/public-form.ts
+++ b/dali-api/app/forms/lib/public-form.ts
@@ -7,6 +7,7 @@
 import { prisma } from "~/lib/db";
 import type { Question } from "~/types";
 import { resolveReferenceOptions } from "./reference-sources";
+import { safeParseJsonString } from "./forms-data";
 import { currentTerm } from "~/lib/roles";
 import { interpretBidForm } from "~/projects/lib/bid-form-interpreter";
 import { validateBids, replaceBidSet } from "~/projects/lib/bid-validation";
@@ -37,15 +38,6 @@ export type PublicForm = {
   // surface "this form can't be completed publicly" rather than silently drop.
   questions: Question[];
 };
-
-function safeParse(s: string | null): unknown {
-  if (!s) return null;
-  try {
-    return JSON.parse(s);
-  } catch {
-    return null;
-  }
-}
 
 // Resolve a public token to its form's latest version. Returns null when the
 // token is unknown, the form is unpublished, or it has no versions yet —
@@ -96,7 +88,7 @@ export async function loadPublicForm(
     formId: form.id,
     name: form.name,
     versionId: version.id,
-    description: safeParse(version.intro),
+    description: safeParseJsonString(version.intro),
     questions: resolved,
   };
 }

--- a/dali-api/app/hiring/components/EmailTemplates.tsx
+++ b/dali-api/app/hiring/components/EmailTemplates.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react'
 import { Link, Form, useLoaderData, useSearchParams } from 'react-router'
 import { Plus, Mail, ChevronRight, X } from 'lucide-react'
+import { Button } from '~/components/ui/Button'
+import { Modal } from '~/components/Modal'
 import type { loader } from '~/hiring/routes/email-templates'
 
 const GMAIL_ERROR_MESSAGES: Record<string, string> = {
@@ -75,13 +77,10 @@ export default function EmailTemplatesList() {
             to a decision type from the cycle admin page.
           </p>
         </div>
-        <button
-          onClick={() => setShowModal(true)}
-          className="inline-flex items-center justify-center px-4 py-2 border border-transparent text-sm font-medium rounded-lg text-white bg-accent-coral hover:bg-accent-coral/90 shadow-sm"
-        >
-          <Plus className="w-4 h-4 mr-2" />
+        <Button variant="primary" size="sm" onClick={() => setShowModal(true)}>
+          <Plus className="w-4 h-4" />
           New Template
-        </button>
+        </Button>
       </div>
 
       <div className="grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-6">
@@ -129,62 +128,52 @@ export default function EmailTemplatesList() {
         )}
       </div>
 
-      {showModal && (
-        <div
-          className="fixed inset-0 z-50 bg-black/40 flex items-center justify-center p-4"
-          onClick={() => setShowModal(false)}
-        >
-          <div
-            className="bg-card rounded-lg shadow-xl w-full max-w-sm p-6 space-y-4"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <div className="flex items-center justify-between">
-              <h2 className="text-lg font-semibold text-foreground">New Email Template</h2>
-              <button
-                onClick={() => setShowModal(false)}
-                className="text-muted-foreground/70 hover:text-muted-foreground"
-                aria-label="Close"
-              >
-                <X className="w-5 h-5" />
-              </button>
+      <Modal
+        open={showModal}
+        onClose={() => setShowModal(false)}
+        labelledBy="new-email-template-title"
+      >
+        <div className="space-y-4">
+          <h2 id="new-email-template-title" className="text-lg font-semibold text-foreground">
+            New Email Template
+          </h2>
+          <Form method="post" onSubmit={() => setShowModal(false)} className="space-y-4">
+            <input type="hidden" name="intent" value="create" />
+            <div>
+              <label className="block text-sm font-medium text-foreground/80 mb-1">
+                Template name
+              </label>
+              <input
+                type="text"
+                name="name"
+                value={newName}
+                onChange={(e) => setNewName(e.target.value)}
+                placeholder="e.g. Rejection — Standard"
+                className="w-full px-3 py-2 text-sm text-foreground border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                autoFocus
+                autoComplete="off"
+              />
             </div>
-            <Form method="post" onSubmit={() => setShowModal(false)} className="space-y-4">
-              <input type="hidden" name="intent" value="create" />
-              <div>
-                <label className="block text-sm font-medium text-foreground/80 mb-1">
-                  Template name
-                </label>
-                <input
-                  type="text"
-                  name="name"
-                  value={newName}
-                  onChange={(e) => setNewName(e.target.value)}
-                  placeholder="e.g. Rejection — Standard"
-                  className="w-full px-3 py-2 text-sm text-foreground border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-                  autoFocus
-                  autoComplete="off"
-                />
-              </div>
-              <div className="flex justify-end gap-2">
-                <button
-                  type="button"
-                  onClick={() => setShowModal(false)}
-                  className="px-3 py-2 text-sm font-medium text-foreground/80 bg-card border border-gray-300 rounded-md hover:bg-muted/50"
-                >
-                  Cancel
-                </button>
-                <button
-                  type="submit"
-                  disabled={!newName.trim()}
-                  className="px-3 py-2 text-sm font-medium text-white bg-accent-coral rounded-md hover:bg-accent-coral/90 disabled:opacity-50"
-                >
-                  Create
-                </button>
-              </div>
-            </Form>
-          </div>
+            <div className="flex justify-end gap-2">
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={() => setShowModal(false)}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="submit"
+                variant="primary"
+                size="sm"
+                disabled={!newName.trim()}
+              >
+                Create
+              </Button>
+            </div>
+          </Form>
         </div>
-      )}
+      </Modal>
     </div>
   )
 }

--- a/dali-api/app/hiring/components/Library.tsx
+++ b/dali-api/app/hiring/components/Library.tsx
@@ -6,9 +6,10 @@ import {
   ListOrdered,
   ShieldCheck,
   ChevronRight,
-  X,
   Trash2,
 } from "lucide-react";
+import { Button } from "~/components/ui/Button";
+import { Modal } from "~/components/Modal";
 import type { loader } from "~/hiring/routes/library";
 
 type Tab = "challenges" | "rubrics" | "agreements";
@@ -124,13 +125,10 @@ function ChallengesPanel({
               </option>
             ))}
           </select>
-          <button
-            onClick={() => setShowModal(true)}
-            className="inline-flex items-center justify-center px-4 py-2 border border-transparent text-sm font-medium rounded-lg text-white bg-accent-coral hover:bg-accent-coral/90 shadow-sm"
-          >
-            <Plus className="w-4 h-4 mr-2" />
+          <Button variant="primary" size="sm" onClick={() => setShowModal(true)}>
+            <Plus className="w-4 h-4" />
             New Challenge
-          </button>
+          </Button>
         </div>
       </div>
 
@@ -189,78 +187,68 @@ function ChallengesPanel({
         )}
       </div>
 
-      {showModal && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
-          <div
-            className="absolute inset-0 bg-black/10 backdrop-blur-[1px]"
-            onClick={() => setShowModal(false)}
-          />
-          <div
-            className="relative bg-card rounded-xl shadow-xl w-full max-w-md p-6 space-y-6"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <div className="flex items-center justify-between">
-              <h2 className="text-xl font-bold text-foreground">New Challenge</h2>
-              <button
-                onClick={() => setShowModal(false)}
-                className="text-muted-foreground/70 hover:text-muted-foreground p-1 rounded-md hover:bg-muted"
-              >
-                <X className="w-5 h-5" />
-              </button>
-            </div>
+      <Modal
+        open={showModal}
+        onClose={() => setShowModal(false)}
+        labelledBy="new-challenge-title"
+        className="fixed inset-0 z-50 flex items-center justify-center bg-black/10 backdrop-blur-[1px] p-4 sm:p-6 overflow-y-auto"
+        containerClassName="bg-card rounded-xl shadow-xl max-w-md w-full p-6 my-auto space-y-6"
+      >
+        <h2 id="new-challenge-title" className="text-xl font-bold text-foreground">
+          New Challenge
+        </h2>
 
-            <Form
-              method="post"
-              onSubmit={() => {
-                setNewChallengeName("");
-                setShowModal(false);
-              }}
-              className="space-y-4"
-            >
-              <input type="hidden" name="entity" value="challenge" />
-              <input type="hidden" name="intent" value="create" />
-              {isGeneral ? (
-                <input type="hidden" name="general" value="1" />
-              ) : (
-                <input type="hidden" name="domainId" value={activeDomain} />
-              )}
-              <div>
-                <label className="block text-sm font-medium text-foreground/80 mb-1">
-                  Challenge Name <span className="text-red-500">*</span>
-                </label>
-                <input
-                  type="text"
-                  name="name"
-                  value={newChallengeName}
-                  onChange={(e) => setNewChallengeName(e.target.value)}
-                  placeholder="e.g. Engineering Challenge Fall 2026"
-                  required
-                  autoFocus
-                  autoComplete="off"
-                  className="block w-full rounded-lg border border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm p-2.5 text-foreground bg-card placeholder-gray-400"
-                />
-              </div>
-
-              <div className="flex justify-end gap-3 pt-2 border-t border-border">
-                <button
-                  type="button"
-                  onClick={() => setShowModal(false)}
-                  className="px-4 py-2 border border-gray-300 shadow-sm text-sm font-medium rounded-lg text-foreground/80 bg-card hover:bg-muted/50"
-                >
-                  Cancel
-                </button>
-                <button
-                  type="submit"
-                  disabled={!newChallengeName.trim()}
-                  className="px-4 py-2 border border-transparent text-sm font-medium rounded-lg text-white bg-accent-coral hover:bg-accent-coral/90 shadow-sm disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                  Create Challenge
-                </button>
-              </div>
-            </Form>
+        <Form
+          method="post"
+          onSubmit={() => {
+            setNewChallengeName("");
+            setShowModal(false);
+          }}
+          className="space-y-4"
+        >
+          <input type="hidden" name="entity" value="challenge" />
+          <input type="hidden" name="intent" value="create" />
+          {isGeneral ? (
+            <input type="hidden" name="general" value="1" />
+          ) : (
+            <input type="hidden" name="domainId" value={activeDomain} />
+          )}
+          <div>
+            <label className="block text-sm font-medium text-foreground/80 mb-1">
+              Challenge Name <span className="text-red-500">*</span>
+            </label>
+            <input
+              type="text"
+              name="name"
+              value={newChallengeName}
+              onChange={(e) => setNewChallengeName(e.target.value)}
+              placeholder="e.g. Engineering Challenge Fall 2026"
+              required
+              autoFocus
+              autoComplete="off"
+              className="block w-full rounded-lg border border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm p-2.5 text-foreground bg-card placeholder-gray-400"
+            />
           </div>
-        </div>
-      )}
+
+          <div className="flex justify-end gap-3 pt-2 border-t border-border">
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => setShowModal(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              variant="primary"
+              size="sm"
+              disabled={!newChallengeName.trim()}
+            >
+              Create Challenge
+            </Button>
+          </div>
+        </Form>
+      </Modal>
     </div>
   );
 }
@@ -278,13 +266,10 @@ function RubricsPanel({ rubrics }: { rubrics: any[] }) {
             Manage rubrics and their versions independently of hiring cycles.
           </p>
         </div>
-        <button
-          onClick={() => setShowModal(true)}
-          className="inline-flex items-center justify-center px-4 py-2 border border-transparent text-sm font-medium rounded-lg text-white bg-accent-coral hover:bg-accent-coral/90 shadow-sm"
-        >
-          <Plus className="w-4 h-4 mr-2" />
+        <Button variant="primary" size="sm" onClick={() => setShowModal(true)}>
+          <Plus className="w-4 h-4" />
           New Rubric
-        </button>
+        </Button>
       </div>
 
       <div className="grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-6">
@@ -322,66 +307,57 @@ function RubricsPanel({ rubrics }: { rubrics: any[] }) {
         )}
       </div>
 
-      {showModal && (
-        <div
-          className="fixed inset-0 z-50 bg-black/40 flex items-center justify-center p-4"
-          onClick={() => setShowModal(false)}
-        >
-          <div
-            className="bg-card rounded-lg shadow-xl w-full max-w-sm p-6 space-y-4"
-            onClick={(e) => e.stopPropagation()}
+      <Modal
+        open={showModal}
+        onClose={() => setShowModal(false)}
+        labelledBy="new-rubric-title"
+      >
+        <div className="space-y-4">
+          <h2 id="new-rubric-title" className="text-lg font-semibold text-foreground">
+            New Rubric
+          </h2>
+          <Form
+            method="post"
+            onSubmit={() => setShowModal(false)}
+            className="space-y-4"
           >
-            <div className="flex items-center justify-between">
-              <h2 className="text-lg font-semibold text-foreground">New Rubric</h2>
-              <button
-                onClick={() => setShowModal(false)}
-                className="text-muted-foreground/70 hover:text-muted-foreground"
-              >
-                <X className="w-5 h-5" />
-              </button>
+            <input type="hidden" name="entity" value="rubric" />
+            <input type="hidden" name="intent" value="create" />
+            <div>
+              <label className="block text-sm font-medium text-foreground/80 mb-1">
+                Rubric name
+              </label>
+              <input
+                type="text"
+                name="name"
+                value={newRubricName}
+                onChange={(e) => setNewRubricName(e.target.value)}
+                placeholder="e.g. Design Challenge Rubric"
+                className="w-full px-3 py-2 text-sm text-foreground border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                autoFocus
+                autoComplete="off"
+              />
             </div>
-            <Form
-              method="post"
-              onSubmit={() => setShowModal(false)}
-              className="space-y-4"
-            >
-              <input type="hidden" name="entity" value="rubric" />
-              <input type="hidden" name="intent" value="create" />
-              <div>
-                <label className="block text-sm font-medium text-foreground/80 mb-1">
-                  Rubric name
-                </label>
-                <input
-                  type="text"
-                  name="name"
-                  value={newRubricName}
-                  onChange={(e) => setNewRubricName(e.target.value)}
-                  placeholder="e.g. Design Challenge Rubric"
-                  className="w-full px-3 py-2 text-sm text-foreground border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-                  autoFocus
-                  autoComplete="off"
-                />
-              </div>
-              <div className="flex justify-end gap-2">
-                <button
-                  type="button"
-                  onClick={() => setShowModal(false)}
-                  className="px-3 py-2 text-sm font-medium text-foreground/80 bg-card border border-gray-300 rounded-md hover:bg-muted/50"
-                >
-                  Cancel
-                </button>
-                <button
-                  type="submit"
-                  disabled={!newRubricName.trim()}
-                  className="px-3 py-2 text-sm font-medium text-white bg-accent-coral rounded-md hover:bg-accent-coral/90 disabled:opacity-50"
-                >
-                  Create
-                </button>
-              </div>
-            </Form>
-          </div>
+            <div className="flex justify-end gap-2">
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={() => setShowModal(false)}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="submit"
+                variant="primary"
+                size="sm"
+                disabled={!newRubricName.trim()}
+              >
+                Create
+              </Button>
+            </div>
+          </Form>
         </div>
-      )}
+      </Modal>
     </div>
   );
 }
@@ -410,13 +386,10 @@ function AgreementsPanel({
           </p>
         </div>
         {canEdit && (
-          <button
-            onClick={() => setShowModal(true)}
-            className="inline-flex items-center justify-center px-4 py-2 border border-transparent text-sm font-medium rounded-lg text-white bg-accent-coral hover:bg-accent-coral/90 shadow-sm"
-          >
-            <Plus className="w-4 h-4 mr-2" />
+          <Button variant="primary" size="sm" onClick={() => setShowModal(true)}>
+            <Plus className="w-4 h-4" />
             New Agreement
-          </button>
+          </Button>
         )}
       </div>
 
@@ -463,69 +436,57 @@ function AgreementsPanel({
         )}
       </div>
 
-      {showModal && (
-        <div
-          className="fixed inset-0 z-50 bg-black/40 flex items-center justify-center p-4"
-          onClick={() => setShowModal(false)}
-        >
-          <div
-            className="bg-card rounded-lg shadow-xl w-full max-w-sm p-6 space-y-4"
-            onClick={(e) => e.stopPropagation()}
+      <Modal
+        open={showModal}
+        onClose={() => setShowModal(false)}
+        labelledBy="new-agreement-title"
+      >
+        <div className="space-y-4">
+          <h2 id="new-agreement-title" className="text-lg font-semibold text-foreground">
+            New Confidentiality Agreement
+          </h2>
+          <Form
+            method="post"
+            onSubmit={() => setShowModal(false)}
+            className="space-y-4"
           >
-            <div className="flex items-center justify-between">
-              <h2 className="text-lg font-semibold text-foreground">
-                New Confidentiality Agreement
-              </h2>
-              <button
-                onClick={() => setShowModal(false)}
-                className="text-muted-foreground/70 hover:text-muted-foreground"
-                aria-label="Close"
-              >
-                <X className="w-5 h-5" />
-              </button>
+            <input type="hidden" name="entity" value="agreement" />
+            <input type="hidden" name="intent" value="create" />
+            <div>
+              <label className="block text-sm font-medium text-foreground/80 mb-1">
+                Agreement name
+              </label>
+              <input
+                type="text"
+                name="name"
+                value={newName}
+                onChange={(e) => setNewName(e.target.value)}
+                placeholder="e.g. Hiring Confidentiality — 2026"
+                className="w-full px-3 py-2 text-sm text-foreground border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                autoFocus
+                autoComplete="off"
+              />
             </div>
-            <Form
-              method="post"
-              onSubmit={() => setShowModal(false)}
-              className="space-y-4"
-            >
-              <input type="hidden" name="entity" value="agreement" />
-              <input type="hidden" name="intent" value="create" />
-              <div>
-                <label className="block text-sm font-medium text-foreground/80 mb-1">
-                  Agreement name
-                </label>
-                <input
-                  type="text"
-                  name="name"
-                  value={newName}
-                  onChange={(e) => setNewName(e.target.value)}
-                  placeholder="e.g. Hiring Confidentiality — 2026"
-                  className="w-full px-3 py-2 text-sm text-foreground border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-                  autoFocus
-                  autoComplete="off"
-                />
-              </div>
-              <div className="flex justify-end gap-2">
-                <button
-                  type="button"
-                  onClick={() => setShowModal(false)}
-                  className="px-3 py-2 text-sm font-medium text-foreground/80 bg-card border border-gray-300 rounded-md hover:bg-muted/50"
-                >
-                  Cancel
-                </button>
-                <button
-                  type="submit"
-                  disabled={!newName.trim()}
-                  className="px-3 py-2 text-sm font-medium text-white bg-accent-coral rounded-md hover:bg-accent-coral/90 disabled:opacity-50"
-                >
-                  Create
-                </button>
-              </div>
-            </Form>
-          </div>
+            <div className="flex justify-end gap-2">
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={() => setShowModal(false)}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="submit"
+                variant="primary"
+                size="sm"
+                disabled={!newName.trim()}
+              >
+                Create
+              </Button>
+            </div>
+          </Form>
         </div>
-      )}
+      </Modal>
     </div>
   );
 }

--- a/dali-api/app/hiring/components/analytics/CycleSelector.tsx
+++ b/dali-api/app/hiring/components/analytics/CycleSelector.tsx
@@ -1,23 +1,10 @@
 import { useNavigate, useSearchParams } from "react-router";
+import { STATUS_COLORS, STATUS_LABELS } from "~/hiring/lib/labels";
 
 interface CycleSelectorProps {
   cycles: Array<{ id: string; name: string; status: string }>;
   selectedCycleId: string;
 }
-
-const STATUS_COLORS: Record<string, string> = {
-  Draft: "bg-muted text-foreground/80",
-  Open: "bg-green-100 text-green-700",
-  UnderReview: "bg-yellow-100 text-yellow-700",
-  Completed: "bg-blue-100 text-blue-700",
-};
-
-const STATUS_LABELS: Record<string, string> = {
-  Draft: "Draft",
-  Open: "Open",
-  UnderReview: "Under Review",
-  Completed: "Completed",
-};
 
 export function CycleSelector({ cycles, selectedCycleId }: CycleSelectorProps) {
   const navigate = useNavigate();

--- a/dali-api/app/hiring/components/delibs/ApplicantContextModal.tsx
+++ b/dali-api/app/hiring/components/delibs/ApplicantContextModal.tsx
@@ -1,28 +1,12 @@
-import { useEffect } from "react";
 import { useFetcher } from "react-router";
-import { X } from "lucide-react";
 import { CollaborativeEditor } from "~/components/CollaborativeEditor";
-
-const RECOMMENDATION_COLORS: Record<string, string> = {
-  "Strong Hire": "bg-green-100 text-green-800",
-  Hire: "bg-green-50 text-green-700",
-  "Lean Hire": "bg-yellow-50 text-yellow-700",
-  "Lean No Hire": "bg-orange-50 text-orange-700",
-  "No Hire": "bg-red-100 text-red-700",
-};
-
-const DECISION_COLORS: Record<string, string> = {
-  Rejected: "bg-red-100 text-red-700",
-  InvitedToInterview: "bg-blue-100 text-blue-700",
-  Accepted: "bg-green-100 text-green-700",
-  Waitlisted: "bg-yellow-100 text-yellow-700",
-};
-
-const STAGE_LABELS: Record<string, string> = {
-  Draft: "Draft",
-  Final: "Finalized",
-  Released: "Released",
-};
+import { Modal } from "~/components/Modal";
+import {
+  DECISION_COLORS,
+  RECOMMENDATION_COLORS,
+  STAGE_LABELS,
+} from "~/hiring/lib/labels";
+import { useEffect } from "react";
 
 export interface ApplicantContextModalProps {
   domainApplicationId: string;
@@ -51,64 +35,50 @@ export function ApplicantContextModal({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [domainApplicationId]);
 
-  useEffect(() => {
-    function onKey(e: KeyboardEvent) {
-      if (e.key === "Escape") onClose();
-    }
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [onClose]);
-
   const data = fetcher.data as any;
   const isError = data && typeof data === "object" && "error" in data;
   const isLoading = fetcher.state === "loading" || (!data && !isError);
 
   return (
-    <div
-      className="fixed inset-0 z-50 bg-black/40 flex items-start justify-center p-4"
-      onClick={onClose}
+    <Modal
+      open
+      onClose={onClose}
+      labelledBy="applicant-context-title"
+      className="fixed inset-0 z-50 flex items-start justify-center bg-black/40 p-4 overflow-y-auto"
+      containerClassName="bg-card rounded-xl shadow-xl w-full max-w-5xl my-8 max-h-[90vh] flex flex-col"
     >
-      <div
-        className="bg-card rounded-xl shadow-xl w-full max-w-5xl my-8 max-h-[90vh] flex flex-col"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <div className="px-6 py-4 border-b border-border flex items-center justify-between bg-card rounded-t-xl flex-shrink-0">
-          <div>
-            {isLoading || isError || !data ? (
-              <h2 className="text-lg font-semibold text-foreground">Applicant Context</h2>
-            ) : (
-              <>
-                <h2 className="text-lg font-semibold text-foreground">
-                  {data.application.applicant.firstName} {data.application.applicant.lastName}
-                </h2>
-                <p className="text-xs text-muted-foreground">
-                  {data.domainApplication.domain?.name ?? ""}
-                  {data.decisions?.length > 0 && (
-                    <>
-                      {" · "}
-                      <span
-                        className={`inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold ${
-                          DECISION_COLORS[data.decisions[0].type] ?? "bg-muted text-foreground/80"
-                        }`}
-                      >
-                        {data.decisions[0].type} ({STAGE_LABELS[data.decisions[0].stage] ?? data.decisions[0].stage})
-                      </span>
-                    </>
-                  )}
-                </p>
-              </>
-            )}
-          </div>
-          <button
-            onClick={onClose}
-            aria-label="Close"
-            className="text-muted-foreground/70 hover:text-muted-foreground"
-          >
-            <X className="w-5 h-5" />
-          </button>
+      <div className="px-6 py-4 border-b border-border flex items-center justify-between bg-card rounded-t-xl flex-shrink-0">
+        <div>
+          {isLoading || isError || !data ? (
+            <h2 id="applicant-context-title" className="text-lg font-semibold text-foreground">
+              Applicant Context
+            </h2>
+          ) : (
+            <>
+              <h2 id="applicant-context-title" className="text-lg font-semibold text-foreground">
+                {data.application.applicant.firstName} {data.application.applicant.lastName}
+              </h2>
+              <p className="text-xs text-muted-foreground">
+                {data.domainApplication.domain?.name ?? ""}
+                {data.decisions?.length > 0 && (
+                  <>
+                    {" · "}
+                    <span
+                      className={`inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold ${
+                        DECISION_COLORS[data.decisions[0].type] ?? "bg-muted text-foreground/80"
+                      }`}
+                    >
+                      {data.decisions[0].type} ({STAGE_LABELS[data.decisions[0].stage] ?? data.decisions[0].stage})
+                    </span>
+                  </>
+                )}
+              </p>
+            </>
+          )}
         </div>
+      </div>
 
-        <div className="flex-1 min-h-0 overflow-y-auto lg:overflow-hidden flex flex-col p-6 gap-6">
+      <div className="flex-1 min-h-0 overflow-y-auto lg:overflow-hidden flex flex-col p-6 gap-6">
           <InterviewPrepNoteSection
             domainApplicationId={domainApplicationId}
             editable={editable}
@@ -157,8 +127,7 @@ export function ApplicantContextModal({
             </div>
           )}
         </div>
-      </div>
-    </div>
+    </Modal>
   );
 }
 

--- a/dali-api/app/hiring/lib/labels.ts
+++ b/dali-api/app/hiring/lib/labels.ts
@@ -1,0 +1,79 @@
+// Shared color + label maps for hiring status/decision/stage pills.
+// Source of truth for adoption (wave 2); see callers in app/hiring/routes
+// and app/hiring/components. Plain (border-less) variants chosen as the
+// majority across sites; bordered/dark-mode variants stay local where used.
+
+// Cycle / Application cycle status pills.
+// Matches lead.tsx, CycleSelector.tsx, lead.cycle.$id.tsx.
+export const STATUS_COLORS: Record<string, string> = {
+  Draft: "bg-muted text-foreground/80",
+  Open: "bg-green-100 text-green-700",
+  UnderReview: "bg-yellow-100 text-yellow-700",
+  Completed: "bg-blue-100 text-blue-700",
+};
+
+// Display labels for the cycle status enum.
+export const STATUS_LABELS: Record<string, string> = {
+  Draft: "Draft",
+  Open: "Open",
+  UnderReview: "Under Review",
+  Completed: "Completed",
+};
+
+// Decision pill colors. Plain (border-less) majority variant.
+// InvitedToInterview is bg-blue-100 (majority); fixes purple drift at
+// domain-lead.application.$id.tsx:44.
+export const DECISION_COLORS: Record<string, string> = {
+  InvitedToInterview: "bg-blue-100 text-blue-700",
+  Accepted: "bg-green-100 text-green-700",
+  Waitlisted: "bg-yellow-100 text-yellow-700",
+  Rejected: "bg-red-100 text-red-700",
+};
+
+// Short decision labels used on action buttons / compact pills.
+// Source: domain-lead.tsx:2049.
+export const DECISION_LABELS: Record<string, string> = {
+  InvitedToInterview: "Interview",
+  Accepted: "Accept",
+  Waitlisted: "Waitlist",
+  Rejected: "Reject",
+};
+
+// Interview status colors. Keys match the InterviewStatus enum used in
+// applications.$domainApplicationId.tsx:13 and interviewer.interview.$interviewId.tsx:38.
+export const INTERVIEW_STATUS_COLORS: Record<string, string> = {
+  Scheduled: "bg-blue-100 text-blue-700",
+  Completed: "bg-green-100 text-green-700",
+  CancelledByApplicant: "bg-red-100 text-red-700",
+  CancelledByAdmin: "bg-muted text-foreground/80",
+};
+
+// Display overrides for interview status. Scheduled/Completed render as-is.
+// Source: applications.$domainApplicationId.tsx:20.
+export const INTERVIEW_STATUS_LABELS: Record<string, string> = {
+  CancelledByApplicant: "Cancelled (applicant)",
+  CancelledByAdmin: "Cancelled (admin)",
+};
+
+// Decision lifecycle stages (Draft -> Final -> Released). Final renders as
+// "Finalized" for users.
+export const STAGE_LABELS: Record<string, string> = {
+  Draft: "Draft",
+  Final: "Finalized",
+  Released: "Released",
+};
+
+// Reviewer overall-recommendation pills. Source: ApplicantContextModal.tsx:6
+// and domain-lead.application.$id.tsx:19.
+export const RECOMMENDATION_COLORS: Record<string, string> = {
+  "Strong Hire": "bg-green-100 text-green-800",
+  Hire: "bg-green-50 text-green-700",
+  "Lean Hire": "bg-yellow-50 text-yellow-700",
+  "Lean No Hire": "bg-orange-50 text-orange-700",
+  "No Hire": "bg-red-100 text-red-700",
+};
+
+// Shared base classes for the common pill shape. Compose with one of the
+// *_COLORS maps above: `${STATUS_PILL_BASE} ${STATUS_COLORS[s]}`.
+export const STATUS_PILL_BASE =
+  "inline-flex items-center px-2 py-0.5 rounded-full text-xs font-bold";

--- a/dali-api/app/hiring/lib/review.ts
+++ b/dali-api/app/hiring/lib/review.ts
@@ -1,0 +1,70 @@
+import { z } from "zod";
+
+export const VALID_RECOMMENDATIONS = [
+  "Strong Hire",
+  "Hire",
+  "Lean Hire",
+  "Lean No Hire",
+  "No Hire",
+] as const;
+
+export type Recommendation = (typeof VALID_RECOMMENDATIONS)[number];
+
+export const MAX_SCORE_KEYS = 50;
+export const MAX_SCORE_KEY_LENGTH = 100;
+export const MIN_SCORE_VALUE = 0;
+export const MAX_SCORE_VALUE = 10;
+export const MAX_FEEDBACK_LENGTH = 10_000;
+export const MAX_REJECTION_RATIONALE_LENGTH = 5_000;
+export const MAX_ANNOTATIONS = 500;
+export const MAX_ANNOTATION_COMMENT_LENGTH = 2_000;
+export const MAX_ANNOTATION_FIELD_LENGTH = 200;
+
+const finiteNumber = z.number().refine((n) => Number.isFinite(n), {
+  message: "must be a finite number",
+});
+
+const ScoresSchema = z
+  .record(
+    z.string().max(MAX_SCORE_KEY_LENGTH),
+    finiteNumber.min(MIN_SCORE_VALUE).max(MAX_SCORE_VALUE),
+  )
+  .refine((obj) => Object.keys(obj).length <= MAX_SCORE_KEYS, {
+    message: `scores cannot have more than ${MAX_SCORE_KEYS} keys`,
+  });
+
+const AnnotationSchema = z.object({
+  id: z.string().min(1).max(MAX_ANNOTATION_FIELD_LENGTH),
+  fieldKey: z.string().min(1).max(MAX_ANNOTATION_FIELD_LENGTH),
+  start: finiteNumber.min(0),
+  end: finiteNumber.min(0),
+  comment: z.string().max(MAX_ANNOTATION_COMMENT_LENGTH),
+  color: z.string().max(MAX_ANNOTATION_FIELD_LENGTH),
+});
+
+export const ReviewPatchSchema = z.object({
+  scores: ScoresSchema.optional(),
+  feedback: z.string().max(MAX_FEEDBACK_LENGTH).optional(),
+  rejectionRationale: z.string().max(MAX_REJECTION_RATIONALE_LENGTH).optional(),
+  // nullable + optional: allows clearing the recommendation explicitly with null
+  overallRecommendation: z.enum(VALID_RECOMMENDATIONS).nullable().optional(),
+  annotations: z.array(AnnotationSchema).max(MAX_ANNOTATIONS).optional(),
+});
+
+export type ReviewPatch = z.infer<typeof ReviewPatchSchema>;
+
+// Back-compat adapter for tests that import this validator directly.
+// Returns the same {ok, data} | {ok: false, error} shape the old imperative
+// validator did; the route handler itself uses `parseJson(ReviewPatchSchema)`.
+export function validateReviewPatch(
+  body: unknown,
+): { ok: true; data: ReviewPatch } | { ok: false; error: string } {
+  const result = ReviewPatchSchema.safeParse(body);
+  if (!result.success) {
+    const first = result.error.issues[0];
+    const path = first?.path.join(".") ?? "";
+    const msg = first?.message ?? "Invalid request body";
+    return { ok: false, error: path ? `${path}: ${msg}` : msg };
+  }
+  return { ok: true, data: result.data };
+}

--- a/dali-api/app/hiring/routes/__tests__/lead.intern-to-full-cycle.$id.test.ts
+++ b/dali-api/app/hiring/routes/__tests__/lead.intern-to-full-cycle.$id.test.ts
@@ -3,6 +3,8 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 vi.mock("~/lib/db");
 vi.mock("~/lib/auth", () => ({
   requireAuth: vi.fn(),
+  forbidden: vi.fn((_req: Request) => Response.json({ error: "Forbidden" }, { status: 403 })),
+  unauthorized: vi.fn((_req: Request) => Response.json({ error: "Unauthorized" }, { status: 401 })),
 }));
 vi.mock("~/lib/roles");
 

--- a/dali-api/app/hiring/routes/api.interviews.$id.complete.ts
+++ b/dali-api/app/hiring/routes/api.interviews.$id.complete.ts
@@ -6,8 +6,7 @@ import { parseJson } from "~/lib/validate";
 import { requireApiSignedOrForbidden } from "~/hiring/lib/confidentiality";
 import { isCore } from "~/lib/roles";
 import { logAuditEvent } from "~/lib/audit";
-
-const VALID_RECOMMENDATIONS = ["Strong Hire", "Hire", "Lean Hire", "Lean No Hire", "No Hire"] as const;
+import { VALID_RECOMMENDATIONS } from "~/hiring/lib/review";
 
 const CompleteSchema = z.object({
   recommendation: z.enum(VALID_RECOMMENDATIONS),

--- a/dali-api/app/hiring/routes/api.reviews.$id.ts
+++ b/dali-api/app/hiring/routes/api.reviews.$id.ts
@@ -2,147 +2,12 @@ import type { Route } from "./+types/api.reviews.$id";
 import { prisma } from "~/lib/db";
 import { requireAuth } from "~/lib/auth";
 import { isCore, isDomainLead } from "~/lib/roles";
-import { safeJson } from "~/lib/safe-json";
+import { parseJson } from "~/lib/validate";
 import { requireApiSignedOrForbidden } from "~/hiring/lib/confidentiality";
+import { ReviewPatchSchema } from "~/hiring/lib/review";
 
-const VALID_RECOMMENDATIONS = ["Strong Hire", "Hire", "Lean Hire", "Lean No Hire", "No Hire"];
-
-const MAX_SCORE_KEYS = 50;
-const MAX_SCORE_KEY_LENGTH = 100;
-const MIN_SCORE_VALUE = 0;
-const MAX_SCORE_VALUE = 10;
-const MAX_FEEDBACK_LENGTH = 10_000;
-const MAX_REJECTION_RATIONALE_LENGTH = 5_000;
-const MAX_ANNOTATIONS = 500;
-const MAX_ANNOTATION_COMMENT_LENGTH = 2_000;
-const MAX_ANNOTATION_FIELD_LENGTH = 200;
-
-type ValidatedPatch = {
-  scores?: Record<string, number>;
-  feedback?: string;
-  rejectionRationale?: string;
-  overallRecommendation?: string | null;
-  annotations?: Array<{
-    id: string;
-    fieldKey: string;
-    start: number;
-    end: number;
-    comment: string;
-    color: string;
-  }>;
-};
-
-function isPlainObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-export function validateReviewPatch(body: unknown): { ok: true; data: ValidatedPatch } | { ok: false; error: string } {
-  if (!isPlainObject(body)) {
-    return { ok: false, error: "Request body must be a JSON object" };
-  }
-
-  const out: ValidatedPatch = {};
-
-  if (body.scores !== undefined) {
-    if (!isPlainObject(body.scores)) {
-      return { ok: false, error: "scores must be a plain object" };
-    }
-    const keys = Object.keys(body.scores);
-    if (keys.length > MAX_SCORE_KEYS) {
-      return { ok: false, error: `scores cannot have more than ${MAX_SCORE_KEYS} keys` };
-    }
-    const scores: Record<string, number> = {};
-    for (const key of keys) {
-      if (key.length > MAX_SCORE_KEY_LENGTH) {
-        return { ok: false, error: `scores key exceeds ${MAX_SCORE_KEY_LENGTH} characters` };
-      }
-      const value = (body.scores as Record<string, unknown>)[key];
-      if (typeof value !== "number" || !Number.isFinite(value)) {
-        return { ok: false, error: `scores.${key} must be a finite number` };
-      }
-      if (value < MIN_SCORE_VALUE || value > MAX_SCORE_VALUE) {
-        return { ok: false, error: `scores.${key} must be between ${MIN_SCORE_VALUE} and ${MAX_SCORE_VALUE}` };
-      }
-      scores[key] = value;
-    }
-    out.scores = scores;
-  }
-
-  if (body.feedback !== undefined) {
-    if (typeof body.feedback !== "string") {
-      return { ok: false, error: "feedback must be a string" };
-    }
-    if (body.feedback.length > MAX_FEEDBACK_LENGTH) {
-      return { ok: false, error: `feedback cannot exceed ${MAX_FEEDBACK_LENGTH} characters` };
-    }
-    out.feedback = body.feedback;
-  }
-
-  if (body.rejectionRationale !== undefined) {
-    if (typeof body.rejectionRationale !== "string") {
-      return { ok: false, error: "rejectionRationale must be a string" };
-    }
-    if (body.rejectionRationale.length > MAX_REJECTION_RATIONALE_LENGTH) {
-      return { ok: false, error: `rejectionRationale cannot exceed ${MAX_REJECTION_RATIONALE_LENGTH} characters` };
-    }
-    out.rejectionRationale = body.rejectionRationale;
-  }
-
-  if (body.overallRecommendation !== undefined) {
-    if (body.overallRecommendation === null) {
-      out.overallRecommendation = null;
-    } else if (typeof body.overallRecommendation !== "string" || !VALID_RECOMMENDATIONS.includes(body.overallRecommendation)) {
-      return {
-        ok: false,
-        error: `overallRecommendation must be null or one of: ${VALID_RECOMMENDATIONS.join(", ")}`,
-      };
-    } else {
-      out.overallRecommendation = body.overallRecommendation;
-    }
-  }
-
-  if (body.annotations !== undefined) {
-    if (!Array.isArray(body.annotations)) {
-      return { ok: false, error: "annotations must be an array" };
-    }
-    if (body.annotations.length > MAX_ANNOTATIONS) {
-      return { ok: false, error: `annotations cannot have more than ${MAX_ANNOTATIONS} entries` };
-    }
-    const annotations: ValidatedPatch["annotations"] = [];
-    for (let i = 0; i < body.annotations.length; i++) {
-      const a = body.annotations[i];
-      if (!isPlainObject(a)) {
-        return { ok: false, error: `annotations[${i}] must be an object` };
-      }
-      const { id, fieldKey, start, end, comment, color } = a;
-      if (typeof id !== "string" || id.length === 0 || id.length > MAX_ANNOTATION_FIELD_LENGTH) {
-        return { ok: false, error: `annotations[${i}].id must be a string up to ${MAX_ANNOTATION_FIELD_LENGTH} chars` };
-      }
-      if (typeof fieldKey !== "string" || fieldKey.length === 0 || fieldKey.length > MAX_ANNOTATION_FIELD_LENGTH) {
-        return { ok: false, error: `annotations[${i}].fieldKey must be a string up to ${MAX_ANNOTATION_FIELD_LENGTH} chars` };
-      }
-      if (typeof start !== "number" || !Number.isFinite(start) || start < 0) {
-        return { ok: false, error: `annotations[${i}].start must be a non-negative finite number` };
-      }
-      if (typeof end !== "number" || !Number.isFinite(end) || end < 0) {
-        return { ok: false, error: `annotations[${i}].end must be a non-negative finite number` };
-      }
-      if (typeof comment !== "string" || comment.length > MAX_ANNOTATION_COMMENT_LENGTH) {
-        return {
-          ok: false,
-          error: `annotations[${i}].comment must be a string up to ${MAX_ANNOTATION_COMMENT_LENGTH} chars`,
-        };
-      }
-      if (typeof color !== "string" || color.length > MAX_ANNOTATION_FIELD_LENGTH) {
-        return { ok: false, error: `annotations[${i}].color must be a string up to ${MAX_ANNOTATION_FIELD_LENGTH} chars` };
-      }
-      annotations.push({ id, fieldKey, start, end, comment, color });
-    }
-    out.annotations = annotations;
-  }
-
-  return { ok: true, data: out };
-}
+// Re-exported so existing tests can import it from this route module.
+export { validateReviewPatch } from "~/hiring/lib/review";
 
 export async function action({ request, params }: Route.ActionArgs) {
   const auth = await requireAuth(request);
@@ -183,27 +48,16 @@ export async function action({ request, params }: Route.ActionArgs) {
       return Response.json({ error: "Forbidden" }, { status: 403 });
     }
 
-    const body = await safeJson<Record<string, unknown>>(request);
-    if (body instanceof Response) return body;
-    const data: Record<string, unknown> = {};
-    if (body.scores !== undefined) data.scores = body.scores;
-    if (body.feedback !== undefined) data.feedback = body.feedback;
-    if (body.rejectionRationale !== undefined) data.rejectionRationale = body.rejectionRationale;
-    if (body.overallRecommendation !== undefined) data.overallRecommendation = body.overallRecommendation;
-    if (body.annotations !== undefined) data.annotations = body.annotations;
-
-    const result = validateReviewPatch(body);
-    if (!result.ok) {
-      return Response.json({ error: result.error }, { status: 400 });
-    }
+    const parsed = await parseJson(request, ReviewPatchSchema);
+    if (parsed instanceof Response) return parsed;
 
     // When scores are written, pin the domain rubric version those keys belong
     // to so a later rubric edit can't orphan them at render time. Only the
     // domain rubric is pinned (its criteria are the crit-<ts> keys that drift);
     // the general-form rubric is resolved separately by consumers.
-    const patch: typeof result.data & { rubricVersionId?: string } = { ...result.data };
+    const patch: typeof parsed & { rubricVersionId?: string } = { ...parsed };
     const da = review.domainApplication;
-    if (result.data.scores !== undefined && !review.rubricVersionId && da) {
+    if (parsed.scores !== undefined && !review.rubricVersionId && da) {
       const domainId = da.domainId ?? da.challengeVersion?.domainId ?? null;
       const applicationCycleId = da.application?.applicationCycleId ?? null;
       if (domainId && applicationCycleId) {

--- a/dali-api/app/hiring/routes/applications.$domainApplicationId.tsx
+++ b/dali-api/app/hiring/routes/applications.$domainApplicationId.tsx
@@ -9,31 +9,12 @@ import { presignAnswers } from "~/hiring/lib/presign";
 import { ApplicationViewer } from "~/hiring/components/ApplicationViewer";
 import { ReviewSummary } from "~/hiring/components/ReviewSummary";
 import type { Question, RubricCriterion } from "~/types";
-
-const INTERVIEW_STATUS_COLORS: Record<string, string> = {
-  Scheduled: "bg-blue-100 text-blue-700",
-  Completed: "bg-green-100 text-green-700",
-  CancelledByApplicant: "bg-red-100 text-red-700",
-  CancelledByAdmin: "bg-muted text-foreground/80",
-};
-
-const INTERVIEW_STATUS_LABELS: Record<string, string> = {
-  CancelledByApplicant: "Cancelled (applicant)",
-  CancelledByAdmin: "Cancelled (admin)",
-};
-
-const DECISION_COLORS: Record<string, string> = {
-  Rejected: "bg-red-100 text-red-700",
-  InvitedToInterview: "bg-blue-100 text-blue-700",
-  Accepted: "bg-green-100 text-green-700",
-  Waitlisted: "bg-yellow-100 text-yellow-700",
-};
-
-const STAGE_LABELS: Record<string, string> = {
-  Draft: "Draft",
-  Final: "Finalized",
-  Released: "Released",
-};
+import {
+  INTERVIEW_STATUS_COLORS,
+  INTERVIEW_STATUS_LABELS,
+  DECISION_COLORS,
+  STAGE_LABELS,
+} from "~/hiring/lib/labels";
 
 const LOCATION_LABELS: Record<string, string> = {
   PodAppa: "Pod Appa",

--- a/dali-api/app/hiring/routes/domain-lead.application.$id.tsx
+++ b/dali-api/app/hiring/routes/domain-lead.application.$id.tsx
@@ -15,14 +15,11 @@ import {
 } from "~/hiring/lib/domain-application-status";
 import type { ApplicationCycleStatus } from "~/generated/prisma/enums";
 import type { Question } from "~/types";
-
-const RECOMMENDATION_COLORS: Record<string, string> = {
-  "Strong Hire": "bg-green-100 text-green-800",
-  Hire: "bg-green-50 text-green-700",
-  "Lean Hire": "bg-yellow-50 text-yellow-700",
-  "Lean No Hire": "bg-orange-50 text-orange-700",
-  "No Hire": "bg-red-100 text-red-700",
-};
+import {
+  RECOMMENDATION_COLORS,
+  DECISION_COLORS,
+  STAGE_LABELS,
+} from "~/hiring/lib/labels";
 
 // bg + text + an explicit same-hue border (e.g. red pill → red border), so the
 // outline always matches the pill and never falls back to the neutral gray
@@ -37,19 +34,6 @@ const STATUS_BADGE: Record<string, { bg: string; label: string }> = {
   PostInterviewPending: { bg: "bg-purple-100 text-purple-700 border-purple-300 dark:bg-purple-900/30 dark:text-purple-400 dark:border-purple-700", label: "Post-Interview" },
   Accepted: { bg: "bg-green-100 text-green-700 border-green-300 dark:bg-green-900/30 dark:text-green-400 dark:border-green-700", label: "Accepted" },
   Waitlisted: { bg: "bg-yellow-100 text-yellow-700 border-yellow-300 dark:bg-yellow-900/30 dark:text-yellow-400 dark:border-yellow-700", label: "Waitlisted" },
-};
-
-const DECISION_COLORS: Record<string, string> = {
-  Rejected: "bg-red-100 text-red-700 border-red-300 dark:bg-red-900/30 dark:text-red-400 dark:border-red-700",
-  InvitedToInterview: "bg-purple-100 text-purple-700 border-purple-300 dark:bg-purple-900/30 dark:text-purple-400 dark:border-purple-700",
-  Accepted: "bg-green-100 text-green-700 border-green-300 dark:bg-green-900/30 dark:text-green-400 dark:border-green-700",
-  Waitlisted: "bg-yellow-100 text-yellow-700 border-yellow-300 dark:bg-yellow-900/30 dark:text-yellow-400 dark:border-yellow-700",
-};
-
-const STAGE_LABELS: Record<string, string> = {
-  Draft: "Draft",
-  Final: "Finalized",
-  Released: "Released",
 };
 
 export const meta: Route.MetaFunction = ({ data }) => {

--- a/dali-api/app/hiring/routes/domain-lead.tsx
+++ b/dali-api/app/hiring/routes/domain-lead.tsx
@@ -27,13 +27,7 @@ import type { ApplicationCycleStatus } from "~/generated/prisma/enums";
 import type { DecisionType } from "~/types";
 import { formatVersionLabel, buildVersionNumberMap } from "~/lib/formatVersion";
 import { selectActiveCycleForDomainLead } from "~/hiring/lib/cycle-picker";
-
-const STATUS_LABELS: Record<string, string> = {
-  Draft: "Draft",
-  Open: "Open",
-  UnderReview: "Under Review",
-  Completed: "Completed",
-};
+import { STATUS_LABELS, DECISION_LABELS } from "~/hiring/lib/labels";
 
 // Every status/decision pill carries a border in its OWN hue (never a neutral
 // black/gray line on a colored pill) so the whole page reads consistently.
@@ -2044,13 +2038,6 @@ const DECISION_COLORS: Record<string, string> = {
   InvitedToInterview: "bg-purple-100 text-purple-700 border-purple-300 dark:bg-purple-900/30 dark:text-purple-400 dark:border-purple-700",
   Accepted: "bg-green-100 text-green-700 border-green-300 dark:bg-green-900/30 dark:text-green-400 dark:border-green-700",
   Waitlisted: "bg-yellow-100 text-yellow-700 border-yellow-300 dark:bg-yellow-900/30 dark:text-yellow-400 dark:border-yellow-700",
-};
-
-const DECISION_LABELS: Record<string, string> = {
-  Rejected: "Reject",
-  InvitedToInterview: "Interview",
-  Accepted: "Accept",
-  Waitlisted: "Waitlist",
 };
 
 // Stage treatment composes on top of the `border border-current/40` the badge

--- a/dali-api/app/hiring/routes/interviewer.interview.$interviewId.tsx
+++ b/dali-api/app/hiring/routes/interviewer.interview.$interviewId.tsx
@@ -26,6 +26,7 @@ import { ReviewSummary } from '~/hiring/components/ReviewSummary'
 import { buildCriteriaLabelMap } from '~/hiring/lib/rubric-criteria'
 import type { Route } from './+types/interviewer.interview.$interviewId'
 import type { Question } from '~/types'
+import { INTERVIEW_STATUS_COLORS } from '~/hiring/lib/labels'
 
 const RECOMMENDATION_OPTIONS = [
   'Strong Hire',
@@ -34,13 +35,6 @@ const RECOMMENDATION_OPTIONS = [
   'Lean No Hire',
   'No Hire',
 ]
-
-const STATUS_COLORS: Record<string, string> = {
-  Scheduled: 'bg-blue-100 text-blue-700',
-  Completed: 'bg-green-100 text-green-700',
-  CancelledByApplicant: 'bg-red-100 text-red-700',
-  CancelledByAdmin: 'bg-muted text-foreground/80',
-}
 
 const ROLE_LABELS: Record<string, string> = {
   InDomain: 'In-domain',
@@ -388,7 +382,7 @@ export default function InterviewDetailPage() {
                 className={`px-2 py-0.5 rounded text-xs font-medium ${
                   isCompleted
                     ? 'bg-green-100 text-green-700'
-                    : STATUS_COLORS[interview.status] ??
+                    : INTERVIEW_STATUS_COLORS[interview.status] ??
                       'bg-muted text-foreground/80'
                 }`}
               >

--- a/dali-api/app/hiring/routes/lead.cycle.$id.tsx
+++ b/dali-api/app/hiring/routes/lead.cycle.$id.tsx
@@ -26,6 +26,7 @@ import { formatVersionLabel, buildVersionNumberMap } from "~/lib/formatVersion";
 import { getCycleConfidentialityState } from "~/hiring/lib/confidentiality";
 import { sendExtensionNoticeIfDue, resendExtensionNotice } from "~/hiring/lib/extension-notice";
 import { ConfidentialityGate } from "~/hiring/components/ConfidentialityGate";
+import { STATUS_COLORS, STATUS_LABELS } from "~/hiring/lib/labels";
 import {
   zonedDayStartUtc,
   zonedDayEndUtc,
@@ -1232,13 +1233,6 @@ export default function HiringLeadCycleDetails() {
   const [showOpenConfirm, setShowOpenConfirm] = useState(false)
 
   const STATUS_FLOW = ['Draft', 'Open', 'UnderReview', 'Completed'] as const
-  const STATUS_LABELS: Record<string, string> = {
-    Draft: 'Draft', Open: 'Open', UnderReview: 'Under Review', Completed: 'Completed',
-  }
-  const STATUS_COLORS: Record<string, string> = {
-    Draft: 'bg-muted text-muted-foreground', Open: 'bg-green-100 text-green-700',
-    UnderReview: 'bg-yellow-100 text-yellow-700', Completed: 'bg-blue-100 text-blue-700',
-  }
 
   // ── Active tab (URL-synced: deep-links, reload, and back/forward all work) ──
   const [searchParams, setSearchParams] = useSearchParams()

--- a/dali-api/app/hiring/routes/lead.intern-to-full-cycle.$id.tsx
+++ b/dali-api/app/hiring/routes/lead.intern-to-full-cycle.$id.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { Form, redirect, useLoaderData, useFetcher, Link } from "react-router";
 import type { Route } from "./+types/lead.intern-to-full-cycle.$id";
 import { prisma } from "~/lib/db";
-import { requireAuth } from "~/lib/auth";
+import { requireAuth, forbidden } from "~/lib/auth";
 import { isCore } from "~/lib/roles";
 import type { Question } from "~/types";
 import type { Prisma } from "~/generated/prisma/client";
@@ -213,7 +213,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 export async function action({ request, params }: Route.ActionArgs) {
   const auth = await requireAuth(request);
   if (!auth.ok) return auth.response;
-  if (!(await isCore(auth.user.sub))) return new Response("Forbidden", { status: 403 });
+  if (!(await isCore(auth.user.sub))) return forbidden(request);
 
   const cycleId = params.id!;
   const formData = await request.formData();

--- a/dali-api/app/hiring/routes/lead.tsx
+++ b/dali-api/app/hiring/routes/lead.tsx
@@ -5,20 +5,7 @@ import { prisma } from "~/lib/db";
 import { requireAuth } from "~/lib/auth";
 import { isCore } from "~/lib/roles";
 import { ChevronRight, ChevronDown, Plus, X } from "lucide-react";
-
-const STATUS_LABELS: Record<string, string> = {
-  Draft: "Draft",
-  Open: "Open",
-  UnderReview: "Under Review",
-  Completed: "Completed",
-};
-
-const STATUS_COLORS: Record<string, string> = {
-  Draft: "bg-muted text-foreground/80",
-  Open: "bg-green-100 text-green-700",
-  UnderReview: "bg-yellow-100 text-yellow-700",
-  Completed: "bg-blue-100 text-blue-700",
-};
+import { STATUS_COLORS, STATUS_LABELS } from "~/hiring/lib/labels";
 
 export const meta: Route.MetaFunction = () => [{ title: "Hiring lead · DALI OS" }];
 

--- a/dali-api/app/lib/app-env.ts
+++ b/dali-api/app/lib/app-env.ts
@@ -1,5 +1,9 @@
 export type AppEnv = 'dev' | 'staging' | 'prod'
 
+// Two parallel "environment" axes exist on purpose:
+//  - NODE_ENV === "production" → Node/runtime gate (cookie Secure, CSP, dev routes).
+//  - getAppEnv() → app-level intent (Fly app name → 'dev'|'staging'|'prod').
+// On Fly.io, staging is NODE_ENV=production AND getAppEnv()==='staging'.
 export function getAppEnv(): AppEnv {
   const override = process.env.DALI_APP_ENV
   if (override === 'dev' || override === 'staging' || override === 'prod') {

--- a/dali-api/app/lib/display.ts
+++ b/dali-api/app/lib/display.ts
@@ -20,6 +20,9 @@ export function userInitials(user: {
   return initialsFromName(localPart);
 }
 
+// Sentinel-string policy:
+//   UNKNOWN_LABEL ("Unknown") → human prose ("Created by Unknown")
+//   EMPTY_DISPLAY ("—")       → table cells / structured data
 export const UNKNOWN_LABEL = "Unknown";
 export const EMPTY_DISPLAY = "—";
 

--- a/dali-api/app/lib/google-workspace.ts
+++ b/dali-api/app/lib/google-workspace.ts
@@ -1,4 +1,5 @@
 import { JWT } from "google-auth-library";
+import { retry } from "./retry";
 
 // Google Workspace account provisioning via the Admin SDK Directory API. Used
 // to create a member's @dali.dartmouth.edu account when they're accepted.
@@ -249,42 +250,52 @@ export async function addGroupMember(args: {
 }): Promise<GroupMemberResult> {
   // ~0.5 + 1 + 2 + 4 + 8 = 15.5s of total backoff across the retries — enough to
   // cover typical group-propagation lag without hanging the finalize for long.
-  const backoffsMs = [500, 1000, 2000, 4000, 8000];
   try {
     const token = await getAccessToken();
-    for (let attempt = 0; ; attempt++) {
-      const res = await fetch(
-        `${DIRECTORY_GROUPS_URL}/${encodeURIComponent(args.groupEmail)}/members`,
-        {
-          method: "POST",
-          headers: {
-            Authorization: `Bearer ${token}`,
-            "Content-Type": "application/json",
+    return await retry(
+      async (): Promise<GroupMemberResult> => {
+        const res = await fetch(
+          `${DIRECTORY_GROUPS_URL}/${encodeURIComponent(args.groupEmail)}/members`,
+          {
+            method: "POST",
+            headers: {
+              Authorization: `Bearer ${token}`,
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({ email: args.memberEmail, role: "MEMBER" }),
           },
-          body: JSON.stringify({ email: args.memberEmail, role: "MEMBER" }),
-        },
-      );
-      if (res.status === 409) {
-        return { status: "ok", added: false };
-      }
-      if (res.ok) {
-        return { status: "ok", added: true };
-      }
-      const body = await res.text();
-      // Retry only the group-not-yet-propagated 404 (groupKey), and only while
-      // we have backoff budget left.
-      const isGroupKeyNotFound =
-        res.status === 404 && /groupKey/i.test(body);
-      if (isGroupKeyNotFound && attempt < backoffsMs.length) {
-        await new Promise((r) => setTimeout(r, backoffsMs[attempt]));
-        continue;
-      }
-      return { status: "error", message: `Directory API ${res.status}: ${body.slice(0, 200)}` };
-    }
+        );
+        if (res.status === 409) {
+          return { status: "ok", added: false };
+        }
+        if (res.ok) {
+          return { status: "ok", added: true };
+        }
+        const body = await res.text();
+        // Throw the group-not-yet-propagated 404 so retry() can ride out propagation lag.
+        if (res.status === 404 && /groupKey/i.test(body)) {
+          throw new GroupPropagation404(body);
+        }
+        return { status: "error", message: `Directory API ${res.status}: ${body.slice(0, 200)}` };
+      },
+      {
+        backoffsMs: [500, 1000, 2000, 4000, 8000],
+        shouldRetry: (err) => err instanceof GroupPropagation404,
+      },
+    );
   } catch (err) {
+    if (err instanceof GroupPropagation404) {
+      return { status: "error", message: `Directory API 404: ${err.body.slice(0, 200)}` };
+    }
     return {
       status: "error",
       message: err instanceof Error ? err.message : String(err),
     };
+  }
+}
+
+class GroupPropagation404 extends Error {
+  constructor(public body: string) {
+    super("group propagation 404");
   }
 }

--- a/dali-api/app/lib/retry.ts
+++ b/dali-api/app/lib/retry.ts
@@ -1,0 +1,26 @@
+export interface RetryOptions {
+  // Backoff intervals in milliseconds. retry() runs the fn up to (backoffsMs.length + 1)
+  // times — the initial call plus one retry per backoff.
+  backoffsMs: number[];
+  // If provided, retry only when this returns true for the thrown error.
+  // Default: retry on every thrown error.
+  shouldRetry?: (err: unknown) => boolean;
+}
+
+export async function retry<T>(
+  fn: () => Promise<T>,
+  opts: RetryOptions,
+): Promise<T> {
+  let lastErr: unknown;
+  for (let i = 0; i <= opts.backoffsMs.length; i++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastErr = err;
+      if (opts.shouldRetry && !opts.shouldRetry(err)) throw err;
+      if (i === opts.backoffsMs.length) throw err;
+      await new Promise((r) => setTimeout(r, opts.backoffsMs[i]!));
+    }
+  }
+  throw lastErr;
+}

--- a/dali-api/app/mcp/tools/rsvp-to-notification.ts
+++ b/dali-api/app/mcp/tools/rsvp-to-notification.ts
@@ -5,6 +5,7 @@
 
 import { prisma } from "~/lib/db";
 import { updateGoogleAttendeeRsvp } from "~/lib/google-calendar";
+import { primaryEmail } from "~/lib/display";
 
 export const RSVP_TO_NOTIFICATION_TOOL = {
   name: "rsvp_to_notification",
@@ -66,7 +67,7 @@ export async function runRsvpToNotification(
     throw new RsvpError("Notification has no associated meeting", 400);
   }
 
-  const attendeeEmail = caller.daliEmail ?? caller.dartmouthEmail;
+  const attendeeEmail = primaryEmail(caller);
 
   let gcalError: string | null = null;
   if (

--- a/dali-api/app/members/routes/members.groups.tsx
+++ b/dali-api/app/members/routes/members.groups.tsx
@@ -7,7 +7,8 @@ import { requireAuth, forbidden } from "~/lib/auth";
 import { canViewForms, currentTermMemberWhere } from "~/lib/roles";
 import { MEMBER_LIST_ORDER_BY } from "~/lib/prisma-shapes";
 import { resolvePhotoUrl } from "~/lib/photo";
-import { initialsFromName } from "~/lib/display";
+import { Avatar } from "~/components/ui/Avatar";
+import { RolePills } from "~/components/ui/RolePills";
 import { deriveCoreTitles } from "~/lib/core-titles";
 import { Modal } from "~/components/Modal";
 import {
@@ -806,11 +807,20 @@ function ExpandedMemberCard({
   return (
     <div className="relative border border-border rounded-md p-2 bg-background flex items-start gap-2 hover:bg-muted/10 transition-colors">
       <Link to={`/members/${member.id}`} className="flex items-start gap-2 min-w-0 flex-1">
-        <Avatar photoUrl={member.photoUrl} name={fullName} />
+        <Avatar photoUrl={member.photoUrl} name={fullName} size="sm" className="flex-shrink-0" />
         <div className="min-w-0 flex-1">
           <div className="text-sm font-medium text-foreground truncate">{fullName}</div>
           <div className="mt-1">
-            <RolePills coreTitles={member.coreTitles} domainRoles={member.domainRoles} />
+            {member.coreTitles.length === 0 && member.domainRoles.length === 0 ? (
+              <span className="text-muted-foreground text-xs">—</span>
+            ) : (
+              <RolePills
+                coreTitles={member.coreTitles}
+                domainRoles={member.domainRoles}
+                size="sm"
+                showLevel
+              />
+            )}
           </div>
         </div>
       </Link>
@@ -828,55 +838,6 @@ function ExpandedMemberCard({
           </button>
         </fetcher.Form>
       )}
-    </div>
-  );
-}
-
-function Avatar({ photoUrl, name }: { photoUrl: string | null; name: string }) {
-  if (photoUrl) {
-    return (
-      <img
-        src={photoUrl}
-        alt=""
-        className="w-8 h-8 rounded-full object-cover flex-shrink-0"
-      />
-    );
-  }
-  return (
-    <div className="w-8 h-8 rounded-full bg-accent-coral/15 text-accent-coral flex items-center justify-center font-bold text-[11px] flex-shrink-0">
-      {initialsFromName(name)}
-    </div>
-  );
-}
-
-function RolePills({
-  coreTitles,
-  domainRoles,
-}: {
-  coreTitles: string[];
-  domainRoles: { domainName: string; level: string }[];
-}) {
-  if (coreTitles.length === 0 && domainRoles.length === 0) {
-    return <span className="text-muted-foreground text-xs">—</span>;
-  }
-  return (
-    <div className="flex flex-wrap gap-1">
-      {coreTitles.map((title) => (
-        <span
-          key={title}
-          className="inline-flex items-center px-1.5 py-0.5 text-[11px] font-medium rounded bg-muted text-foreground"
-        >
-          {title}
-        </span>
-      ))}
-      {domainRoles.map((d) => (
-        <span
-          key={`${d.domainName}-${d.level}`}
-          className="inline-flex items-center px-1.5 py-0.5 text-[11px] font-medium rounded bg-blue-50 text-blue-700 border border-blue-100"
-        >
-          {d.domainName} · {d.level}
-        </span>
-      ))}
     </div>
   );
 }

--- a/dali-api/app/members/routes/members.tsx
+++ b/dali-api/app/members/routes/members.tsx
@@ -14,7 +14,9 @@ import { isCore } from "~/lib/roles";
 import { requestOpenTabIfEmbedded } from "~/components/workspace-link";
 import { prisma } from "~/lib/db";
 import { promoteToMember } from "~/members/lib/membership.server";
-import { initialsFromName, fullName, primaryEmail } from "~/lib/display";
+import { fullName, primaryEmail } from "~/lib/display";
+import { Avatar } from "~/components/ui/Avatar";
+import { RolePills } from "~/components/ui/RolePills";
 import { LAB_MEMBER_WHERE, MEMBER_LIST_ORDER_BY } from "~/lib/prisma-shapes";
 import { resolvePhotoUrl } from "~/lib/photo";
 import { ViewToggle, useViewPreference } from "~/components/ViewToggle";
@@ -448,10 +450,15 @@ function MembersTable({ rows }: { rows: MemberRow[] }) {
               </td>
               <td className="px-4 py-2 text-muted-foreground">{m.email ?? "—"}</td>
               <td className="px-4 py-2">
-                <RolePills
-                  coreTitles={m.coreTitles}
-                  domainRoles={m.domainRoles}
-                />
+                {m.coreTitles.length === 0 && m.domainRoles.length === 0 ? (
+                  <span className="text-muted-foreground text-xs">—</span>
+                ) : (
+                  <RolePills
+                    coreTitles={m.coreTitles}
+                    domainRoles={m.domainRoles}
+                    size="md"
+                  />
+                )}
               </td>
             </tr>
           ))}
@@ -478,7 +485,7 @@ function MemberCard({ member }: { member: MemberRow }) {
       to={`/members/${member.id}`}
       className="border border-border rounded-md p-3 bg-background flex items-start gap-3 hover:bg-muted/10 transition-colors"
     >
-      <Avatar photoUrl={member.photoUrl} name={fullName} />
+      <Avatar photoUrl={member.photoUrl} name={fullName} size="md" className="flex-shrink-0" />
       <div className="min-w-0 flex-1">
         <div className="flex items-baseline gap-2 flex-wrap">
           <span className="font-semibold text-foreground truncate">{fullName}</span>
@@ -493,61 +500,18 @@ function MemberCard({ member }: { member: MemberRow }) {
           <div className="text-xs text-muted-foreground truncate mt-0.5">{member.email}</div>
         )}
         <div className="mt-2">
-          <RolePills
-            coreTitles={member.coreTitles}
-            domainRoles={member.domainRoles}
-          />
+          {member.coreTitles.length === 0 && member.domainRoles.length === 0 ? (
+            <span className="text-muted-foreground text-xs">—</span>
+          ) : (
+            <RolePills
+              coreTitles={member.coreTitles}
+              domainRoles={member.domainRoles}
+              size="md"
+            />
+          )}
         </div>
       </div>
     </Link>
   );
 }
 
-function Avatar({ photoUrl, name }: { photoUrl: string | null; name: string }) {
-  if (photoUrl) {
-    return (
-      <img
-        src={photoUrl}
-        alt=""
-        className="w-10 h-10 rounded-full object-cover flex-shrink-0"
-      />
-    );
-  }
-  return (
-    <div className="w-10 h-10 rounded-full bg-accent-coral/15 text-accent-coral flex items-center justify-center font-bold text-sm flex-shrink-0">
-      {initialsFromName(name)}
-    </div>
-  );
-}
-
-function RolePills({
-  coreTitles,
-  domainRoles,
-}: {
-  coreTitles: string[];
-  domainRoles: { domainName: string; level: string }[];
-}) {
-  if (coreTitles.length === 0 && domainRoles.length === 0) {
-    return <span className="text-muted-foreground text-xs">—</span>;
-  }
-  return (
-    <div className="flex flex-wrap gap-1.5">
-      {coreTitles.map((title) => (
-        <span
-          key={title}
-          className="inline-flex items-center px-2 py-0.5 text-xs font-medium rounded bg-muted text-foreground"
-        >
-          {title}
-        </span>
-      ))}
-      {domainRoles.map((d) => (
-        <span
-          key={d.domainName}
-          className="inline-flex items-center px-2 py-0.5 text-xs font-medium rounded bg-blue-50 text-blue-700 border border-blue-100"
-        >
-          {d.domainName}
-        </span>
-      ))}
-    </div>
-  );
-}

--- a/dali-api/app/projects/components/EpicSprintManager.tsx
+++ b/dali-api/app/projects/components/EpicSprintManager.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useRevalidator } from "react-router";
 import { Modal } from "~/components/Modal";
+import { Button } from "~/components/ui/Button";
 import { CollaborativeEditor } from "~/components/CollaborativeEditor";
 import { PresenceProvider } from "~/components/collab/PresenceProvider";
 import { EpicsTimeline, type TimelineEpic } from "./EpicsTimeline";
@@ -842,13 +843,14 @@ function EpicForm({
       </div>
 
       <div className="flex gap-1.5">
-        <button
+        <Button
           type="submit"
+          variant="primary"
+          size="sm"
           disabled={busy}
-          className="px-3 py-1.5 text-xs font-medium rounded-md bg-accent-coral text-white hover:bg-accent-coral/90 disabled:opacity-60 transition-colors"
         >
           Save
-        </button>
+        </Button>
         <button
           type="button"
           onClick={onCancel}
@@ -945,13 +947,14 @@ function SprintForm({
         </select>
       </label>
       <div className="flex gap-1.5">
-        <button
+        <Button
           type="submit"
+          variant="primary"
+          size="sm"
           disabled={busy}
-          className="px-3 py-1.5 text-xs font-medium rounded-md bg-accent-coral text-white hover:bg-accent-coral/90 disabled:opacity-60 transition-colors"
         >
           Save
-        </button>
+        </Button>
         <button
           type="button"
           onClick={onCancel}
@@ -1035,13 +1038,14 @@ function StoryForm({
         />
       </label>
       <div className="flex gap-1.5">
-        <button
+        <Button
           type="submit"
+          variant="primary"
+          size="sm"
           disabled={busy}
-          className="px-3 py-1.5 text-xs font-medium rounded-md bg-accent-coral text-white hover:bg-accent-coral/90 disabled:opacity-60 transition-colors"
         >
           Save
-        </button>
+        </Button>
         <button
           type="button"
           onClick={onCancel}

--- a/dali-api/app/projects/components/FinalizeModal.tsx
+++ b/dali-api/app/projects/components/FinalizeModal.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useRevalidator } from "react-router";
 import { Modal } from "~/components/Modal";
+import { Button } from "~/components/ui/Button";
 
 type Automation = "assignments" | "slack" | "gmail" | "github";
 
@@ -333,14 +334,14 @@ export function FinalizeModal({
           >
             {running ? "Running…" : "Run selected"}
           </button>
-          <button
-            type="button"
+          <Button
+            variant="primary"
+            size="sm"
             disabled={running || savingFields}
             onClick={() => run(AUTOMATIONS.filter((a) => a.configured).map((a) => a.id))}
-            className="px-3 py-1.5 text-sm font-medium rounded-md bg-accent-coral text-white hover:bg-accent-coral/90 disabled:opacity-60 transition-colors"
           >
             {running ? "Running…" : "Run all"}
-          </button>
+          </Button>
         </div>
       </div>
     </Modal>

--- a/dali-api/app/projects/components/MemberCard.tsx
+++ b/dali-api/app/projects/components/MemberCard.tsx
@@ -1,6 +1,8 @@
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { initialsFromName, fullName as buildFullName } from "~/lib/display";
+import { fullName as buildFullName } from "~/lib/display";
+import { Avatar } from "~/components/ui/Avatar";
+import { RolePills } from "~/components/ui/RolePills";
 import type { MemberCardModel, Level } from "../lib/staffing-board";
 
 const LEVEL_BADGE: Record<Level, { label: string; cls: string }> = {
@@ -98,7 +100,7 @@ function MemberCardBody({
   return (
     <>
       <div className="flex items-start gap-2">
-        <Avatar photoUrl={card.photoUrl} name={fullName} />
+        <Avatar photoUrl={card.photoUrl} name={fullName} size="sm" />
         <div className="min-w-0 flex-1">
           <div className="flex items-baseline gap-1.5 flex-wrap">
             <span className="text-sm font-semibold text-foreground truncate text-left">
@@ -121,7 +123,12 @@ function MemberCardBody({
               </span>
             )}
           </div>
-          <RoleStrip card={card} />
+          <RolePills
+            isAdmin={card.isAdmin}
+            coreTitles={card.coreTitles}
+            size="sm"
+            className="mt-0.5"
+          />
         </div>
         {onRemove && card.manuallyAdded && (
           <button
@@ -187,38 +194,6 @@ function DomainLevelStrip({ card }: { card: MemberCardModel }) {
           <span className={`px-1 rounded font-bold ${LEVEL_BADGE[d.level].cls}`}>
             {LEVEL_BADGE[d.level].label}
           </span>
-        </span>
-      ))}
-    </div>
-  );
-}
-
-function Avatar({ photoUrl, name }: { photoUrl: string | null; name: string }) {
-  if (photoUrl) {
-    return <img src={photoUrl} alt="" className="w-8 h-8 rounded-full object-cover flex-shrink-0" />;
-  }
-  return (
-    <div className="w-8 h-8 rounded-full bg-accent-coral/15 text-accent-coral flex items-center justify-center font-bold text-[11px] flex-shrink-0">
-      {initialsFromName(name)}
-    </div>
-  );
-}
-
-function RoleStrip({ card }: { card: MemberCardModel }) {
-  if (!card.isAdmin && card.coreTitles.length === 0) return null;
-  return (
-    <div className="flex flex-wrap gap-1 mt-0.5">
-      {card.isAdmin && (
-        <span className="inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium rounded bg-accent-coral/15 text-accent-coral">
-          Admin
-        </span>
-      )}
-      {card.coreTitles.map((t) => (
-        <span
-          key={t}
-          className="inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium rounded bg-muted text-foreground"
-        >
-          {t}
         </span>
       ))}
     </div>

--- a/dali-api/app/projects/components/SlotColumnMapper.tsx
+++ b/dali-api/app/projects/components/SlotColumnMapper.tsx
@@ -15,6 +15,7 @@
 // not a component change.
 import { useMemo, useRef, useState } from "react";
 import { useFetcher } from "react-router";
+import { Button } from "~/components/ui/Button";
 import {
   SLOT_ROLES,
   BUILTIN_SOURCES,
@@ -591,14 +592,15 @@ export function SlotColumnMapper({
           >
             + Extra column
           </button>
-          <button
-            type="button"
+          <Button
+            variant="primary"
+            size="sm"
             onClick={save}
             disabled={saving || !dirty || missing.length > 0}
-            className="ml-auto px-3 py-1.5 text-sm font-medium rounded-md bg-accent-coral text-white hover:bg-accent-coral/90 transition-colors disabled:opacity-60"
+            className="ml-auto"
           >
             {saving ? "Saving…" : "Save columns"}
-          </button>
+          </Button>
         </div>
       )}
     </div>

--- a/dali-api/app/projects/components/SlotFormPicker.tsx
+++ b/dali-api/app/projects/components/SlotFormPicker.tsx
@@ -5,6 +5,7 @@
 // — this only controls which form is surfaced to members.
 import { useState } from "react";
 import { useFetcher } from "react-router";
+import { Button } from "~/components/ui/Button";
 
 type SelectableForm = { id: string; name: string; published: boolean };
 
@@ -73,13 +74,14 @@ export function SlotFormPicker({
                 </option>
               ))}
             </select>
-            <button
+            <Button
               type="submit"
+              variant="primary"
+              size="sm"
               disabled={saving || !dirty}
-              className="px-3 py-1.5 text-sm font-medium rounded-md bg-accent-coral text-white hover:bg-accent-coral/90 transition-colors disabled:opacity-60"
             >
               {saving ? "Saving…" : "Save"}
-            </button>
+            </Button>
           </fetcher.Form>
         ) : (
           <div className="flex-1 text-sm text-foreground">

--- a/dali-api/app/projects/components/StaffingBoard.tsx
+++ b/dali-api/app/projects/components/StaffingBoard.tsx
@@ -22,6 +22,7 @@ import {
   type Preference,
 } from "../lib/staffing-board";
 import { CheckCircle2 } from "lucide-react";
+import { Button } from "~/components/ui/Button";
 import { MemberCard, MemberCardPreview } from "./MemberCard";
 import { BidModal } from "./BidModal";
 import { FinalizeModal } from "./FinalizeModal";
@@ -509,14 +510,15 @@ function TermChannelBanner({ termId, termCode }: { termId: string; termCode: str
           aria-label="Term channel name"
           className="w-32 px-2 py-1 text-sm border border-border rounded-md bg-background text-foreground disabled:opacity-60 focus:outline-none focus:ring-2 focus:ring-accent-coral/30"
         />
-        <button
-          type="button"
+        <Button
+          variant="primary"
+          size="sm"
           disabled={running || !channel.trim()}
           onClick={run}
-          className="px-3 py-1.5 text-sm font-medium rounded-md bg-accent-coral text-white hover:bg-accent-coral/90 disabled:opacity-60 transition-colors whitespace-nowrap"
+          className="whitespace-nowrap"
         >
           {running ? "Creating…" : "Create + invite"}
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/dali-api/app/projects/components/TaskBoard.tsx
+++ b/dali-api/app/projects/components/TaskBoard.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo, useState } from "react";
 import { useSearchParams } from "react-router";
+import { Button } from "~/components/ui/Button";
 import { DndContext, useDraggable, useDroppable, type DragEndEvent } from "@dnd-kit/core";
 import { GripVertical } from "lucide-react";
 import {
@@ -189,13 +190,13 @@ export function TaskBoard({ projectId, initialTasks, options, canManage }: Props
 
       {canManage && (
         <div>
-          <button
-            type="button"
+          <Button
+            variant="primary"
+            size="sm"
             onClick={() => setIsCreating(true)}
-            className="px-3 py-1.5 text-xs font-medium rounded-md bg-accent-coral text-white hover:bg-accent-coral/90 transition-colors"
           >
             + Add task
-          </button>
+          </Button>
         </div>
       )}
 

--- a/dali-api/app/projects/components/TaskModal.tsx
+++ b/dali-api/app/projects/components/TaskModal.tsx
@@ -6,6 +6,7 @@
 
 import { useEffect, useState } from "react";
 import { Modal } from "~/components/Modal";
+import { Button } from "~/components/ui/Button";
 import type { TaskBoardOptions, TaskCardModel, Priority } from "../lib/task-board";
 
 const PRIORITIES: Priority[] = ["Low", "Normal", "High", "Urgent"];
@@ -256,22 +257,22 @@ export function TaskModal({
           </button>
           {canManage &&
             (isCreate ? (
-              <button
-                type="button"
+              <Button
+                variant="primary"
+                size="sm"
                 onClick={() => void handleCreate()}
                 disabled={!title.trim() || saving}
-                className="px-3 py-1.5 text-sm font-medium rounded-md bg-accent-coral text-white hover:bg-accent-coral/90 disabled:opacity-50 transition-colors"
               >
                 {saving ? "Creating…" : "Create task"}
-              </button>
+              </Button>
             ) : (
-              <button
-                type="button"
+              <Button
+                variant="primary"
+                size="sm"
                 onClick={() => void handleSave()}
-                className="px-3 py-1.5 text-sm font-medium rounded-md bg-accent-coral text-white hover:bg-accent-coral/90 transition-colors"
               >
                 Save
-              </button>
+              </Button>
             ))}
         </div>
       </div>

--- a/dali-api/app/projects/components/UserSubmissionShell.tsx
+++ b/dali-api/app/projects/components/UserSubmissionShell.tsx
@@ -1,0 +1,73 @@
+import type { ReactNode } from "react";
+import { cn } from "~/lib/cn";
+
+interface UserSubmissionRow {
+  key: string;
+  label: string;
+  value: ReactNode;
+  // When false, label is annotated "(not in table)" — matches the staffing
+  // submission detail pages where managers need to see which form fields
+  // aren't surfaced in the board table.
+  mapped?: boolean;
+}
+
+interface UserSubmissionShellProps {
+  title?: string;
+  subtitle?: string;
+  rows: UserSubmissionRow[];
+  emptyMessage?: string;
+  className?: string;
+}
+
+export function UserSubmissionShell({
+  title,
+  subtitle,
+  rows,
+  emptyMessage = "This submission is empty.",
+  className,
+}: UserSubmissionShellProps) {
+  return (
+    <div className={cn("flex flex-col gap-6", className)}>
+      {(title || subtitle) && (
+        <div>
+          {title && (
+            <h1 className="font-heading text-2xl font-bold text-foreground">
+              {title}
+            </h1>
+          )}
+          {subtitle && (
+            <p className="text-sm text-muted-foreground">{subtitle}</p>
+          )}
+        </div>
+      )}
+      {rows.length === 0 ? (
+        <p className="text-sm text-muted-foreground">{emptyMessage}</p>
+      ) : (
+        <dl className="bg-card border border-border rounded-lg divide-y divide-border">
+          {rows.map((row) => (
+            <div
+              key={row.key}
+              className="px-4 py-3 flex flex-col sm:flex-row sm:gap-4"
+            >
+              <dt className="sm:w-56 shrink-0 text-sm font-medium text-foreground">
+                {row.label}
+                {row.mapped === false && (
+                  <span className="ml-2 text-[11px] text-muted-foreground">
+                    (not in table)
+                  </span>
+                )}
+              </dt>
+              <dd className="text-sm text-foreground mt-1 sm:mt-0 whitespace-pre-wrap break-words">
+                {row.value === "" || row.value == null ? (
+                  <span className="text-muted-foreground">—</span>
+                ) : (
+                  row.value
+                )}
+              </dd>
+            </div>
+          ))}
+        </dl>
+      )}
+    </div>
+  );
+}

--- a/dali-api/app/projects/lib/bid-validation.ts
+++ b/dali-api/app/projects/lib/bid-validation.ts
@@ -12,10 +12,10 @@
 // (ProjectRoleRequest is headcount display only; it never gates bids.)
 
 import { prisma } from "~/lib/db";
+import type { Level } from "~/lib/level";
 
-// Level is the Prisma enum; kept as a string union to avoid importing the
-// generated enum into pure call sites.
-export type BidLevel = "P1" | "P2" | "P3";
+// Re-export under the legacy name for callers that still import `BidLevel`.
+export type BidLevel = Level;
 
 export type RawBid = {
   projectId: string;

--- a/dali-api/app/projects/lib/staffing-board.ts
+++ b/dali-api/app/projects/lib/staffing-board.ts
@@ -2,7 +2,8 @@
 // means the route loader/action stay thin and we can iterate on board shape
 // without dragging Prisma + React in.
 
-export type Level = "P1" | "P2" | "P3";
+import type { Level } from "~/lib/level";
+export type { Level };
 
 export type Preference = {
   projectId: string;

--- a/dali-api/app/projects/routes/api.staffing.assign.ts
+++ b/dali-api/app/projects/routes/api.staffing.assign.ts
@@ -4,6 +4,7 @@ import { requireAuth, forbidden } from "~/lib/auth";
 import { canManageStaffing } from "~/lib/roles";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { logAuditEvent } from "~/lib/audit";
+import { isLevel, type Level } from "~/lib/level";
 import { publishCycleChange } from "../lib/staffing-events.server";
 
 // POST /api/staffing/assign
@@ -25,7 +26,7 @@ type Body = {
   cycleId: string;
   projectId: string | null;
   domainId?: string;
-  level?: "P1" | "P2" | "P3";
+  level?: Level;
 };
 
 function isBody(x: unknown): x is Body {
@@ -36,7 +37,7 @@ function isBody(x: unknown): x is Body {
   if (o.projectId !== null && typeof o.projectId !== "string") return false;
   if (o.projectId !== null) {
     if (typeof o.domainId !== "string") return false;
-    if (o.level !== "P1" && o.level !== "P2" && o.level !== "P3") return false;
+    if (!isLevel(o.level)) return false;
   }
   return true;
 }

--- a/dali-api/app/projects/routes/api.staffing.events.ts
+++ b/dali-api/app/projects/routes/api.staffing.events.ts
@@ -1,5 +1,5 @@
 import type { Route } from "./+types/api.staffing.events";
-import { requireAuth } from "~/lib/auth";
+import { requireAuth, forbidden } from "~/lib/auth";
 import { canViewStaffing } from "~/lib/roles";
 import { subscribeToCycle } from "../lib/staffing-events.server";
 
@@ -22,7 +22,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   // the client's onerror handles by backing off.
   if (!auth.ok) return new Response("Unauthorized", { status: 401 });
   if (!(await canViewStaffing(auth.user.sub))) {
-    return new Response("Forbidden", { status: 403 });
+    return forbidden(request);
   }
 
   const cycleId = new URL(request.url).searchParams.get("cycleId");

--- a/dali-api/app/projects/routes/api.staffing.finalize.ts
+++ b/dali-api/app/projects/routes/api.staffing.finalize.ts
@@ -8,6 +8,8 @@ import {
   ensureChannel,
   inviteUsersToChannel,
   slackErrorMessage,
+  slackConfigured,
+  SLACK_NOT_CONFIGURED_MESSAGE,
 } from "~/slack/lib/slack-client";
 import { resolveSlackIdsForInvite } from "~/members/lib/slack-sync.server";
 import { ensureTeam, addTeamMember } from "~/lib/github";
@@ -290,8 +292,8 @@ export async function action({ request }: Route.ActionArgs) {
   // announcement (each member's domain + level, plus the project's repos). The
   // channel id is reused across runs (stored on Project.slackChannelId).
   if (selected.has("slack")) {
-    if (!process.env.SLACK_BOT_TOKEN) {
-      results.slack = { status: "skipped", message: "SLACK_BOT_TOKEN not set." };
+    if (!slackConfigured()) {
+      results.slack = { status: "skipped" as const, message: SLACK_NOT_CONFIGURED_MESSAGE };
     } else {
       try {
         // Confirmed roster with level + slack id, regardless of whether the

--- a/dali-api/app/projects/routes/api.staffing.term-channel.ts
+++ b/dali-api/app/projects/routes/api.staffing.term-channel.ts
@@ -3,7 +3,13 @@ import { prisma } from "~/lib/db";
 import { requireAuth, forbidden } from "~/lib/auth";
 import { canManageStaffing } from "~/lib/roles";
 import { withCors, handlePreflight } from "~/lib/cors";
-import { ensureChannel, inviteUsersToChannel, slackErrorMessage } from "~/slack/lib/slack-client";
+import {
+  ensureChannel,
+  inviteUsersToChannel,
+  slackErrorMessage,
+  slackConfigured,
+  SLACK_NOT_CONFIGURED_MESSAGE,
+} from "~/slack/lib/slack-client";
 import { resolveSlackIdsForInvite } from "~/members/lib/slack-sync.server";
 import { logAuditEvent } from "~/lib/audit";
 
@@ -49,8 +55,8 @@ export async function action({ request }: Route.ActionArgs) {
     return withCors(request, Response.json({ error: "Invalid body" }, { status: 400 }));
   }
 
-  if (!process.env.SLACK_BOT_TOKEN) {
-    return withCors(request, Response.json({ error: "SLACK_BOT_TOKEN not set." }, { status: 400 }));
+  if (!slackConfigured()) {
+    return withCors(request, Response.json({ error: SLACK_NOT_CONFIGURED_MESSAGE }, { status: 400 }));
   }
 
   const term = await prisma.term.findUnique({

--- a/dali-api/app/projects/routes/projects.intent-to-work.$userId.tsx
+++ b/dali-api/app/projects/routes/projects.intent-to-work.$userId.tsx
@@ -7,6 +7,7 @@ import { ensureStaffingCycle } from "../lib/staffing-cycle";
 import { getSlotBinding } from "../lib/form-slots";
 import { resolveTermFilter } from "~/lib/terms";
 import { buildSubmissionView } from "../lib/submission-view.server";
+import { UserSubmissionShell } from "../components/UserSubmissionShell";
 
 const SLOT = "intent-to-work" as const;
 
@@ -68,44 +69,15 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 export default function IntentSubmissionDetail() {
   const data = useLoaderData<typeof loader>();
   return (
-    <div className="flex flex-col gap-6">
-      <div>
-        <h1 className="font-heading text-2xl font-bold text-foreground">
-          {data.record.name}
-        </h1>
-        <p className="text-sm text-muted-foreground">{data.cycleName}</p>
-      </div>
-
-      {data.fields.length === 0 ? (
-        <p className="text-sm text-muted-foreground">
-          This submission is empty.
-        </p>
-      ) : (
-        <dl className="bg-card border border-border rounded-lg divide-y divide-border">
-          {data.fields.map((f) => (
-            <div
-              key={f.key}
-              className="px-4 py-3 flex flex-col sm:flex-row sm:gap-4"
-            >
-              <dt className="sm:w-56 shrink-0 text-sm font-medium text-foreground">
-                {f.label}
-                {!f.mapped && (
-                  <span className="ml-2 text-[11px] text-muted-foreground">
-                    (not in table)
-                  </span>
-                )}
-              </dt>
-              <dd className="text-sm text-foreground mt-1 sm:mt-0 whitespace-pre-wrap break-words">
-                {f.value === "" ? (
-                  <span className="text-muted-foreground">—</span>
-                ) : (
-                  f.value
-                )}
-              </dd>
-            </div>
-          ))}
-        </dl>
-      )}
-    </div>
+    <UserSubmissionShell
+      title={data.record.name}
+      subtitle={data.cycleName}
+      rows={data.fields.map((f) => ({
+        key: f.key,
+        label: f.label,
+        value: f.value,
+        mapped: f.mapped,
+      }))}
+    />
   );
 }

--- a/dali-api/app/projects/routes/projects.level-up.$userId.tsx
+++ b/dali-api/app/projects/routes/projects.level-up.$userId.tsx
@@ -7,6 +7,7 @@ import { ensureStaffingCycle } from "../lib/staffing-cycle";
 import { getSlotBinding } from "../lib/form-slots";
 import { resolveTermFilter } from "~/lib/terms";
 import { buildSubmissionView } from "../lib/submission-view.server";
+import { UserSubmissionShell } from "../components/UserSubmissionShell";
 
 const SLOT = "level-up" as const;
 
@@ -63,42 +64,15 @@ export default function LevelUpSubmissionDetail() {
   const data = useLoaderData<typeof loader>();
 
   return (
-    <div className="flex flex-col gap-6">
-      <div>
-        <h1 className="font-heading text-2xl font-bold text-foreground">
-          {data.record.name}
-        </h1>
-        <p className="text-sm text-muted-foreground">{data.cycleName}</p>
-      </div>
-
-      {data.fields.length === 0 ? (
-        <p className="text-sm text-muted-foreground">This submission is empty.</p>
-      ) : (
-        <dl className="bg-card border border-border rounded-lg divide-y divide-border">
-          {data.fields.map((f) => (
-            <div
-              key={f.key}
-              className="px-4 py-3 flex flex-col sm:flex-row sm:gap-4"
-            >
-              <dt className="sm:w-56 shrink-0 text-sm font-medium text-foreground">
-                {f.label}
-                {!f.mapped && (
-                  <span className="ml-2 text-[11px] text-muted-foreground">
-                    (not in table)
-                  </span>
-                )}
-              </dt>
-              <dd className="text-sm text-foreground mt-1 sm:mt-0 whitespace-pre-wrap break-words">
-                {f.value === "" ? (
-                  <span className="text-muted-foreground">—</span>
-                ) : (
-                  f.value
-                )}
-              </dd>
-            </div>
-          ))}
-        </dl>
-      )}
-    </div>
+    <UserSubmissionShell
+      title={data.record.name}
+      subtitle={data.cycleName}
+      rows={data.fields.map((f) => ({
+        key: f.key,
+        label: f.label,
+        value: f.value,
+        mapped: f.mapped,
+      }))}
+    />
   );
 }

--- a/dali-api/app/projects/routes/projects.level-up.tsx
+++ b/dali-api/app/projects/routes/projects.level-up.tsx
@@ -24,7 +24,7 @@ import {
 } from "../lib/slot-roles";
 import { buildSubmissionView } from "../lib/submission-view.server";
 import type { Question } from "~/types";
-import type { Level } from "~/generated/prisma/enums";
+import { isLevel, type Level } from "~/lib/level";
 
 const SLOT = "level-up" as const;
 
@@ -355,8 +355,8 @@ export async function action({ request }: Route.ActionArgs) {
       return Response.json({ error: "Forbidden" }, { status: 403 });
     const targetUserId = String(form.get("userId") ?? "");
     const domainId = String(form.get("domainId") ?? "");
-    const targetLevel = String(form.get("targetLevel") ?? "") as Level;
-    if (!targetUserId || !domainId || !["P1", "P2", "P3"].includes(targetLevel))
+    const targetLevel = String(form.get("targetLevel") ?? "");
+    if (!targetUserId || !domainId || !isLevel(targetLevel))
       return Response.json({ error: "Invalid parameters." }, { status: 400 });
 
     await prisma.domainEligibility.upsert({

--- a/dali-api/app/projects/routes/projects.project-bids.$userId.tsx
+++ b/dali-api/app/projects/routes/projects.project-bids.$userId.tsx
@@ -7,6 +7,7 @@ import { ensureStaffingCycle } from "../lib/staffing-cycle";
 import { getSlotBinding } from "../lib/form-slots";
 import { resolveTermFilter } from "~/lib/terms";
 import { buildSubmissionView } from "../lib/submission-view.server";
+import { UserSubmissionShell } from "../components/UserSubmissionShell";
 
 const SLOT = "project-bids" as const;
 
@@ -71,44 +72,15 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 export default function ProjectBidSubmissionDetail() {
   const data = useLoaderData<typeof loader>();
   return (
-    <div className="flex flex-col gap-6">
-      <div>
-        <h1 className="font-heading text-2xl font-bold text-foreground">
-          {data.record.name}
-        </h1>
-        <p className="text-sm text-muted-foreground">{data.cycleName}</p>
-      </div>
-
-      {data.fields.length === 0 ? (
-        <p className="text-sm text-muted-foreground">
-          This submission is empty.
-        </p>
-      ) : (
-        <dl className="bg-card border border-border rounded-lg divide-y divide-border">
-          {data.fields.map((f) => (
-            <div
-              key={f.key}
-              className="px-4 py-3 flex flex-col sm:flex-row sm:gap-4"
-            >
-              <dt className="sm:w-56 shrink-0 text-sm font-medium text-foreground">
-                {f.label}
-                {!f.mapped && (
-                  <span className="ml-2 text-[11px] text-muted-foreground">
-                    (not in table)
-                  </span>
-                )}
-              </dt>
-              <dd className="text-sm text-foreground mt-1 sm:mt-0 whitespace-pre-wrap break-words">
-                {f.value === "" ? (
-                  <span className="text-muted-foreground">—</span>
-                ) : (
-                  f.value
-                )}
-              </dd>
-            </div>
-          ))}
-        </dl>
-      )}
-    </div>
+    <UserSubmissionShell
+      title={data.record.name}
+      subtitle={data.cycleName}
+      rows={data.fields.map((f) => ({
+        key: f.key,
+        label: f.label,
+        value: f.value,
+        mapped: f.mapped,
+      }))}
+    />
   );
 }

--- a/dali-api/app/routes/api.notifications.$id.rsvp.ts
+++ b/dali-api/app/routes/api.notifications.$id.rsvp.ts
@@ -5,6 +5,7 @@ import { requireAuth, forbidden } from "~/lib/auth";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { parseJson } from "~/lib/validate";
 import { updateGoogleAttendeeRsvp } from "~/lib/google-calendar";
+import { primaryEmail } from "~/lib/display";
 
 const Schema = z.object({
   response: z.enum(["accepted", "declined", "tentative"]),
@@ -60,7 +61,7 @@ export async function action({ request, params }: Route.ActionArgs) {
     where: { id: auth.user.sub },
     select: { daliEmail: true, dartmouthEmail: true },
   });
-  const attendeeEmail = recipient?.daliEmail ?? recipient?.dartmouthEmail ?? auth.user.email;
+  const attendeeEmail = (recipient ? primaryEmail(recipient) : null) ?? auth.user.email;
 
   // Best-effort: push the RSVP to Google. If the meeting wasn't pushed to GCal
   // (no externalEventId or no organizer link), we still record the in-app RSVP.

--- a/dali-api/app/routes/login.tsx
+++ b/dali-api/app/routes/login.tsx
@@ -12,6 +12,8 @@ const OAUTH_STATE_COOKIE = "__dali_oauth_state";
 const RATE_LIMIT_MAX = 5;
 const RATE_LIMIT_WINDOW_MS = 60_000;
 
+const isProduction = process.env.NODE_ENV === "production";
+
 export const meta: Route.MetaFunction = () => [{ title: "DALI OS · Sign in" }];
 
 export async function loader({ request }: Route.LoaderArgs) {
@@ -62,7 +64,7 @@ export async function action({ request }: Route.ActionArgs) {
       "Max-Age=600",
       "HttpOnly",
       "SameSite=Lax",
-      ...(process.env.NODE_ENV === "production" ? ["Secure"] : []),
+      ...(isProduction ? ["Secure"] : []),
     ].join("; ");
     headers.append("Set-Cookie", stateCookie);
     headers.set(
@@ -79,7 +81,7 @@ export async function action({ request }: Route.ActionArgs) {
     "Max-Age=600",
     "HttpOnly",
     "SameSite=Lax",
-    ...(process.env.NODE_ENV === "production" ? ["Secure"] : []),
+    ...(isProduction ? ["Secure"] : []),
   ].join("; ");
   headers.append("Set-Cookie", stateCookie);
 

--- a/dali-api/app/routes/oauth.consent.tsx
+++ b/dali-api/app/routes/oauth.consent.tsx
@@ -4,6 +4,7 @@ import { prisma } from "~/lib/db";
 import { getOAuthClient, generateAuthorizationCode } from "~/lib/oauth";
 import { parseSessionId } from "~/lib/cookies";
 import { lookupSession } from "~/lib/session";
+import { displayEmail } from "~/lib/display";
 
 const SCOPE_DESCRIPTIONS: Record<string, string> = {
   "mcp:read": "Read your DALI OS data on your behalf",
@@ -58,10 +59,7 @@ export async function loader({ request }: Route.LoaderArgs): Promise<LoaderData>
     where: { id: oauthSession.userId },
     select: { daliEmail: true, dartmouthEmail: true, netId: true },
   });
-  const userEmail =
-    user?.daliEmail ??
-    user?.dartmouthEmail ??
-    (user?.netId ? `${user.netId}@dartmouth.edu` : "(unknown)");
+  const userEmail = (user ? displayEmail(user) : "") || "(unknown)";
 
   return {
     ok: true,

--- a/dali-api/app/routes/portal.tsx
+++ b/dali-api/app/routes/portal.tsx
@@ -16,6 +16,7 @@ import { ApplicantErrorBoundary } from "~/components/ApplicantErrorBoundary";
 import { Confetti } from "~/components/Confetti";
 import { formatInterviewDate, formatInterviewTimeRange } from "~/hiring/lib/interview-time";
 import { APPLICATIONS_FROM_EMAIL } from "~/lib/app-env";
+import { Button } from "~/components/ui/Button";
 
 export const meta: Route.MetaFunction = () => [{ title: "Applicant portal · DALI OS" }];
 
@@ -552,13 +553,14 @@ function InvitedToInterviewView({
             />
           </div>
 
-          <button
+          <Button
+            variant="primary"
+            size="md"
             onClick={handleConfirm}
             disabled={!selectedSlot || booking}
-            className="px-6 py-2.5 rounded-full bg-accent-coral text-white text-sm font-semibold hover:bg-accent-coral/90 transition disabled:opacity-50"
           >
             {booking ? "Booking..." : "Confirm Time"}
-          </button>
+          </Button>
         </>
       )}
 
@@ -708,13 +710,15 @@ function InterviewScheduledView({
               />
             </div>
 
-            <button
+            <Button
+              variant="primary"
+              size="md"
               onClick={handleConfirmReschedule}
               disabled={!selectedRescheduleSlotId || confirmingReschedule}
-              className="px-6 py-2.5 rounded-full bg-accent-coral text-white text-sm font-semibold hover:bg-accent-coral/90 transition disabled:opacity-50 mr-3"
+              className="mr-3"
             >
               {confirmingReschedule ? "Rescheduling..." : "Confirm Reschedule"}
-            </button>
+            </Button>
           </>
         )}
         <button onClick={exitRescheduling} className="text-sm font-semibold text-muted-foreground hover:underline">

--- a/dali-api/app/slack/lib/slack-client.ts
+++ b/dali-api/app/slack/lib/slack-client.ts
@@ -16,6 +16,12 @@ export type SlackFile = {
   urlPrivate: string;
 };
 
+export const SLACK_NOT_CONFIGURED_MESSAGE = "SLACK_BOT_TOKEN not set.";
+
+export function slackConfigured(): boolean {
+  return Boolean(process.env.SLACK_BOT_TOKEN);
+}
+
 let cached: WebClient | null = null;
 function client(): WebClient {
   if (cached) return cached;


### PR DESCRIPTION
…helper (#838)

Largest remaining DRY items from DRY_DEFERRED.md, bundled into one PR. 1249/1249 tests pass, typecheck clean for app/.

## New shared modules

- `app/components/ui/Avatar` — `<Avatar photoUrl name size="sm|md|lg" />` with brand-coral fallback chip
- `app/components/ui/RolePills` — pluggable role/admin/core badges with size + showLevel props
- `app/components/ui/SearchInput` — search-icon-inside-input primitive
- `app/projects/components/UserSubmissionShell` — extracted from 3 sibling user-detail routes
- `app/hiring/lib/labels` — consolidated STATUS_COLORS, STATUS_LABELS, DECISION_COLORS/LABELS, INTERVIEW_STATUS_COLORS/LABELS, STAGE_LABELS, RECOMMENDATION_COLORS, STATUS_PILL_BASE
- `app/hiring/lib/review` — VALID_RECOMMENDATIONS, MAX_*_LENGTH consts, ReviewPatchSchema (Zod). Replaces 120-line imperative validateReviewPatch
- `app/lib/retry` — generic retry-with-backoff helper; adopted in google-workspace.ts:addGroupMember

## Adoption highlights

### Phase 4.1/4.2 — UI primitives
- `<Button variant="primary">` adopted at 24 sites across hiring, projects, forms, admin-console, portal, ApplicantErrorBoundary
- `<Modal>` adopted at 5 sites in hiring/components/Library, EmailTemplates, delibs/ApplicantContextModal
- Skipped sites where the design system's rounded-full pill would significantly diverge from the existing rounded-md rectangle (calendar manual-block forms, projects list/$id/level-up). These are visual redesign decisions, not pure DRY.

### Phase 4.3 — Avatar/RolePills consolidation
- members.tsx, members.groups.tsx: deleted 2 local Avatar + 2 local RolePills declarations; replaced with shared components
- MemberCard.tsx: same treatment
- Label maps in 6 hiring route/component files: deleted local declarations, imported shared. **Fixed drift** at `domain-lead.application.$id.tsx:42` where InvitedToInterview was `bg-purple-100` instead of `bg-blue-100`

### Phase 7.1 — validateReviewPatch → Zod
- Replaced 120-line imperative validator with `ReviewPatchSchema` + `parseJson()`. Test pass count unchanged (463/463 hiring tests).
- VALID_RECOMMENDATIONS deduplicated; both api.reviews and api.interviews.$id.complete now import from `~/hiring/lib/review`

### Phase 5.2 — Slack response shape
- Added `slackConfigured()` predicate + `SLACK_NOT_CONFIGURED_MESSAGE` constant in slack-client.ts
- api.staffing.finalize.ts and api.staffing.term-channel.ts share the message constant (preserving their distinct wire shapes — skipped/JSON vs action/error JSON)

### Phase 5.3 — retry helper extraction
- `retry(fn, { backoffsMs, shouldRetry })` in app/lib/retry.ts
- google-workspace.ts:addGroupMember refactored; retry budget unchanged (5 backoffs = 6 attempts, 15.5s total). 409-as-success preserved.

### Phase 7.3 — getAppEnv vs NODE_ENV
- Policy documented in app-env.ts: NODE_ENV for Node/runtime (cookie Secure, CSP, dev gates); getAppEnv() for app-level intent
- login.tsx: inline NODE_ENV check de-duped to local const

### Phase 3.3 — displayEmail leftovers
- 3 sites: mcp/tools/rsvp-to-notification.ts, routes/api.notifications.$id.rsvp.ts, routes/oauth.consent.tsx

### Phase 2.1 / 2.2 / 2.3
- safeParse dedup: canonical safeParseJsonString in forms-data.ts; both forms files share it
- UserSubmissionShell adopted in 3 sibling routes
- SearchInput adopted in admin-console.announcements.tsx (2 sites)

### H1 Level type centralization
- bid-validation.ts, staffing-board.ts, eligibility.ts, admin-console.domains.tsx, api.staffing.assign.ts, projects.level-up.tsx all adopt `~/lib/level`
- Hand-rolled `if (x !== "P1" && ...)` validator → `isLevel(x)`

### H2 Forbidden plain-text
- 3 sites: api.staffing.events.ts, admin-console.payroll-export.csv.ts, lead.intern-to-full-cycle.$id.tsx — adopted `forbidden(request)`

### H4 sentinel doc
- 3-line policy comment in lib/display.ts: UNKNOWN_LABEL for prose, EMPTY_DISPLAY for tables

## Test infra
- Extended `~/lib/auth` mock in hiring/routes/__tests__/lead.intern-to-full-cycle.$id.test.ts to include the `forbidden` / `unauthorized` exports

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/839"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784068479&installation_id=133523038&pr_number=839&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F839&signature=e43500be36cdb9fa090931a34a8c02ed510ecf5f9c5239c06331c811bed663fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->