### PR TITLE
IA/navigation restructure + browsable notification history (PR-07 + PR-10)

### DIFF
--- a/dali-api/app/admin-console/routes/admin-console.activity.tsx
+++ b/dali-api/app/admin-console/routes/admin-console.activity.tsx
@@ -14,7 +14,7 @@ import {
 } from "~/lib/audit-query";
 import { ListTodo, ChevronLeft, ChevronRight, X } from "lucide-react";
 
-export const meta: Route.MetaFunction = () => [{ title: "Activity · Operations · DALI OS" }];
+export const meta: Route.MetaFunction = () => [{ title: "Activity · Admin · DALI OS" }];
 
 // Read-only viewer over the AuditLog table. Offset-paginated and filterable
 // on the indexed columns (action, userId, createdAt) plus a cheap equality

--- a/dali-api/app/admin-console/routes/admin-console.analytics.tsx
+++ b/dali-api/app/admin-console/routes/admin-console.analytics.tsx
@@ -6,7 +6,7 @@ import { isAdmin } from "~/lib/roles";
 import { BarChart3, AlertTriangle } from "lucide-react";
 
 export const meta: Route.MetaFunction = () => [
-  { title: "Analytics · Operations · DALI OS" },
+  { title: "Analytics · Admin · DALI OS" },
 ];
 
 // Slim usage + crash dashboard for a mandated internal tool. We don't track

