### PR TITLE
Payroll export: format JobX hire dates as MMDDYY (#850)

### DIFF
--- a/dali-api/app/admin-console/lib/payroll-export.ts
+++ b/dali-api/app/admin-console/lib/payroll-export.ts
@@ -53,8 +53,13 @@ export type PayrollRow = {
 };
 
 export function formatDate(d: Date): string {
-  // ISO YYYY-MM-DD; Dartmouth payroll accepts this format.
-  return d.toISOString().slice(0, 10);
+  // MMDDYY with no separators — the format JobX expects for hire dates. UTC to
+  // match how Term start/end dates are stored (midnight UTC), avoiding an
+  // off-by-one from local-timezone conversion.
+  const mm = String(d.getUTCMonth() + 1).padStart(2, "0");
+  const dd = String(d.getUTCDate()).padStart(2, "0");
+  const yy = String(d.getUTCFullYear()).slice(-2);
+  return mm + dd + yy;
 }
 
 // JobCodeLookup uses nullable `level` and `domainId` as wildcards. Match the

--- a/dali-api/app/admin-console/routes/admin-console.payroll-export.csv.ts
+++ b/dali-api/app/admin-console/routes/admin-console.payroll-export.csv.ts
@@ -8,7 +8,6 @@ import {
   buildCoreRows,
   buildInstructorRows,
   buildPayrollRows,
-  formatDate,
   pickDefaultTermId,
   rowsToCsv,
 } from "~/admin-console/lib/payroll-export";
@@ -60,7 +59,10 @@ export async function loader({ request }: Route.LoaderArgs) {
     buildInstructorRows(selectedTerm.id, instructorIds),
   ]);
   const csv = rowsToCsv([...projectRows, ...coreRows, ...instructorRows]);
-  const filename = `payroll-${selectedTerm.code}-${formatDate(new Date())}.csv`;
+  // Sortable ISO date stamp for the filename (distinct from the MMDDYY hire
+  // dates inside the CSV).
+  const fileStamp = new Date().toISOString().slice(0, 10);
+  const filename = `payroll-${selectedTerm.code}-${fileStamp}.csv`;
 
   return csvResponse(csv, filename, {
     status: 200,


### PR DESCRIPTION
The payroll CSV uploaded into JobX needs hire dates as MMDDYY with no separators. Rewrite formatDate (was ISO YYYY-MM-DD) to emit MMDDYY, reading parts in UTC to match how Term start/end dates are stored (midnight UTC) and avoid a local-timezone off-by-one.

formatDate had also been doubling as the download filename stamp; keep the filename on a sortable YYYY-MM-DD stamp instead so downloaded files still order chronologically.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/852"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784739224&installation_id=133523038&pr_number=852&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F852&signature=5760ae96eb88c0954033ce8383928d1749d53ce529153b73163d3138d8c30c26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->