### PR TITLE
Editor: extract shared leaves (no core merge)

### DIFF
--- a/dali-api/app/components/CollaborativeEditor.tsx
+++ b/dali-api/app/components/CollaborativeEditor.tsx
@@ -27,6 +27,7 @@ import {
 } from "./collab/util";
 import { useRegisterCollabEditor } from "./collab/PresenceProvider";
 import { VersionHistoryPanel } from "./collab/VersionHistoryPanel";
+import { EDITOR_CONTENT_CLASS, EditorShell } from "./editor/shared";
 
 interface CollaborativeEditorProps {
   documentName: string;
@@ -391,8 +392,7 @@ function CollaborativeEditorInner({
     editable: !disabled,
     editorProps: {
       attributes: {
-        class:
-          "prose prose-sm max-w-none focus:outline-none min-h-[6rem] px-3 py-2",
+        class: EDITOR_CONTENT_CLASS,
       },
     },
   });
@@ -593,13 +593,11 @@ function CollaborativeEditorInner({
   }, [editor, presenceEnabled, reportFocus]);
 
   return (
-    <div
+    <EditorShell
       ref={containerRef}
-      className={`relative rounded-lg border bg-card ${
-        disabled
-          ? "border-border bg-muted/50 opacity-75"
-          : "border-gray-300 focus-within:ring-2 focus-within:ring-blue-500 focus-within:border-transparent"
-      } ${className ?? ""}`}
+      relative
+      disabled={disabled}
+      className={className}
     >
       <button
         type="button"
@@ -684,6 +682,6 @@ function CollaborativeEditorInner({
           pointer-events: none;
         }
       `}</style>
-    </div>
+    </EditorShell>
   );
 }

--- a/dali-api/app/components/RichTextEditor.tsx
+++ b/dali-api/app/components/RichTextEditor.tsx
@@ -1,8 +1,13 @@
 import { useEditor, EditorContent, type Editor } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
 import Placeholder from "@tiptap/extension-placeholder";
-import Link from "@tiptap/extension-link";
 import { useEffect, useRef, useState } from "react";
+import {
+  EDITOR_CONTENT_CLASS,
+  EditorShell,
+  isProseMirrorDoc,
+  linkExtension,
+} from "./editor/shared";
 
 interface RichTextEditorProps {
   value: unknown;
@@ -11,12 +16,6 @@ interface RichTextEditorProps {
   disabled?: boolean;
   className?: string;
 }
-
-const LINK_HTML_ATTRIBUTES = {
-  target: "_blank",
-  rel: "noopener noreferrer nofollow",
-  class: "text-blue-600 underline hover:text-blue-800",
-};
 
 const LINK_PROTOCOLS = ["http", "https", "mailto"];
 
@@ -47,20 +46,13 @@ export function RichTextEditor({
     extensions: [
       StarterKit,
       Placeholder.configure({ placeholder }),
-      Link.configure({
-        openOnClick: false,
-        autolink: true,
-        linkOnPaste: true,
-        protocols: LINK_PROTOCOLS,
-        HTMLAttributes: LINK_HTML_ATTRIBUTES,
-      }),
+      linkExtension({ interactive: false }),
     ],
     content: isProseMirrorDoc(value) ? (value as object) : "",
     editable: !disabled,
     editorProps: {
       attributes: {
-        class:
-          "prose prose-sm max-w-none focus:outline-none min-h-[6rem] px-3 py-2",
+        class: EDITOR_CONTENT_CLASS,
       },
     },
     onUpdate: ({ editor }) => {
@@ -73,16 +65,10 @@ export function RichTextEditor({
   }, [editor, disabled]);
 
   return (
-    <div
-      className={`rounded-lg border bg-card ${
-        disabled
-          ? "border-border bg-muted/50 opacity-75"
-          : "border-gray-300 focus-within:ring-2 focus-within:ring-blue-500 focus-within:border-transparent"
-      } ${className ?? ""}`}
-    >
+    <EditorShell disabled={disabled} className={className}>
       {editor && !disabled ? <Toolbar editor={editor} /> : null}
       <EditorContent editor={editor} />
-    </div>
+    </EditorShell>
   );
 }
 
@@ -158,10 +144,4 @@ function Toolbar({ editor }: { editor: Editor }) {
       )}
     </div>
   );
-}
-
-function isProseMirrorDoc(value: unknown): boolean {
-  if (!value || typeof value !== "object") return false;
-  const maybe = value as { type?: unknown; content?: unknown };
-  return maybe.type === "doc";
 }

--- a/dali-api/app/components/RichTextViewer.tsx
+++ b/dali-api/app/components/RichTextViewer.tsx
@@ -1,55 +1,29 @@
 import { useEditor, EditorContent } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
-import Link from "@tiptap/extension-link";
 import { useEffect } from "react";
+import {
+  EDITOR_VIEWER_CONTENT_CLASS,
+  isEmptyDoc,
+  linkExtension,
+} from "./editor/shared";
 
 interface RichTextViewerProps {
   content: unknown;
   className?: string;
 }
 
-const LINK_HTML_ATTRIBUTES = {
-  target: "_blank",
-  rel: "noopener noreferrer nofollow",
-  class: "text-blue-600 underline hover:text-blue-800",
-};
-
-export function isEmptyDoc(content: unknown): boolean {
-  if (!content || typeof content !== "object") return true;
-  const doc = content as { type?: unknown; content?: unknown };
-  if (doc.type !== "doc") return true;
-  if (!Array.isArray(doc.content) || doc.content.length === 0) return true;
-  return doc.content.every(node => isEmptyNode(node));
-}
-
-function isEmptyNode(node: unknown): boolean {
-  if (!node || typeof node !== "object") return true;
-  const n = node as { content?: unknown; text?: unknown };
-  if (typeof n.text === "string" && n.text.length > 0) return false;
-  if (Array.isArray(n.content) && n.content.length > 0) {
-    return n.content.every(child => isEmptyNode(child));
-  }
-  return true;
-}
+// Re-exported for back-compat: many call sites import isEmptyDoc from here.
+export { isEmptyDoc };
 
 export function RichTextViewer({ content, className }: RichTextViewerProps) {
   const editor = useEditor({
     immediatelyRender: false,
-    extensions: [
-      StarterKit,
-      Link.configure({
-        openOnClick: true,
-        autolink: false,
-        linkOnPaste: false,
-        protocols: ["http", "https", "mailto"],
-        HTMLAttributes: LINK_HTML_ATTRIBUTES,
-      }),
-    ],
+    extensions: [StarterKit, linkExtension({ interactive: true })],
     content: isEmptyDoc(content) ? "" : (content as object),
     editable: false,
     editorProps: {
       attributes: {
-        class: "prose prose-sm max-w-none focus:outline-none",
+        class: EDITOR_VIEWER_CONTENT_CLASS,
       },
     },
   });

--- a/dali-api/app/components/editor/shared.tsx
+++ b/dali-api/app/components/editor/shared.tsx
@@ -1,0 +1,79 @@
+import { forwardRef, type ReactNode } from "react";
+import Link from "@tiptap/extension-link";
+
+export const EDITOR_CONTENT_CLASS =
+  "prose prose-sm max-w-none focus:outline-none min-h-[6rem] px-3 py-2";
+// Viewer has no min-height/padding (RichTextViewer's read-only variant).
+export const EDITOR_VIEWER_CONTENT_CLASS =
+  "prose prose-sm max-w-none focus:outline-none";
+
+const LINK_HTML_ATTRIBUTES = {
+  target: "_blank",
+  rel: "noopener noreferrer nofollow",
+  class: "text-blue-600 underline hover:text-blue-800",
+};
+
+const LINK_PROTOCOLS = ["http", "https", "mailto"];
+
+// interactive=true → viewer (click-through, no autolink/paste capture);
+// interactive=false → editor (autolink + linkOnPaste, click disabled).
+export function linkExtension({ interactive }: { interactive: boolean }) {
+  return Link.configure({
+    openOnClick: interactive,
+    autolink: !interactive,
+    linkOnPaste: !interactive,
+    protocols: LINK_PROTOCOLS,
+    HTMLAttributes: LINK_HTML_ATTRIBUTES,
+  });
+}
+
+export function isProseMirrorDoc(value: unknown): boolean {
+  if (!value || typeof value !== "object") return false;
+  const maybe = value as { type?: unknown; content?: unknown };
+  return maybe.type === "doc";
+}
+
+export function isEmptyDoc(content: unknown): boolean {
+  if (!content || typeof content !== "object") return true;
+  const doc = content as { type?: unknown; content?: unknown };
+  if (doc.type !== "doc") return true;
+  if (!Array.isArray(doc.content) || doc.content.length === 0) return true;
+  return doc.content.every(node => isEmptyNode(node));
+}
+
+function isEmptyNode(node: unknown): boolean {
+  if (!node || typeof node !== "object") return true;
+  const n = node as { content?: unknown; text?: unknown };
+  if (typeof n.text === "string" && n.text.length > 0) return false;
+  if (Array.isArray(n.content) && n.content.length > 0) {
+    return n.content.every(child => isEmptyNode(child));
+  }
+  return true;
+}
+
+interface EditorShellProps {
+  disabled?: boolean;
+  className?: string;
+  relative?: boolean; // CollaborativeEditor needs position:relative for its overlay buttons
+  children: ReactNode;
+}
+
+export const EditorShell = forwardRef<HTMLDivElement, EditorShellProps>(
+  function EditorShell(
+    { disabled = false, className, relative = false, children },
+    ref,
+  ) {
+    return (
+      <div
+        ref={ref}
+        className={`${relative ? "relative " : ""}rounded-lg border bg-card ${
+          disabled
+            ? "border-border bg-muted/50 opacity-75"
+            : "border-gray-300 focus-within:ring-2 focus-within:ring-blue-500 focus-within:border-transparent"
+        } ${className ?? ""}`}
+      >
+        {children}
+      </div>
+    );
+  },
+);


### PR DESCRIPTION
## CRDT / collab caution (read first)

Per `CLAUDE.md`, `@tiptap/*`, `@hocuspocus/*`, and `yjs` are CRDT-based, and collaborative-document changes can break sync in production even when tests pass locally. **This PR was deliberately scoped to avoid that.** It does **not** touch `CollaborativeEditor`'s `useEditor` extensions array, `createCollabExtension`, `createCommentDecorationExtension`, the awareness/idle effects, `followPeer`, or the `docCache`/`acquireDoc`/`releaseDoc` lifecycle. The only changes to `CollaborativeEditor.tsx` are the presentational wrapper `<div>` and the content-class string literal (see the diff — three hunks: an import, the `attributes.class` constant, and the wrapper element). Editor **cores were intentionally left intact.**

## What this does (PR-06: Editor shared leaves)

Extracts the four duplicated *leaf* pieces shared across the three Tiptap setups into a new `dali-api/app/components/editor/shared.tsx`, without merging the cores (which legitimately differ: collab/Yjs, local-JSON, read-only):

- **`EditorShell`** — `forwardRef`-based wrapper rendering the border/disabled/focus shell. `forwardRef` is preserved because `CollaborativeEditor` relies on `containerRef` for comment-button positioning and follow-mode scroll. A `relative` prop keeps `CollaborativeEditor`'s `position: relative` (load-bearing for its overlay buttons); defaults to `false` for `RichTextEditor`.
- **`EDITOR_CONTENT_CLASS`** + **`EDITOR_VIEWER_CONTENT_CLASS`** — kept as two constants on purpose; the viewer intentionally omits `min-h`/padding.
- **`linkExtension({ interactive })`** — the duplicated `Link.configure(...)`; `interactive: true` = viewer (click-through), `interactive: false` = editor (autolink + linkOnPaste).
- **`isProseMirrorDoc`** / **`isEmptyDoc`** — moved verbatim (`isEmptyNode` kept private).

Adopted across `CollaborativeEditor.tsx`, `RichTextEditor.tsx`, `RichTextViewer.tsx`. `isEmptyDoc` is **re-exported** from `RichTextViewer.tsx` for back-compat — many call sites and the existing unit test import it from that module. `isSafeLinkUrl` stays in `RichTextEditor.tsx` (Toolbar uses it).

## Verification

- `npm run typecheck` — clean for `app/` (0 errors). Pre-existing errors in `scripts/*` (missing/typed generated Prisma client) are unrelated to this change and present on the base branch.
- `npm test` — 1249 passed (152 files).

## Out of scope / follow-up

- **Markdown-vs-ProseMirror inconsistency (FLAG ONLY).** `Markdown.tsx` (`react-markdown` + `remark-gfm`) is a 4th rendering path used for project descriptions, while epic descriptions go through the collaborative ProseMirror editor / `RichTextViewer`. Two content models for sibling "description" fields is a product inconsistency — that's a data-model decision, not a leaf extraction, so it is **not** converged here.
- Merging editor cores, normalizing StarterKit config, or sharing the `setEditable` effect via a hook are explicitly not done (CRDT risk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/853"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784742878&installation_id=133523038&pr_number=853&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F853&signature=3bfcf15cee192fcc55d8106aa1e626ce34568d1d73c91b37bc6136f1f8a7ae57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->