--- a/dali-api/app/admin-console/routes/admin-console.announcements.tsx
+++ b/dali-api/app/admin-console/routes/admin-console.announcements.tsx
@@ -19,7 +19,7 @@ import {
 import { SearchInput } from "~/components/ui/SearchInput";
 
 export const meta: Route.MetaFunction = () => [
-  { title: "Announcements · Operations · DALI OS" },
+  { title: "Announcements · Admin · DALI OS" },
 ];
 
 // Admin composer: write an announcement or a todo and send it to the whole

--- a/dali-api/app/admin-console/routes/admin-console.domains.tsx
+++ b/dali-api/app/admin-console/routes/admin-console.domains.tsx
@@ -20,7 +20,7 @@ import {
   RemoveDomainLeadButton,
 } from "~/admin-console/components/admin-console-shared";
 
-export const meta: Route.MetaFunction = () => [{ title: "Domains · Operations · DALI OS" }];
+export const meta: Route.MetaFunction = () => [{ title: "Domains · Admin · DALI OS" }];
 
 // Phase 2 rewrite: domain-lead assignments now key off User.id (not
 // DALIMember.id) and require a termId. Lead picker lists Users with a

--- a/dali-api/app/admin-console/routes/admin-console.members.tsx
+++ b/dali-api/app/admin-console/routes/admin-console.members.tsx
@@ -14,7 +14,7 @@ import {
   type Member,
 } from "~/admin-console/components/admin-console-shared";
 
-export const meta: Route.MetaFunction = () => [{ title: "Roles · Operations · DALI OS" }];
+export const meta: Route.MetaFunction = () => [{ title: "Roles & Permissions · Admin · DALI OS" }];
 
 // Phase 2 rewrite: role state lives in AdminMembership / CoreAssignment /
 // DomainLeadAssignment instead of DALIMember.roles[]. The admin page now
@@ -213,7 +213,7 @@ export default function AdminConsoleMembers() {
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex items-center gap-3">
           <Users className="w-6 h-6 text-foreground/80" />
-          <h1 className="text-2xl font-bold text-foreground">Roles</h1>
+          <h1 className="text-2xl font-bold text-foreground">Roles & Permissions</h1>
           <span className="px-2.5 py-0.5 rounded-full text-xs font-medium bg-muted text-muted-foreground">
             {filtered.length}{filtered.length !== members.length ? ` of ${members.length}` : ""} members
           </span>

--- a/dali-api/app/admin-console/routes/admin-console.payroll-export.tsx
+++ b/dali-api/app/admin-console/routes/admin-console.payroll-export.tsx
@@ -15,7 +15,7 @@ import {
 } from "~/admin-console/lib/payroll-export";
 
 export const meta: Route.MetaFunction = () => [
-  { title: "Payroll export · Operations · DALI OS" },
+  { title: "Payroll export · Admin · DALI OS" },
 ];
 
 // The CSV itself is served by the sibling resource route at

--- a/dali-api/app/admin-console/routes/admin-console.tsx
+++ b/dali-api/app/admin-console/routes/admin-console.tsx
@@ -1,7 +1,7 @@
 import { redirect } from "react-router";
 import type { Route } from "./+types/admin-console";
 
-export const meta: Route.MetaFunction = () => [{ title: "Operations · DALI OS" }];
+export const meta: Route.MetaFunction = () => [{ title: "Admin · DALI OS" }];
 
 export async function loader(_args: Route.LoaderArgs) {
   return redirect("/admin-console/members");

--- a/dali-api/app/components/Breadcrumbs.tsx
+++ b/dali-api/app/components/Breadcrumbs.tsx
@@ -1,0 +1,119 @@
+import { Link, useMatches, useLocation } from 'react-router'
+import { ChevronRight } from 'lucide-react'
+
+export type Crumb = { label: string; to?: string }
+
+// A route opts into a dynamic leaf crumb by exporting:
+//   export const handle = { breadcrumb: (data) => data.application.applicantName }
+// The component calls it with that route's loader data to resolve the last
+// crumb (e.g. an applicant's name in place of a raw id).
+type Handle = { breadcrumb?: (data: unknown) => string | null | undefined }
+
+// Static label map for the fixed path segments. Keeps lab vocabulary verbatim
+// (Domain, Delibs, Intent to Work, Project Bids, JobX, Level Up, Core, Hub,
+// Library). Unknown segments fall back to titlecase. Area labels mirror the
+// sidebar (People / Lab Processes / Admin / Documents).
+const SEGMENT_LABELS: Record<string, string> = {
+  hiring: 'Hiring',
+  applications: 'Applications',
+  reviewer: 'Reviews',
+  'domain-lead': 'Domain',
+  delibs: 'Delibs',
+  lead: 'Cycles',
+  cycles: 'Cycles',
+  waitlists: 'Waitlists',
+  library: 'Library',
+  challenges: 'Challenges',
+  rubrics: 'Rubrics',
+  'confidentiality-agreements': 'Confidentiality',
+  confidentiality: 'Confidentiality',
+  emails: 'Emails',
+  interviewer: 'Interviews',
+  interview: 'Interview',
+  analytics: 'Analytics',
+
+  'admin-console': 'Admin',
+  members: 'People',
+  domains: 'Domains',
+  announcements: 'Announcements',
+  activity: 'Activity',
+  'payroll-export': 'Payroll export',
+
+  projects: 'Projects',
+  list: 'Hub',
+  staffing: 'Staffing',
+  'my-staffing': 'My Staffing',
+  'level-up': 'Level Up',
+  'intent-to-work': 'Intent to Work',
+  'project-bids': 'Project Bids',
+
+  partners: 'Partners',
+  education: 'Education',
+
+  'internal-processes': 'Lab Processes',
+  onboarding: 'Onboarding',
+  transfer: 'Transfer',
+  jobx: 'JobX',
+
+  documents: 'Documents',
+  forms: 'Documents',
+  calendar: 'Calendar',
+  profile: 'Profile',
+  settings: 'Settings',
+  help: 'Help',
+}
+
+function titleCase(seg: string) {
+  return seg.replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
+}
+
+export function Breadcrumbs() {
+  const matches = useMatches()
+  const { pathname } = useLocation()
+
+  // Build crumbs from the path segments. The last matched route may supply a
+  // dynamic leaf label via its `handle.breadcrumb(loaderData)`.
+  const segments = pathname.split('/').filter(Boolean)
+  const leaf = matches[matches.length - 1] as
+    | { handle?: Handle; data?: unknown }
+    | undefined
+  const leafLabel =
+    leaf?.handle?.breadcrumb && leaf.data != null
+      ? leaf.handle.breadcrumb(leaf.data)
+      : null
+
+  const crumbs: Crumb[] = segments.map((seg, i) => {
+    const to = '/' + segments.slice(0, i + 1).join('/')
+    const isLast = i === segments.length - 1
+    if (isLast && leafLabel) {
+      return { label: leafLabel }
+    }
+    return {
+      label: SEGMENT_LABELS[seg] ?? titleCase(seg),
+      to: isLast ? undefined : to,
+    }
+  })
+
+  // Home / single-segment pages get no trail.
+  if (crumbs.length <= 1) return null
+
+  return (
+    <nav
+      aria-label="Breadcrumb"
+      className="hidden md:flex items-center gap-1 text-sm text-muted-foreground"
+    >
+      {crumbs.map((c, i) => (
+        <span key={i} className="flex items-center gap-1">
+          {i > 0 && <ChevronRight className="w-3.5 h-3.5 opacity-50" />}
+          {c.to ? (
+            <Link to={c.to} className="hover:text-foreground transition-colors">
+              {c.label}
+            </Link>
+          ) : (
+            <span className="text-foreground font-medium">{c.label}</span>
+          )}
+        </span>
+      ))}
+    </nav>
+  )
+}

--- a/dali-api/app/components/Layout.tsx
+++ b/dali-api/app/components/Layout.tsx
@@ -148,9 +148,6 @@ export function Layout({ user, photoUrl, isCore = false, isAdmin = false, isDoma
     const areaKey: AreaKey | null =
       path.startsWith('/admin-console') ? 'admin-console'
       : path.startsWith('/hiring') ? 'hiring'
-      // Level Up lives at /projects/level-up but is surfaced under Internal
-      // Processes — resolve it there before the generic /projects branch.
-      : path.startsWith('/projects/level-up') ? 'internal-processes'
       : path.startsWith('/projects') ? 'projects'
       : path.startsWith('/members') ? 'members'
       : path.startsWith('/partners') ? 'partners'
@@ -239,9 +236,6 @@ export function Layout({ user, photoUrl, isCore = false, isAdmin = false, isDoma
   const activeAreaKey: AreaKey | null =
     path.startsWith('/admin-console') ? 'admin-console'
     : path.startsWith('/hiring') ? 'hiring'
-    // Level Up lives at /projects/level-up but is surfaced under Internal
-    // Processes — resolve it there before the generic /projects branch.
-    : path.startsWith('/projects/level-up') ? 'internal-processes'
     : path.startsWith('/projects') ? 'projects'
     : path.startsWith('/members') ? 'members'
     : path.startsWith('/partners') ? 'partners'
@@ -319,7 +313,7 @@ export function Layout({ user, photoUrl, isCore = false, isAdmin = false, isDoma
 
   const adminSections = [
     {
-      label: 'Roles',
+      label: 'Roles & Permissions',
       to: '/admin-console/members',
       icon: Users,
       show: true,
@@ -388,6 +382,17 @@ export function Layout({ user, photoUrl, isCore = false, isAdmin = false, isDoma
       sub: null,
     },
     {
+      // Member-facing staffing surface (created by the Staffing PR; the route
+      // string works even before that PR merges). Sits under the Staffing
+      // grouping alongside Intent to Work / Project Bids / Level Up.
+      label: 'My Staffing',
+      to: '/projects/my-staffing',
+      icon: UserPlus,
+      show: true,
+      active: path.startsWith('/projects/my-staffing'),
+      sub: null,
+    },
+    {
       label: 'Intent to Work',
       to: '/projects/intent-to-work',
       icon: FileText,
@@ -403,11 +408,24 @@ export function Layout({ user, photoUrl, isCore = false, isAdmin = false, isDoma
       active: path.startsWith('/projects/project-bids'),
       sub: null,
     },
+    {
+      label: 'Level Up',
+      // Page lives under /projects/level-up; regrouped here under Projects →
+      // Staffing. Match the legacy /internal-processes/level-up path too so
+      // the entry highlights on either path (the redirect stub is unchanged).
+      to: '/projects/level-up',
+      icon: TrendingUp,
+      show: canViewStaffing,
+      active:
+        path.startsWith('/projects/level-up') ||
+        path.startsWith('/internal-processes/level-up'),
+      sub: null,
+    },
   ].filter((s) => s.show)
 
   const membersSections = [
     {
-      label: 'Database',
+      label: 'Directory',
       to: '/members',
       icon: UsersRound,
       show: true,
@@ -472,18 +490,6 @@ export function Layout({ user, photoUrl, isCore = false, isAdmin = false, isDoma
       sub: null as { label: string; to: string; active: boolean }[] | null,
     },
     {
-      label: 'Level Up',
-      // Page lives under /projects/level-up; surfaced here under Internal
-      // Processes. Match both so the entry highlights on either path.
-      to: '/projects/level-up',
-      icon: TrendingUp,
-      show: canViewStaffing,
-      active:
-        path.startsWith('/projects/level-up') ||
-        path.startsWith('/internal-processes/level-up'),
-      sub: null,
-    },
-    {
       label: 'JobX',
       to: '/internal-processes/jobx',
       icon: Rocket,
@@ -514,7 +520,7 @@ export function Layout({ user, photoUrl, isCore = false, isAdmin = false, isDoma
     },
     {
       key: 'members' as AreaKey,
-      label: 'Members',
+      label: 'People',
       to: '/members',
       icon: UsersRound,
       show: true,
@@ -541,7 +547,7 @@ export function Layout({ user, photoUrl, isCore = false, isAdmin = false, isDoma
     },
     {
       key: 'internal-processes' as AreaKey,
-      label: 'Internal Processes',
+      label: 'Lab Processes',
       to: '/internal-processes/transfer',
       icon: Workflow,
       show: true,
@@ -550,7 +556,7 @@ export function Layout({ user, photoUrl, isCore = false, isAdmin = false, isDoma
     },
     {
       key: 'admin-console' as AreaKey,
-      label: 'Operations',
+      label: 'Admin',
       to: '/admin-console',
       icon: Settings,
       show: isCore,
@@ -630,9 +636,10 @@ export function Layout({ user, photoUrl, isCore = false, isAdmin = false, isDoma
         {(() => {
           const hasTasks = taskCount > 0
           const homeActive = path === '/'
-          // Tasks has no page of its own. With no todos it's an inert label.
-          // With todos the header navigates to Home (the task overview) and
-          // sits above one subtab per todo, each linking to its own target.
+          const tasksActive = path.startsWith('/notifications')
+          // "My Tasks" opens the dedicated surface (Open + History tabs). With
+          // todos it also sits above one subtab per open todo, each linking to
+          // that todo's own target; the header itself goes to /notifications.
           const headerInner = (
             <>
               <span className="relative flex-shrink-0">
@@ -644,7 +651,7 @@ export function Layout({ user, photoUrl, isCore = false, isAdmin = false, isDoma
               </span>
               {!collapsed && (
                 <>
-                  <span className="truncate">Tasks</span>
+                  <span className="truncate">My Tasks</span>
                   <span
                     className={`ml-auto inline-flex items-center justify-center min-w-[20px] h-5 px-1.5 rounded-full text-[11px] font-bold ${
                       hasTasks
@@ -676,23 +683,16 @@ export function Layout({ user, photoUrl, isCore = false, isAdmin = false, isDoma
                 {!collapsed && <span className="truncate">Home</span>}
               </button>
               <div className="flex flex-col">
-                {hasTasks ? (
-                  <button
-                    type="button"
-                    title={collapsed ? `Tasks (${taskCount})` : undefined}
-                    {...tabClickProps({ url: '/', label: 'Home' })}
-                    className={`relative flex items-center gap-3 rounded-md ${collapsed ? 'px-3 py-2 justify-center' : 'px-3 py-2'} text-sm font-heading font-semibold text-left text-white transition-colors hover:bg-white/5`}
-                  >
-                    {headerInner}
-                  </button>
-                ) : (
-                  <div
-                    title={collapsed ? 'Tasks (0)' : undefined}
-                    className={`relative flex items-center gap-3 rounded-md ${collapsed ? 'px-3 py-2 justify-center' : 'px-3 py-2'} text-sm font-heading font-semibold text-white/40`}
-                  >
-                    {headerInner}
-                  </div>
-                )}
+                <button
+                  type="button"
+                  title={collapsed ? `My Tasks (${taskCount})` : undefined}
+                  {...tabClickProps({ url: '/notifications', label: 'My Tasks' })}
+                  className={`relative flex items-center gap-3 rounded-md ${collapsed ? 'px-3 py-2 justify-center' : 'px-3 py-2'} text-sm font-heading font-semibold text-left transition-colors hover:bg-white/5 ${
+                    tasksActive || hasTasks ? 'text-white' : 'text-white/40 hover:text-white'
+                  }`}
+                >
+                  {headerInner}
+                </button>
 
                 {!collapsed && hasTasks && (
                   <div className="mt-1 mb-1 ml-4 pl-2 border-l border-white/10 flex flex-col gap-0.5">
@@ -730,6 +730,15 @@ export function Layout({ user, photoUrl, isCore = false, isAdmin = false, isDoma
                         </div>
                       )
                     })}
+                    {/* Entry point into the full My Tasks surface — Open list
+                        plus the browsable cleared/history view. */}
+                    <button
+                      type="button"
+                      {...tabClickProps({ url: '/notifications?tab=history', label: 'My Tasks' })}
+                      className="flex items-center gap-2.5 px-2.5 py-1.5 rounded-md text-[12px] font-medium text-left text-white/40 hover:text-white hover:bg-white/5 transition-colors"
+                    >
+                      <span className="truncate">See all →</span>
+                    </button>
                   </div>
                 )}
               </div>
@@ -1019,11 +1028,14 @@ export function Layout({ user, photoUrl, isCore = false, isAdmin = false, isDoma
         </div>
       </div>
 
-      {/* Mobile section breadcrumb — visible below header on small screens */}
-      {activeSection && (
+      {/* Mobile breadcrumb — visible below header on small screens. Shows the
+          full ancestry (Area › Section [› Sub]) rather than only the section. */}
+      {activeSection && activeArea && (
         <div className="md:hidden bg-card border-b border-border">
           <div className="px-4 h-11 flex items-center gap-2 text-sm font-heading font-semibold text-foreground">
             <activeSection.icon className="w-4 h-4 text-accent-coral" />
+            <span className="text-muted-foreground font-medium">{activeArea.label}</span>
+            <ChevronRight className="w-3.5 h-3.5 text-muted-foreground/50" />
             <span>{activeSection.label}</span>
             {activeSection.sub && (
               <nav className="flex items-center gap-0.5 ml-auto overflow-x-auto">

--- a/dali-api/app/hiring/routes/applications.$domainApplicationId.tsx
+++ b/dali-api/app/hiring/routes/applications.$domainApplicationId.tsx
@@ -27,6 +27,13 @@ export const meta: Route.MetaFunction = ({ data }) => {
   return [{ title: `${name ?? "Application"} · Applications · DALI OS` }];
 };
 
+// Resolves the dynamic leaf crumb so the trail reads
+// "Hiring › Applications › <applicant name>" instead of a raw id.
+export const handle = {
+  breadcrumb: (data: unknown) =>
+    (data as { applicantName?: string } | undefined)?.applicantName ?? null,
+};
+
 // Read-only view of one (applicant, domain) submission with a selectable
 // reviewer-review viewer. Reachable from the Applications database list.
 //

--- a/dali-api/app/lib/__tests__/tasks.test.ts
+++ b/dali-api/app/lib/__tests__/tasks.test.ts
@@ -3,7 +3,13 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 vi.mock("~/lib/db");
 
 import { prisma } from "~/lib/db";
-import { listOpenTasks, countOpenTasks } from "~/lib/tasks";
+import {
+  listOpenTasks,
+  countOpenTasks,
+  resolveNotificationState,
+  listNotificationHistory,
+  type NotifLiveness,
+} from "~/lib/tasks";
 
 const mockPrisma = prisma as unknown as {
   notification: {
@@ -11,6 +17,19 @@ const mockPrisma = prisma as unknown as {
     count: ReturnType<typeof vi.fn>;
   };
 };
+
+// Minimal liveness row; override per-case.
+function liveness(over: Partial<NotifLiveness> = {}): NotifLiveness {
+  return {
+    readAt: null,
+    dueAt: null,
+    formId: null,
+    scheduledMeetingId: null,
+    scheduledMeeting: null,
+    interviewAssignment: null,
+    ...over,
+  };
+}
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -78,5 +97,166 @@ describe("countOpenTasks", () => {
     expect(mockPrisma.notification.count).toHaveBeenCalledWith({
       where: expectedWhere("user-1"),
     });
+  });
+});
+
+describe("resolveNotificationState", () => {
+  const now = new Date("2026-06-01T12:00:00Z");
+
+  it("unread plain → Open", () => {
+    expect(resolveNotificationState(liveness(), now)).toBe("Open");
+  });
+
+  it("read plain → Cleared", () => {
+    expect(resolveNotificationState(liveness({ readAt: now }), now)).toBe(
+      "Cleared",
+    );
+  });
+
+  it("read with formId → Submitted", () => {
+    expect(
+      resolveNotificationState(liveness({ readAt: now, formId: "f1" }), now),
+    ).toBe("Submitted");
+  });
+
+  it("unread with a Cancelled linked meeting → Cancelled", () => {
+    expect(
+      resolveNotificationState(
+        liveness({
+          scheduledMeetingId: "m1",
+          scheduledMeeting: { status: "Cancelled" },
+        }),
+        now,
+      ),
+    ).toBe("Cancelled");
+  });
+
+  it("unread with a non-Active interview assignment → Cancelled", () => {
+    expect(
+      resolveNotificationState(
+        liveness({
+          interviewAssignment: {
+            status: "Declined",
+            interview: { status: "Scheduled" },
+          },
+        }),
+        now,
+      ),
+    ).toBe("Cancelled");
+  });
+
+  it("unread past dueAt → Expired", () => {
+    expect(
+      resolveNotificationState(
+        liveness({ dueAt: new Date("2026-05-01T00:00:00Z") }),
+        now,
+      ),
+    ).toBe("Expired");
+  });
+
+  it("Cancelled wins over a set readAt", () => {
+    expect(
+      resolveNotificationState(
+        liveness({
+          readAt: now,
+          scheduledMeetingId: "m1",
+          scheduledMeeting: { status: "Cancelled" },
+        }),
+        now,
+      ),
+    ).toBe("Cancelled");
+  });
+});
+
+describe("listNotificationHistory", () => {
+  function row(over: Record<string, unknown> = {}) {
+    return {
+      id: "n1",
+      kind: "General",
+      title: "Hello",
+      body: "World",
+      link: "/somewhere",
+      dueAt: null,
+      readAt: null,
+      createdAt: new Date("2026-05-20T10:00:00Z"),
+      formId: null,
+      scheduledMeetingId: null,
+      createdBy: { id: "u9", firstName: "Ada", lastName: "Lovelace" },
+      form: null,
+      scheduledMeeting: null,
+      interviewAssignment: null,
+      ...over,
+    };
+  }
+
+  it("returns items with derived state, sender, and counts", async () => {
+    mockPrisma.notification.findMany.mockResolvedValue([row()]);
+    mockPrisma.notification.count
+      .mockResolvedValueOnce(3) // open
+      .mockResolvedValueOnce(7); // cleared
+
+    const res = await listNotificationHistory("user-1");
+    expect(res.counts).toEqual({ open: 3, cleared: 7 });
+    expect(res.items[0]).toMatchObject({
+      id: "n1",
+      sender: "Ada Lovelace",
+      state: "Open",
+      clearedAt: null,
+    });
+    expect(res.nextCursor).toBeNull();
+  });
+
+  it("status=cleared filters on readAt not null", async () => {
+    mockPrisma.notification.findMany.mockResolvedValue([]);
+    await listNotificationHistory("user-1", { status: "cleared" });
+    const call = mockPrisma.notification.findMany.mock.calls[0][0];
+    expect(call.where.AND).toContainEqual({ NOT: { readAt: null } });
+  });
+
+  it("kind + q compose into the base where", async () => {
+    mockPrisma.notification.findMany.mockResolvedValue([]);
+    await listNotificationHistory("user-1", { kind: "General", q: "budget" });
+    const call = mockPrisma.notification.findMany.mock.calls[0][0];
+    const base = call.where.AND[0];
+    expect(base.kind).toBe("General");
+    expect(base.OR).toEqual([
+      { title: { contains: "budget", mode: "insensitive" } },
+      { body: { contains: "budget", mode: "insensitive" } },
+    ]);
+  });
+
+  it("clamps limit to 50 and overfetches by one", async () => {
+    mockPrisma.notification.findMany.mockResolvedValue([]);
+    await listNotificationHistory("user-1", { limit: 999 });
+    const call = mockPrisma.notification.findMany.mock.calls[0][0];
+    expect(call.take).toBe(51);
+  });
+
+  it("emits a nextCursor when more rows exist than the limit", async () => {
+    // limit 1 → overfetch 2; two rows means hasMore.
+    mockPrisma.notification.findMany.mockResolvedValue([
+      row({ id: "a", createdAt: new Date("2026-05-20T10:00:00Z") }),
+      row({ id: "b", createdAt: new Date("2026-05-19T10:00:00Z") }),
+    ]);
+    const res = await listNotificationHistory("user-1", { limit: 1 });
+    expect(res.items).toHaveLength(1);
+    expect(res.items[0].id).toBe("a");
+    expect(res.nextCursor).toEqual({
+      createdAt: "2026-05-20T10:00:00.000Z",
+      id: "a",
+    });
+  });
+
+  it("links a Submitted form row to its fill page", async () => {
+    mockPrisma.notification.findMany.mockResolvedValue([
+      row({
+        readAt: new Date("2026-05-21T10:00:00Z"),
+        formId: "f1",
+        form: { published: true, publicToken: "tok123" },
+      }),
+    ]);
+    const res = await listNotificationHistory("user-1");
+    expect(res.items[0].state).toBe("Submitted");
+    expect(res.items[0].link).toBe("/forms/fill/tok123");
   });
 });

--- a/dali-api/app/lib/tasks.ts
+++ b/dali-api/app/lib/tasks.ts
@@ -3,6 +3,7 @@ import { prisma } from "~/lib/db";
 import { getActiveCycle } from "~/hiring/lib/cycles";
 import { isInternToFullEligible } from "~/hiring/lib/intern-eligibility";
 import { ONBOARDING_LINK } from "~/members/lib/welcome.server";
+import { fullName } from "~/lib/display";
 
 // A "task" (todo) is any unread notification — every NotificationKind counts.
 // The Tasks sidebar, Home attention banner, and sidebar count all read this
@@ -46,6 +47,56 @@ export type Task = {
   // user is done, so the UI offers a "Confirm" button that marks it read.
   hasAction: boolean;
 };
+
+// Server-derived display state for a single notification row. Mirrors the
+// liveness rules that gate Tasks (see resolveNotificationState).
+export type NotificationState =
+  | "Open" // unread, still actionable
+  | "Submitted" // self-clearing form task that was completed (readAt set via submit)
+  | "Cleared" // read normally (mark-read / mark-all / RSVP)
+  | "Cancelled" // linked meeting Cancelled or interview assignment no longer Active
+  | "Expired"; // had a dueAt that has passed while still unread
+
+// The liveness facts resolveNotificationState needs from one fetched row.
+// Mirror this `select` in every caller so the resolver has what it needs.
+export type NotifLiveness = {
+  readAt: Date | null;
+  dueAt: Date | null;
+  formId: string | null;
+  scheduledMeetingId: string | null;
+  scheduledMeeting: { status: string } | null;
+  interviewAssignment: { status: string; interview: { status: string } } | null;
+};
+
+// Single source of truth for "what state is this notification in", shared by
+// the tasks loader and the history view. Mirrors the liveness rules that were
+// inline in TASK_WHERE (the Cancelled-meeting and inactive interview-assignment
+// branches) so the two surfaces never disagree.
+//
+// TASK_WHERE *hides* the Cancelled/inactive rows from live surfaces; History
+// keeps them and renders this state as an annotation instead.
+export function resolveNotificationState(
+  n: NotifLiveness,
+  now = new Date(),
+): NotificationState {
+  const meetingDead =
+    !!n.scheduledMeetingId && n.scheduledMeeting?.status === "Cancelled";
+  const assignmentDead =
+    n.interviewAssignment != null &&
+    (n.interviewAssignment.status !== "Active" ||
+      n.interviewAssignment.interview.status !== "Scheduled");
+  if (meetingDead || assignmentDead) return "Cancelled";
+
+  if (n.readAt) {
+    // A completed self-clearing form task reads as "Submitted", not "Cleared",
+    // and links to its submission rather than re-opening the form.
+    if (n.formId) return "Submitted";
+    return "Cleared";
+  }
+
+  if (n.dueAt && n.dueAt.getTime() < now.getTime()) return "Expired";
+  return "Open";
+}
 
 const TASK_WHERE = (userId: string): Prisma.NotificationWhereInput => ({
   recipientUserId: userId,
@@ -137,8 +188,13 @@ export async function listOpenTasks(userId: string): Promise<Task[]> {
         link: true,
         dueAt: true,
         createdAt: true,
+        readAt: true,
+        formId: true,
         scheduledMeetingId: true,
-        scheduledMeeting: { select: { selectedAt: true } },
+        scheduledMeeting: { select: { selectedAt: true, status: true } },
+        interviewAssignment: {
+          select: { status: true, interview: { select: { status: true } } },
+        },
         // Attached published form, if any — link the recipient straight to it.
         form: { select: { published: true, publicToken: true } },
       },
@@ -146,7 +202,24 @@ export async function listOpenTasks(userId: string): Promise<Task[]> {
     getFellowshipTask(userId),
   ]);
 
-  const notifTasks = rows.map((n) => {
+  const notifTasks = rows
+    // TASK_WHERE already excludes Cancelled-meeting / inactive-assignment rows
+    // at the DB level; running them back through the shared resolver keeps the
+    // "is this still a live task" definition in one place (no behavior change —
+    // Expired/Open both remain tasks; only Cancelled is dropped, which the
+    // WHERE already prevents).
+    .filter(
+      (n) =>
+        resolveNotificationState({
+          readAt: n.readAt,
+          dueAt: n.dueAt,
+          formId: n.formId,
+          scheduledMeetingId: n.scheduledMeetingId,
+          scheduledMeeting: n.scheduledMeeting,
+          interviewAssignment: n.interviewAssignment,
+        }) !== "Cancelled",
+    )
+    .map((n) => {
     const source: Task["source"] =
       n.kind === "MeetingInvite"
         ? "meeting"
@@ -189,4 +262,142 @@ export async function listOpenTasks(userId: string): Promise<Task[]> {
   });
 
   return fellowship ? [fellowship, ...notifTasks] : notifTasks;
+}
+
+export interface NotificationHistoryOptions {
+  status?: "open" | "cleared" | "all"; // default "all"
+  kind?: string; // NotificationKind filter
+  q?: string; // title/body contains (case-insensitive)
+  cursor?: { createdAt: string; id: string } | null; // keyset on (createdAt,id)
+  limit?: number; // default 30, max 50
+}
+
+export type NotificationHistoryItem = {
+  id: string;
+  kind: string;
+  title: string;
+  body: string | null;
+  sender: string | null;
+  state: NotificationState;
+  sentAt: string;
+  clearedAt: string | null;
+  link: string | null;
+};
+
+export interface NotificationHistoryResult {
+  items: NotificationHistoryItem[];
+  nextCursor: { createdAt: string; id: string } | null;
+  counts: { open: number; cleared: number };
+}
+
+const HISTORY_SELECT = {
+  id: true,
+  kind: true,
+  title: true,
+  body: true,
+  link: true,
+  dueAt: true,
+  readAt: true,
+  createdAt: true,
+  formId: true,
+  scheduledMeetingId: true,
+  createdBy: { select: { id: true, firstName: true, lastName: true } },
+  form: { select: { published: true, publicToken: true } },
+  scheduledMeeting: { select: { status: true } },
+  interviewAssignment: {
+    select: { status: true, interview: { select: { status: true } } },
+  },
+} satisfies Prisma.NotificationSelect;
+
+/**
+ * Browsable notification/task history for a user. Unlike listOpenTasks /
+ * listMyNotifications this applies NONE of the live-surface hides — stale
+ * Cancelled-meeting and inactive interview-assignment rows are returned and
+ * annotated via resolveNotificationState so the user can see they existed.
+ *
+ * Keyset pagination on (createdAt desc, id desc) rides the existing
+ * [recipientUserId, createdAt] index. `counts` are the open/cleared totals for
+ * the (kind/q-filtered) result set, independent of the status bucket shown.
+ */
+export async function listNotificationHistory(
+  userId: string,
+  opts: NotificationHistoryOptions = {},
+): Promise<NotificationHistoryResult> {
+  const limit = Math.max(1, Math.min(opts.limit ?? 30, 50));
+  const status = opts.status ?? "all";
+
+  const base: Prisma.NotificationWhereInput = { recipientUserId: userId };
+  if (opts.kind) base.kind = opts.kind as Prisma.NotificationWhereInput["kind"];
+  if (opts.q) {
+    base.OR = [
+      { title: { contains: opts.q, mode: "insensitive" } },
+      { body: { contains: opts.q, mode: "insensitive" } },
+    ];
+  }
+
+  // status maps onto readAt only; Cancelled/Expired are derived for display,
+  // not stored, so they fall under whichever readAt bucket they live in.
+  const statusWhere: Prisma.NotificationWhereInput =
+    status === "open"
+      ? { readAt: null }
+      : status === "cleared"
+        ? { NOT: { readAt: null } }
+        : {};
+
+  // Keyset pagination on (createdAt, id).
+  const cursorWhere: Prisma.NotificationWhereInput = opts.cursor
+    ? {
+        OR: [
+          { createdAt: { lt: new Date(opts.cursor.createdAt) } },
+          {
+            createdAt: new Date(opts.cursor.createdAt),
+            id: { lt: opts.cursor.id },
+          },
+        ],
+      }
+    : {};
+
+  const where: Prisma.NotificationWhereInput = {
+    AND: [base, statusWhere, cursorWhere],
+  };
+
+  const [rows, open, cleared] = await Promise.all([
+    prisma.notification.findMany({
+      where,
+      orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+      take: limit + 1, // overfetch one to detect nextCursor
+      select: HISTORY_SELECT,
+    }),
+    prisma.notification.count({ where: { AND: [base, { readAt: null }] } }),
+    prisma.notification.count({
+      where: { AND: [base, { NOT: { readAt: null } }] },
+    }),
+  ]);
+
+  const hasMore = rows.length > limit;
+  const page = hasMore ? rows.slice(0, limit) : rows;
+  const items: NotificationHistoryItem[] = page.map((n) => ({
+    id: n.id,
+    kind: n.kind,
+    title: n.title,
+    body: n.body,
+    sender: n.createdBy ? fullName(n.createdBy) || null : null,
+    state: resolveNotificationState(n),
+    sentAt: n.createdAt.toISOString(),
+    clearedAt: n.readAt ? n.readAt.toISOString() : null,
+    // Submitted form tasks link to the submission; everything else re-opens its
+    // own link. Mirrors how listOpenTasks resolves the authed fill route.
+    link:
+      n.formId && n.form?.published && n.form.publicToken
+        ? `/forms/fill/${n.form.publicToken}`
+        : n.link,
+  }));
+
+  const last = page.at(-1);
+  const nextCursor =
+    hasMore && last
+      ? { createdAt: last.createdAt.toISOString(), id: last.id }
+      : null;
+
+  return { items, nextCursor, counts: { open, cleared } };
 }

--- a/dali-api/app/members/routes/members.tsx
+++ b/dali-api/app/members/routes/members.tsx
@@ -24,7 +24,7 @@ import { TermFilter } from "~/components/TermFilter";
 import { resolveTermFilter } from "~/lib/terms";
 import { deriveCoreTitles } from "~/lib/core-titles";
 
-export const meta: Route.MetaFunction = () => [{ title: "Members · DALI OS" }];
+export const meta: Route.MetaFunction = () => [{ title: "Directory · People · DALI OS" }];
 
 type MemberRow = {
   id: string;
@@ -254,7 +254,7 @@ export default function MembersList() {
       <header className="flex items-start justify-between gap-3 flex-wrap">
         <div>
           <h1 className="font-heading text-2xl font-bold text-foreground">
-            Members
+            Directory
           </h1>
           <p className="text-sm text-muted-foreground mt-1">
             Everyone with a DALI membership row.

--- a/dali-api/app/routes.ts
+++ b/dali-api/app/routes.ts
@@ -7,6 +7,8 @@ export default [
     route("profile", "routes/profile.tsx"),
     route("onboarding", "routes/onboarding.tsx"),
     route("calendar", "calendar/routes/calendar.tsx"),
+    // My Tasks surface: Open tasks + browsable notification history.
+    route("notifications", "routes/notifications.tsx"),
 
     // Hiring section
     route("hiring/reviewer", "hiring/routes/reviewer.tsx"),

--- a/dali-api/app/routes/__tests__/api.notifications.$id.read.test.ts
+++ b/dali-api/app/routes/__tests__/api.notifications.$id.read.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("~/lib/auth", () => ({
+  requireAuth: vi.fn(),
+  forbidden: vi.fn(
+    () => new Response(JSON.stringify({ error: "Forbidden" }), { status: 403 }),
+  ),
+}));
+vi.mock("~/lib/db");
+vi.mock("~/members/lib/welcome.server", () => ({
+  ONBOARDING_LINK: "/onboarding",
+}));
+
+import { requireAuth } from "~/lib/auth";
+import { prisma } from "~/lib/db";
+import { action } from "~/routes/api.notifications.$id.read";
+
+const USER_ID = "user-1";
+
+const mockPrisma = prisma as unknown as {
+  notification: {
+    findUnique: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+  };
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(requireAuth).mockResolvedValue({
+    ok: true,
+    user: { sub: USER_ID, email: "u@x.com", type: "user" },
+  } as any);
+  (mockPrisma as any).notification = {
+    findUnique: vi.fn(),
+    update: vi.fn().mockResolvedValue({}),
+  };
+});
+
+function unreadReq(id: string) {
+  return new Request(`http://localhost/api/notifications/${id}/read`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ intent: "unread" }),
+  });
+}
+
+describe("POST /api/notifications/:id/read intent=unread", () => {
+  it("flips readAt back to null for an owned, cleared row", async () => {
+    mockPrisma.notification.findUnique.mockResolvedValue({
+      recipientUserId: USER_ID,
+      readAt: new Date(),
+      scheduledMeetingId: null,
+      kind: "General",
+      link: "/x",
+    });
+    const res = await action({
+      request: unreadReq("n1"),
+      params: { id: "n1" },
+    } as any);
+    expect(res.status).toBe(200);
+    expect(mockPrisma.notification.update).toHaveBeenCalledWith({
+      where: { id: "n1" },
+      data: { readAt: null },
+    });
+  });
+
+  it("enforces ownership", async () => {
+    mockPrisma.notification.findUnique.mockResolvedValue({
+      recipientUserId: "someone-else",
+      readAt: new Date(),
+      scheduledMeetingId: null,
+      kind: "General",
+      link: "/x",
+    });
+    const res = await action({
+      request: unreadReq("n1"),
+      params: { id: "n1" },
+    } as any);
+    expect(res.status).toBe(403);
+    expect(mockPrisma.notification.update).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op echo for a meeting invite", async () => {
+    mockPrisma.notification.findUnique.mockResolvedValue({
+      recipientUserId: USER_ID,
+      readAt: new Date(),
+      scheduledMeetingId: "m1",
+      kind: "MeetingInvite",
+      link: null,
+    });
+    const res = await action({
+      request: unreadReq("n1"),
+      params: { id: "n1" },
+    } as any);
+    const json = await res.json();
+    expect(json).toMatchObject({ ok: true, skipped: "meeting-invite" });
+    expect(mockPrisma.notification.update).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op echo for the onboarding task", async () => {
+    mockPrisma.notification.findUnique.mockResolvedValue({
+      recipientUserId: USER_ID,
+      readAt: new Date(),
+      scheduledMeetingId: null,
+      kind: "SystemAnnouncement",
+      link: "/onboarding",
+    });
+    const res = await action({
+      request: unreadReq("n1"),
+      params: { id: "n1" },
+    } as any);
+    const json = await res.json();
+    expect(json).toMatchObject({ ok: true, skipped: "onboarding" });
+    expect(mockPrisma.notification.update).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op when the row is already unread", async () => {
+    mockPrisma.notification.findUnique.mockResolvedValue({
+      recipientUserId: USER_ID,
+      readAt: null,
+      scheduledMeetingId: null,
+      kind: "General",
+      link: "/x",
+    });
+    const res = await action({
+      request: unreadReq("n1"),
+      params: { id: "n1" },
+    } as any);
+    expect(res.status).toBe(200);
+    expect(mockPrisma.notification.update).not.toHaveBeenCalled();
+  });
+});

--- a/dali-api/app/routes/__tests__/api.notifications.test.ts
+++ b/dali-api/app/routes/__tests__/api.notifications.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("~/lib/auth", () => ({
+  requireAuth: vi.fn(),
+}));
+vi.mock("~/lib/db");
+vi.mock("~/lib/tasks", () => ({
+  listOpenTasks: vi.fn(),
+  listNotificationHistory: vi.fn(),
+}));
+vi.mock("~/lib/notifications", () => ({
+  listMyNotifications: vi.fn(),
+}));
+
+import { requireAuth } from "~/lib/auth";
+import { listOpenTasks, listNotificationHistory } from "~/lib/tasks";
+import { listMyNotifications } from "~/lib/notifications";
+import { loader } from "~/routes/api.notifications";
+
+const USER_ID = "user-1";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(requireAuth).mockResolvedValue({
+    ok: true,
+    user: { sub: USER_ID, email: "u@x.com", type: "user" },
+  } as any);
+  vi.mocked(listMyNotifications).mockResolvedValue({
+    items: [{ id: "i1" }],
+    unreadCount: 2,
+  } as any);
+  vi.mocked(listOpenTasks).mockResolvedValue([
+    { id: "t1", title: "Do it", link: "/x" },
+  ] as any);
+  vi.mocked(listNotificationHistory).mockResolvedValue({
+    items: [{ id: "h1" }],
+    nextCursor: null,
+    counts: { open: 1, cleared: 4 },
+  } as any);
+});
+
+function req(query = "") {
+  return new Request(`http://localhost/api/notifications${query}`);
+}
+
+describe("GET /api/notifications", () => {
+  it("returns the legacy payload when no history params are present", async () => {
+    const res = await loader({ request: req() } as any);
+    const json = await res.json();
+    expect(json).toEqual({
+      items: [{ id: "i1" }],
+      unreadCount: 2,
+      taskCount: 1,
+      tasks: [{ id: "t1", title: "Do it", link: "/x" }],
+    });
+    expect(listNotificationHistory).not.toHaveBeenCalled();
+  });
+
+  it("returns the history payload when a history param is present", async () => {
+    const res = await loader({ request: req("?status=cleared") } as any);
+    const json = await res.json();
+    expect(json).toEqual({
+      items: [{ id: "h1" }],
+      nextCursor: null,
+      counts: { open: 1, cleared: 4 },
+    });
+    expect(listNotificationHistory).toHaveBeenCalledWith(
+      USER_ID,
+      expect.objectContaining({ status: "cleared" }),
+    );
+    expect(listOpenTasks).not.toHaveBeenCalled();
+  });
+
+  it("parses a JSON cursor param", async () => {
+    const cursor = JSON.stringify({ createdAt: "2026-05-20T10:00:00.000Z", id: "a" });
+    await loader({
+      request: req(`?cursor=${encodeURIComponent(cursor)}`),
+    } as any);
+    expect(listNotificationHistory).toHaveBeenCalledWith(
+      USER_ID,
+      expect.objectContaining({
+        cursor: { createdAt: "2026-05-20T10:00:00.000Z", id: "a" },
+      }),
+    );
+  });
+
+  it("falls back to first page on a malformed cursor", async () => {
+    await loader({ request: req("?cursor=not-json") } as any);
+    expect(listNotificationHistory).toHaveBeenCalledWith(
+      USER_ID,
+      expect.objectContaining({ cursor: null }),
+    );
+  });
+});

--- a/dali-api/app/routes/api.notifications.$id.read.ts
+++ b/dali-api/app/routes/api.notifications.$id.read.ts
@@ -15,6 +15,27 @@ export async function action({ request, params }: Route.ActionArgs) {
     return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));
   }
 
+  // `intent=unread` re-opens a cleared notification (History "Mark unread").
+  // Read both form-encoded and JSON bodies so the History page can post either.
+  let intent: string | null = null;
+  const contentType = request.headers.get("content-type") ?? "";
+  if (contentType.includes("application/json")) {
+    try {
+      const json = (await request.clone().json()) as { intent?: unknown };
+      if (typeof json.intent === "string") intent = json.intent;
+    } catch {
+      // ignore — treat as a plain read
+    }
+  } else {
+    try {
+      const form = await request.clone().formData();
+      const v = form.get("intent");
+      if (typeof v === "string") intent = v;
+    } catch {
+      // ignore — treat as a plain read
+    }
+  }
+
   const id = params.id!;
   const existing = await prisma.notification.findUnique({
     where: { id },
@@ -31,6 +52,27 @@ export async function action({ request, params }: Route.ActionArgs) {
   }
   if (existing.recipientUserId !== auth.user.sub) {
     return forbidden(request);
+  }
+
+  // Re-open path: flip readAt back to null so the row returns to Open in
+  // History + the Tasks list. Self-clearing rows (meeting invites / onboarding)
+  // own their own read state, so re-opening them is a no-op echo — mirrors the
+  // skips below for the read path.
+  if (intent === "unread") {
+    if (existing.scheduledMeetingId) {
+      return withCors(request, Response.json({ ok: true, skipped: "meeting-invite" }));
+    }
+    if (existing.kind === "SystemAnnouncement" && existing.link === ONBOARDING_LINK) {
+      return withCors(request, Response.json({ ok: true, skipped: "onboarding" }));
+    }
+    if (!existing.readAt) {
+      return withCors(request, Response.json({ ok: true }));
+    }
+    await prisma.notification.update({
+      where: { id },
+      data: { readAt: null },
+    });
+    return withCors(request, Response.json({ ok: true }));
   }
 
   // A meeting invite only clears once the recipient RSVPs (via the rsvp

--- a/dali-api/app/routes/api.notifications.ts
+++ b/dali-api/app/routes/api.notifications.ts
@@ -2,9 +2,14 @@ import type { Route } from "./+types/api.notifications";
 import { prisma } from "~/lib/db";
 import { requireAuth } from "~/lib/auth";
 import { withCors, handlePreflight } from "~/lib/cors";
-import { listOpenTasks } from "~/lib/tasks";
+import { listOpenTasks, listNotificationHistory } from "~/lib/tasks";
 import { listMyNotifications } from "~/lib/notifications";
 import { ONBOARDING_LINK } from "~/members/lib/welcome.server";
+
+// Query params that switch the loader into history mode. Their presence (not
+// their value) flips the payload, so the legacy poller — which sends none — is
+// untouched.
+const HISTORY_PARAMS = ["status", "kind", "q", "cursor", "limit"] as const;
 
 export async function loader({ request }: Route.LoaderArgs) {
   const preflight = handlePreflight(request);
@@ -14,6 +19,45 @@ export async function loader({ request }: Route.LoaderArgs) {
   if (!auth.ok) return withCors(request, auth.response);
 
   const userId = auth.user.sub;
+
+  // History mode: any history param present → return the browsable history
+  // payload { items, nextCursor, counts }. Additive and back-compatible.
+  const url = new URL(request.url);
+  const isHistory = HISTORY_PARAMS.some((p) => url.searchParams.has(p));
+  if (isHistory) {
+    const statusRaw = url.searchParams.get("status");
+    const status =
+      statusRaw === "open" || statusRaw === "cleared" || statusRaw === "all"
+        ? statusRaw
+        : "all";
+    const cursorRaw = url.searchParams.get("cursor");
+    let cursor: { createdAt: string; id: string } | null = null;
+    if (cursorRaw) {
+      try {
+        const parsed = JSON.parse(cursorRaw);
+        if (
+          parsed &&
+          typeof parsed.createdAt === "string" &&
+          typeof parsed.id === "string"
+        ) {
+          cursor = { createdAt: parsed.createdAt, id: parsed.id };
+        }
+      } catch {
+        // Malformed cursor → treat as first page.
+      }
+    }
+    const limitRaw = Number(url.searchParams.get("limit"));
+    const result = await listNotificationHistory(userId, {
+      status,
+      kind: url.searchParams.get("kind") ?? undefined,
+      q: url.searchParams.get("q") ?? undefined,
+      limit: Number.isFinite(limitRaw) && limitRaw > 0 ? limitRaw : undefined,
+      cursor,
+    });
+    return withCors(request, Response.json(result));
+  }
+
+  // Legacy payload (unchanged): the bell poller reads taskCount/tasks.
   // dev (#…) refactored notification fetching into listMyNotifications();
   // keep that helper and layer the open-tasks payload on top so the bell
   // still shows tasks (Tasks-nav feature).

--- a/dali-api/app/routes/layout.tsx
+++ b/dali-api/app/routes/layout.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { Outlet, redirect, useLoaderData, useLocation, useNavigate, useSearchParams } from 'react-router'
 import { Layout } from '~/components/Layout'
+import { Breadcrumbs } from '~/components/Breadcrumbs'
 import { LaunchWelcome } from '~/components/LaunchWelcome'
 import { requireAuth } from "~/lib/auth";
 import { getUserRoles } from '~/lib/roles'
@@ -221,11 +222,17 @@ export default function AppLayoutRoute() {
     };
   }, [location.key]);
 
-  // Skip the sidebar shell when rendered inside a TabWorkspace iframe.
+  // Skip the sidebar shell when rendered inside a TabWorkspace iframe. This is
+  // where every routed page actually renders, so the breadcrumb trail (derived
+  // from the iframe document's matched routes) lives here — it picks up each
+  // detail route's `handle.breadcrumb` for the dynamic leaf crumb.
   if (embedded) {
     return (
       <div className="min-h-dvh bg-page overflow-x-hidden">
         <div className="w-full px-3 sm:px-6 lg:px-10 pt-4 sm:pt-8 md:pt-12 pb-6 sm:pb-8">
+          <div className="mb-4 empty:mb-0">
+            <Breadcrumbs />
+          </div>
           <Outlet />
         </div>
       </div>

--- a/dali-api/app/routes/notifications.tsx
+++ b/dali-api/app/routes/notifications.tsx
@@ -1,0 +1,419 @@
+import { useEffect, useMemo, useState } from "react";
+import { redirect, useLoaderData, useSearchParams } from "react-router";
+import {
+  ListTodo,
+  History as HistoryIcon,
+  Search,
+  ExternalLink,
+  RotateCcw,
+} from "lucide-react";
+import { requireAuth } from "~/lib/auth";
+import {
+  listOpenTasks,
+  listNotificationHistory,
+  type Task,
+  type NotificationHistoryItem,
+  type NotificationHistoryResult,
+  type NotificationState,
+} from "~/lib/tasks";
+import { requestOpenTabIfEmbedded } from "~/components/workspace-link";
+import type { Route } from "./+types/notifications";
+
+export const meta: Route.MetaFunction = () => [
+  { title: "My Tasks · DALI OS" },
+];
+
+export const handle = {
+  breadcrumb: () => "My Tasks",
+};
+
+// Tab is driven by ?tab=open|history (default open). The History tab fetches
+// incrementally from /api/notifications with the additive history params.
+export async function loader({ request }: Route.LoaderArgs) {
+  const auth = await requireAuth(request);
+  if (!auth.ok) return redirect("/login");
+  if (auth.user.type === "applicant") return redirect("/portal");
+
+  const url = new URL(request.url);
+  const tab = url.searchParams.get("tab") === "history" ? "history" : "open";
+
+  if (tab === "history") {
+    const status =
+      (url.searchParams.get("status") as "open" | "cleared" | "all") ?? "all";
+    const history = await listNotificationHistory(auth.user.sub, {
+      status:
+        status === "open" || status === "cleared" || status === "all"
+          ? status
+          : "all",
+    });
+    return { tab, tasks: [] as Task[], history };
+  }
+
+  const tasks = await listOpenTasks(auth.user.sub);
+  return { tab, tasks, history: null as NotificationHistoryResult | null };
+}
+
+const STATE_STYLES: Record<NotificationState, string> = {
+  Open: "bg-accent-coral/15 text-accent-coral",
+  Submitted: "bg-emerald-500/15 text-emerald-600",
+  Cleared: "bg-muted text-muted-foreground",
+  Cancelled: "bg-amber-500/15 text-amber-600",
+  Expired: "bg-zinc-500/15 text-zinc-500",
+};
+
+function StateBadge({ state }: { state: NotificationState }) {
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-semibold ${STATE_STYLES[state]}`}
+    >
+      {state}
+    </span>
+  );
+}
+
+// Group history rows into Today / Yesterday / <date> buckets, preserving the
+// newest-first order the server returns.
+function dayLabel(iso: string): string {
+  const d = new Date(iso);
+  const now = new Date();
+  const startOf = (x: Date) =>
+    new Date(x.getFullYear(), x.getMonth(), x.getDate()).getTime();
+  const diffDays = Math.round((startOf(now) - startOf(d)) / 86_400_000);
+  if (diffDays === 0) return "Today";
+  if (diffDays === 1) return "Yesterday";
+  return d.toLocaleDateString(undefined, {
+    month: "long",
+    day: "numeric",
+    year: now.getFullYear() === d.getFullYear() ? undefined : "numeric",
+  });
+}
+
+function timeLabel(iso: string): string {
+  return new Date(iso).toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+function openLink(link: string, label: string) {
+  if (!requestOpenTabIfEmbedded(link, label)) {
+    window.location.assign(link);
+  }
+}
+
+function OpenTab({ tasks }: { tasks: Task[] }) {
+  if (tasks.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground py-8 text-center">
+        You're all caught up — no open tasks.
+      </p>
+    );
+  }
+  return (
+    <ul className="flex flex-col gap-2">
+      {tasks.map((t) => (
+        <li
+          key={t.id}
+          className="flex items-start gap-3 rounded-lg border border-border bg-card px-4 py-3"
+        >
+          <ListTodo className="w-4 h-4 mt-0.5 text-accent-coral flex-shrink-0" />
+          <div className="min-w-0 flex-1">
+            <p className="text-sm font-medium text-foreground truncate">
+              {t.title}
+            </p>
+            {t.body && (
+              <p className="text-xs text-muted-foreground mt-0.5 line-clamp-2">
+                {t.body}
+              </p>
+            )}
+          </div>
+          {t.link && (
+            <button
+              type="button"
+              onClick={() => openLink(t.link!, t.title)}
+              className="flex items-center gap-1 text-xs font-medium text-accent-coral hover:underline flex-shrink-0"
+            >
+              Open <ExternalLink className="w-3 h-3" />
+            </button>
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function HistoryTab({
+  initial,
+  initialStatus,
+}: {
+  initial: NotificationHistoryResult;
+  initialStatus: "open" | "cleared" | "all";
+}) {
+  const [status, setStatus] = useState<"open" | "cleared" | "all">(
+    initialStatus,
+  );
+  const [q, setQ] = useState("");
+  const [debouncedQ, setDebouncedQ] = useState("");
+  const [items, setItems] = useState<NotificationHistoryItem[]>(initial.items);
+  const [cursor, setCursor] = useState(initial.nextCursor);
+  const [counts, setCounts] = useState(initial.counts);
+  const [loading, setLoading] = useState(false);
+
+  // Debounce the search box so typing doesn't fire a request per keystroke.
+  useEffect(() => {
+    const id = window.setTimeout(() => setDebouncedQ(q.trim()), 300);
+    return () => window.clearTimeout(id);
+  }, [q]);
+
+  // (Re)load the first page whenever a filter changes.
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    const params = new URLSearchParams({ status });
+    if (debouncedQ) params.set("q", debouncedQ);
+    fetch(`/api/notifications?${params.toString()}`, {
+      credentials: "include",
+    })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data: NotificationHistoryResult | null) => {
+        if (cancelled || !data) return;
+        setItems(data.items);
+        setCursor(data.nextCursor);
+        setCounts(data.counts);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [status, debouncedQ]);
+
+  async function loadMore() {
+    if (!cursor || loading) return;
+    setLoading(true);
+    const params = new URLSearchParams({
+      status,
+      cursor: JSON.stringify(cursor),
+    });
+    if (debouncedQ) params.set("q", debouncedQ);
+    try {
+      const r = await fetch(`/api/notifications?${params.toString()}`, {
+        credentials: "include",
+      });
+      if (!r.ok) return;
+      const data = (await r.json()) as NotificationHistoryResult;
+      setItems((prev) => [...prev, ...data.items]);
+      setCursor(data.nextCursor);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function markUnread(id: string) {
+    const r = await fetch(`/api/notifications/${id}/read`, {
+      method: "POST",
+      credentials: "include",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ intent: "unread" }),
+    });
+    if (!r.ok) return;
+    // Reflect the flip locally: move the row's state to Open and bump counts.
+    setItems((prev) =>
+      prev
+        .map((n) =>
+          n.id === id ? { ...n, state: "Open" as const, clearedAt: null } : n,
+        )
+        // If we're viewing only cleared rows, a re-opened row no longer belongs.
+        .filter((n) => (status === "cleared" ? n.id !== id : true)),
+    );
+    setCounts((c) => ({ open: c.open + 1, cleared: Math.max(0, c.cleared - 1) }));
+  }
+
+  // Group rows by calendar day, keeping server order.
+  const groups = useMemo(() => {
+    const out: { label: string; rows: NotificationHistoryItem[] }[] = [];
+    for (const item of items) {
+      const label = dayLabel(item.sentAt);
+      const last = out[out.length - 1];
+      if (last && last.label === label) last.rows.push(item);
+      else out.push({ label, rows: [item] });
+    }
+    return out;
+  }, [items]);
+
+  const tabs: { key: "all" | "open" | "cleared"; label: string }[] = [
+    { key: "all", label: "All" },
+    { key: "open", label: `Open (${counts.open})` },
+    { key: "cleared", label: `Cleared (${counts.cleared})` },
+  ];
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="flex items-center gap-1 rounded-lg bg-muted p-0.5">
+          {tabs.map((t) => (
+            <button
+              key={t.key}
+              type="button"
+              onClick={() => setStatus(t.key)}
+              className={`px-3 py-1 text-xs font-medium rounded-md transition-colors ${
+                status === t.key
+                  ? "bg-card text-foreground shadow-sm"
+                  : "text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              {t.label}
+            </button>
+          ))}
+        </div>
+        <div className="relative flex-1 min-w-[180px]">
+          <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground" />
+          <input
+            type="search"
+            value={q}
+            onChange={(e) => setQ(e.target.value)}
+            placeholder="Search notifications…"
+            className="w-full rounded-lg border border-border bg-card pl-8 pr-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-accent-coral/30"
+          />
+        </div>
+      </div>
+
+      {items.length === 0 ? (
+        <p className="text-sm text-muted-foreground py-8 text-center">
+          {loading ? "Loading…" : "No notifications match these filters."}
+        </p>
+      ) : (
+        <div className="flex flex-col gap-5">
+          {groups.map((g) => (
+            <div key={g.label} className="flex flex-col gap-2">
+              <h2 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                {g.label}
+              </h2>
+              <ul className="flex flex-col gap-2">
+                {g.rows.map((n) => (
+                  <li
+                    key={n.id}
+                    className="flex items-start gap-3 rounded-lg border border-border bg-card px-4 py-3"
+                  >
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <p className="text-sm font-medium text-foreground">
+                          {n.title}
+                        </p>
+                        <StateBadge state={n.state} />
+                      </div>
+                      {n.body && (
+                        <p className="text-xs text-muted-foreground mt-0.5 line-clamp-2">
+                          {n.body}
+                        </p>
+                      )}
+                      <p className="text-[11px] text-muted-foreground mt-1">
+                        {n.sender ? `${n.sender} · ` : ""}
+                        sent {timeLabel(n.sentAt)}
+                        {n.clearedAt ? ` · cleared ${timeLabel(n.clearedAt)}` : ""}
+                      </p>
+                    </div>
+                    <div className="flex flex-col items-end gap-1.5 flex-shrink-0">
+                      {n.link && (
+                        <button
+                          type="button"
+                          onClick={() => openLink(n.link!, n.title)}
+                          className="flex items-center gap-1 text-xs font-medium text-accent-coral hover:underline"
+                        >
+                          {n.state === "Submitted" ? "View" : "Open"}{" "}
+                          <ExternalLink className="w-3 h-3" />
+                        </button>
+                      )}
+                      {n.clearedAt && (
+                        <button
+                          type="button"
+                          onClick={() => void markUnread(n.id)}
+                          className="flex items-center gap-1 text-xs font-medium text-muted-foreground hover:text-foreground"
+                        >
+                          <RotateCcw className="w-3 h-3" /> Mark unread
+                        </button>
+                      )}
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+          {cursor && (
+            <button
+              type="button"
+              onClick={() => void loadMore()}
+              disabled={loading}
+              className="self-center rounded-lg border border-border bg-card px-4 py-1.5 text-sm font-medium text-foreground hover:bg-muted disabled:opacity-50"
+            >
+              {loading ? "Loading…" : "Load more"}
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function NotificationsRoute() {
+  const data = useLoaderData<typeof loader>();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const tab = searchParams.get("tab") === "history" ? "history" : "open";
+
+  function switchTab(next: "open" | "history") {
+    const params = new URLSearchParams(searchParams);
+    if (next === "open") params.delete("tab");
+    else params.set("tab", "history");
+    setSearchParams(params);
+  }
+
+  const initialStatus =
+    (searchParams.get("status") as "open" | "cleared" | "all") || "all";
+
+  return (
+    <div className="mx-auto w-full max-w-3xl flex flex-col gap-6">
+      <div>
+        <h1 className="font-heading text-2xl font-bold text-foreground">
+          My Tasks
+        </h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Your open tasks and the full history of everything you've been sent.
+        </p>
+      </div>
+
+      <div className="flex items-center gap-1 border-b border-border">
+        <button
+          type="button"
+          onClick={() => switchTab("open")}
+          className={`flex items-center gap-1.5 px-3 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
+            tab === "open"
+              ? "border-accent-coral text-foreground"
+              : "border-transparent text-muted-foreground hover:text-foreground"
+          }`}
+        >
+          <ListTodo className="w-4 h-4" /> Open
+        </button>
+        <button
+          type="button"
+          onClick={() => switchTab("history")}
+          className={`flex items-center gap-1.5 px-3 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
+            tab === "history"
+              ? "border-accent-coral text-foreground"
+              : "border-transparent text-muted-foreground hover:text-foreground"
+          }`}
+        >
+          <HistoryIcon className="w-4 h-4" /> History
+        </button>
+      </div>
+
+      {tab === "history" && data.history ? (
+        <HistoryTab initial={data.history} initialStatus={initialStatus} />
+      ) : (
+        <OpenTab tasks={data.tasks} />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Implements **PR-07 (IA & navigation)** and **PR-10 (notification & task history)** together. No schema or migration changes.

## PR-07 — IA & navigation (structural only; lab vocabulary kept verbatim)

- **Area renames** in `Layout.tsx` (display `label` only; `AreaKey` values untouched so persisted sidebar/expansion state survives): Members → **People**, Internal Processes → **Lab Processes**, Operations → **Admin**. The task surface is finalized as **My Tasks**.
- **Level Up regrouped** under **Projects → Staffing** (next to Intent to Work / Project Bids). Route `/projects/level-up` is unchanged; the `/projects/level-up` special-case branch in `activeAreaKey` (and the matching `lastSubtab` effect) was removed so it now highlights the **Projects** area. The `internal-processes/level-up` redirect stub is untouched.
- **My Staffing** sidebar entry added under Projects → Staffing, member-gated, route `/projects/my-staffing`. The route string works before the Staffing PR merges (that PR owns the route file).
- **Two Members pages disambiguated** (title + label only): People → **Directory** (`/members`), Admin → **Roles & Permissions** (`/admin-console/members`).
- **Breadcrumbs** (`app/components/Breadcrumbs.tsx`): derives the trail from the path against a static segment-label map (lab vocab verbatim) and the leaf route's `handle.breadcrumb(loaderData)`. Rendered in the embedded content shell (`routes/layout.tsx`) where routed pages actually mount, so e.g. `Hiring › Applications › Jane Doe` resolves with the ancestor crumbs linked. `applications.$domainApplicationId.tsx` opts in via `handle`.
- **Mobile breadcrumb** now shows `Area › Section` ancestry (plus the active sub when present), not just the section.
- Admin `meta` titles aligned to `· Admin · DALI OS`.

**Kept verbatim:** Domain, Domain Lead, Delibs, Intent to Work, Project Bids, JobX, Level Up, Core, Hub, Library, P1/P2/P3.

## PR-10 — notification & task history (additive, no schema change)

- **`resolveNotificationState()`** extracted in `lib/tasks.ts` — single source of truth for `Open | Submitted | Cleared | Cancelled | Expired`, mirroring the liveness rules previously inline in `TASK_WHERE`. `listOpenTasks` reuses it (no behavior change — `TASK_WHERE` still gates the DB query).
- **`listNotificationHistory(userId, opts)`** — keyset pagination on `(createdAt desc, id desc)` over the existing index; `status` / `kind` / `q` filters; `counts.{open,cleared}`; returns `{ items, nextCursor, counts }`.
- **`api.notifications.ts`** loader serves the history payload when any of `status|kind|q|cursor|limit` is present; with **no** params it returns the unchanged legacy `{ items, unreadCount, taskCount, tasks }` (the bell poller is untouched). Cursor is parsed as opaque `{createdAt,id}` JSON; malformed cursors fall back to the first page.
- **History surface** at `/notifications` (`routes/notifications.tsx`) with an `Open | History` tab UI under **My Tasks**: newest-first, grouped by Today/Yesterday/date, status + search filters, per-row sender + sent/cleared times, a state badge, a re-open/view link, and **Mark unread**. A **See all →** entry point was added to the sidebar Tasks group, which now also navigates to the My Tasks surface.
- **Mark unread**: `api.notifications.$id.read.ts` accepts `intent=unread` to flip `readAt` back to null, with the same ownership check; self-clearing rows (meeting invites / onboarding) are no-op echoes.

### Edge cases (the 3 decisions)
1. Self-clearing **form** tasks resolve to **Submitted** (not Cleared) and link to the submission (`/forms/fill/<token>`).
2. Stale **Cancelled-meeting** / inactive interview-assignment rows are **shown annotated** in History (not silently hidden as on live surfaces).
3. One definition of state — `listOpenTasks` and the history view both go through `resolveNotificationState`.

## Tests
- Unit: `resolveNotificationState` (all states), `listNotificationHistory` (status buckets, kind+q compose, limit clamp, keyset `nextCursor`, Submitted form link).
- Route: `api.notifications` legacy vs history payload + cursor parsing; `api.notifications.$id.read` `intent=unread` (flip, ownership, no-op echoes).
- `npm test` → **1271 passed**. `npm run typecheck` → **no new errors in app code** (pre-existing `scripts/`+`prisma/seeds/` errors are identical on `origin/dev`).

## Notes for reviewers
- `D3` (the `dismissedAt`/`clearedReason` migration) is deliberately **deferred** — no schema change here.
- The `Page` Prisma model, `pageId` params, and `/documents`/`/forms` route paths are untouched; "Documents" is UI copy only (the document surface already read "Documents").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/858"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784743960&installation_id=133523038&pr_number=858&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F858&signature=6d110b08ea01ab2b7d9389471cfacfa271078c941ca205767c10fd843f52482c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->