### PR TITLE
Staffing: useFilteredList hook + member-facing page & bind/notify guardrails

### DIFF
--- a/dali-api/app/admin-console/routes/admin-console.announcements.tsx
+++ b/dali-api/app/admin-console/routes/admin-console.announcements.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { redirect, useLoaderData } from "react-router";
+import { redirect, useLoaderData, useSearchParams } from "react-router";
 import type { Route } from "./+types/admin-console.announcements";
 import { prisma } from "~/lib/db";
 import { listVisibleGroupsForUser } from "~/lib/groups";
@@ -64,8 +64,18 @@ export async function loader({ request }: Route.LoaderArgs) {
 export default function AnnouncementsPage() {
   const { members, groups, publishedForms } = useLoaderData<typeof loader>();
 
+  // Optional deep-link pre-seed (e.g. the staffing boards' "Send to members"
+  // affordance opens this composer with the bound form + whole-lab audience
+  // already selected). Only honored for forms that exist in the published list.
+  const [searchParams] = useSearchParams();
+  const seedFormId = searchParams.get("formId") ?? "";
+  const seededForm = publishedForms.some((f) => f.id === seedFormId)
+    ? seedFormId
+    : "";
+  const seedAllMembers = searchParams.get("audience") === "all";
+
   // Composable audience: any mix of whole-lab + groups + individuals.
-  const [allMembers, setAllMembers] = useState(false);
+  const [allMembers, setAllMembers] = useState(seedAllMembers);
   const [pickedGroups, setPickedGroups] = useState<Set<string>>(new Set());
   const [pickedUsers, setPickedUsers] = useState<Set<string>>(new Set());
   const [search, setSearch] = useState("");
@@ -74,7 +84,7 @@ export default function AnnouncementsPage() {
   const [title, setTitle] = useState("");
   const [body, setBody] = useState("");
   const [dueAt, setDueAt] = useState("");
-  const [formId, setFormId] = useState("");
+  const [formId, setFormId] = useState(seededForm);
   const [formSearch, setFormSearch] = useState("");
 
   const [sending, setSending] = useState(false);

--- a/dali-api/app/hooks/__tests__/useFilteredList.test.ts
+++ b/dali-api/app/hooks/__tests__/useFilteredList.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { filterRows } from "~/hooks/useFilteredList";
+
+// Mirrors the staffing-submission rows: a name, a nullable email, and a list
+// of domain ids the predicate filters on. `filterRows` is the pure pipeline
+// the hook runs inside its useMemo; testing it directly exercises the
+// load-bearing substring-match + predicate AND-ing without a React renderer.
+type Row = { name: string; email: string | null; domainIds: string[] };
+
+const rows: Row[] = [
+  { name: "Ada Lovelace", email: "ada@dali.dev", domainIds: ["d1"] },
+  { name: "Grace Hopper", email: "grace@dali.dev", domainIds: ["d2"] },
+  { name: "Alan Turing", email: null, domainIds: ["d1", "d2"] },
+];
+
+const searchFields = (r: Row) => [r.name, r.email];
+
+describe("filterRows", () => {
+  it("returns all rows when the query is empty", () => {
+    expect(filterRows(rows, "", searchFields)).toHaveLength(3);
+  });
+
+  it("matches on name, case-insensitively", () => {
+    const out = filterRows(rows, "ADA", searchFields);
+    expect(out.map((r) => r.name)).toEqual(["Ada Lovelace"]);
+  });
+
+  it("matches on email independently of name", () => {
+    const out = filterRows(rows, "grace@dali", searchFields);
+    expect(out.map((r) => r.name)).toEqual(["Grace Hopper"]);
+  });
+
+  it("trims leading/trailing whitespace from the query", () => {
+    const out = filterRows(rows, "   turing  ", searchFields);
+    expect(out.map((r) => r.name)).toEqual(["Alan Turing"]);
+  });
+
+  it("does not throw on a null email and only matches on name", () => {
+    // Alan's email is null; a query for the name still matches, and a query
+    // for another row's email does not leak onto him.
+    expect(filterRows(rows, "alan", searchFields).map((r) => r.name)).toEqual([
+      "Alan Turing",
+    ]);
+    expect(filterRows(rows, "ada@dali.dev", searchFields)).toHaveLength(1);
+  });
+
+  it("applies a domain predicate but is a no-op when the id is empty", () => {
+    const domainId = "";
+    const all = filterRows(rows, "", searchFields, [
+      (r) => !domainId || r.domainIds.includes(domainId),
+    ]);
+    expect(all).toHaveLength(3);
+
+    const d2 = "d2";
+    const onlyD2 = filterRows(rows, "", searchFields, [
+      (r) => !d2 || r.domainIds.includes(d2),
+    ]);
+    expect(onlyD2.map((r) => r.name)).toEqual(["Grace Hopper", "Alan Turing"]);
+  });
+
+  it("composes search and predicate with AND semantics", () => {
+    const domainId = "d1";
+    const out = filterRows(rows, "alan", searchFields, [
+      (r) => !domainId || r.domainIds.includes(domainId),
+    ]);
+    expect(out.map((r) => r.name)).toEqual(["Alan Turing"]);
+
+    // Grace is in no d1 domain, so the predicate excludes her even though the
+    // name query would match.
+    const none = filterRows(rows, "grace", searchFields, [
+      (r) => !domainId || r.domainIds.includes(domainId),
+    ]);
+    expect(none).toHaveLength(0);
+  });
+});

--- a/dali-api/app/hooks/useFilteredList.ts
+++ b/dali-api/app/hooks/useFilteredList.ts
@@ -1,0 +1,67 @@
+import { useMemo, useState, type DependencyList } from "react";
+
+export interface UseFilteredListOptions<T> {
+  /** Initial value for the internal search string. Defaults to "". */
+  initialSearch?: string;
+  /**
+   * Pull the searchable strings out of a row. Nullish entries are skipped.
+   * The query is matched (case-insensitive substring) against the
+   * space-joined, lowercased result.
+   */
+  searchFields?: (row: T) => Array<string | null | undefined>;
+  /** Extra AND-ed predicates (e.g. domain membership). All must pass. */
+  predicates?: Array<(row: T) => boolean>;
+  /**
+   * Inputs the predicates close over (e.g. a selected domainId), folded
+   * into the memo dependency list so `filtered` recomputes when they change.
+   */
+  deps?: DependencyList;
+}
+
+export interface UseFilteredListResult<T> {
+  search: string;
+  setSearch: (value: string) => void;
+  filtered: T[];
+}
+
+// Pure filter pipeline shared by the hook. Extracted so the load-bearing
+// substring-match + predicate AND-ing can be unit-tested without a React
+// renderer (no DOM env / @testing-library/react dependency is wired up).
+export function filterRows<T>(
+  rows: readonly T[],
+  search: string,
+  searchFields?: (row: T) => Array<string | null | undefined>,
+  predicates?: Array<(row: T) => boolean>,
+): T[] {
+  const q = search.trim().toLowerCase();
+  return rows.filter((row) => {
+    if (q && searchFields) {
+      const haystack = searchFields(row)
+        .filter((v): v is string => v != null)
+        .join(" ")
+        .toLowerCase();
+      if (!haystack.includes(q)) return false;
+    }
+    if (predicates) {
+      for (const pred of predicates) if (!pred(row)) return false;
+    }
+    return true;
+  });
+}
+
+export function useFilteredList<T>(
+  rows: readonly T[],
+  options: UseFilteredListOptions<T> = {},
+): UseFilteredListResult<T> {
+  const { initialSearch = "", searchFields, predicates } = options;
+  const [search, setSearch] = useState(initialSearch);
+
+  const filtered = useMemo(
+    () => filterRows(rows, search, searchFields, predicates),
+    // `deps` carries predicate-closed-over values (e.g. domainId).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [rows, search, ...(options.deps ?? [])],
+  );
+
+  return { search, setSearch, filtered };
+}

--- a/dali-api/app/projects/components/SlotFormPicker.tsx
+++ b/dali-api/app/projects/components/SlotFormPicker.tsx
@@ -92,6 +92,36 @@ export function SlotFormPicker({
 
       {error && <p className="text-xs text-destructive">{error}</p>}
 
+      {/* Binding a form and telling members about it are two separate steps —
+          setSlotBinding sends nothing. Surface the send action right here so a
+          form can't be bound but silently never announced. Deep-links to the
+          existing Announcements composer (pre-seeded with this form + the whole
+          lab); no new send path, so the composer's published-form check still
+          applies. Disabled until the form is published, since the composer
+          rejects unpublished forms. */}
+      {canManage && binding && (
+        <div className="flex flex-wrap items-center gap-2">
+          {fillUrl ? (
+            <a
+              href={`/admin-console/announcements?formId=${encodeURIComponent(binding.formId)}&audience=all`}
+              className="px-3 py-1.5 text-xs font-medium rounded-md border border-border text-foreground hover:bg-muted"
+            >
+              Send to members
+            </a>
+          ) : (
+            <span
+              className="px-3 py-1.5 text-xs font-medium rounded-md border border-border text-muted-foreground opacity-60 cursor-not-allowed"
+              title="Publish the form before sending it to members"
+            >
+              Send to members
+            </span>
+          )}
+          <span className="text-xs text-muted-foreground">
+            Opens the Announcements composer with this form attached.
+          </span>
+        </div>
+      )}
+
       {binding && (
         <p className="text-xs text-muted-foreground">
           {fillUrl ? (

--- a/dali-api/app/projects/components/SlotStatusStrip.tsx
+++ b/dali-api/app/projects/components/SlotStatusStrip.tsx
@@ -1,0 +1,44 @@
+// Per-slot guardrail strip for the Core staffing boards. Binding a form,
+// mapping its columns, and announcing it to members are three independent
+// steps; this makes all three visible so a slot that's bound-but-unsent
+// (nobody can apply) doesn't look the same as "sent, nobody responded".
+import type { SlotStatus } from "../lib/slot-status.server";
+
+export function SlotStatusStrip({ status }: { status: SlotStatus }) {
+  const yn = (b: boolean) => (b ? "yes" : "no");
+  // Bound, mapping aside, but never announced → nobody can apply. Surface it
+  // with the same amber treatment as the mapping warning.
+  const unsent = status.bound && status.sentToCount === 0;
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-1 rounded-md border border-border bg-muted/20 px-3 py-2 text-xs text-muted-foreground">
+        <span>
+          Form bound:{" "}
+          <span className="font-medium text-foreground">{yn(status.bound)}</span>
+        </span>
+        <span>
+          Column mapping complete:{" "}
+          <span className="font-medium text-foreground">
+            {yn(status.mappingComplete)}
+          </span>
+        </span>
+        <span>
+          Sent to{" "}
+          <span className="font-medium text-foreground">
+            {status.sentToCount}
+          </span>{" "}
+          {status.sentToCount === 1 ? "member" : "members"}
+        </span>
+      </div>
+
+      {unsent && (
+        <div className="rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-800">
+          <span className="font-medium">Bound but not yet sent:</span> a form is
+          connected but no announcement has gone out, so members can't apply
+          yet. Use <em>Send to members</em> in Advanced settings to notify them.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dali-api/app/projects/lib/__tests__/member-staffing.test.ts
+++ b/dali-api/app/projects/lib/__tests__/member-staffing.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("~/lib/db");
+vi.mock("~/lib/roles", () => ({ currentTerm: vi.fn() }));
+vi.mock("~/projects/lib/staffing-cycle", () => ({
+  ensureStaffingCycle: vi.fn(),
+}));
+
+import { prisma } from "~/lib/db";
+import { currentTerm } from "~/lib/roles";
+import { ensureStaffingCycle } from "~/projects/lib/staffing-cycle";
+import { listMemberStaffingForms } from "~/projects/lib/member-staffing.server";
+
+const mockPrisma = prisma as unknown as {
+  staffingCycleFormBinding: { findUnique: ReturnType<typeof vi.fn> };
+  formSubmission: { findFirst: ReturnType<typeof vi.fn> };
+};
+const mockCurrentTerm = currentTerm as unknown as ReturnType<typeof vi.fn>;
+const mockEnsure = ensureStaffingCycle as unknown as ReturnType<typeof vi.fn>;
+
+function bindingRow(opts: {
+  formId: string;
+  name?: string;
+  published?: boolean;
+  publicToken?: string | null;
+}) {
+  return {
+    updatedAt: new Date("2026-01-01"),
+    columnMapping: null,
+    form: {
+      id: opts.formId,
+      name: opts.name ?? "Intent Form",
+      published: opts.published ?? true,
+      publicToken: opts.publicToken === undefined ? "tok" : opts.publicToken,
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (mockPrisma as any).staffingCycleFormBinding = { findUnique: vi.fn() };
+  (mockPrisma as any).formSubmission = { findFirst: vi.fn() };
+  mockCurrentTerm.mockResolvedValue({ id: "t1", code: "26S" });
+  mockEnsure.mockResolvedValue({ id: "cycle-1" });
+});
+
+describe("listMemberStaffingForms", () => {
+  it("returns [] when there is no current term", async () => {
+    mockCurrentTerm.mockResolvedValue(null);
+    expect(await listMemberStaffingForms("u1")).toEqual([]);
+    expect(mockEnsure).not.toHaveBeenCalled();
+  });
+
+  it("published+bound slot with no submission → submitted false", async () => {
+    // Only intent-to-work bound; the other two slots resolve to null.
+    mockPrisma.staffingCycleFormBinding.findUnique.mockImplementation(
+      ({ where }: any) =>
+        where.staffingCycleId_slot.slot === "intent-to-work"
+          ? bindingRow({ formId: "f1" })
+          : null,
+    );
+    mockPrisma.formSubmission.findFirst.mockResolvedValue(null);
+
+    const out = await listMemberStaffingForms("u1");
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      slot: "intent-to-work",
+      slotLabel: "Intent to Work",
+      formName: "Intent Form",
+      fillLink: "/forms/fill/tok",
+      submitted: false,
+      submittedAt: null,
+    });
+  });
+
+  it("a submission → submitted true with ISO submittedAt", async () => {
+    mockPrisma.staffingCycleFormBinding.findUnique.mockImplementation(
+      ({ where }: any) =>
+        where.staffingCycleId_slot.slot === "intent-to-work"
+          ? bindingRow({ formId: "f1" })
+          : null,
+    );
+    mockPrisma.formSubmission.findFirst.mockResolvedValue({
+      createdAt: new Date("2026-02-03T04:05:06.000Z"),
+    });
+
+    const out = await listMemberStaffingForms("u1");
+    expect(out[0].submitted).toBe(true);
+    expect(out[0].submittedAt).toBe("2026-02-03T04:05:06.000Z");
+  });
+
+  it("omits unpublished or token-less bindings", async () => {
+    mockPrisma.staffingCycleFormBinding.findUnique.mockImplementation(
+      ({ where }: any) => {
+        const slot = where.staffingCycleId_slot.slot;
+        if (slot === "intent-to-work")
+          return bindingRow({ formId: "f1", published: false });
+        if (slot === "project-bids")
+          return bindingRow({ formId: "f2", publicToken: null });
+        return null;
+      },
+    );
+    mockPrisma.formSubmission.findFirst.mockResolvedValue(null);
+
+    expect(await listMemberStaffingForms("u1")).toEqual([]);
+    // No submission lookups for slots that were filtered out.
+    expect(mockPrisma.formSubmission.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("scopes the submission lookup to the requesting user", async () => {
+    mockPrisma.staffingCycleFormBinding.findUnique.mockImplementation(
+      ({ where }: any) =>
+        where.staffingCycleId_slot.slot === "intent-to-work"
+          ? bindingRow({ formId: "f1" })
+          : null,
+    );
+    mockPrisma.formSubmission.findFirst.mockResolvedValue(null);
+
+    await listMemberStaffingForms("u-me");
+    expect(mockPrisma.formSubmission.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ userId: "u-me", slot: "intent-to-work" }),
+      }),
+    );
+  });
+});

--- a/dali-api/app/projects/lib/__tests__/slot-status.test.ts
+++ b/dali-api/app/projects/lib/__tests__/slot-status.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("~/lib/db");
+
+import { prisma } from "~/lib/db";
+import { deriveSlotStatus } from "~/projects/lib/slot-status.server";
+
+const mockPrisma = prisma as unknown as {
+  staffingCycleFormBinding: { findUnique: ReturnType<typeof vi.fn> };
+  notification: { findMany: ReturnType<typeof vi.fn> };
+};
+
+// getSlotBinding reads StaffingCycleFormBinding.findUnique and returns a
+// parsed binding; deriveSlotStatus then counts distinct Notification
+// recipients keyed on the bound form id.
+function bindingRow(opts: {
+  formId: string;
+  published?: boolean;
+  publicToken?: string | null;
+  columnMapping?: object | null;
+}) {
+  return {
+    updatedAt: new Date("2026-01-01"),
+    columnMapping: opts.columnMapping ?? null,
+    form: {
+      id: opts.formId,
+      name: "A Form",
+      published: opts.published ?? true,
+      publicToken: opts.publicToken ?? "tok",
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (mockPrisma as any).staffingCycleFormBinding = { findUnique: vi.fn() };
+  (mockPrisma as any).notification = { findMany: vi.fn() };
+});
+
+describe("deriveSlotStatus", () => {
+  it("bound + mapped + sent → bound/mappingComplete true, count N", async () => {
+    mockPrisma.staffingCycleFormBinding.findUnique.mockResolvedValue(
+      bindingRow({
+        formId: "f1",
+        columnMapping: { version: 1, entries: [] },
+      }),
+    );
+    mockPrisma.notification.findMany.mockResolvedValue([
+      { recipientUserId: "u1" },
+      { recipientUserId: "u2" },
+      { recipientUserId: "u3" },
+    ]);
+
+    const out = await deriveSlotStatus("cycle-1");
+    const itw = out.find((s) => s.slot === "intent-to-work")!;
+    expect(itw.bound).toBe(true);
+    expect(itw.mappingComplete).toBe(true);
+    expect(itw.sentToCount).toBe(3);
+    // All three slots are reported.
+    expect(out.map((s) => s.slot).sort()).toEqual(
+      ["intent-to-work", "level-up", "project-bids"].sort(),
+    );
+  });
+
+  it("bound but no column mapping → mappingComplete false", async () => {
+    mockPrisma.staffingCycleFormBinding.findUnique.mockResolvedValue(
+      bindingRow({ formId: "f1", columnMapping: null }),
+    );
+    mockPrisma.notification.findMany.mockResolvedValue([
+      { recipientUserId: "u1" },
+    ]);
+
+    const out = await deriveSlotStatus("cycle-1");
+    expect(out[0].mappingComplete).toBe(false);
+    expect(out[0].bound).toBe(true);
+  });
+
+  it("bound but zero notifications → sentToCount 0 (the bound-but-unsent case)", async () => {
+    mockPrisma.staffingCycleFormBinding.findUnique.mockResolvedValue(
+      bindingRow({ formId: "f1", columnMapping: { version: 1, entries: [] } }),
+    );
+    mockPrisma.notification.findMany.mockResolvedValue([]);
+
+    const out = await deriveSlotStatus("cycle-1");
+    expect(out[0].bound).toBe(true);
+    expect(out[0].sentToCount).toBe(0);
+  });
+
+  it("no binding → all false / count 0 and no notification query", async () => {
+    mockPrisma.staffingCycleFormBinding.findUnique.mockResolvedValue(null);
+
+    const out = await deriveSlotStatus("cycle-1");
+    expect(out.every((s) => !s.bound)).toBe(true);
+    expect(out.every((s) => !s.mappingComplete)).toBe(true);
+    expect(out.every((s) => s.sentToCount === 0)).toBe(true);
+    expect(mockPrisma.notification.findMany).not.toHaveBeenCalled();
+  });
+});

--- a/dali-api/app/projects/lib/member-staffing.server.ts
+++ b/dali-api/app/projects/lib/member-staffing.server.ts
@@ -1,0 +1,50 @@
+import { prisma } from "~/lib/db";
+import { currentTerm } from "~/lib/roles";
+import { ensureStaffingCycle } from "./staffing-cycle";
+import { SLOTS, type Slot, getSlotBinding } from "./form-slots";
+
+// The member-facing view of the current cycle's staffing forms. Mirrors what a
+// member would otherwise only ever see as an ephemeral My Tasks tile: each
+// published, bound slot with the same /forms/fill/:token link, plus whether
+// they've already submitted so the page can show "View / update".
+export type MemberStaffingForm = {
+  slot: Slot;
+  slotLabel: string;
+  formName: string;
+  fillLink: string; // /forms/fill/:token (same link as the My Tasks tile)
+  submitted: boolean;
+  submittedAt: string | null;
+};
+
+export async function listMemberStaffingForms(
+  userId: string,
+): Promise<MemberStaffingForm[]> {
+  const term = await currentTerm();
+  if (!term) return [];
+  const cycle = await ensureStaffingCycle(term.id, term.code);
+
+  const out: MemberStaffingForm[] = [];
+  for (const slot of Object.keys(SLOTS) as Slot[]) {
+    const binding = await getSlotBinding(cycle.id, slot);
+    // Only surface forms a member can actually open & submit.
+    if (!binding || !binding.published || !binding.publicToken) continue;
+
+    // Submissions are scoped to this member only — the member page must never
+    // surface another member's submissions (CLAUDE.md role-check discipline).
+    const last = await prisma.formSubmission.findFirst({
+      where: { staffingCycleId: cycle.id, slot, userId },
+      orderBy: { createdAt: "desc" },
+      select: { createdAt: true },
+    });
+
+    out.push({
+      slot,
+      slotLabel: SLOTS[slot],
+      formName: binding.formName,
+      fillLink: `/forms/fill/${binding.publicToken}`,
+      submitted: last !== null,
+      submittedAt: last?.createdAt.toISOString() ?? null,
+    });
+  }
+  return out;
+}

--- a/dali-api/app/projects/lib/slot-status.server.ts
+++ b/dali-api/app/projects/lib/slot-status.server.ts
@@ -1,0 +1,42 @@
+import { prisma } from "~/lib/db";
+import { SLOTS, type Slot, getSlotBinding } from "./form-slots";
+
+// Per-slot guardrail status for the Core staffing boards. Binding a form to a
+// slot, mapping its columns, and actually telling members about it are three
+// independent steps; this surfaces all three so a slot that's bound-but-unsent
+// (nobody can apply) or sent-but-unmapped (submissions can't be interpreted)
+// is visible rather than silent.
+export type SlotStatus = {
+  slot: Slot;
+  slotLabel: string;
+  bound: boolean;
+  mappingComplete: boolean;
+  sentToCount: number; // distinct recipients who got an announcement w/ this form
+};
+
+export async function deriveSlotStatus(cycleId: string): Promise<SlotStatus[]> {
+  return Promise.all(
+    (Object.keys(SLOTS) as Slot[]).map(async (slot) => {
+      const binding = await getSlotBinding(cycleId, slot);
+      let sentToCount = 0;
+      if (binding) {
+        // No Notification->cycle link; key off the bound form id. Counts every
+        // announcement that attached this form (answers "did anyone get
+        // told?", not an exact per-cycle audience).
+        const recips = await prisma.notification.findMany({
+          where: { formId: binding.formId },
+          distinct: ["recipientUserId"],
+          select: { recipientUserId: true },
+        });
+        sentToCount = recips.length;
+      }
+      return {
+        slot,
+        slotLabel: SLOTS[slot],
+        bound: binding !== null,
+        mappingComplete: binding?.mapping != null,
+        sentToCount,
+      };
+    }),
+  );
+}

--- a/dali-api/app/projects/routes/projects.intent-to-work.tsx
+++ b/dali-api/app/projects/routes/projects.intent-to-work.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from "react";
 import { redirect, useLoaderData } from "react-router";
 import type { Route } from "./+types/projects.intent-to-work";
+import { useFilteredList } from "~/hooks/useFilteredList";
 import { requireAuth, redirectApplicantToPortal } from "~/lib/auth";
 import { parseFormDataJson } from "~/lib/safe-json";
 import { canManageStaffing, canViewStaffing, currentTerm } from "~/lib/roles";
@@ -24,6 +25,8 @@ import {
   type ColumnMapping,
 } from "../lib/slot-roles";
 import { buildSubmissionView } from "../lib/submission-view.server";
+import { deriveSlotStatus, type SlotStatus } from "../lib/slot-status.server";
+import { SlotStatusStrip } from "../components/SlotStatusStrip";
 import type { Question } from "~/types";
 
 const SLOT = "intent-to-work" as const;
@@ -148,6 +151,13 @@ export async function loader({ request }: Route.LoaderArgs) {
     select: { id: true, displayName: true },
   });
 
+  // Per-slot guardrail status (bound / mapped / sent-to). Single-cycle view
+  // only — the all-terms aggregate has no one slot to bind, mirroring binding.
+  const slotStatus: SlotStatus | null = singleCycleId
+    ? (await deriveSlotStatus(singleCycleId)).find((s) => s.slot === SLOT) ??
+      null
+    : null;
+
   return {
     gate: "ok" as const,
     cycle: { name: cycleName },
@@ -164,6 +174,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     mappingWarning,
     allTerms,
     domainOptions,
+    slotStatus,
   };
 }
 
@@ -261,19 +272,14 @@ function Loaded({
     { gate: "ok" }
   >;
 }) {
-  const [query, setQuery] = useState("");
   const [domainId, setDomainId] = useState("");
   const [settingsOpen, setSettingsOpen] = useState(false);
 
-  const filtered = useMemo(() => {
-    const q = query.trim().toLowerCase();
-    return data.submissions.filter((s) => {
-      if (q && !`${s.name} ${s.email ?? ""}`.toLowerCase().includes(q))
-        return false;
-      if (domainId && !s.domainIds.includes(domainId)) return false;
-      return true;
-    });
-  }, [data.submissions, query, domainId]);
+  const { search, setSearch, filtered } = useFilteredList(data.submissions, {
+    searchFields: (s) => [s.name, s.email],
+    predicates: [(s) => !domainId || s.domainIds.includes(domainId)],
+    deps: [domainId],
+  });
 
   const domains = useMemo(
     () => data.domainOptions.map((d) => ({ id: d.id, name: d.displayName })),
@@ -314,9 +320,11 @@ function Loaded({
         </div>
       )}
 
+      {data.slotStatus && <SlotStatusStrip status={data.slotStatus} />}
+
       <div className="flex flex-col sm:flex-row gap-2">
         <div className="flex-1">
-          <SubmissionFilters query={query} onQueryChange={setQuery} />
+          <SubmissionFilters query={search} onQueryChange={setSearch} />
         </div>
         <DomainFilter
           domains={domains}

--- a/dali-api/app/projects/routes/projects.level-up.tsx
+++ b/dali-api/app/projects/routes/projects.level-up.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState, useEffect } from "react";
 import { redirect, useLoaderData, useFetcher } from "react-router";
 import type { Route } from "./+types/projects.level-up";
+import { useFilteredList } from "~/hooks/useFilteredList";
 import { requireAuth, redirectApplicantToPortal } from "~/lib/auth";
 import { parseFormDataJson } from "~/lib/safe-json";
 import { canManageStaffing, canViewStaffing, currentTerm } from "~/lib/roles";
@@ -23,6 +24,8 @@ import {
   type ColumnMapping,
 } from "../lib/slot-roles";
 import { buildSubmissionView } from "../lib/submission-view.server";
+import { deriveSlotStatus, type SlotStatus } from "../lib/slot-status.server";
+import { SlotStatusStrip } from "../components/SlotStatusStrip";
 import type { Question } from "~/types";
 import { isLevel, type Level } from "~/lib/level";
 
@@ -142,6 +145,13 @@ export async function loader({ request }: Route.LoaderArgs) {
     select: { id: true, displayName: true },
   });
 
+  // Per-slot guardrail status (bound / mapped / sent-to). Single-cycle view
+  // only — the all-terms aggregate has no one slot to bind, mirroring binding.
+  const slotStatus: SlotStatus | null = singleCycleId
+    ? (await deriveSlotStatus(singleCycleId)).find((s) => s.slot === SLOT) ??
+      null
+    : null;
+
   return {
     gate: "ok" as const,
     cycle: { name: cycleName, id: singleCycleId },
@@ -157,6 +167,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     mappingWarning,
     noFormConnected,
     domainOptions,
+    slotStatus,
   };
 }
 
@@ -402,7 +413,6 @@ export default function LevelUpDatabase() {
 type LoadedData = Extract<Awaited<ReturnType<typeof loader>>, { gate: "ok" }>;
 
 function Loaded({ data }: { data: LoadedData }) {
-  const [query, setQuery] = useState("");
   const [domainId, setDomainId] = useState("");
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [confirmRow, setConfirmRow] = useState<{
@@ -413,15 +423,11 @@ function Loaded({ data }: { data: LoadedData }) {
     targetLevel: Level;
   } | null>(null);
 
-  const filtered = useMemo(() => {
-    const q = query.trim().toLowerCase();
-    return data.submissions.filter((s) => {
-      if (q && !`${s.name} ${s.email ?? ""}`.toLowerCase().includes(q))
-        return false;
-      if (domainId && !s.domainIds.includes(domainId)) return false;
-      return true;
-    });
-  }, [data.submissions, query, domainId]);
+  const { search, setSearch, filtered } = useFilteredList(data.submissions, {
+    searchFields: (s) => [s.name, s.email],
+    predicates: [(s) => !domainId || s.domainIds.includes(domainId)],
+    deps: [domainId],
+  });
 
   const domains = useMemo(
     () => data.domainOptions.map((d) => ({ id: d.id, name: d.displayName })),
@@ -462,9 +468,11 @@ function Loaded({ data }: { data: LoadedData }) {
         </div>
       )}
 
+      {data.slotStatus && <SlotStatusStrip status={data.slotStatus} />}
+
       <div className="flex flex-col sm:flex-row gap-2">
         <div className="flex-1">
-          <SubmissionFilters query={query} onQueryChange={setQuery} />
+          <SubmissionFilters query={search} onQueryChange={setSearch} />
         </div>
         <DomainFilter domains={domains} value={domainId} onChange={setDomainId} />
         <TermFilter terms={data.termOptions} selected={data.selectedTerm} />

--- a/dali-api/app/projects/routes/projects.my-staffing.tsx
+++ b/dali-api/app/projects/routes/projects.my-staffing.tsx
@@ -1,0 +1,77 @@
+import { redirect, useLoaderData } from "react-router";
+import type { Route } from "./+types/projects.my-staffing";
+import { requireAuth, redirectApplicantToPortal } from "~/lib/auth";
+import { requireMember } from "~/lib/roles";
+import { listMemberStaffingForms } from "../lib/member-staffing.server";
+
+export const meta: Route.MetaFunction = () => [
+  { title: "My Staffing · DALI OS" },
+];
+
+// Member-facing "My Staffing" page: the persistent destination for the staffing
+// forms a member is meant to fill this cycle. Without it, the only apply
+// surface is an ephemeral My Tasks tile that vanishes once dismissed and gives
+// no way to revisit a submitted form. Gated `requireMember` (NOT
+// canViewStaffing — this is the member's own surface, not the Core board);
+// every submission lookup is scoped to the session user.
+export async function loader({ request }: Route.LoaderArgs) {
+  const auth = await requireAuth(request);
+  if (!auth.ok) return redirect("/login");
+  const portal = redirectApplicantToPortal(auth);
+  if (portal) return portal;
+  if (!(await requireMember(auth.user.sub))) return redirect("/");
+
+  const forms = await listMemberStaffingForms(auth.user.sub);
+  return { forms };
+}
+
+export default function MyStaffingPage() {
+  const { forms } = useLoaderData<typeof loader>();
+
+  return (
+    <div className="flex flex-col gap-4">
+      <header>
+        <h1 className="font-heading text-2xl font-bold text-foreground">
+          My Staffing
+        </h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Staffing forms open for you this cycle. Submitting here is the same as
+          completing the task in your sidebar.
+        </p>
+      </header>
+
+      {forms.length === 0 ? (
+        <div className="bg-card border border-border rounded-lg px-4 py-8 text-center text-sm text-muted-foreground">
+          No staffing forms are open for you right now.
+        </div>
+      ) : (
+        <ul className="flex flex-col gap-2">
+          {forms.map((f) => (
+            <li
+              key={f.slot}
+              className="bg-card border border-border rounded-lg px-4 py-3 flex flex-col sm:flex-row sm:items-center justify-between gap-2"
+            >
+              <div>
+                <div className="text-sm font-medium text-foreground">
+                  {f.slotLabel}
+                </div>
+                <div className="text-xs text-muted-foreground">
+                  {f.formName}
+                  {f.submitted && f.submittedAt
+                    ? ` · Submitted ${new Date(f.submittedAt).toLocaleDateString()}`
+                    : ""}
+                </div>
+              </div>
+              <a
+                href={f.fillLink}
+                className="shrink-0 px-3 py-1.5 text-sm font-medium rounded-md border border-border text-foreground hover:bg-muted"
+              >
+                {f.submitted ? "View / update" : "Open form"}
+              </a>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/dali-api/app/projects/routes/projects.project-bids.tsx
+++ b/dali-api/app/projects/routes/projects.project-bids.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from "react";
 import { redirect, useLoaderData } from "react-router";
 import type { Route } from "./+types/projects.project-bids";
+import { useFilteredList } from "~/hooks/useFilteredList";
 import { requireAuth, redirectApplicantToPortal } from "~/lib/auth";
 import { parseFormDataJson } from "~/lib/safe-json";
 import { canManageStaffing, canViewStaffing, currentTerm } from "~/lib/roles";
@@ -24,6 +25,8 @@ import {
   type ColumnMapping,
 } from "../lib/slot-roles";
 import { buildSubmissionView } from "../lib/submission-view.server";
+import { deriveSlotStatus, type SlotStatus } from "../lib/slot-status.server";
+import { SlotStatusStrip } from "../components/SlotStatusStrip";
 import type { Question } from "~/types";
 
 const SLOT = "project-bids" as const;
@@ -146,6 +149,13 @@ export async function loader({ request }: Route.LoaderArgs) {
     select: { id: true, displayName: true },
   });
 
+  // Per-slot guardrail status (bound / mapped / sent-to). Single-cycle view
+  // only — the all-terms aggregate has no one slot to bind, mirroring binding.
+  const slotStatus: SlotStatus | null = singleCycleId
+    ? (await deriveSlotStatus(singleCycleId)).find((s) => s.slot === SLOT) ??
+      null
+    : null;
+
   return {
     gate: "ok" as const,
     cycle: { name: cycleName },
@@ -161,6 +171,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     mappingWarning,
     noFormConnected,
     domainOptions,
+    slotStatus,
   };
 }
 
@@ -257,19 +268,14 @@ function Loaded({
 }: {
   data: Extract<Awaited<ReturnType<typeof loader>>, { gate: "ok" }>;
 }) {
-  const [query, setQuery] = useState("");
   const [domainId, setDomainId] = useState("");
   const [settingsOpen, setSettingsOpen] = useState(false);
 
-  const filtered = useMemo(() => {
-    const q = query.trim().toLowerCase();
-    return data.submissions.filter((s) => {
-      if (q && !`${s.name} ${s.email ?? ""}`.toLowerCase().includes(q))
-        return false;
-      if (domainId && !s.domainIds.includes(domainId)) return false;
-      return true;
-    });
-  }, [data.submissions, query, domainId]);
+  const { search, setSearch, filtered } = useFilteredList(data.submissions, {
+    searchFields: (s) => [s.name, s.email],
+    predicates: [(s) => !domainId || s.domainIds.includes(domainId)],
+    deps: [domainId],
+  });
 
   const domains = useMemo(
     () => data.domainOptions.map((d) => ({ id: d.id, name: d.displayName })),
@@ -312,9 +318,11 @@ function Loaded({
         </div>
       )}
 
+      {data.slotStatus && <SlotStatusStrip status={data.slotStatus} />}
+
       <div className="flex flex-col sm:flex-row gap-2">
         <div className="flex-1">
-          <SubmissionFilters query={query} onQueryChange={setQuery} />
+          <SubmissionFilters query={search} onQueryChange={setSearch} />
         </div>
         <DomainFilter
           domains={domains}

--- a/dali-api/app/routes.ts
+++ b/dali-api/app/routes.ts
@@ -47,6 +47,10 @@ export default [
     // Projects
     route("projects/list", "projects/routes/projects.list.tsx"),
     route("projects/staffing", "projects/routes/projects.staffing.tsx"),
+    // Member-facing staffing destination (requireMember, not canViewStaffing):
+    // the persistent place a member fills/revisits the cycle's staffing forms.
+    // Must precede projects/:id so it isn't captured by the :id param.
+    route("projects/my-staffing", "projects/routes/projects.my-staffing.tsx"),
     // Staffing input forms (member self-service). Must precede projects/:id
     // so these literal segments aren't captured by the :id param.
     route("projects/intent-to-work", "projects/routes/projects.intent-to-work.tsx"),


### PR DESCRIPTION
Combines two plan docs: **PR-01** (useFilteredList) then **PR-08** (member staffing destination + bind/notify guardrails).

## PR-01 — `useFilteredList` hook
- New `app/hooks/useFilteredList.ts`: generic hook owning the search string + a `useMemo`'d filter, configurable via `searchFields` / `predicates` / `deps`. Also exports a pure `filterRows` helper.
- Migrated the three staffing submission routes that had a byte-identical inline filter block: `projects.intent-to-work.tsx`, `projects.project-bids.tsx`, `projects.level-up.tsx`. Filter behavior (name+email search + domain filter) is unchanged.
- New unit test `app/hooks/__tests__/useFilteredList.test.ts` covers empty query, name/email match, trimming, null-email, domain predicate no-op, and search+predicate AND semantics. (No `@testing-library/react`/DOM env is wired up, so the test exercises the pure `filterRows` pipeline rather than adding a dependency, per CLAUDE.md.)

### Follow-up adopter checklist (NOT in this PR)
- [ ] `app/hiring/routes/applications.tsx:223`
- [ ] `app/partners/routes/partners.applications.tsx:214,220–222`
- [ ] `app/projects/routes/projects.list.tsx:172–173`
- [ ] `app/members/routes/members.groups.tsx:257,384–385,618–619`
- [ ] `app/members/routes/members.tsx:243`
- [ ] `app/calendar/routes/calendar.tsx:2399–2405`
- [ ] `app/admin-console/routes/admin-console.domains.tsx:242–244,419–421`
- [ ] `app/admin-console/routes/admin-console.announcements.tsx:95–113`
- [ ] `app/forms/components/FormsBrowser.tsx:50–55`

### PR-07 conflict note
PR-07 (IA navigation) relocates Level Up under Staffing and touches the same `useMemo` block in `projects.level-up.tsx`. Landing PR-01 first shrinks that block to a single hook call; if PR-07 lands first it must rebase (trivial — ~10 lines collapse to one).

## PR-08 — member staffing destination + guardrails
- New member-facing route `/projects/my-staffing` (`projects.my-staffing.tsx`), gated `requireMember` (NOT `canViewStaffing`/`isCore`); applicants redirect to `/portal`, non-members to `/`. Registered in `app/routes.ts` before `projects/:id`.
- New `member-staffing.server.ts#listMemberStaffingForms`: for the current cycle, returns each published+bound slot with the same `/forms/fill/:token` link as the My Tasks tile and whether the member has already submitted (submission lookups are strictly scoped to the session user).
- New `slot-status.server.ts#deriveSlotStatus`: per-slot `{ bound, mappingComplete, sentToCount }`. `sentToCount` is keyed on the bound form id (no Notification→cycle link exists) and is documented as an approximation answering "did anyone get told?".
- New `SlotStatusStrip` rendered on all three Core boards: a status row (`form bound` / `column mapping complete` / `sent to N members`) plus an amber "bound but not yet sent" banner when `bound && sentToCount === 0`, matching the existing `mappingWarning` styling.
- "Send to members" affordance added to `SlotFormPicker` (manager-only, disabled until the form is published), deep-linking the existing Announcements composer pre-seeded with the bound form + whole-lab audience. No new send endpoint — `admin-console.announcements.tsx` now reads optional `?formId=` / `?audience=all` to pre-seed, so the composer's published-form check still gates the actual send.
- **No schema/migration change.** No `setSlotBinding` behavior change.

## Nav surfacing — TODO (owned by the Nav PR, intentionally not added here)
Per task scope, `app/components/Layout.tsx` is owned by the Nav PR and is **not** edited here. Desired sidebar entry:
- **Label:** "My Staffing"
- **Route:** `/projects/my-staffing`
- **Placement:** under Projects → Staffing
- **Gating:** member-gated (every lab member; not Core-only)

The page is reachable by URL and via My Tasks form tiles even before the nav entry lands.

## CI checks that apply
- `test.yml` — Vitest unit tests (relevant: the new hook + slot-status + member-staffing tests). E2E unaffected (no new submit path).
- `codeql.yml` — static security scan; member route is `requireMember`-gated and only returns the session user's own submissions.
- `build-check.yml` — Docker build.
- `migration-check.yml` — should be a no-op: no schema or migration changes.
- `preview-deploy.yml` — per-PR preview.

## Verification
- `npm run typecheck`: passes for all changed app files (`react-router typegen` regenerates `+types/projects.my-staffing`). One pre-existing unrelated error remains in `app/routes/layout.tsx` (references a not-yet-created `~/components/Breadcrumbs` from in-progress Nav work) — that file is not part of this PR.
- `npm test`: 1265/1265 pass, including the 16 new tests across the three new test files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/857"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784743719&installation_id=133523038&pr_number=857&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F857&signature=50d7d3ab68ddba1778e64080dc5a336b8a18cfac26d53b35d6a4ce79e9923952"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->