### PR TITLE
NetID: consolidate User.collegeId into User.netId

### DIFF
--- a/dali-api/app/members/__tests__/profile-form-interpreter.test.ts
+++ b/dali-api/app/members/__tests__/profile-form-interpreter.test.ts
@@ -77,6 +77,9 @@ describe("interpretProfileForm", () => {
   });
 
   it("maps the new onboarding profile fields", () => {
+    // The legacy "profile.collegeId" answer key now maps to User.netId — the
+    // two columns were consolidated. Existing form versions don't need to be
+    // re-published; the destination column moved.
     const res = interpretProfileForm({
       "profile.nameOnFile": "Jonathan Doe",
       "profile.collegeId": "F00ABCD",
@@ -88,7 +91,7 @@ describe("interpretProfileForm", () => {
     if (!res.ok) return;
     expect(res.update).toEqual({
       nameOnFile: "Jonathan Doe",
-      collegeId: "F00ABCD",
+      netId: "F00ABCD",
       phoneNumber: "+1 555 010 1234",
       ethnicity: "Asian",
       dietaryRestrictions: "Vegetarian",

--- a/dali-api/app/members/components/MemberProfileView.tsx
+++ b/dali-api/app/members/components/MemberProfileView.tsx
@@ -329,9 +329,9 @@ function PersonalSection({
                 defaultValue={member.phoneNumber ?? ""}
               />
               <FieldInput
-                name="collegeId"
-                label="College ID"
-                defaultValue={member.collegeId ?? ""}
+                name="netId"
+                label="NetID"
+                defaultValue={member.netId ?? ""}
               />
               <FieldInput
                 name="personalEmail"
@@ -381,7 +381,7 @@ function PersonalSection({
                 value={formatBirthday(member.birthday)}
               />
               <Detail label="Phone" value={member.phoneNumber} />
-              <Detail label="College ID" value={member.collegeId} />
+              <Detail label="NetID" value={member.netId} />
               <Detail label="Time zone" value={member.timeZone} />
               <div>
                 <dt className="text-xs text-muted-foreground mb-0.5">GitHub</dt>
@@ -763,7 +763,7 @@ const PERSONAL_FIELDS = new Set<keyof ProfileMember>([
   "hometown",
   "birthday",
   "phoneNumber",
-  "collegeId",
+  "netId",
   "personalEmail",
   "timeZone",
   "githubUsername",
@@ -795,8 +795,8 @@ function HiddenProfileFields({
     entries.push(["birthday", birthdayInputValue(member.birthday)]);
   if (!skip.has("phoneNumber"))
     entries.push(["phoneNumber", member.phoneNumber ?? ""]);
-  if (!skip.has("collegeId"))
-    entries.push(["collegeId", member.collegeId ?? ""]);
+  if (!skip.has("netId"))
+    entries.push(["netId", member.netId ?? ""]);
   if (!skip.has("personalEmail"))
     entries.push(["personalEmail", member.personalEmail ?? ""]);
   if (!skip.has("timeZone")) entries.push(["timeZone", member.timeZone ?? ""]);

--- a/dali-api/app/members/lib/profile-form-interpreter.ts
+++ b/dali-api/app/members/lib/profile-form-interpreter.ts
@@ -24,7 +24,10 @@ const STRING_FIELDS: Record<string, string> = {
   "profile.linkedinUrl": "linkedinUrl",
   // Onboarding profile additions.
   "profile.nameOnFile": "nameOnFile",
-  "profile.collegeId": "collegeId",
+  // The "College ID" question on the onboarding form is the Dartmouth NetID
+  // (single canonical column). Kept under the legacy key so existing form
+  // versions don't need re-publishing; the destination column moved to netId.
+  "profile.collegeId": "netId",
   "profile.phoneNumber": "phoneNumber",
   "profile.ethnicity": "ethnicity",
   "profile.dietaryRestrictions": "dietaryRestrictions",
@@ -42,7 +45,7 @@ export type ProfileUpdate = {
   linkedinUrl?: string;
   classYear?: number;
   nameOnFile?: string;
-  collegeId?: string;
+  netId?: string;
   phoneNumber?: string;
   ethnicity?: string;
   dietaryRestrictions?: string;

--- a/dali-api/app/members/lib/profile-page.server.ts
+++ b/dali-api/app/members/lib/profile-page.server.ts
@@ -41,7 +41,7 @@ export type ProfileMember = {
   githubUsername: string | null;
   personalSite: string | null;
   timeZone: string | null;
-  collegeId: string | null;
+  netId: string | null;
   phoneNumber: string | null;
   birthday: string | null;
   dietaryRestrictions: string | null;
@@ -94,7 +94,7 @@ const TEXT_FIELDS = [
   "timeZone",
   "dietaryRestrictions",
   "phoneNumber",
-  "collegeId",
+  "netId",
   "personalEmail",
 ] as const;
 
@@ -157,7 +157,7 @@ export async function loadProfilePage({
       personalSite: true,
       timeZone: true,
       photoUrl: true,
-      collegeId: true,
+      netId: true,
       phoneNumber: true,
       birthday: true,
       dietaryRestrictions: true,
@@ -321,6 +321,11 @@ export async function runProfileAction({
     const raw = (form.get(field) as string | null)?.trim() ?? "";
     if (field === "firstName" || field === "lastName") {
       data[field] = raw;
+    } else if (field === "netId") {
+      // NetID is case-normalized to lowercase — the CAS handler writes it the
+      // same way, and the column has a unique index. Storing mixed case would
+      // produce false "duplicates" against CAS-written rows.
+      data[field] = raw === "" ? null : raw.toLowerCase();
     } else {
       data[field] = raw === "" ? null : raw;
     }
@@ -355,7 +360,20 @@ export async function runProfileAction({
     data.birthday = d;
   }
 
-  await prisma.user.update({ where: { id: targetId }, data });
+  try {
+    await prisma.user.update({ where: { id: targetId }, data });
+  } catch (e) {
+    // P2002 = Prisma unique-constraint violation. The only unique text field
+    // saved here is netId; surface a friendly error instead of a 500.
+    const code = (e as { code?: string } | null)?.code;
+    if (code === "P2002") {
+      return {
+        error:
+          "That NetID is already on another account — contact ops to merge or correct the duplicate.",
+      };
+    }
+    throw e;
+  }
   return redirect(redirectPathFor(request, targetId));
 }
 

--- a/dali-api/prisma/migrations/20260615000000_user_netid_backfill_from_collegeid/migration.sql
+++ b/dali-api/prisma/migrations/20260615000000_user_netid_backfill_from_collegeid/migration.sql
@@ -1,0 +1,73 @@
+-- Consolidate the user's Dartmouth NetID onto a single column.
+--
+-- Historically, `User.netId` (written by CAS sign-in) and `User.collegeId`
+-- (user-edited via the profile UI, labelled "College ID") were two columns
+-- holding the same identifier. The profile editor wrote one; everything else
+-- (payroll export, search, isCore, MentorshipPair lookups, …) read the other.
+-- That caused real bugs — a member could fill in their "College ID" in the
+-- profile and still appear NetID-less to the payroll export.
+--
+-- This migration copies collegeId → netId where netId is NULL so every user
+-- ends up with the canonical column populated. The follow-up migration
+-- (20260615000010_drop_user_collegeid) drops the now-redundant column.
+--
+-- Rules:
+--   - Lowercase the value on copy (matches the CAS handler's normalization).
+--   - Skip any row where the lowercased collegeId would collide with another
+--     user's existing netId (unique constraint). The mismatch report below
+--     surfaces those for manual cleanup BEFORE this migration runs in any
+--     env where it might trip — `psql -f` the SELECT and resolve duplicates
+--     by hand if anything shows up.
+--   - Don't overwrite a populated netId. If both columns are set and disagree,
+--     we keep netId (it's the CAS-canonical value) and rely on the mismatch
+--     report to surface the disagreement.
+
+-- ── Mismatch report (informational; doesn't gate the migration) ────────────
+DO $$
+DECLARE
+  mismatch RECORD;
+BEGIN
+  FOR mismatch IN
+    SELECT id, "firstName", "lastName", "netId", "collegeId"
+    FROM "User"
+    WHERE "netId" IS NOT NULL
+      AND "collegeId" IS NOT NULL
+      AND lower("collegeId") <> "netId"
+  LOOP
+    RAISE NOTICE 'netId/collegeId mismatch — user %, name "% %", netId=%, collegeId=%',
+      mismatch.id, mismatch."firstName", mismatch."lastName",
+      mismatch."netId", mismatch."collegeId";
+  END LOOP;
+END $$;
+
+-- ── Collision report (informational; will be skipped by the backfill) ──────
+DO $$
+DECLARE
+  collision RECORD;
+BEGIN
+  FOR collision IN
+    SELECT u.id, u."firstName", u."lastName", u."collegeId",
+           other.id AS other_id, other."netId" AS other_netid
+    FROM "User" u
+    JOIN "User" other ON other."netId" = lower(u."collegeId")
+    WHERE u."netId" IS NULL
+      AND u."collegeId" IS NOT NULL
+      AND u.id <> other.id
+  LOOP
+    RAISE NOTICE
+      'collegeId-to-netId collision — user % ("% %"), collegeId=% would collide with user % (netId=%)',
+      collision.id, collision."firstName", collision."lastName",
+      collision."collegeId", collision.other_id, collision.other_netid;
+  END LOOP;
+END $$;
+
+-- ── Backfill: copy lower(collegeId) → netId where safe ─────────────────────
+UPDATE "User" u
+SET "netId" = lower(u."collegeId")
+WHERE u."netId" IS NULL
+  AND u."collegeId" IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM "User" other
+    WHERE other.id <> u.id
+      AND other."netId" = lower(u."collegeId")
+  );

--- a/dali-api/prisma/migrations/20260615000010_drop_user_collegeid/migration.sql
+++ b/dali-api/prisma/migrations/20260615000010_drop_user_collegeid/migration.sql
@@ -1,0 +1,9 @@
+-- Drop the now-redundant collegeId column.
+--
+-- The preceding migration (20260615000000_user_netid_backfill_from_collegeid)
+-- copied lower(collegeId) → netId for every user with a NULL netId. Profile
+-- UI is updated in the same release to write netId directly. Nothing should
+-- read collegeId after this PR ships; dropping it removes the divergent
+-- second source of truth.
+
+ALTER TABLE "User" DROP COLUMN "collegeId";

--- a/dali-api/prisma/schema.prisma
+++ b/dali-api/prisma/schema.prisma
@@ -66,8 +66,6 @@ model User {
   // Name as it appears on file with the College, when different from the
   // first/last above (e.g. a legal name). Optional — blank means "same".
   nameOnFile          String?
-  // The student's college ID number (the number on their ID card), not a FK.
-  collegeId           String?
   phoneNumber         String?
   birthday            DateTime?
   // Free-text demographic; collected optionally (includes a "Prefer not to

--- a/dali-api/prisma/seeds/accepted-applicants.ts
+++ b/dali-api/prisma/seeds/accepted-applicants.ts
@@ -49,7 +49,10 @@ const PROFILE_QUESTIONS = [
     required: false,
     data: { label: "Name on file with the College (if different from above)" },
   },
-  { key: "profile.collegeId", type: "text", required: true, data: { label: "College ID number" } },
+  // The form question key stays "profile.collegeId" for backward compatibility
+  // with already-published onboarding form versions; the interpreter maps it
+  // to User.netId (consolidated column).
+  { key: "profile.collegeId", type: "text", required: true, data: { label: "Dartmouth NetID" } },
   { key: "profile.phoneNumber", type: "text", required: true, data: { label: "Phone number" } },
   {
     key: "profile.birthday",


### PR DESCRIPTION
## Summary

`User.netId` (CAS-written) and `User.collegeId` (profile-UI-edited, labelled "College ID") were two columns holding the same Dartmouth identifier. The profile editor wrote one; everything else (payroll export, search, `isCore`, `get-member-profile`, MentorshipPair lookups, …) read the other. A member could type their NetID into the profile and still appear NetID-less to the payroll export.

This consolidates onto `netId`, the column CAS already writes and the schema comment already calls "the canonical Dartmouth identifier."

## Migration plan (two ordered SQL files, same PR)

1. **`20260615000000_user_netid_backfill_from_collegeid`** — copies `lower(collegeId)` → `netId` where `netId IS NULL` and the lowercased value doesn't already exist on another user. Mismatches (both columns set, values disagree) and collisions (would violate `User_netId_key`) get surfaced as `RAISE NOTICE` lines instead of being silently overwritten — review the deploy log if either category fires and resolve those rows by hand.
2. **`20260615000010_drop_user_collegeid`** — drops the now-redundant column.

Per `keep netId` decision: when both columns are set and differ, the migration leaves `netId` alone (CAS is the authoritative writer) and only logs the mismatch.

## Code changes

- **`MemberProfileView.tsx`** — input renamed "College ID" → "NetID", `name="collegeId"` → `name="netId"`, hidden-fields helper updated, `PERSONAL_FIELDS` set updated.
- **`profile-page.server.ts`** — `select` / `data` / `ProfileMember` shape moves to `netId`. The action lowercases the value on save (matches the CAS handler's normalization) and catches Prisma's `P2002` to surface a friendly "NetID is already on another account" error instead of a 500.
- **`profile-form-interpreter.ts`** — the legacy `"profile.collegeId"` answer key keeps pointing at this profile field, but the destination column moves to `netId`. Already-published onboarding form versions don't need to be re-published.
- **`prisma/seeds/accepted-applicants.ts`** — re-labels the onboarding form question "Dartmouth NetID"; the form key stays for the same backward-compat reason.
- **Test** updated for the new destination column.

## Deploy ordering caveat

The migrations run as part of the release step before new instances start serving. There's a brief window where the old code (still reading `collegeId`) could see the column dropped if the rollout overlaps. In practice the only path that touches `collegeId` is the profile editor, so the blast radius is "a profile save during the ~30s deploy window fails." Acceptable for this size of change.

## Test plan

- [ ] Apply both migrations to a preview env. Confirm `collegeId` is gone (`\d "User"` in psql).
- [ ] Spot-check: `SELECT COUNT(*) FROM "User" WHERE "netId" IS NULL;` — should be lower than before the backfill.
- [ ] Look at the deploy log for `RAISE NOTICE` lines about mismatches or collisions; resolve any that surface.
- [ ] As a member, open `/profile`, edit the new NetID field, save. Confirm the value persists.
- [ ] Try saving an uppercase NetID — confirm it's stored lowercase.
- [ ] Try saving a NetID that's already on another user — confirm the friendly error appears (not a 500).
- [ ] Open `/admin-console/payroll-export` and confirm the "User missing NetID" warning is gone for users who only had `collegeId` set before.
- [ ] Confirm the onboarding form still accepts a "Dartmouth NetID" answer (legacy key `profile.collegeId`) and writes it to `User.netId`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/840"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784136421&installation_id=133523038&pr_number=840&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F840&signature=c87c3c18747cddf1efa813da023d75bc14eadfacf00b50b9b9c1c77343129373"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->