### PR TITLE
Hiring detail chrome + InvitedToInterview label-color bug fix

### DIFF
--- a/dali-api/app/hiring/components/ApplicantDetailHeader.tsx
+++ b/dali-api/app/hiring/components/ApplicantDetailHeader.tsx
@@ -1,0 +1,27 @@
+import type React from "react";
+
+// Applicant name + "domain · cycle" subtitle for the hiring detail routes,
+// with an optional status pill rendered top-right.
+export function ApplicantDetailHeader({
+  name,
+  domainName,
+  cycleName,
+  statusSlot,
+}: {
+  name: string;
+  domainName: string;
+  cycleName: string;
+  statusSlot?: React.ReactNode;
+}): React.ReactElement {
+  return (
+    <div className="flex items-start justify-between gap-4">
+      <div>
+        <h1 className="text-2xl font-bold text-foreground">{name}</h1>
+        <p className="mt-1 text-muted-foreground">
+          {domainName} · {cycleName}
+        </p>
+      </div>
+      {statusSlot != null && <div className="flex-shrink-0">{statusSlot}</div>}
+    </div>
+  );
+}

--- a/dali-api/app/hiring/components/DecisionHistoryList.tsx
+++ b/dali-api/app/hiring/components/DecisionHistoryList.tsx
@@ -1,0 +1,89 @@
+import type React from "react";
+import { DECISION_COLORS, STAGE_LABELS, STATUS_PILL_BASE } from "~/hiring/lib/labels";
+
+export interface DecisionHistoryRow {
+  id: string;
+  type: string; // DecisionType key into labels.DECISION_COLORS
+  stage: string; // key into labels.STAGE_LABELS
+  waitlistRank?: number | null;
+  notes?: string | null;
+  createdAt: string | Date;
+  madeByName?: string | null;
+}
+
+// Shared decision-history rows for the hiring detail routes. Pill colors come
+// from the canonical labels.DECISION_COLORS so the same decision renders the
+// same color everywhere.
+//
+// `showNotes` switches between the two existing layouts:
+//   - true  → full route: roomy rows with notes + the maker's name + year.
+//   - false → sidebar: compact rows, pill + stage + short date only.
+export function DecisionHistoryList({
+  decisions,
+  showNotes = false,
+}: {
+  decisions: DecisionHistoryRow[];
+  showNotes?: boolean;
+}): React.ReactElement {
+  const pillClass = (type: string) =>
+    `${STATUS_PILL_BASE} ${DECISION_COLORS[type] ?? "bg-muted text-foreground/80"}`;
+
+  if (!showNotes) {
+    return (
+      <div className="px-4 py-3 space-y-2">
+        {decisions.map((d) => (
+          <div key={d.id} className="flex items-center justify-between text-sm">
+            <div className="flex items-center gap-2">
+              <span className={`${pillClass(d.type)} border border-current/30`}>
+                {d.type}
+                {d.waitlistRank != null && ` #${d.waitlistRank}`}
+              </span>
+              <span className="text-xs text-muted-foreground">
+                {STAGE_LABELS[d.stage] ?? d.stage}
+              </span>
+            </div>
+            <span className="text-xs text-muted-foreground/70">
+              {new Date(d.createdAt).toLocaleDateString(undefined, {
+                month: "short",
+                day: "numeric",
+              })}
+            </span>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <ol className="divide-y divide-border">
+      {decisions.map((d) => (
+        <li key={d.id} className="px-6 py-3 flex items-start gap-3">
+          <span className={`${pillClass(d.type)} flex-shrink-0`}>
+            {d.type}
+            {d.waitlistRank != null && ` #${d.waitlistRank}`}
+          </span>
+          <span className="text-xs text-muted-foreground flex-shrink-0 mt-0.5">
+            {STAGE_LABELS[d.stage] ?? d.stage}
+          </span>
+          <div className="flex-1 min-w-0">
+            {d.notes && (
+              <p className="text-sm text-foreground whitespace-pre-wrap">{d.notes}</p>
+            )}
+          </div>
+          <div className="text-xs text-muted-foreground/80 text-right flex-shrink-0">
+            <div>
+              {new Date(d.createdAt).toLocaleDateString(undefined, {
+                month: "short",
+                day: "numeric",
+                year: "numeric",
+              })}
+            </div>
+            {d.madeByName && (
+              <div className="text-[11px] text-muted-foreground/70">by {d.madeByName}</div>
+            )}
+          </div>
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/dali-api/app/hiring/components/DetailCard.tsx
+++ b/dali-api/app/hiring/components/DetailCard.tsx
@@ -1,0 +1,37 @@
+import type React from "react";
+
+// Shared card shell for the hiring detail routes: rounded-xl card with a
+// muted header band (title + optional subtitle + optional right-aligned extra)
+// and an arbitrary body. This is a hiring-local composition — the global
+// ~/components/ui/Card uses a different visual contract (rounded-lg +
+// shadow-brand-1, no header slot) and does not cover this shell.
+export function DetailCard({
+  title,
+  subtitle,
+  headerExtra,
+  children,
+  className,
+}: {
+  title: string;
+  subtitle?: React.ReactNode;
+  headerExtra?: React.ReactNode;
+  children?: React.ReactNode;
+  className?: string;
+}): React.ReactElement {
+  return (
+    <section
+      className={`bg-card rounded-xl border border-border shadow-sm${className ? ` ${className}` : ""}`}
+    >
+      <div className="px-6 py-4 border-b border-border bg-muted/50 flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h2 className="text-lg font-bold text-foreground">{title}</h2>
+          {subtitle != null && (
+            <p className="text-xs text-muted-foreground mt-0.5">{subtitle}</p>
+          )}
+        </div>
+        {headerExtra != null && <div className="flex-shrink-0">{headerExtra}</div>}
+      </div>
+      {children}
+    </section>
+  );
+}

--- a/dali-api/app/hiring/components/InterviewNotesCard.tsx
+++ b/dali-api/app/hiring/components/InterviewNotesCard.tsx
@@ -1,0 +1,273 @@
+import type React from "react";
+import { Link } from "react-router";
+import { Calendar, MapPin, Users } from "lucide-react";
+import { INTERVIEW_STATUS_COLORS, INTERVIEW_STATUS_LABELS } from "~/hiring/lib/labels";
+
+const LOCATION_LABELS: Record<string, string> = {
+  PodAppa: "Pod Appa",
+  PodMomo: "Pod Momo",
+  Online: "Online",
+};
+
+export interface InterviewNotesInterviewer {
+  id: string;
+  name: string;
+  role?: string; // "InDomain" | "CrossDomain" etc.
+  domainName?: string;
+  notes?: string | null;
+  notesUpdatedAt?: string | Date | null; // shown as "Last edit" in the full layout
+}
+
+export interface InterviewNotesData {
+  id: string;
+  startTime: string | Date;
+  endTime?: string | Date | null;
+  status: string; // key into labels.INTERVIEW_STATUS_COLORS
+  location?: string | null;
+  zoomJoinUrl?: string | null;
+  recommendation?: string | null;
+  recommendationNotes?: string | null;
+  // Either the rich shape (full route) or a plain string (sidebar route).
+  jointNotes?: { plainText: string; updatedAt: string | Date } | string | null;
+  interviewers?: InterviewNotesInterviewer[];
+  openInInterviewerHref?: string; // omit to hide the link
+}
+
+function jointNotesText(
+  jointNotes: InterviewNotesData["jointNotes"],
+): { text: string; updatedAt: string | Date | null } | null {
+  if (jointNotes == null) return null;
+  if (typeof jointNotes === "string") {
+    const trimmed = jointNotes.trim();
+    return trimmed.length > 0 ? { text: trimmed, updatedAt: null } : null;
+  }
+  const trimmed = jointNotes.plainText.trim();
+  return trimmed.length > 0 ? { text: trimmed, updatedAt: jointNotes.updatedAt } : null;
+}
+
+// Meta-row label: in-domain shows the domain name, cross shows just "Cross".
+function interviewerMetaLabel(a: InterviewNotesInterviewer): string {
+  return a.role === "InDomain" ? a.domainName ?? "In-domain" : "Cross";
+}
+
+// Per-interviewer-note label: cross also carries the domain in parens.
+function interviewerNoteLabel(a: InterviewNotesInterviewer): string {
+  if (a.role === "InDomain") return a.domainName ?? "In-domain";
+  return a.domainName ? `Cross (${a.domainName})` : "Cross";
+}
+
+// Shared interview content for the hiring detail routes: meta row (status,
+// date/time, location, interviewers), joint notes, joint recommendation, and
+// per-interviewer notes. Renders the content only — wrap it in a DetailCard or
+// list <li> at the call site.
+//
+// Two layouts via `variant`:
+//   - "full"    → roomy list-item layout used by applications.$domainApplicationId.
+//   - "compact" → tighter sidebar layout used by domain-lead.application.$id.
+export function InterviewNotesCard({
+  interview,
+  variant = "full",
+}: {
+  interview: InterviewNotesData;
+  variant?: "full" | "compact";
+}): React.ReactElement {
+  const start = new Date(interview.startTime);
+  const end = interview.endTime != null ? new Date(interview.endTime) : null;
+  const statusLabel = INTERVIEW_STATUS_LABELS[interview.status] ?? interview.status;
+  const statusClass = INTERVIEW_STATUS_COLORS[interview.status] ?? "bg-muted text-foreground/80";
+  const joint = jointNotesText(interview.jointNotes);
+  const interviewers = interview.interviewers ?? [];
+  const interviewersWithNotes = interviewers.filter(
+    (a) => a.notes != null && a.notes.trim().length > 0,
+  );
+
+  if (variant === "compact") {
+    return (
+      <div className="px-4 py-3 space-y-2">
+        <div className="flex items-center justify-between">
+          <span className="text-sm text-muted-foreground">
+            {start.toLocaleDateString(undefined, { month: "short", day: "numeric" })}{" "}
+            {start.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" })}
+          </span>
+          <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${statusClass}`}>
+            {statusLabel}
+          </span>
+        </div>
+        {interview.recommendation && (
+          <div className="text-sm">
+            <span className="text-muted-foreground">Recommendation:</span>{" "}
+            <span className="font-medium text-foreground">{interview.recommendation}</span>
+          </div>
+        )}
+        {interview.recommendationNotes && (
+          <p className="text-xs text-muted-foreground bg-muted/50 rounded p-2">
+            {interview.recommendationNotes}
+          </p>
+        )}
+        {interviewers.length > 0 && (
+          <div className="text-xs text-muted-foreground pt-1">
+            Interviewers: {interviewers.map((a) => a.name).join(", ")}
+          </div>
+        )}
+
+        {/* Joint interview notes (shared by both interviewers). */}
+        <div className="pt-2 border-t border-border">
+          <div className="text-xs font-bold text-muted-foreground uppercase tracking-wider">
+            Interview notes
+          </div>
+          {joint ? (
+            <p className="mt-1 text-sm text-foreground whitespace-pre-wrap">{joint.text}</p>
+          ) : (
+            <p className="mt-1 text-xs text-muted-foreground/70 italic">No interview notes.</p>
+          )}
+        </div>
+
+        {/* Per-interviewer recommendation notes, when present. */}
+        {interviewersWithNotes.length > 0 && (
+          <div className="pt-2 space-y-2">
+            {interviewersWithNotes.map((a) => (
+              <div key={a.id}>
+                <div className="text-xs font-medium text-muted-foreground">
+                  {a.name}&rsquo;s notes
+                </div>
+                <p className="mt-0.5 text-sm text-foreground whitespace-pre-wrap">{a.notes}</p>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  const locationLabel =
+    interview.location != null
+      ? LOCATION_LABELS[interview.location] ?? interview.location
+      : null;
+
+  return (
+    <div className="px-6 py-4 space-y-3">
+      <div className="flex flex-wrap items-center gap-3">
+        <span
+          className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-bold ${statusClass}`}
+        >
+          {statusLabel}
+        </span>
+        <span className="inline-flex items-center gap-1.5 text-sm text-foreground">
+          <Calendar className="w-3.5 h-3.5 text-muted-foreground" aria-hidden />
+          {start.toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" })}
+          {" · "}
+          {start.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" })}
+          {end && (
+            <>
+              {" – "}
+              {end.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" })}
+            </>
+          )}
+        </span>
+        {locationLabel != null && (
+          <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
+            <MapPin className="w-3.5 h-3.5" aria-hidden />
+            {locationLabel}
+            {interview.location === "Online" && interview.zoomJoinUrl && (
+              <a
+                href={interview.zoomJoinUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-600 hover:underline ml-1"
+              >
+                link
+              </a>
+            )}
+          </span>
+        )}
+        <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
+          <Users className="w-3.5 h-3.5" aria-hidden />
+          {interviewers.length === 0
+            ? "No interviewers assigned"
+            : interviewers.map((a) => `${a.name} (${interviewerMetaLabel(a)})`).join(", ")}
+        </span>
+      </div>
+      <div className="rounded-md border border-border bg-background/50 p-3">
+        <div className="flex items-center justify-between gap-2">
+          <div className="text-xs font-bold text-muted-foreground uppercase tracking-wider">
+            Joint notes
+          </div>
+          {interview.openInInterviewerHref && (
+            <Link
+              to={interview.openInInterviewerHref}
+              className="text-xs text-blue-600 hover:underline"
+            >
+              Open in interviewer view
+            </Link>
+          )}
+        </div>
+        {joint ? (
+          <>
+            <p className="mt-2 text-sm text-foreground whitespace-pre-wrap">{joint.text}</p>
+            {joint.updatedAt != null && (
+              <p className="mt-1 text-[11px] text-muted-foreground/80">
+                Last edit{" "}
+                {new Date(joint.updatedAt).toLocaleString(undefined, {
+                  month: "short",
+                  day: "numeric",
+                  hour: "numeric",
+                  minute: "2-digit",
+                })}
+              </p>
+            )}
+          </>
+        ) : (
+          <p className="mt-2 text-xs text-muted-foreground/70 italic">No notes yet.</p>
+        )}
+      </div>
+      {(interview.recommendation || interview.recommendationNotes) && (
+        <div className="rounded-md border border-border bg-background/50 p-3">
+          <div className="text-xs font-bold text-muted-foreground uppercase tracking-wider">
+            Joint recommendation
+          </div>
+          {interview.recommendation && (
+            <div className="mt-2">
+              <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-bold bg-muted text-foreground/80">
+                {interview.recommendation}
+              </span>
+            </div>
+          )}
+          {interview.recommendationNotes && interview.recommendationNotes.trim().length > 0 && (
+            <p className="mt-2 text-sm text-foreground whitespace-pre-wrap">
+              {interview.recommendationNotes}
+            </p>
+          )}
+        </div>
+      )}
+      {interviewersWithNotes.length > 0 && (
+        <div className="space-y-2 pl-1">
+          <div className="text-xs font-bold text-muted-foreground uppercase tracking-wider">
+            Per-interviewer notes
+          </div>
+          {interviewersWithNotes.map((a) => (
+            <div key={a.id} className="rounded-md border border-border bg-background/50 p-3">
+              <div className="text-sm font-medium text-foreground">
+                {a.name}{" "}
+                <span className="text-xs font-normal text-muted-foreground">
+                  · {interviewerNoteLabel(a)}
+                </span>
+              </div>
+              <p className="mt-2 text-sm text-foreground whitespace-pre-wrap">{a.notes}</p>
+              {a.notesUpdatedAt != null && (
+                <p className="mt-1 text-[11px] text-muted-foreground/80">
+                  Last edit{" "}
+                  {new Date(a.notesUpdatedAt).toLocaleString(undefined, {
+                    month: "short",
+                    day: "numeric",
+                    hour: "numeric",
+                    minute: "2-digit",
+                  })}
+                </p>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dali-api/app/hiring/routes/applications.$domainApplicationId.tsx
+++ b/dali-api/app/hiring/routes/applications.$domainApplicationId.tsx
@@ -1,5 +1,4 @@
-import { Link, redirect, useLoaderData, useSearchParams } from "react-router";
-import { Calendar, MapPin, Users } from "lucide-react";
+import { redirect, useLoaderData, useSearchParams } from "react-router";
 import type { Route } from "./+types/applications.$domainApplicationId";
 import { prisma } from "~/lib/db";
 import { requireAuth } from "~/lib/auth";
@@ -8,19 +7,14 @@ import { requirePageSignedOrRedirect } from "~/hiring/lib/confidentiality";
 import { presignAnswers } from "~/hiring/lib/presign";
 import { ApplicationViewer } from "~/hiring/components/ApplicationViewer";
 import { ReviewSummary } from "~/hiring/components/ReviewSummary";
-import type { Question, RubricCriterion } from "~/types";
+import { DetailCard } from "~/hiring/components/DetailCard";
+import { ApplicantDetailHeader } from "~/hiring/components/ApplicantDetailHeader";
 import {
-  INTERVIEW_STATUS_COLORS,
-  INTERVIEW_STATUS_LABELS,
-  DECISION_COLORS,
-  STAGE_LABELS,
-} from "~/hiring/lib/labels";
-
-const LOCATION_LABELS: Record<string, string> = {
-  PodAppa: "Pod Appa",
-  PodMomo: "Pod Momo",
-  Online: "Online",
-};
+  InterviewNotesCard,
+  type InterviewNotesData,
+} from "~/hiring/components/InterviewNotesCard";
+import { DecisionHistoryList } from "~/hiring/components/DecisionHistoryList";
+import type { Question, RubricCriterion } from "~/types";
 
 export const meta: Route.MetaFunction = ({ data }) => {
   const name = (data as { applicantName?: string } | undefined)?.applicantName;
@@ -437,14 +431,11 @@ export default function ApplicationReadOnlyDetail() {
 
   return (
     <div className="space-y-6 pb-12">
-      <div>
-        <h1 className="text-2xl font-bold text-foreground">
-          {data.applicantName}
-        </h1>
-        <p className="mt-1 text-muted-foreground">
-          {data.domainName} · {data.cycleName}
-        </p>
-      </div>
+      <ApplicantDetailHeader
+        name={data.applicantName}
+        domainName={data.domainName}
+        cycleName={data.cycleName}
+      />
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
         {/* Left: application content (read-only annotations from the selected
@@ -460,16 +451,15 @@ export default function ApplicationReadOnlyDetail() {
 
         {/* Right: review viewer. */}
         <div className="space-y-4">
-          <div className="bg-card rounded-xl border border-border shadow-sm sticky top-24">
-            <div className="px-6 py-4 border-b border-border bg-muted/50">
-              <h2 className="text-lg font-bold text-foreground">Reviews</h2>
-              <p className="text-xs text-muted-foreground mt-0.5">
-                {data.reviews.length === 0
-                  ? "No submitted reviews yet."
-                  : `${data.reviews.length} submitted`}
-              </p>
-            </div>
-
+          <DetailCard
+            title="Reviews"
+            subtitle={
+              data.reviews.length === 0
+                ? "No submitted reviews yet."
+                : `${data.reviews.length} submitted`
+            }
+            className="sticky top-24"
+          >
             {data.reviews.length > 0 && (
               <div className="p-6 space-y-5">
                 {/* Reviewer selector */}
@@ -527,7 +517,7 @@ export default function ApplicationReadOnlyDetail() {
                 )}
               </div>
             )}
-          </div>
+          </DetailCard>
         </div>
       </div>
 
@@ -558,15 +548,14 @@ function InterviewsSection({
 }) {
   const hasPrepNote = interviewPrepNote != null && interviewPrepNote.trim().length > 0;
   return (
-    <section className="bg-card rounded-xl border border-border shadow-sm">
-      <div className="px-6 py-4 border-b border-border bg-muted/50">
-        <h2 className="text-lg font-bold text-foreground">Interviews</h2>
-        <p className="text-xs text-muted-foreground mt-0.5">
-          {interviews.length === 0
-            ? "No interviews yet."
-            : `${interviews.length} ${interviews.length === 1 ? "interview" : "interviews"}`}
-        </p>
-      </div>
+    <DetailCard
+      title="Interviews"
+      subtitle={
+        interviews.length === 0
+          ? "No interviews yet."
+          : `${interviews.length} ${interviews.length === 1 ? "interview" : "interviews"}`
+      }
+    >
       {hasPrepNote && (
         <div className="px-6 py-3 border-b border-border bg-amber-50/40">
           <div className="text-xs font-bold text-amber-900 uppercase tracking-wider">
@@ -582,145 +571,43 @@ function InterviewsSection({
       )}
       {interviews.length > 0 && (
         <ul className="divide-y divide-border">
-          {interviews.map((iv) => {
-            const start = new Date(iv.startTime);
-            const end = new Date(iv.endTime);
-            const statusLabel = INTERVIEW_STATUS_LABELS[iv.status] ?? iv.status;
-            const statusClass =
-              INTERVIEW_STATUS_COLORS[iv.status] ?? "bg-muted text-foreground/80";
-            const locationLabel = LOCATION_LABELS[iv.location] ?? iv.location;
-            return (
-              <li key={iv.id} className="px-6 py-4 space-y-3">
-                <div className="flex flex-wrap items-center gap-3">
-                  <span
-                    className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-bold ${statusClass}`}
-                  >
-                    {statusLabel}
-                  </span>
-                  <span className="inline-flex items-center gap-1.5 text-sm text-foreground">
-                    <Calendar className="w-3.5 h-3.5 text-muted-foreground" aria-hidden />
-                    {start.toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" })}
-                    {" · "}
-                    {start.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" })}
-                    {" – "}
-                    {end.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" })}
-                  </span>
-                  <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
-                    <MapPin className="w-3.5 h-3.5" aria-hidden />
-                    {locationLabel}
-                    {iv.location === "Online" && iv.zoomJoinUrl && (
-                      <a
-                        href={iv.zoomJoinUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-blue-600 hover:underline ml-1"
-                      >
-                        link
-                      </a>
-                    )}
-                  </span>
-                  <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
-                    <Users className="w-3.5 h-3.5" aria-hidden />
-                    {iv.assignments.length === 0
-                      ? "No interviewers assigned"
-                      : iv.assignments
-                          .map((a) => `${a.interviewerName} (${a.role === "InDomain" ? a.domainName : "Cross"})`)
-                          .join(", ")}
-                  </span>
-                </div>
-                <div className="rounded-md border border-border bg-background/50 p-3">
-                  <div className="flex items-center justify-between gap-2">
-                    <div className="text-xs font-bold text-muted-foreground uppercase tracking-wider">
-                      Joint notes
-                    </div>
-                    {iv.assignments.some((a) => a.canEditNotes) && (
-                      <Link
-                        to={`/hiring/interviewer/interview/${iv.id}`}
-                        className="text-xs text-blue-600 hover:underline"
-                      >
-                        Open in interviewer view
-                      </Link>
-                    )}
-                  </div>
-                  {iv.jointNotes && iv.jointNotes.plainText.trim().length > 0 ? (
-                    <>
-                      <p className="mt-2 text-sm text-foreground whitespace-pre-wrap">
-                        {iv.jointNotes.plainText}
-                      </p>
-                      <p className="mt-1 text-[11px] text-muted-foreground/80">
-                        Last edit{" "}
-                        {new Date(iv.jointNotes.updatedAt).toLocaleString(undefined, {
-                          month: "short",
-                          day: "numeric",
-                          hour: "numeric",
-                          minute: "2-digit",
-                        })}
-                      </p>
-                    </>
-                  ) : (
-                    <p className="mt-2 text-xs text-muted-foreground/70 italic">
-                      No notes yet.
-                    </p>
-                  )}
-                </div>
-                {(iv.recommendation || iv.recommendationNotes) && (
-                  <div className="rounded-md border border-border bg-background/50 p-3">
-                    <div className="text-xs font-bold text-muted-foreground uppercase tracking-wider">
-                      Joint recommendation
-                    </div>
-                    {iv.recommendation && (
-                      <div className="mt-2">
-                        <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-bold bg-muted text-foreground/80">
-                          {iv.recommendation}
-                        </span>
-                      </div>
-                    )}
-                    {iv.recommendationNotes && iv.recommendationNotes.trim().length > 0 && (
-                      <p className="mt-2 text-sm text-foreground whitespace-pre-wrap">
-                        {iv.recommendationNotes}
-                      </p>
-                    )}
-                  </div>
-                )}
-                {iv.assignments.some((a) => a.privateNotes) && (
-                  <div className="space-y-2 pl-1">
-                    <div className="text-xs font-bold text-muted-foreground uppercase tracking-wider">
-                      Per-interviewer notes
-                    </div>
-                    {iv.assignments
-                      .filter((a) => a.privateNotes && a.privateNotes.plainText.trim().length > 0)
-                      .map((a) => (
-                        <div key={a.id} className="rounded-md border border-border bg-background/50 p-3">
-                          <div className="text-sm font-medium text-foreground">
-                            {a.interviewerName}{" "}
-                            <span className="text-xs font-normal text-muted-foreground">
-                              · {a.role === "InDomain" ? a.domainName : `Cross (${a.domainName})`}
-                            </span>
-                          </div>
-                          <p className="mt-2 text-sm text-foreground whitespace-pre-wrap">
-                            {a.privateNotes!.plainText}
-                          </p>
-                          <p className="mt-1 text-[11px] text-muted-foreground/80">
-                            Last edit{" "}
-                            {new Date(a.privateNotes!.updatedAt).toLocaleString(undefined, {
-                              month: "short",
-                              day: "numeric",
-                              hour: "numeric",
-                              minute: "2-digit",
-                            })}
-                          </p>
-                        </div>
-                      ))}
-                  </div>
-                )}
-              </li>
-            );
-          })}
+          {interviews.map((iv) => (
+            <li key={iv.id}>
+              <InterviewNotesCard interview={toInterviewNotesData(iv)} />
+            </li>
+          ))}
         </ul>
       )}
-    </section>
+    </DetailCard>
   );
 }
+
+// Map the rich loader row into the shared InterviewNotesCard prop shape.
+function toInterviewNotesData(iv: InterviewRow): InterviewNotesData {
+  return {
+    id: iv.id,
+    startTime: iv.startTime,
+    endTime: iv.endTime,
+    status: iv.status,
+    location: iv.location,
+    zoomJoinUrl: iv.zoomJoinUrl,
+    recommendation: iv.recommendation,
+    recommendationNotes: iv.recommendationNotes,
+    jointNotes: iv.jointNotes,
+    openInInterviewerHref: iv.assignments.some((a) => a.canEditNotes)
+      ? `/hiring/interviewer/interview/${iv.id}`
+      : undefined,
+    interviewers: iv.assignments.map((a) => ({
+      id: a.id,
+      name: a.interviewerName,
+      role: a.role,
+      domainName: a.domainName,
+      notes: a.privateNotes?.plainText ?? null,
+      notesUpdatedAt: a.privateNotes?.updatedAt ?? null,
+    })),
+  };
+}
+
 
 function DecisionsSection({
   decisions,
@@ -730,69 +617,34 @@ function DecisionsSection({
   canSeePreReleaseDecisions: boolean;
 }) {
   return (
-    <section className="bg-card rounded-xl border border-border shadow-sm">
-      <div className="px-6 py-4 border-b border-border bg-muted/50">
-        <h2 className="text-lg font-bold text-foreground">Decisions</h2>
-        <p className="text-xs text-muted-foreground mt-0.5">
+    <DetailCard
+      title="Decisions"
+      subtitle={
+        <>
           {decisions.length === 0
             ? canSeePreReleaseDecisions
               ? "No decisions recorded."
               : "No released decisions yet."
             : `${decisions.length} ${decisions.length === 1 ? "record" : "records"}`}
           {!canSeePreReleaseDecisions && decisions.length > 0 && " (released only)"}
-        </p>
-      </div>
-      {decisions.length > 0 && (
-        <ol className="divide-y divide-border">
-          {decisions.map((d) => (
-            <li key={d.id} className="px-6 py-3 flex items-start gap-3">
-              <span
-                className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-bold flex-shrink-0 ${
-                  DECISION_COLORS[d.type] ?? "bg-muted text-foreground/80"
-                }`}
-              >
-                {d.type}
-                {d.waitlistRank != null && ` #${d.waitlistRank}`}
-              </span>
-              <span className="text-xs text-muted-foreground flex-shrink-0 mt-0.5">
-                {STAGE_LABELS[d.stage] ?? d.stage}
-              </span>
-              <div className="flex-1 min-w-0">
-                {d.notes && (
-                  <p className="text-sm text-foreground whitespace-pre-wrap">{d.notes}</p>
-                )}
-              </div>
-              <div className="text-xs text-muted-foreground/80 text-right flex-shrink-0">
-                <div>
-                  {new Date(d.createdAt).toLocaleDateString(undefined, {
-                    month: "short",
-                    day: "numeric",
-                    year: "numeric",
-                  })}
-                </div>
-                {d.madeByName && (
-                  <div className="text-[11px] text-muted-foreground/70">by {d.madeByName}</div>
-                )}
-              </div>
-            </li>
-          ))}
-        </ol>
-      )}
-    </section>
+        </>
+      }
+    >
+      {decisions.length > 0 && <DecisionHistoryList decisions={decisions} showNotes />}
+    </DetailCard>
   );
 }
 
 function DelibsSection({ delibs }: { delibs: DelibsRef[] }) {
   return (
-    <section className="bg-card rounded-xl border border-border shadow-sm">
-      <div className="px-6 py-4 border-b border-border bg-muted/50">
-        <h2 className="text-lg font-bold text-foreground">Delibs</h2>
-        <p className="text-xs text-muted-foreground mt-0.5">
-          {delibs.length === 0
-            ? "Not part of any delibs session."
-            : `${delibs.length} ${delibs.length === 1 ? "session" : "sessions"}`}
-        </p>
-      </div>
+    <DetailCard
+      title="Delibs"
+      subtitle={
+        delibs.length === 0
+          ? "Not part of any delibs session."
+          : `${delibs.length} ${delibs.length === 1 ? "session" : "sessions"}`
+      }
+    >
       {delibs.length > 0 && (
         <ul className="divide-y divide-border">
           {delibs.map((s) => (
@@ -821,6 +673,6 @@ function DelibsSection({ delibs }: { delibs: DelibsRef[] }) {
           ))}
         </ul>
       )}
-    </section>
+    </DetailCard>
   );
 }

--- a/dali-api/app/hiring/routes/domain-lead.application.$id.tsx
+++ b/dali-api/app/hiring/routes/domain-lead.application.$id.tsx
@@ -8,6 +8,16 @@ import { presignAnswers } from "~/hiring/lib/presign";
 import { ChevronDown } from "lucide-react";
 import { ApplicationViewer } from "~/hiring/components/ApplicationViewer";
 import { ReviewSummary } from "~/hiring/components/ReviewSummary";
+import { DetailCard } from "~/hiring/components/DetailCard";
+import { ApplicantDetailHeader } from "~/hiring/components/ApplicantDetailHeader";
+import {
+  InterviewNotesCard,
+  type InterviewNotesData,
+} from "~/hiring/components/InterviewNotesCard";
+import {
+  DecisionHistoryList,
+  type DecisionHistoryRow,
+} from "~/hiring/components/DecisionHistoryList";
 import { buildCriteriaLabelMap } from "~/hiring/lib/rubric-criteria";
 import {
   inferDomainApplicationStatus,
@@ -15,11 +25,7 @@ import {
 } from "~/hiring/lib/domain-application-status";
 import type { ApplicationCycleStatus } from "~/generated/prisma/enums";
 import type { Question } from "~/types";
-import {
-  RECOMMENDATION_COLORS,
-  DECISION_COLORS,
-  STAGE_LABELS,
-} from "~/hiring/lib/labels";
+import { RECOMMENDATION_COLORS } from "~/hiring/lib/labels";
 
 // bg + text + an explicit same-hue border (e.g. red pill → red border), so the
 // outline always matches the pill and never falls back to the neutral gray
@@ -258,19 +264,16 @@ export default function DomainLeadApplicationView() {
   return (
     <div className="space-y-6 pb-12">
       {/* Header */}
-      <div className="flex items-start justify-between gap-4">
-        <div>
-          <h1 className="text-2xl font-bold text-foreground">
-            {application.user.firstName} {application.user.lastName}
-          </h1>
-          <p className="mt-1 text-muted-foreground">
-            {da.challengeVersion.domain?.name} · {application.applicationCycle.name}
-          </p>
-        </div>
-        <span className={`inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold border flex-shrink-0 ${statusInfo.bg}`}>
-          {statusInfo.label}
-        </span>
-      </div>
+      <ApplicantDetailHeader
+        name={`${application.user.firstName} ${application.user.lastName}`}
+        domainName={da.challengeVersion.domain?.name}
+        cycleName={application.applicationCycle.name}
+        statusSlot={
+          <span className={`inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold border ${statusInfo.bg}`}>
+            {statusInfo.label}
+          </span>
+        }
+      />
 
       {/* Two-column layout */}
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
@@ -286,15 +289,15 @@ export default function DomainLeadApplicationView() {
         {/* Right: Context sidebar */}
         <div className="space-y-4 lg:sticky lg:top-24 lg:self-start">
           {/* Reviews */}
-          <div className="bg-card border border-border rounded-xl shadow-sm overflow-hidden">
-            <div className="px-6 py-4 bg-muted/50 border-b border-border">
-              <h2 className="text-lg font-bold text-foreground">Reviews</h2>
-              <p className="text-xs text-muted-foreground mt-0.5">
-                {reviews.length === 0
-                  ? "No reviewers assigned yet."
-                  : `${reviews.filter((r: any) => r.submittedAt).length}/${reviews.length} submitted`}
-              </p>
-            </div>
+          <DetailCard
+            title="Reviews"
+            subtitle={
+              reviews.length === 0
+                ? "No reviewers assigned yet."
+                : `${reviews.filter((r: any) => r.submittedAt).length}/${reviews.length} submitted`
+            }
+            className="overflow-hidden"
+          >
             {reviews.length > 0 && (
               <div className="divide-y divide-gray-100">
                 {reviews.map((review: any) => (
@@ -302,112 +305,57 @@ export default function DomainLeadApplicationView() {
                 ))}
               </div>
             )}
-          </div>
+          </DetailCard>
 
           {/* Interview */}
           {interview && (
-            <div className="bg-card border border-border rounded-xl shadow-sm overflow-hidden">
-              <div className="px-6 py-4 bg-muted/50 border-b border-border">
-                <h2 className="text-lg font-bold text-foreground">Interview</h2>
-              </div>
-              <div className="px-4 py-3 space-y-2">
-                <div className="flex items-center justify-between">
-                  <span className="text-sm text-muted-foreground">
-                    {new Date(interview.startTime).toLocaleDateString(undefined, { month: "short", day: "numeric" })}{" "}
-                    {new Date(interview.startTime).toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" })}
-                  </span>
-                  <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${
-                    interview.status === "Completed" ? "bg-green-100 text-green-700" : "bg-blue-100 text-blue-700"
-                  }`}>
-                    {interview.status}
-                  </span>
-                </div>
-                {interview.recommendation && (
-                  <div className="text-sm">
-                    <span className="text-muted-foreground">Recommendation:</span>{" "}
-                    <span className="font-medium text-foreground">{interview.recommendation}</span>
-                  </div>
-                )}
-                {interview.recommendationNotes && (
-                  <p className="text-xs text-muted-foreground bg-muted/50 rounded p-2">{interview.recommendationNotes}</p>
-                )}
-                {interview.assignments?.length > 0 && (
-                  <div className="text-xs text-muted-foreground pt-1">
-                    Interviewers: {interview.assignments.map((a: any) => {
-                      const m = a.cycleInterviewer?.user;
-                      return m ? `${m.firstName} ${m.lastName}` : "?";
-                    }).join(", ")}
-                  </div>
-                )}
-
-                {/* Joint interview notes (shared by both interviewers). */}
-                <div className="pt-2 border-t border-border">
-                  <div className="text-xs font-bold text-muted-foreground uppercase tracking-wider">
-                    Interview notes
-                  </div>
-                  {interview.jointNotes ? (
-                    <p className="mt-1 text-sm text-foreground whitespace-pre-wrap">
-                      {interview.jointNotes}
-                    </p>
-                  ) : (
-                    <p className="mt-1 text-xs text-muted-foreground/70 italic">
-                      No interview notes.
-                    </p>
-                  )}
-                </div>
-
-                {/* Per-interviewer recommendation notes, when present. */}
-                {interview.assignments?.some((a: any) => a.recNotes) && (
-                  <div className="pt-2 space-y-2">
-                    {interview.assignments
-                      .filter((a: any) => a.recNotes)
-                      .map((a: any) => {
-                        const m = a.cycleInterviewer?.user;
-                        const who = m ? `${m.firstName} ${m.lastName}` : "Interviewer";
-                        return (
-                          <div key={a.id}>
-                            <div className="text-xs font-medium text-muted-foreground">
-                              {who}&rsquo;s notes
-                            </div>
-                            <p className="mt-0.5 text-sm text-foreground whitespace-pre-wrap">
-                              {a.recNotes}
-                            </p>
-                          </div>
-                        );
-                      })}
-                  </div>
-                )}
-              </div>
-            </div>
+            <DetailCard title="Interview" className="overflow-hidden">
+              <InterviewNotesCard interview={toInterviewNotesData(interview)} variant="compact" />
+            </DetailCard>
           )}
 
           {/* Decision history */}
           {decisions.length > 0 && (
-            <div className="bg-card border border-border rounded-xl shadow-sm overflow-hidden">
-              <div className="px-6 py-4 bg-muted/50 border-b border-border">
-                <h2 className="text-lg font-bold text-foreground">Decision History</h2>
-              </div>
-              <div className="px-4 py-3 space-y-2">
-                {decisions.map((d: any) => (
-                  <div key={d.id} className="flex items-center justify-between text-sm">
-                    <div className="flex items-center gap-2">
-                      <span className={`text-xs px-2 py-0.5 rounded-full font-medium border ${DECISION_COLORS[d.type] ?? "bg-muted text-foreground/80 border-current/30"}`}>
-                        {d.type}
-                      </span>
-                      <span className="text-xs text-muted-foreground">{STAGE_LABELS[d.stage] ?? d.stage}</span>
-                    </div>
-                    <span className="text-xs text-muted-foreground/70">
-                      {new Date(d.createdAt).toLocaleDateString(undefined, { month: "short", day: "numeric" })}
-                    </span>
-                  </div>
-                ))}
-              </div>
-            </div>
+            <DetailCard title="Decision History" className="overflow-hidden">
+              <DecisionHistoryList decisions={decisions.map(toDecisionHistoryRow)} />
+            </DetailCard>
           )}
         </div>
       </div>
     </div>
   );
+}
+
+// Map this route's interview shape (joint notes as a plain string, recNotes
+// per assignment) into the shared InterviewNotesCard prop shape.
+function toInterviewNotesData(interview: any): InterviewNotesData {
+  return {
+    id: interview.id,
+    startTime: interview.startTime,
+    endTime: interview.endTime,
+    status: interview.status,
+    recommendation: interview.recommendation,
+    recommendationNotes: interview.recommendationNotes,
+    jointNotes: interview.jointNotes ?? null,
+    interviewers: (interview.assignments ?? []).map((a: any) => {
+      const m = a.cycleInterviewer?.user;
+      return {
+        id: a.id,
+        name: m ? `${m.firstName} ${m.lastName}` : "Interviewer",
+        notes: a.recNotes ?? null,
+      };
+    }),
+  };
+}
+
+function toDecisionHistoryRow(d: any): DecisionHistoryRow {
+  return {
+    id: d.id,
+    type: d.type,
+    stage: d.stage,
+    waitlistRank: d.waitlistRank,
+    createdAt: d.createdAt,
+  };
 }
 
 function ReviewCard({

--- a/dali-api/app/hiring/routes/domain-lead.tsx
+++ b/dali-api/app/hiring/routes/domain-lead.tsx
@@ -27,16 +27,7 @@ import type { ApplicationCycleStatus } from "~/generated/prisma/enums";
 import type { DecisionType } from "~/types";
 import { formatVersionLabel, buildVersionNumberMap } from "~/lib/formatVersion";
 import { selectActiveCycleForDomainLead } from "~/hiring/lib/cycle-picker";
-import { STATUS_LABELS, DECISION_LABELS } from "~/hiring/lib/labels";
-
-// Every status/decision pill carries a border in its OWN hue (never a neutral
-// black/gray line on a colored pill) so the whole page reads consistently.
-const STATUS_COLORS: Record<string, string> = {
-  Draft: "bg-muted text-foreground/80 border border-current/30",
-  Open: "bg-green-100 text-green-700 border border-green-200",
-  UnderReview: "bg-yellow-100 text-yellow-700 border border-yellow-200",
-  Completed: "bg-blue-100 text-blue-700 border border-blue-200",
-};
+import { STATUS_LABELS, DECISION_LABELS, STATUS_COLORS, DECISION_COLORS } from "~/hiring/lib/labels";
 
 const STATUS_MESSAGES: Record<string, string> = {
   Draft: "This cycle is still being set up.",
@@ -715,7 +706,7 @@ export default function DomainLeadDashboard() {
                       <span className="text-muted-foreground/70 hidden sm:inline">·</span>
                       <span className="text-lg text-muted-foreground">{cycle.name}</span>
                       {currentStatus && (
-                        <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${STATUS_COLORS[currentStatus]}`}>
+                        <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium border border-current/30 ${STATUS_COLORS[currentStatus]}`}>
                           {STATUS_LABELS[currentStatus]}
                         </span>
                       )}
@@ -2030,16 +2021,6 @@ function DelibsSection({ cycleId, domainId, sessions, initialCount, finalCount }
   );
 }
 
-// bg + text + an explicit same-hue border (e.g. red pill → red border), so the
-// outline always matches the pill and never falls back to the neutral gray
-// border from the global `*` rule.
-const DECISION_COLORS: Record<string, string> = {
-  Rejected: "bg-red-100 text-red-700 border-red-300 dark:bg-red-900/30 dark:text-red-400 dark:border-red-700",
-  InvitedToInterview: "bg-purple-100 text-purple-700 border-purple-300 dark:bg-purple-900/30 dark:text-purple-400 dark:border-purple-700",
-  Accepted: "bg-green-100 text-green-700 border-green-300 dark:bg-green-900/30 dark:text-green-400 dark:border-green-700",
-  Waitlisted: "bg-yellow-100 text-yellow-700 border-yellow-300 dark:bg-yellow-900/30 dark:text-yellow-400 dark:border-yellow-700",
-};
-
 // Stage treatment composes on top of the `border border-current/40` the badge
 // always applies. Draft reads as "tentative" (faded + dashed, same hue);
 // Final/Released keep the solid same-hue border.
@@ -2079,7 +2060,7 @@ function DecisionPillBadge({ pill, isCurrent = false }: { pill: DecisionPill; is
     <span
       title={tooltip}
       aria-label={tooltip}
-      className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-bold border ${DECISION_COLORS[pill.type] ?? "bg-muted text-muted-foreground border-current/40"} ${STAGE_TREATMENT[pill.stage]} ${accent}`}
+      className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-bold border border-current/40 ${DECISION_COLORS[pill.type] ?? "bg-muted text-muted-foreground"} ${STAGE_TREATMENT[pill.stage]} ${accent}`}
     >
       {Icon && <Icon className="w-3 h-3" />}
       {baseLabel}{rankSuffix}{stageSuffix}


### PR DESCRIPTION
Implements **PR-03: Hiring detail chrome + label-color bug fix** (`implementation-plans/PR-03-hiring-detail-chrome.md`).

## STEP 1 — fixes the live `InvitedToInterview` color bug

`domain-lead.tsx` kept its **own** local `DECISION_COLORS` that hard-coded `InvitedToInterview` as **purple**, while the canonical `~/hiring/lib/labels` map (already adopted on every application-detail screen) renders it **blue**. The same decision therefore showed two different colors depending on the screen.

- Deleted the local `DECISION_COLORS` and `STATUS_COLORS` maps in `domain-lead.tsx`.
- Imported `STATUS_COLORS, DECISION_COLORS` from `~/hiring/lib/labels` alongside the existing `STATUS_LABELS, DECISION_LABELS`.
- **Result: `InvitedToInterview` is now blue on the domain-lead dashboard and on both application-detail routes — one source of truth.**
- The dashboard's "same-hue border" look is preserved via `border-current` composition on the pill className (`border-current/40` on `DecisionPillBadge`, `border-current/30` on the cycle-status pill) rather than reintroducing a divergent per-route color map (which is what caused the drift).

**Visual delta to note:** the old local map carried explicit `dark:` border/bg variants (`-300`/`dark:*-700`). The canonical plain maps omit those; dark-mode pill borders now derive from `border-current`, so they tint with the pill's own text color instead of a fixed `-700` shade. No light-mode change to the fill colors except `InvitedToInterview` (purple → blue, the bug).

## STEP 2 — extract shared detail chrome

New components under `app/hiring/components/`:
- `DetailCard` — card shell + muted header band (title / subtitle / optional `headerExtra`).
- `ApplicantDetailHeader` — name + `domain · cycle` subtitle + optional `statusSlot`.
- `InterviewNotesCard` — interview meta + joint notes + joint recommendation + per-interviewer notes. Normalizes both routes' differing data shapes (rich `{plainText, updatedAt}` joint notes vs. a thin string) and offers `full`/`compact` layouts.
- `DecisionHistoryList` — decision rows, pill via canonical `DECISION_COLORS` + `STAGE_LABELS`; `showNotes` toggles the roomy (notes + maker) vs. compact layout.

Adopted across `applications.$domainApplicationId.tsx` and `domain-lead.application.$id.tsx`. The shared `ApplicationViewer` / `ApplicationAnswers` / `ReviewSummary` content components were left untouched. Net ~373 lines removed from the routes.

## Testing
- `npm run typecheck`: passes for all changed `app/` code (0 errors). The only remaining errors are pre-existing baseline failures in `scripts/` and `prisma/seeds/` that are identical on `origin/dev` and untouched here.
- `npm test`: 1249 passed / 152 files.
- Not CRDT-adjacent — these are read-only viewers; no Tiptap/Yjs schema touched.

## Notes
- File overlap with PR-05 (modal primitives) in `domain-lead.tsx` — land this first or rebase, per the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/855"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784743568&installation_id=133523038&pr_number=855&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F855&signature=67c4baa4f437f338ea9881bb67da76c869ab427c5fbdb78376a1effb8cda0d8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->