### PR TITLE
Forms: shared <FormField> wrapper + form-answer utils

### DIFF
--- a/dali-api/app/forms/components/FormField.tsx
+++ b/dali-api/app/forms/components/FormField.tsx
@@ -1,0 +1,131 @@
+import type { Question } from "~/types";
+import {
+  ChallengeQuestionField,
+  type UrlCheckState,
+} from "~/hiring/components/ChallengeQuestionField";
+import { InfoBody } from "~/hiring/lib/info-body";
+
+// The per-question wrapper that every fill surface used to hand-write:
+// label + standardized required star + optional description + the field.
+// The field renderer itself stays in ChallengeQuestionField — this only owns
+// the chrome around it (and the `info` prose block, which is not a field).
+
+export interface FormFieldProps {
+  question: Question;
+  value: string;
+  onChange: (v: string) => void;
+  disabled?: boolean;
+  // Optional wrapper id (e.g. portal.apply's `question-${key}` scroll anchor).
+  id?: string;
+  urlCheckState?: UrlCheckState;
+  onUrlBlur?: () => void;
+  // default "font-medium"; sites that want the heavier label pass "font-semibold"
+  labelClassName?: string;
+  // e.g. ChallengePreview's "Shown after domain questions" pill
+  labelSuffix?: React.ReactNode;
+  // e.g. portal.apply's url-warning / word-count line
+  belowField?: React.ReactNode;
+  // Override the field renderer (e.g. MemberFormFillView's "no uploads here" notice).
+  renderField?: (q: Question) => React.ReactNode;
+}
+
+export function FormField({
+  question,
+  value,
+  onChange,
+  disabled = false,
+  id,
+  urlCheckState,
+  onUrlBlur,
+  labelClassName = "font-medium",
+  labelSuffix,
+  belowField,
+  renderField,
+}: FormFieldProps) {
+  if (question.type === "info") {
+    return (
+      <div
+        id={id}
+        className="rounded-lg border border-border bg-muted/30 px-4 py-3 text-sm text-muted-foreground"
+      >
+        <InfoBody body={question.data.body} />
+      </div>
+    );
+  }
+
+  return (
+    <div id={id}>
+      <label className={`block text-sm ${labelClassName} text-dark-blue mb-1`}>
+        {question.data.label}
+        {question.required && <span className="text-accent-coral ml-0.5">*</span>}
+        {labelSuffix}
+      </label>
+      {question.data.description && (
+        <p className="text-xs text-muted-foreground mb-1">{question.data.description}</p>
+      )}
+      {renderField ? (
+        renderField(question)
+      ) : (
+        <ChallengeQuestionField
+          question={question}
+          value={value}
+          onChange={onChange}
+          disabled={disabled}
+          urlCheckState={urlCheckState}
+          onUrlBlur={onUrlBlur}
+        />
+      )}
+      {belowField}
+    </div>
+  );
+}
+
+export interface FormFieldListProps {
+  questions: Question[];
+  disabled?: boolean;
+  labelClassName?: string;
+  values?: Record<string, string>;
+  onChange?: (key: string, v: string) => void;
+  // Per-question slots, keyed implicitly by the question, for route-specific extras.
+  id?: (q: Question) => string | undefined;
+  labelSuffix?: (q: Question) => React.ReactNode;
+  belowField?: (q: Question) => React.ReactNode;
+  renderField?: (q: Question) => React.ReactNode;
+  urlCheckState?: (q: Question) => UrlCheckState | undefined;
+  onUrlBlur?: (q: Question) => void;
+}
+
+export function FormFieldList({
+  questions,
+  disabled,
+  labelClassName,
+  values,
+  onChange,
+  id,
+  labelSuffix,
+  belowField,
+  renderField,
+  urlCheckState,
+  onUrlBlur,
+}: FormFieldListProps) {
+  return (
+    <>
+      {questions.map((q) => (
+        <FormField
+          key={q.key}
+          question={q}
+          value={values?.[q.key] ?? ""}
+          onChange={(v) => onChange?.(q.key, v)}
+          disabled={disabled}
+          id={id?.(q)}
+          labelClassName={labelClassName}
+          labelSuffix={labelSuffix?.(q)}
+          belowField={belowField?.(q)}
+          renderField={renderField}
+          urlCheckState={urlCheckState?.(q)}
+          onUrlBlur={onUrlBlur ? () => onUrlBlur(q) : undefined}
+        />
+      ))}
+    </>
+  );
+}

--- a/dali-api/app/forms/components/MemberFormFillView.tsx
+++ b/dali-api/app/forms/components/MemberFormFillView.tsx
@@ -1,7 +1,9 @@
 import { useState } from "react";
 import { ChallengeQuestionField } from "~/hiring/components/ChallengeQuestionField";
+import { FormFieldList } from "~/forms/components/FormField";
 import { RichTextViewer, isEmptyDoc } from "~/components/RichTextViewer";
 import { Button } from "~/components/ui/Button";
+import { findMissingRequired } from "~/lib/form-answers";
 import type { Question } from "~/types";
 
 // The shared authenticated form-fill UI. Rendered both by /forms/fill/:token
@@ -38,12 +40,12 @@ export function MemberFormFillView({
   async function submit(e: React.FormEvent) {
     e.preventDefault();
     setError(null);
-    for (const q of questions) {
-      if (!q.required || q.type === "file") continue;
-      if (!answers[q.key]?.trim()) {
-        setError(`"${q.data.label}" is required.`);
-        return;
-      }
+    const missing = findMissingRequired(questions, (q) => answers[q.key], {
+      excludeFileType: true,
+    });
+    if (missing.length > 0) {
+      setError(`"${missing[0].data.label}" is required.`);
+      return;
     }
     setState("submitting");
     try {
@@ -101,18 +103,12 @@ export function MemberFormFillView({
       )}
 
       <form onSubmit={submit} className="mt-6 flex flex-col gap-5">
-        {questions.map((q) => (
-          <div key={q.key}>
-            <label className="block text-sm font-medium text-dark-blue mb-1">
-              {q.data.label}
-              {q.required && <span className="text-destructive"> *</span>}
-            </label>
-            {q.data.description && (
-              <p className="text-xs text-muted-foreground mb-1.5">
-                {q.data.description}
-              </p>
-            )}
-            {q.type === "file" ? (
+        <FormFieldList
+          questions={questions}
+          values={answers}
+          onChange={set}
+          renderField={(q) =>
+            q.type === "file" ? (
               <div className="text-xs text-muted-foreground italic border border-dashed border-border rounded-md px-3 py-2">
                 File uploads aren’t available here.
               </div>
@@ -122,9 +118,9 @@ export function MemberFormFillView({
                 value={answers[q.key] ?? ""}
                 onChange={(v) => set(q.key, v)}
               />
-            )}
-          </div>
-        ))}
+            )
+          }
+        />
 
         <Button
           type="submit"

--- a/dali-api/app/forms/components/__tests__/FormField.test.tsx
+++ b/dali-api/app/forms/components/__tests__/FormField.test.tsx
@@ -1,0 +1,177 @@
+import { describe, it, expect } from "vitest";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { FormField, FormFieldList } from "../FormField";
+import type { Question } from "~/types";
+
+const noop = () => {};
+
+describe("FormField", () => {
+  it("renders an info-type question as a muted prose block, not a text input", () => {
+    const infoQ: Question = {
+      key: "intro",
+      type: "info",
+      required: false,
+      data: { label: "", body: "Read this before answering." },
+    };
+    const html = renderToStaticMarkup(
+      createElement(FormField, { question: infoQ, value: "", onChange: noop }),
+    );
+    expect(html).toContain("Read this before answering.");
+    expect(html).toContain("bg-muted/30");
+    expect(html).not.toMatch(/<input[^>]*type="text"/);
+    // No label / required star on a prose block.
+    expect(html).not.toContain("text-accent-coral");
+  });
+
+  it("renders exactly one standardized required asterisk for a required question", () => {
+    const reqQ: Question = {
+      key: "name",
+      type: "text",
+      required: true,
+      data: { label: "Full Name" },
+    };
+    const html = renderToStaticMarkup(
+      createElement(FormField, { question: reqQ, value: "", onChange: noop }),
+    );
+    const stars = html.match(/text-accent-coral ml-0\.5/g) ?? [];
+    expect(stars.length).toBe(1);
+    // The legacy text-destructive star must be gone.
+    expect(html).not.toContain("text-destructive");
+  });
+
+  it("renders no asterisk for an optional question", () => {
+    const optQ: Question = {
+      key: "bio",
+      type: "textarea",
+      required: false,
+      data: { label: "Bio" },
+    };
+    const html = renderToStaticMarkup(
+      createElement(FormField, { question: optQ, value: "", onChange: noop }),
+    );
+    expect(html).not.toContain("text-accent-coral");
+  });
+
+  it("uses the renderField override instead of the default field renderer", () => {
+    const fileQ: Question = {
+      key: "resume",
+      type: "file",
+      required: false,
+      data: { label: "Resume" },
+    };
+    const html = renderToStaticMarkup(
+      createElement(FormField, {
+        question: fileQ,
+        value: "",
+        onChange: noop,
+        renderField: () =>
+          createElement("div", null, "File uploads aren't available here."),
+      }),
+    );
+    expect(html).toContain("File uploads aren&#x27;t available here.");
+    // Default file upload button must not appear.
+    expect(html).not.toContain("Choose file to upload");
+  });
+
+  it("passes disabled through to the default field renderer", () => {
+    const reqQ: Question = {
+      key: "name",
+      type: "text",
+      required: true,
+      data: { label: "Full Name" },
+    };
+    const html = renderToStaticMarkup(
+      createElement(FormField, {
+        question: reqQ,
+        value: "",
+        onChange: noop,
+        disabled: true,
+      }),
+    );
+    expect(html).toMatch(/<input[^>]*disabled/);
+  });
+
+  it("renders the labelSuffix slot", () => {
+    const reqQ: Question = {
+      key: "name",
+      type: "text",
+      required: false,
+      data: { label: "Full Name" },
+    };
+    const html = renderToStaticMarkup(
+      createElement(FormField, {
+        question: reqQ,
+        value: "",
+        onChange: noop,
+        labelSuffix: createElement("span", null, "Shown after domain questions"),
+      }),
+    );
+    expect(html).toContain("Shown after domain questions");
+  });
+
+  it("renders the belowField slot below the field", () => {
+    const reqQ: Question = {
+      key: "url",
+      type: "github_url",
+      required: false,
+      data: { label: "Repo" },
+    };
+    const html = renderToStaticMarkup(
+      createElement(FormField, {
+        question: reqQ,
+        value: "",
+        onChange: noop,
+        belowField: createElement("p", null, "Over the word limit"),
+      }),
+    );
+    expect(html).toContain("Over the word limit");
+  });
+
+  it("applies a custom id to the wrapper for scroll anchoring", () => {
+    const reqQ: Question = {
+      key: "name",
+      type: "text",
+      required: false,
+      data: { label: "Full Name" },
+    };
+    const html = renderToStaticMarkup(
+      createElement(FormField, {
+        question: reqQ,
+        value: "",
+        onChange: noop,
+        id: "question-name",
+      }),
+    );
+    expect(html).toContain('id="question-name"');
+  });
+});
+
+describe("FormFieldList", () => {
+  const questions: Question[] = [
+    { key: "name", type: "text", required: true, data: { label: "Full Name" } },
+    {
+      key: "intro",
+      type: "info",
+      required: false,
+      data: { label: "", body: "An info block." },
+    },
+    { key: "bio", type: "textarea", required: false, data: { label: "Bio" } },
+  ];
+
+  it("renders each question, with info as prose", () => {
+    const html = renderToStaticMarkup(
+      createElement(FormFieldList, { questions }),
+    );
+    expect(html).toContain("Full Name");
+    expect(html).toContain("An info block.");
+    expect(html).toContain("Bio");
+  });
+
+  it("respects labelClassName for every field", () => {
+    const html = renderToStaticMarkup(
+      createElement(FormFieldList, { questions, labelClassName: "font-semibold" }),
+    );
+    expect(html).toContain("font-semibold");
+  });
+});

--- a/dali-api/app/hiring/components/ChallengePreview.tsx
+++ b/dali-api/app/hiring/components/ChallengePreview.tsx
@@ -1,14 +1,11 @@
 import type { Question } from "~/types";
-import { ChallengeQuestionField } from "~/hiring/components/ChallengeQuestionField";
+import { FormFieldList } from "~/forms/components/FormField";
 import { RichTextViewer, isEmptyDoc } from "~/components/RichTextViewer";
-import { InfoBody } from "~/hiring/lib/info-body";
 
 export interface ChallengePreviewProps {
   description?: unknown;
   questions: Question[];
 }
-
-const noop = () => {};
 
 export function ChallengePreview({ description, questions }: ChallengePreviewProps) {
   return (
@@ -27,40 +24,18 @@ export function ChallengePreview({ description, questions }: ChallengePreviewPro
         <p className="text-sm text-muted-foreground/70 italic">No questions in this version.</p>
       ) : (
         <div className="space-y-6">
-          {questions.map(q => {
-            if (q.type === "info") {
-              return (
-                <div
-                  key={q.key}
-                  className="rounded-lg border border-border bg-muted/30 px-4 py-3 text-sm text-muted-foreground"
-                >
-                  <InfoBody body={q.data.body} />
-                </div>
-              );
+          <FormFieldList
+            questions={questions}
+            disabled
+            labelClassName="font-semibold"
+            labelSuffix={q =>
+              q.data.afterDomains ? (
+                <span className="ml-2 inline-flex items-center px-2 py-0.5 rounded text-[10px] font-medium bg-amber-100 text-amber-800 align-middle">
+                  Shown after domain questions
+                </span>
+              ) : null
             }
-            return (
-              <div key={q.key}>
-                <label className="block text-sm font-semibold text-dark-blue mb-1">
-                  {q.data.label}
-                  {q.required && <span className="text-accent-coral ml-0.5">*</span>}
-                  {q.data.afterDomains && (
-                    <span className="ml-2 inline-flex items-center px-2 py-0.5 rounded text-[10px] font-medium bg-amber-100 text-amber-800 align-middle">
-                      Shown after domain questions
-                    </span>
-                  )}
-                </label>
-                {q.data.description && (
-                  <p className="text-xs text-muted-foreground mb-1">{q.data.description}</p>
-                )}
-                <ChallengeQuestionField
-                  question={q}
-                  value=""
-                  onChange={noop}
-                  disabled
-                />
-              </div>
-            );
-          })}
+          />
         </div>
       )}
     </div>

--- a/dali-api/app/lib/__tests__/form-answers.test.ts
+++ b/dali-api/app/lib/__tests__/form-answers.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from "vitest";
+import { isAnswered, findMissingRequired } from "../form-answers";
+import type { Question } from "~/types";
+
+function q(partial: Partial<Question> & { key: string }): Question {
+  return {
+    type: "text",
+    required: false,
+    data: { label: partial.key },
+    ...partial,
+  } as Question;
+}
+
+describe("isAnswered", () => {
+  it("is false for an empty string", () => {
+    expect(isAnswered("")).toBe(false);
+  });
+
+  it("is false for whitespace-only", () => {
+    expect(isAnswered("   ")).toBe(false);
+  });
+
+  it("is false for undefined", () => {
+    expect(isAnswered(undefined)).toBe(false);
+  });
+
+  it("is true for non-empty text", () => {
+    expect(isAnswered("hi")).toBe(true);
+  });
+
+  it("treats info-type questions as always answered (prose, never an answer)", () => {
+    const info = q({ key: "intro", type: "info", required: false });
+    expect(isAnswered("", info)).toBe(true);
+    expect(isAnswered(undefined, info)).toBe(true);
+  });
+
+  describe("skills_rating — delegates to isSkillsRatingComplete", () => {
+    const skills = q({
+      key: "skills",
+      type: "skills_rating",
+      required: true,
+      data: { label: "Skills", options: ["React", "TypeScript"] },
+    });
+
+    it("is false when partially rated", () => {
+      expect(isAnswered("React: 4\nTypeScript: -", skills)).toBe(false);
+    });
+
+    it("is false when unrated", () => {
+      expect(isAnswered("React: -\nTypeScript: -", skills)).toBe(false);
+      expect(isAnswered("", skills)).toBe(false);
+    });
+
+    it("is true when every skill has a 0–5 rating", () => {
+      expect(isAnswered("React: 3\nTypeScript: 5", skills)).toBe(true);
+    });
+
+    it("is true when there are no skills to rate", () => {
+      const noSkills = q({
+        key: "skills",
+        type: "skills_rating",
+        required: true,
+        data: { label: "Skills", options: [] },
+      });
+      expect(isAnswered("", noSkills)).toBe(true);
+    });
+
+    it("falls back to the plain trim check when no question is passed", () => {
+      // Without the question arg, a serialized skills answer is just a non-empty string.
+      expect(isAnswered("React: -\nTypeScript: -")).toBe(true);
+    });
+  });
+});
+
+describe("findMissingRequired", () => {
+  const text = q({ key: "name", type: "text", required: true });
+  const optional = q({ key: "bio", type: "textarea", required: false });
+  const file = q({ key: "resume", type: "file", required: true });
+  const skills = q({
+    key: "skills",
+    type: "skills_rating",
+    required: true,
+    data: { label: "Skills", options: ["React"] },
+  });
+
+  it("returns required-unanswered questions in order", () => {
+    const questions = [text, optional, skills];
+    const missing = findMissingRequired(questions, () => "");
+    expect(missing.map((m) => m.key)).toEqual(["name", "skills"]);
+  });
+
+  it("excludes optional questions", () => {
+    const missing = findMissingRequired([optional], () => "");
+    expect(missing).toEqual([]);
+  });
+
+  it("excludes info questions even if something marked them required", () => {
+    const requiredInfo = q({ key: "intro", type: "info", required: true });
+    const missing = findMissingRequired([requiredInfo], () => "");
+    expect(missing).toEqual([]);
+  });
+
+  it("treats answered required questions as satisfied", () => {
+    const missing = findMissingRequired([text], (qq) => (qq.key === "name" ? "Ada" : ""));
+    expect(missing).toEqual([]);
+  });
+
+  it("honors excludeFileType", () => {
+    const withFile = findMissingRequired([text, file], () => "");
+    expect(withFile.map((m) => m.key)).toEqual(["name", "resume"]);
+
+    const withoutFile = findMissingRequired([text, file], () => "", {
+      excludeFileType: true,
+    });
+    expect(withoutFile.map((m) => m.key)).toEqual(["name"]);
+  });
+
+  it("uses skills-rating awareness for required skills questions", () => {
+    const missingPartial = findMissingRequired([skills], () => "React: -");
+    expect(missingPartial.map((m) => m.key)).toEqual(["skills"]);
+
+    const satisfied = findMissingRequired([skills], () => "React: 3");
+    expect(satisfied).toEqual([]);
+  });
+});

--- a/dali-api/app/lib/form-answers.ts
+++ b/dali-api/app/lib/form-answers.ts
@@ -1,0 +1,30 @@
+import type { Question } from "~/types";
+import { isSkillsRatingComplete } from "~/hiring/lib/skills-rating";
+
+// Single source of truth for "is this question answered?". Preserves the
+// skills-rating-aware behavior from portal.apply.tsx's external-applicant flow:
+// a skills_rating answer counts as answered only when every skill is rated.
+export function isAnswered(value: string | undefined, question?: Question): boolean {
+  if (question?.type === "info") return true; // prose block, never an answer
+  if (question?.type === "skills_rating") {
+    return isSkillsRatingComplete(value, question.data.options ?? []);
+  }
+  return typeof value === "string" && value.trim() !== "";
+}
+
+// Required, unanswered questions in their original order. `info` is always
+// excluded (it is never a real answer). `file` is optionally excluded for fill
+// surfaces that can't upload (e.g. the member form-fill view).
+export function findMissingRequired(
+  questions: Question[],
+  getValue: (q: Question) => string | undefined,
+  opts?: { excludeFileType?: boolean },
+): Question[] {
+  return questions.filter(
+    (q) =>
+      q.type !== "info" &&
+      q.required &&
+      !(opts?.excludeFileType && q.type === "file") &&
+      !isAnswered(getValue(q), q),
+  );
+}

--- a/dali-api/app/routes/intern-to-full.tsx
+++ b/dali-api/app/routes/intern-to-full.tsx
@@ -11,8 +11,8 @@ import {
   currentInternDomains,
 } from "~/hiring/lib/intern-eligibility";
 import type { Question } from "~/types";
-import { InfoBody } from "~/hiring/lib/info-body";
-import { ChallengeQuestionField } from "~/hiring/components/ChallengeQuestionField";
+import { FormFieldList } from "~/forms/components/FormField";
+import { findMissingRequired } from "~/lib/form-answers";
 import { APPLICATION_TZ, APPLICATION_TZ_LABEL } from "~/lib/timezone";
 
 export const meta: Route.MetaFunction = () => [
@@ -136,8 +136,7 @@ export async function action({ request }: Route.ActionArgs) {
     ) as string[]).filter((id) => allowedDomainIds.has(id));
 
     if (intent === "submit") {
-      const missing = questions
-        .filter((q) => q.type !== "info" && q.required && !isAnswered(answers[q.key]))
+      const missing = findMissingRequired(questions, (q) => answers[q.key])
         .map((q) => q.data.label || q.key);
       if (missing.length > 0) {
         return Response.json(
@@ -222,10 +221,6 @@ export async function action({ request }: Route.ActionArgs) {
   }
 
   return Response.json({ error: "Unknown intent" }, { status: 400 });
-}
-
-function isAnswered(value: string | undefined): boolean {
-  return typeof value === "string" && value.trim() !== "";
 }
 
 // ─── UI ──────────────────────────────────────────────────────────────────────
@@ -400,34 +395,12 @@ function FormView({
           Questions
         </h2>
         <div className="space-y-5">
-          {cycle.questions.map((q) => {
-            if (q.type === "info") {
-              return (
-                <div
-                  key={q.key}
-                  className="rounded-lg border border-border bg-muted/30 px-4 py-3 text-sm text-muted-foreground"
-                >
-                  <InfoBody body={q.data.body} />
-                </div>
-              );
-            }
-            return (
-              <div key={q.key}>
-                <label className="block text-sm font-semibold text-dark-blue mb-1">
-                  {q.data.label}
-                  {q.required && <span className="text-accent-coral ml-0.5">*</span>}
-                </label>
-                {q.data.description && (
-                  <p className="text-xs text-muted-foreground mb-1">{q.data.description}</p>
-                )}
-                <ChallengeQuestionField
-                  question={q}
-                  value={answers[q.key] ?? ""}
-                  onChange={(v) => setAnswers((prev) => ({ ...prev, [q.key]: v }))}
-                />
-              </div>
-            );
-          })}
+          <FormFieldList
+            questions={cycle.questions}
+            labelClassName="font-semibold"
+            values={answers}
+            onChange={(key, v) => setAnswers((prev) => ({ ...prev, [key]: v }))}
+          />
         </div>
       </section>
 

--- a/dali-api/app/routes/portal.apply.tsx
+++ b/dali-api/app/routes/portal.apply.tsx
@@ -12,16 +12,14 @@ import { checkGitHubUrl, checkFigmaUrl, checkDriveUrl } from "~/hiring/lib/submi
 import type { SubmissionCheckResult } from "~/hiring/lib/submission-check";
 import { validateWordLimits } from "~/lib/word-count";
 import type { WordCountViolation } from "~/lib/word-count";
-import { isSkillsRatingComplete } from "~/hiring/lib/skills-rating";
+import { isAnswered } from "~/lib/form-answers";
 import type { Question } from "~/types";
 import { ApplicantErrorBoundary } from "~/components/ApplicantErrorBoundary";
 import { Modal } from "~/components/Modal";
 import { QuestionList } from "~/hiring/components/ApplicationAnswers";
 import { RichTextViewer, isEmptyDoc } from "~/components/RichTextViewer";
-import {
-  ChallengeQuestionField,
-  type UrlCheckState,
-} from "~/hiring/components/ChallengeQuestionField";
+import { type UrlCheckState } from "~/hiring/components/ChallengeQuestionField";
+import { FormField } from "~/forms/components/FormField";
 
 export const meta: Route.MetaFunction = () => [{ title: "Apply · DALI OS" }];
 
@@ -510,13 +508,6 @@ type Section = {
   requiredCount: number;
   answeredRequiredCount: number;
 };
-
-function isAnswered(value: string | undefined, question?: Question) {
-  if (question?.type === "skills_rating") {
-    return isSkillsRatingComplete(value, question.data.options ?? []);
-  }
-  return typeof value === "string" && value.trim() !== "";
-}
 
 type DomainShape = {
   id: string;
@@ -1365,30 +1356,28 @@ export default function PortalApply() {
                 </div>
               )}
               {beforeQuestions.map(q => (
-                <div key={q.key} id={`question-${q.key}`}>
-                  <label className="block text-sm font-semibold text-dark-blue mb-1">
-                    {q.data.label}
-                    {q.required && <span className="text-accent-coral ml-0.5">*</span>}
-                  </label>
-                  {q.data.description && (
-                    <p className="text-xs text-muted-foreground mb-1">{q.data.description}</p>
-                  )}
-                  <ChallengeQuestionField
-                    question={q}
-                    value={answers[q.key] ?? ""}
-                    onChange={v => setAnswer(q.key, v)}
-                    urlCheckState={urlChecks[q.key]}
-                    onUrlBlur={() => checkUrlField(q.key, answers[q.key] ?? "", q.type as "github_url" | "figma_url" | "drive_url")}
-                  />
-                  {urlWarnings[q.key] && (
-                    <p className="text-xs text-amber-600 mt-1">{urlWarnings[q.key]}</p>
-                  )}
-                  {wordCountErrors[q.key] && (
-                    <p className="text-xs text-red-500 mt-1">
-                      Over the {wordCountErrors[q.key].maxWords}-word limit ({wordCountErrors[q.key].wordCount} words).
-                    </p>
-                  )}
-                </div>
+                <FormField
+                  key={q.key}
+                  id={`question-${q.key}`}
+                  question={q}
+                  labelClassName="font-semibold"
+                  value={answers[q.key] ?? ""}
+                  onChange={v => setAnswer(q.key, v)}
+                  urlCheckState={urlChecks[q.key]}
+                  onUrlBlur={() => checkUrlField(q.key, answers[q.key] ?? "", q.type as "github_url" | "figma_url" | "drive_url")}
+                  belowField={
+                    <>
+                      {urlWarnings[q.key] && (
+                        <p className="text-xs text-amber-600 mt-1">{urlWarnings[q.key]}</p>
+                      )}
+                      {wordCountErrors[q.key] && (
+                        <p className="text-xs text-red-500 mt-1">
+                          Over the {wordCountErrors[q.key].maxWords}-word limit ({wordCountErrors[q.key].wordCount} words).
+                        </p>
+                      )}
+                    </>
+                  }
+                />
               ))}
             </div>
           ) : null;
@@ -1460,30 +1449,28 @@ export default function PortalApply() {
                     ) : null;
                   })()}
                   {pickedQuestions.map((q: Question) => (
-                    <div key={q.key} id={`question-${q.key}`}>
-                      <label className="block text-sm font-semibold text-dark-blue mb-1">
-                        {q.data.label}
-                        {q.required && <span className="text-accent-coral ml-0.5">*</span>}
-                      </label>
-                      {q.data.description && (
-                        <p className="text-xs text-muted-foreground mb-1">{q.data.description}</p>
-                      )}
-                      <ChallengeQuestionField
-                        question={q}
-                        value={domainAnswers[domainId]?.[q.key] ?? ""}
-                        onChange={v => setDomainAnswer(domainId, q.key, v)}
-                        urlCheckState={urlChecks[q.key]}
-                        onUrlBlur={() => checkUrlField(q.key, domainAnswers[domainId]?.[q.key] ?? "", q.type as "github_url" | "figma_url" | "drive_url")}
-                      />
-                      {urlWarnings[q.key] && (
-                        <p className="text-xs text-amber-600 mt-1">{urlWarnings[q.key]}</p>
-                      )}
-                      {wordCountErrors[q.key] && (
-                        <p className="text-xs text-red-500 mt-1">
-                          Over the {wordCountErrors[q.key].maxWords}-word limit ({wordCountErrors[q.key].wordCount} words).
-                        </p>
-                      )}
-                    </div>
+                    <FormField
+                      key={q.key}
+                      id={`question-${q.key}`}
+                      question={q}
+                      labelClassName="font-semibold"
+                      value={domainAnswers[domainId]?.[q.key] ?? ""}
+                      onChange={v => setDomainAnswer(domainId, q.key, v)}
+                      urlCheckState={urlChecks[q.key]}
+                      onUrlBlur={() => checkUrlField(q.key, domainAnswers[domainId]?.[q.key] ?? "", q.type as "github_url" | "figma_url" | "drive_url")}
+                      belowField={
+                        <>
+                          {urlWarnings[q.key] && (
+                            <p className="text-xs text-amber-600 mt-1">{urlWarnings[q.key]}</p>
+                          )}
+                          {wordCountErrors[q.key] && (
+                            <p className="text-xs text-red-500 mt-1">
+                              Over the {wordCountErrors[q.key].maxWords}-word limit ({wordCountErrors[q.key].wordCount} words).
+                            </p>
+                          )}
+                        </>
+                      }
+                    />
                   ))}
                 </>
               ) : (
@@ -1502,25 +1489,21 @@ export default function PortalApply() {
             <div id="section-general-after" className="rounded-2xl bg-brand-tint px-6 py-5 space-y-6 scroll-mt-24">
               <h3 className="font-heading text-sm font-bold text-dark-blue uppercase tracking-wider">Anything Else</h3>
               {afterQuestions.map(q => (
-                <div key={q.key} id={`question-${q.key}`}>
-                  <label className="block text-sm font-semibold text-dark-blue mb-1">
-                    {q.data.label}
-                    {q.required && <span className="text-accent-coral ml-0.5">*</span>}
-                  </label>
-                  {q.data.description && (
-                    <p className="text-xs text-muted-foreground mb-1">{q.data.description}</p>
-                  )}
-                  <ChallengeQuestionField
-                    question={q}
-                    value={answers[q.key] ?? ""}
-                    onChange={v => setAnswer(q.key, v)}
-                  />
-                  {wordCountErrors[q.key] && (
-                    <p className="text-xs text-red-500 mt-1">
-                      Over the {wordCountErrors[q.key].maxWords}-word limit ({wordCountErrors[q.key].wordCount} words).
-                    </p>
-                  )}
-                </div>
+                <FormField
+                  key={q.key}
+                  id={`question-${q.key}`}
+                  question={q}
+                  labelClassName="font-semibold"
+                  value={answers[q.key] ?? ""}
+                  onChange={v => setAnswer(q.key, v)}
+                  belowField={
+                    wordCountErrors[q.key] ? (
+                      <p className="text-xs text-red-500 mt-1">
+                        Over the {wordCountErrors[q.key].maxWords}-word limit ({wordCountErrors[q.key].wordCount} words).
+                      </p>
+                    ) : null
+                  }
+                />
               ))}
             </div>
           ) : null;


### PR DESCRIPTION
Implements **PR 04 — Shared form-field wrapper + answer utils** (`implementation-plans/PR-04-form-fill-fields.md`).

## What

- **New `app/forms/components/FormField.tsx`** — `<FormField>` (one question's wrapper: label + standardized required star + optional description + the field) and `<FormFieldList>` (maps an array). Both **wrap, not reimplement,** the existing `ChallengeQuestionField` (the field-type switch is untouched).
- **New `app/lib/form-answers.ts`** — a single `isAnswered(value, question?)` and `findMissingRequired(questions, getValue, opts?)`.
- Migrated all **5 hand-rolled wrapper sites** onto these: `MemberFormFillView.tsx`, `portal.apply.tsx` (×3 sections), `intern-to-full.tsx`, `ChallengePreview.tsx`.

## The 3 inconsistencies fixed

1. **Required-star class standardized** to `text-accent-coral ml-0.5` everywhere. The `text-destructive` star in `MemberFormFillView` is gone.
2. **`info`-type questions now render as prose (`InfoBody`) on every fill flow.** Previously `MemberFormFillView` and all 3 `portal.apply` sections fell straight through to a stray empty text input for an `info` block. **User-visible change on the live external applicant route (`portal.apply`) and the member form-fill route** — a form author's prose block now renders correctly instead of as an empty labeled text field. (Intended per plan inconsistency (b).)
3. **`isAnswered` unified** into one definition; the 3 divergent local copies (`portal.apply.tsx`, `intern-to-full.tsx`, the inline loop in `MemberFormFillView`) are deleted.

## Preserved skills-rating behavior (critical)

The shared `isAnswered` replicates `portal.apply.tsx`'s skills-rating-aware logic exactly: `skills_rating` delegates to `isSkillsRatingComplete`. All `portal.apply` call sites (`computeRequiredProgress`, `buildSections`, submit checks) still thread the `question` arg, so the external CAS-applicant progress meter is unchanged. As a side effect of unifying `isAnswered`, `MemberFormFillView` and `intern-to-full` submit-validation are now also skills-rating-aware (stricter, consistent — a partially-rated required `skills_rating` now correctly counts as unanswered).

Other behavior preserved:
- `MemberFormFillView` keeps its "File uploads aren't available here" notice (via `renderField`) and does not block submit on a required file question (`findMissingRequired(..., { excludeFileType: true })`).
- `portal.apply` url-check indicators and word-count error lines still render (via the `belowField` slot), and the `question-${key}` scroll-anchor ids are preserved (via `FormField`'s `id` prop).
- `ChallengePreview`'s "Shown after domain questions" pill is preserved (via `labelSuffix`).

## Out of scope

`useFormDraft` / autosave / `SaveStatusIndicator` consolidation, per the plan (higher risk; tracked as a follow-up).

## Testing

- `app/lib/__tests__/form-answers.test.ts` — `isAnswered` (empty/whitespace/non-empty, `info` always-true, `skills_rating` complete/partial/unrated, no-question fallback) + `findMissingRequired` (order, `info` excluded, `excludeFileType`, skills-rating awareness).
- `app/forms/components/__tests__/FormField.test.tsx` — `info` renders prose not an input, exactly one standardized asterisk, `renderField` override wins, `disabled` passthrough, `labelSuffix`/`belowField`/`id` slots.
- `npm run typecheck`: no new errors from this PR (pre-existing errors live only in `scripts/` and `prisma/seeds/`).
- `npm test`: full suite green (154 files / 1275 tests).

No changes to `ChallengeQuestionField.tsx`, `schema.prisma`, migrations, or `.github/workflows/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/856"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784743569&installation_id=133523038&pr_number=856&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F856&signature=5390e7a425b4c8916be5a336e955b65943fba89cefa24c7ff9aa3aaa225d1f3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->