### PR TITLE
Modal primitives + overlay migration (a11y)

### DIFF
--- a/dali-api/app/components/Modal.tsx
+++ b/dali-api/app/components/Modal.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, type ReactNode } from "react";
+import { X } from "lucide-react";
 
 const FOCUSABLE_SELECTOR = [
   "a[href]",
@@ -122,6 +123,78 @@ export function Modal({
       <div ref={dialogRef} className={containerClassName} tabIndex={-1}>
         {children}
       </div>
+    </div>
+  );
+}
+
+export interface ModalHeaderProps {
+  /** Must equal the `labelledBy` id passed to <Modal>. */
+  titleId: string;
+  title: ReactNode;
+  subtitle?: ReactNode;
+  onClose: () => void;
+  /** Accessible name for the close button. */
+  closeLabel?: string;
+  /** Hide the standardized close button (rare; e.g. blocking flows). */
+  hideClose?: boolean;
+  className?: string;
+}
+
+export function ModalHeader({
+  titleId,
+  title,
+  subtitle,
+  onClose,
+  closeLabel = "Close",
+  hideClose = false,
+  className = "",
+}: ModalHeaderProps) {
+  return (
+    <div className={`flex items-start justify-between gap-4 mb-4 ${className}`}>
+      <div>
+        <h2 id={titleId} className="font-heading text-lg font-bold text-foreground">
+          {title}
+        </h2>
+        {subtitle && <p className="text-xs text-muted-foreground mt-0.5">{subtitle}</p>}
+      </div>
+      {!hideClose && (
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label={closeLabel}
+          className="text-muted-foreground/70 hover:text-foreground rounded p-1 hover:bg-muted"
+        >
+          <X className="w-5 h-5" aria-hidden />
+        </button>
+      )}
+    </div>
+  );
+}
+
+export interface ModalFooterProps {
+  onCancel: () => void;
+  cancelLabel?: string;
+  /** Primary action button(s). Rendered right-most. */
+  children: ReactNode;
+  className?: string;
+}
+
+export function ModalFooter({
+  onCancel,
+  cancelLabel = "Cancel",
+  children,
+  className = "",
+}: ModalFooterProps) {
+  return (
+    <div className={`mt-6 flex items-center justify-end gap-2 ${className}`}>
+      <button
+        type="button"
+        onClick={onCancel}
+        className="px-3 py-1.5 text-sm rounded-lg text-foreground/80 hover:bg-muted"
+      >
+        {cancelLabel}
+      </button>
+      {children}
     </div>
   );
 }

--- a/dali-api/app/components/PhotoCropModal.tsx
+++ b/dali-api/app/components/PhotoCropModal.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useState } from "react";
 import Cropper, { type Area } from "react-easy-crop";
-import { Modal } from "./Modal";
+import { Modal, ModalHeader } from "./Modal";
 
 const OUTPUT_SIZE = 512;
 
@@ -96,12 +96,13 @@ export function PhotoCropModal({
       disableEscape={processing}
       containerClassName="bg-card rounded-2xl shadow-brand-2 max-w-md w-full p-5 sm:p-6 my-auto"
     >
-      <h2
-        id="photo-crop-title"
-        className="font-heading text-lg font-bold text-foreground mb-3"
-      >
-        Adjust photo
-      </h2>
+      <ModalHeader
+        titleId="photo-crop-title"
+        title="Adjust photo"
+        onClose={onCancel}
+        hideClose={processing}
+        className="mb-3"
+      />
 
       <div className="relative w-full h-72 bg-black rounded-lg overflow-hidden">
         <Cropper

--- a/dali-api/app/components/__tests__/Modal.test.tsx
+++ b/dali-api/app/components/__tests__/Modal.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { Modal, nextTrapTarget } from "../Modal";
+import { Modal, ModalHeader, ModalFooter, nextTrapTarget } from "../Modal";
 
 describe("nextTrapTarget (focus-trap cycling)", () => {
   function makeButtons(n: number): HTMLElement[] {
@@ -77,5 +77,83 @@ describe("Modal render output", () => {
     expect(html).toContain('id="my-title"');
     expect(html).toContain("Hello");
     expect(html).toContain("OK");
+  });
+});
+
+describe("ModalHeader", () => {
+  it("renders an <h2> carrying the passed titleId and a close button with the default aria-label", () => {
+    const html = renderToStaticMarkup(
+      createElement(ModalHeader, {
+        titleId: "my-title",
+        title: "Settings",
+        onClose: () => {},
+      }),
+    );
+    expect(html).toContain('id="my-title"');
+    expect(html).toContain("Settings");
+    expect(html).toContain('aria-label="Close"');
+  });
+
+  it("renders the subtitle when provided", () => {
+    const html = renderToStaticMarkup(
+      createElement(ModalHeader, {
+        titleId: "t",
+        title: "Title",
+        subtitle: "A helpful description",
+        onClose: () => {},
+      }),
+    );
+    expect(html).toContain("A helpful description");
+  });
+
+  it("uses a custom close label", () => {
+    const html = renderToStaticMarkup(
+      createElement(ModalHeader, {
+        titleId: "t",
+        title: "Title",
+        onClose: () => {},
+        closeLabel: "Close settings",
+      }),
+    );
+    expect(html).toContain('aria-label="Close settings"');
+  });
+
+  it("omits the close button when hideClose is set", () => {
+    const html = renderToStaticMarkup(
+      createElement(ModalHeader, {
+        titleId: "t",
+        title: "Title",
+        onClose: () => {},
+        hideClose: true,
+      }),
+    );
+    expect(html).not.toContain("aria-label");
+    expect(html).not.toContain("<button");
+  });
+});
+
+describe("ModalFooter", () => {
+  it("renders a Cancel button and the primary child", () => {
+    const html = renderToStaticMarkup(
+      createElement(
+        ModalFooter,
+        { onCancel: () => {} },
+        createElement("button", { key: "p" }, "Save"),
+      ),
+    );
+    expect(html).toContain("Cancel");
+    expect(html).toContain("Save");
+  });
+
+  it("uses a custom cancel label", () => {
+    const html = renderToStaticMarkup(
+      createElement(
+        ModalFooter,
+        { onCancel: () => {}, cancelLabel: "Go back" },
+        createElement("button", { key: "p" }, "Confirm"),
+      ),
+    );
+    expect(html).toContain("Go back");
+    expect(html).not.toContain(">Cancel<");
   });
 });

--- a/dali-api/app/components/collab/VersionHistoryPanel.tsx
+++ b/dali-api/app/components/collab/VersionHistoryPanel.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { X } from "lucide-react";
+import { Modal } from "~/components/Modal";
 
 interface Author {
   id: string;
@@ -132,25 +133,27 @@ export function VersionHistoryPanel({ documentName, onClose }: VersionHistoryPan
   }, [selectedId, onClose]);
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
-      onClick={onClose}
+    <Modal
+      open
+      onClose={onClose}
+      labelledBy="version-history-title"
+      disableEscape={restoring}
+      containerClassName="bg-card rounded-xl shadow-2xl border border-border w-[min(900px,92vw)] h-[min(640px,86vh)] flex overflow-hidden"
     >
-      <div
-        className="bg-card rounded-xl shadow-2xl border border-border w-[min(900px,92vw)] h-[min(640px,86vh)] flex overflow-hidden"
-        onClick={(e) => e.stopPropagation()}
-      >
+      <>
         {/* Left: version list */}
         <div className="w-72 border-r border-border flex flex-col">
           <div className="px-4 py-3 border-b border-border flex items-center justify-between bg-muted/50">
-            <h2 className="text-sm font-semibold text-foreground">Version history</h2>
+            <h2 id="version-history-title" className="text-sm font-semibold text-foreground">
+              Version history
+            </h2>
             <button
               type="button"
               onClick={onClose}
-              className="text-muted-foreground/70 hover:text-muted-foreground"
+              className="text-muted-foreground/70 hover:text-foreground rounded p-1 hover:bg-muted"
               aria-label="Close"
             >
-              <X size={16} />
+              <X className="w-5 h-5" aria-hidden />
             </button>
           </div>
           <div className="flex-1 overflow-y-auto">
@@ -234,7 +237,7 @@ export function VersionHistoryPanel({ documentName, onClose }: VersionHistoryPan
             </div>
           )}
         </div>
-      </div>
-    </div>
+      </>
+    </Modal>
   );
 }

--- a/dali-api/app/forms/components/FormsBrowser.tsx
+++ b/dali-api/app/forms/components/FormsBrowser.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Link, useFetcher } from "react-router";
 import { Folder, FileText, MoreVertical } from "lucide-react";
 import { Button } from "~/components/ui/Button";
+import { Modal, ModalHeader, ModalFooter } from "~/components/Modal";
 import type { FormCard, FolderCard } from "~/forms/lib/forms-data";
 
 function errorOf(data: unknown): string | null {
@@ -388,27 +389,18 @@ function FormsDialog({
   }
 
   return (
-    <div
-      className="fixed inset-0 z-50 bg-black/50 flex items-center justify-center p-4"
-      onClick={onCancel}
+    <Modal
+      open
+      onClose={onCancel}
+      labelledBy="forms-dialog-title"
+      containerClassName="bg-card border border-border rounded-lg w-full max-w-sm p-5 flex flex-col gap-4"
     >
-      <div
-        className="bg-card border border-border rounded-lg w-full max-w-sm p-5 flex flex-col gap-4"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <div className="flex items-start justify-between gap-3">
-          <h2 className="font-heading text-lg font-bold text-foreground">
-            {dialog.title}
-          </h2>
-          <button
-            type="button"
-            onClick={onCancel}
-            aria-label="Close"
-            className="text-muted-foreground hover:text-foreground text-lg leading-none"
-          >
-            ✕
-          </button>
-        </div>
+      <>
+        <ModalHeader
+          titleId="forms-dialog-title"
+          title={dialog.title}
+          onClose={onCancel}
+        />
 
         {dialog.kind === "prompt" ? (
           <form
@@ -437,14 +429,7 @@ function FormsDialog({
           <p className="text-sm text-muted-foreground">{dialog.message}</p>
         )}
 
-        <div className="flex items-center justify-end gap-2">
-          <button
-            type="button"
-            onClick={onCancel}
-            className="px-3 py-1.5 text-sm border border-border rounded-md text-foreground hover:bg-muted/40 transition-colors"
-          >
-            Cancel
-          </button>
+        <ModalFooter onCancel={onCancel} className="mt-0">
           <button
             type="button"
             onClick={confirm}
@@ -459,8 +444,8 @@ function FormsDialog({
           >
             {dialog.confirmLabel}
           </button>
-        </div>
-      </div>
-    </div>
+        </ModalFooter>
+      </>
+    </Modal>
   );
 }

--- a/dali-api/app/hiring/components/ChallengePreviewModal.tsx
+++ b/dali-api/app/hiring/components/ChallengePreviewModal.tsx
@@ -1,6 +1,5 @@
-import { X } from "lucide-react";
 import type { Question } from "~/types";
-import { Modal } from "~/components/Modal";
+import { Modal, ModalHeader } from "~/components/Modal";
 import { ChallengePreview } from "~/hiring/components/ChallengePreview";
 
 export interface ChallengePreviewModalProps {
@@ -30,24 +29,14 @@ export function ChallengePreviewModal({
       containerClassName="bg-card rounded-2xl shadow-xl max-w-2xl w-full mx-4 p-6 max-h-[85vh] overflow-y-auto"
     >
       <div className="space-y-5">
-        <div className="flex items-start justify-between gap-3">
-          <div>
-            <h2 id={headingId} className="text-lg font-bold text-foreground">
-              {challengeName}
-            </h2>
-            {versionLabel && (
-              <p className="text-xs text-muted-foreground mt-0.5">{versionLabel}</p>
-            )}
-          </div>
-          <button
-            type="button"
-            onClick={onClose}
-            aria-label="Close preview"
-            className="text-muted-foreground hover:text-foreground"
-          >
-            <X className="w-4 h-4" />
-          </button>
-        </div>
+        <ModalHeader
+          titleId={headingId}
+          title={challengeName}
+          subtitle={versionLabel}
+          onClose={onClose}
+          closeLabel="Close preview"
+          className="mb-0"
+        />
         <ChallengePreview description={description} questions={questions} />
       </div>
     </Modal>

--- a/dali-api/app/hiring/components/EmailTemplates.tsx
+++ b/dali-api/app/hiring/components/EmailTemplates.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 import { Link, Form, useLoaderData, useSearchParams } from 'react-router'
 import { Plus, Mail, ChevronRight, X } from 'lucide-react'
 import { Button } from '~/components/ui/Button'
-import { Modal } from '~/components/Modal'
+import { Modal, ModalHeader } from '~/components/Modal'
 import type { loader } from '~/hiring/routes/email-templates'
 
 const GMAIL_ERROR_MESSAGES: Record<string, string> = {
@@ -134,9 +134,12 @@ export default function EmailTemplatesList() {
         labelledBy="new-email-template-title"
       >
         <div className="space-y-4">
-          <h2 id="new-email-template-title" className="text-lg font-semibold text-foreground">
-            New Email Template
-          </h2>
+          <ModalHeader
+            titleId="new-email-template-title"
+            title="New Email Template"
+            onClose={() => setShowModal(false)}
+            className="mb-0"
+          />
           <Form method="post" onSubmit={() => setShowModal(false)} className="space-y-4">
             <input type="hidden" name="intent" value="create" />
             <div>

--- a/dali-api/app/hiring/components/Library.tsx
+++ b/dali-api/app/hiring/components/Library.tsx
@@ -9,7 +9,7 @@ import {
   Trash2,
 } from "lucide-react";
 import { Button } from "~/components/ui/Button";
-import { Modal } from "~/components/Modal";
+import { Modal, ModalHeader } from "~/components/Modal";
 import type { loader } from "~/hiring/routes/library";
 
 type Tab = "challenges" | "rubrics" | "agreements";
@@ -194,9 +194,12 @@ function ChallengesPanel({
         className="fixed inset-0 z-50 flex items-center justify-center bg-black/10 backdrop-blur-[1px] p-4 sm:p-6 overflow-y-auto"
         containerClassName="bg-card rounded-xl shadow-xl max-w-md w-full p-6 my-auto space-y-6"
       >
-        <h2 id="new-challenge-title" className="text-xl font-bold text-foreground">
-          New Challenge
-        </h2>
+        <ModalHeader
+          titleId="new-challenge-title"
+          title="New Challenge"
+          onClose={() => setShowModal(false)}
+          className="mb-0"
+        />
 
         <Form
           method="post"
@@ -313,9 +316,12 @@ function RubricsPanel({ rubrics }: { rubrics: any[] }) {
         labelledBy="new-rubric-title"
       >
         <div className="space-y-4">
-          <h2 id="new-rubric-title" className="text-lg font-semibold text-foreground">
-            New Rubric
-          </h2>
+          <ModalHeader
+            titleId="new-rubric-title"
+            title="New Rubric"
+            onClose={() => setShowModal(false)}
+            className="mb-0"
+          />
           <Form
             method="post"
             onSubmit={() => setShowModal(false)}
@@ -442,9 +448,12 @@ function AgreementsPanel({
         labelledBy="new-agreement-title"
       >
         <div className="space-y-4">
-          <h2 id="new-agreement-title" className="text-lg font-semibold text-foreground">
-            New Confidentiality Agreement
-          </h2>
+          <ModalHeader
+            titleId="new-agreement-title"
+            title="New Confidentiality Agreement"
+            onClose={() => setShowModal(false)}
+            className="mb-0"
+          />
           <Form
             method="post"
             onSubmit={() => setShowModal(false)}

--- a/dali-api/app/hiring/routes/domain-lead.tsx
+++ b/dali-api/app/hiring/routes/domain-lead.tsx
@@ -2795,15 +2795,6 @@ function ReviewModal({ review, rubricCriteria, onClose }: {
     if (c?.key) criteriaByKey[c.key] = { label: c.label ?? c.key, description: c.description, maxScore: c.maxScore };
   }
 
-  // Close on Escape
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [onClose]);
-
   const hasAnyContent =
     scoreEntries.length > 0 ||
     (review.feedback && review.feedback.trim() !== "") ||
@@ -2811,17 +2802,16 @@ function ReviewModal({ review, rubricCriteria, onClose }: {
     !!review.overallRecommendation;
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
-      onClick={onClose}
+    <Modal
+      open
+      onClose={onClose}
+      labelledBy="reviewer-detail-title"
+      containerClassName="relative bg-card rounded-xl shadow-xl max-w-2xl w-full max-h-[90vh] overflow-y-auto my-auto"
     >
-      <div
-        className="relative bg-card rounded-xl shadow-xl max-w-2xl w-full max-h-[90vh] overflow-y-auto"
-        onClick={(e) => e.stopPropagation()}
-      >
+      <>
         <div className="flex items-start justify-between px-6 py-4 border-b border-border">
           <div>
-            <h2 className="text-lg font-semibold text-foreground">{reviewerName}</h2>
+            <h2 id="reviewer-detail-title" className="text-lg font-semibold text-foreground">{reviewerName}</h2>
             <div className="mt-1 flex items-center gap-2 text-xs">
               {isSubmitted ? (
                 <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full font-medium bg-green-50 text-green-700 border border-green-200">
@@ -2847,11 +2837,12 @@ function ReviewModal({ review, rubricCriteria, onClose }: {
             </div>
           </div>
           <button
+            type="button"
             onClick={onClose}
-            className="text-muted-foreground/70 hover:text-foreground/80 transition"
+            className="text-muted-foreground/70 hover:text-foreground rounded p-1 hover:bg-muted"
             aria-label="Close"
           >
-            <X className="w-5 h-5" />
+            <X className="w-5 h-5" aria-hidden />
           </button>
         </div>
 
@@ -2925,8 +2916,8 @@ function ReviewModal({ review, rubricCriteria, onClose }: {
             </>
           )}
         </div>
-      </div>
-    </div>
+      </>
+    </Modal>
   );
 }
 

--- a/dali-api/app/hiring/routes/lead.cycle.$id.tsx
+++ b/dali-api/app/hiring/routes/lead.cycle.$id.tsx
@@ -18,7 +18,7 @@ import {
   type DecisionSlotType,
   type NotificationSlotType,
 } from "~/hiring/lib/email-variables";
-import { Modal } from "~/components/Modal";
+import { Modal, ModalHeader } from "~/components/Modal";
 import { requestOpenTabIfEmbedded } from "~/components/workspace-link";
 import { ChallengePreviewModal } from "~/hiring/components/ChallengePreviewModal";
 import { Settings, Users, Calendar, AlertTriangle, Trash2, Plus, CheckCircle, ArrowRight, Circle, ChevronRight, X, LayoutDashboard, Eye, Mail } from 'lucide-react'
@@ -3303,34 +3303,29 @@ function DecisionEmailPreviewModal({ decision, binding, onClose }: {
     : null
 
   return (
-    <div
-      className="fixed inset-0 z-50 bg-black/40 flex items-center justify-center p-4"
-      onClick={onClose}
+    <Modal
+      open
+      onClose={onClose}
+      labelledBy="email-preview-title"
+      containerClassName="bg-card rounded-lg shadow-xl w-full max-w-2xl max-h-[80vh] overflow-y-auto my-auto"
     >
-      <div
-        className="bg-card rounded-lg shadow-xl w-full max-w-2xl max-h-[80vh] overflow-y-auto"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <div className="flex items-center justify-between gap-3 px-4 sm:px-6 py-3 sm:py-4 border-b border-border">
-          <div className="min-w-0">
-            <h2 className="text-lg font-bold text-foreground">Email preview</h2>
-            <p className="text-xs text-muted-foreground break-words">
+      <>
+        <ModalHeader
+          titleId="email-preview-title"
+          title="Email preview"
+          subtitle={
+            <>
               {decision.domainApplication.application.user.firstName} {decision.domainApplication.application.user.lastName}
               {' · '}
               {decision.domainApplication.challengeVersion.domain.name}
               {' · '}
               <span className="font-medium">{decision.type}</span>
-            </p>
-          </div>
-          <button
-            type="button"
-            onClick={onClose}
-            className="text-muted-foreground/70 hover:text-foreground flex-shrink-0"
-            aria-label="Close preview"
-          >
-            <X className="w-5 h-5" />
-          </button>
-        </div>
+            </>
+          }
+          onClose={onClose}
+          closeLabel="Close preview"
+          className="px-4 sm:px-6 py-3 sm:py-4 border-b border-border mb-0"
+        />
         <div className="px-4 sm:px-6 py-4 space-y-4">
           {tmpl ? (
             <>
@@ -3383,8 +3378,8 @@ function DecisionEmailPreviewModal({ decision, binding, onClose }: {
             Close
           </button>
         </div>
-      </div>
-    </div>
+      </>
+    </Modal>
   )
 }
 
@@ -3442,15 +3437,21 @@ function CompleteConfirmModal({ cycleId, onClose, onCompleted, onError }: {
   }
 
   return (
-    <div className="fixed inset-0 z-50 bg-black/40 flex items-center justify-center p-4" onClick={onClose}>
-      <div className="bg-card rounded-lg shadow-xl w-full max-w-md p-6 space-y-4" onClick={e => e.stopPropagation()}>
+    <Modal
+      open
+      onClose={onClose}
+      labelledBy="complete-confirm-title"
+      disableEscape={submitting}
+      containerClassName="bg-card rounded-lg shadow-xl w-full max-w-md p-6 space-y-4 my-auto"
+    >
+      <>
         {checking ? (
           <div className="text-center py-4">
             <p className="text-sm text-muted-foreground">Checking cycle readiness...</p>
           </div>
         ) : hasBlockers ? (
           <>
-            <h2 className="text-lg font-semibold text-foreground">Cycle has unfinished work</h2>
+            <h2 id="complete-confirm-title" className="text-lg font-semibold text-foreground">Cycle has unfinished work</h2>
             <div className="space-y-2">
               {pendingInterviews > 0 && (
                 <div className="flex items-center gap-2 text-sm bg-yellow-50 border border-yellow-200 rounded-lg px-4 py-3">
@@ -3485,8 +3486,8 @@ function CompleteConfirmModal({ cycleId, onClose, onCompleted, onError }: {
             </div>
           </>
         ) : null}
-      </div>
-    </div>
+      </>
+    </Modal>
   );
 }
 

--- a/dali-api/app/hiring/routes/lead.intern-to-full-cycle.$id.tsx
+++ b/dali-api/app/hiring/routes/lead.intern-to-full-cycle.$id.tsx
@@ -18,7 +18,8 @@ import {
   type TemplateSlot,
   type DecisionSlotType,
 } from "~/hiring/lib/email-variables";
-import { AlertTriangle, CheckCircle, Eye, Mail, X } from "lucide-react";
+import { AlertTriangle, CheckCircle, Eye, Mail } from "lucide-react";
+import { Modal, ModalHeader, ModalFooter } from "~/components/Modal";
 
 import {
   zonedDayEndUtc,
@@ -727,15 +728,19 @@ function CreateFormVersionModal({
     );
   }
   return (
-    <div className="fixed inset-0 z-50 bg-black/40 flex items-center justify-center p-4" onClick={onClose}>
-      <div
-        className="bg-card rounded-lg shadow-xl w-full max-w-2xl p-6 space-y-4 max-h-[90vh] overflow-auto"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <div className="flex items-center justify-between">
-          <h2 className="text-lg font-semibold text-foreground">New shortform version</h2>
-          <button onClick={onClose} className="text-muted-foreground/70">✕</button>
-        </div>
+    <Modal
+      open
+      onClose={onClose}
+      labelledBy="new-shortform-title"
+      containerClassName="bg-card rounded-lg shadow-xl w-full max-w-2xl p-6 space-y-4 max-h-[90vh] overflow-auto my-auto"
+    >
+      <>
+        <ModalHeader
+          titleId="new-shortform-title"
+          title="New shortform version"
+          onClose={onClose}
+          className="mb-0"
+        />
         <div className="space-y-3">
           {qs.map((q, idx) => {
             const isInfo = q.type === "info";
@@ -822,13 +827,7 @@ function CreateFormVersionModal({
             + Add info text
           </button>
         </div>
-        <div className="flex justify-end gap-2 pt-3 border-t border-border">
-          <button
-            onClick={onClose}
-            className="px-3 py-2 text-sm font-medium text-foreground/80 bg-card border border-gray-300 rounded-md hover:bg-muted/50"
-          >
-            Cancel
-          </button>
+        <ModalFooter onCancel={onClose} className="pt-3 border-t border-border">
           <button
             onClick={() => setPreviewing(true)}
             className="px-3 py-2 text-sm font-medium text-blue-700 bg-card border border-blue-300 rounded-md hover:bg-blue-50"
@@ -847,12 +846,8 @@ function CreateFormVersionModal({
           >
             Create
           </button>
-        </div>
-      </div>
-      {previewing && (
-        // Stop propagation so the preview's overlay/close don't bubble up to
-        // the create modal's outer onClick={onClose} and dismiss the draft.
-        <div onClick={(e) => e.stopPropagation()} onMouseDown={(e) => e.stopPropagation()}>
+        </ModalFooter>
+        {previewing && (
           <ChallengePreviewModal
             challengeVersionId="draft"
             challengeName="Shortform"
@@ -862,9 +857,9 @@ function CreateFormVersionModal({
             )}
             onClose={() => setPreviewing(false)}
           />
-        </div>
-      )}
-    </div>
+        )}
+      </>
+    </Modal>
   );
 }
 
@@ -1639,35 +1634,30 @@ function DecisionEmailPreviewModal({
     : null;
 
   return (
-    <div
-      className="fixed inset-0 z-50 bg-black/40 flex items-center justify-center p-4"
-      onClick={onClose}
+    <Modal
+      open
+      onClose={onClose}
+      labelledBy="itf-email-preview-title"
+      containerClassName="bg-card rounded-lg shadow-xl w-full max-w-2xl max-h-[80vh] overflow-y-auto my-auto"
     >
-      <div
-        className="bg-card rounded-lg shadow-xl w-full max-w-2xl max-h-[80vh] overflow-y-auto"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <div className="flex items-center justify-between gap-3 px-4 sm:px-6 py-3 sm:py-4 border-b border-border">
-          <div className="min-w-0">
-            <h2 className="text-lg font-bold text-foreground">Email preview</h2>
-            <p className="text-xs text-muted-foreground break-words">
+      <>
+        <ModalHeader
+          titleId="itf-email-preview-title"
+          title="Email preview"
+          subtitle={
+            <>
               {decision.domainApplication.application.user.firstName}{" "}
               {decision.domainApplication.application.user.lastName}
               {" · "}
               {domain}
               {" · "}
               <span className="font-medium">{decision.type}</span>
-            </p>
-          </div>
-          <button
-            type="button"
-            onClick={onClose}
-            className="text-muted-foreground/70 hover:text-foreground flex-shrink-0"
-            aria-label="Close preview"
-          >
-            <X className="w-5 h-5" />
-          </button>
-        </div>
+            </>
+          }
+          onClose={onClose}
+          closeLabel="Close preview"
+          className="px-4 sm:px-6 py-3 sm:py-4 border-b border-border mb-0"
+        />
         <div className="px-4 sm:px-6 py-4 space-y-4">
           {tmpl ? (
             <>
@@ -1721,8 +1711,8 @@ function DecisionEmailPreviewModal({
             Close
           </button>
         </div>
-      </div>
-    </div>
+      </>
+    </Modal>
   );
 }
 

--- a/dali-api/app/hiring/routes/lead.tsx
+++ b/dali-api/app/hiring/routes/lead.tsx
@@ -4,7 +4,8 @@ import type { Route } from "./+types/lead";
 import { prisma } from "~/lib/db";
 import { requireAuth } from "~/lib/auth";
 import { isCore } from "~/lib/roles";
-import { ChevronRight, ChevronDown, Plus, X } from "lucide-react";
+import { ChevronRight, ChevronDown, Plus } from "lucide-react";
+import { Modal, ModalHeader } from "~/components/Modal";
 import { STATUS_COLORS, STATUS_LABELS } from "~/hiring/lib/labels";
 
 export const meta: Route.MetaFunction = () => [{ title: "Hiring lead · DALI OS" }];
@@ -79,17 +80,20 @@ export default function HiringLeadDashboard() {
         </div>
       </div>
 
-      {showModal && (
+      <Modal
+        open={showModal}
+        onClose={() => setShowModal(false)}
+        labelledBy="new-cycle-title"
+        containerClassName="bg-card rounded-lg shadow-xl w-full max-w-sm p-6 space-y-4 my-auto"
+      >
         <>
-          <div className="fixed inset-0 z-50 bg-black/40 flex items-center justify-center p-4" onClick={() => setShowModal(false)}>
-            <div className="bg-card rounded-lg shadow-xl w-full max-w-sm p-6 space-y-4" onClick={(e) => e.stopPropagation()}>
-              <div className="flex items-center justify-between">
-                <h2 className="text-lg font-semibold text-foreground">New Hiring Cycle</h2>
-                <button onClick={() => setShowModal(false)} className="text-muted-foreground/70 hover:text-muted-foreground">
-                  <X className="w-5 h-5" />
-                </button>
-              </div>
-              <Form method="post" onSubmit={() => setShowModal(false)} className="space-y-4">
+          <ModalHeader
+            titleId="new-cycle-title"
+            title="New Hiring Cycle"
+            onClose={() => setShowModal(false)}
+            className="mb-0"
+          />
+          <Form method="post" onSubmit={() => setShowModal(false)} className="space-y-4">
                 <div>
                   <label htmlFor="cycle-name" className="block text-sm font-medium text-foreground/80 mb-1">
                     Cycle name
@@ -137,10 +141,8 @@ export default function HiringLeadDashboard() {
                   </button>
                 </div>
               </Form>
-            </div>
-          </div>
         </>
-      )}
+      </Modal>
 
 
       <ActiveCycleHero cycles={cycles} />

--- a/dali-api/app/members/routes/members.groups.tsx
+++ b/dali-api/app/members/routes/members.groups.tsx
@@ -10,7 +10,7 @@ import { resolvePhotoUrl } from "~/lib/photo";
 import { Avatar } from "~/components/ui/Avatar";
 import { RolePills } from "~/components/ui/RolePills";
 import { deriveCoreTitles } from "~/lib/core-titles";
-import { Modal } from "~/components/Modal";
+import { Modal, ModalHeader } from "~/components/Modal";
 import {
   Users,
   Plus,
@@ -393,19 +393,13 @@ function CreateGroupForm({
 
   return (
     <div className="space-y-3">
-      <div className="flex items-center justify-between">
-        <h2 id="create-group-title" className="font-semibold text-lg text-foreground">
-          New group
-        </h2>
-        <button
-          type="button"
-          onClick={onDone}
-          className="text-muted-foreground hover:text-foreground"
-          aria-label="Cancel"
-        >
-          <X className="w-4 h-4" />
-        </button>
-      </div>
+      <ModalHeader
+        titleId="create-group-title"
+        title="New group"
+        onClose={onDone}
+        closeLabel="Cancel"
+        className="mb-0"
+      />
       <fetcher.Form
         method="post"
         onSubmit={(e) => {

--- a/dali-api/app/projects/components/BidModal.tsx
+++ b/dali-api/app/projects/components/BidModal.tsx
@@ -1,4 +1,4 @@
-import { Modal } from "~/components/Modal";
+import { Modal, ModalHeader } from "~/components/Modal";
 import type { BidField, Level, Preference } from "../lib/staffing-board";
 
 type BidModalProps = {
@@ -70,23 +70,12 @@ export function BidModal({
       labelledBy="bid-modal-title"
       containerClassName="bg-card rounded-2xl shadow-xl max-w-lg w-full p-5 sm:p-6 my-auto max-h-[85vh] overflow-y-auto"
     >
-      <div className="flex items-start justify-between gap-4 mb-4">
-        <div>
-          <h2 id="bid-modal-title" className="font-heading text-lg font-bold text-foreground">
-            {memberName}'s bid
-          </h2>
-          <p className="text-xs text-muted-foreground mt-0.5">
-            Full bid submission for this staffing cycle.
-          </p>
-        </div>
-        <button
-          type="button"
-          onClick={onClose}
-          className="text-muted-foreground hover:text-foreground text-sm px-2 py-1 rounded hover:bg-muted"
-        >
-          Close
-        </button>
-      </div>
+      <ModalHeader
+        titleId="bid-modal-title"
+        title={`${memberName}'s bid`}
+        subtitle="Full bid submission for this staffing cycle."
+        onClose={onClose}
+      />
 
       {sorted.length === 0 && bidFields.length === 0 ? (
         <p className="text-sm text-muted-foreground italic">

--- a/dali-api/app/projects/components/EpicSprintManager.tsx
+++ b/dali-api/app/projects/components/EpicSprintManager.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { useRevalidator } from "react-router";
+import { X } from "lucide-react";
 import { Modal } from "~/components/Modal";
 import { Button } from "~/components/ui/Button";
 import { CollaborativeEditor } from "~/components/CollaborativeEditor";
@@ -474,9 +475,9 @@ function EpicDetail({
             type="button"
             onClick={onClose}
             aria-label="Close"
-            className="text-muted-foreground hover:text-foreground text-lg leading-none"
+            className="text-muted-foreground/70 hover:text-foreground rounded p-1 hover:bg-muted"
           >
-            ×
+            <X className="w-5 h-5" aria-hidden />
           </button>
         </div>
       </div>

--- a/dali-api/app/projects/components/FinalizeModal.tsx
+++ b/dali-api/app/projects/components/FinalizeModal.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useRevalidator } from "react-router";
-import { Modal } from "~/components/Modal";
+import { Modal, ModalHeader } from "~/components/Modal";
 import { Button } from "~/components/ui/Button";
 
 type Automation = "assignments" | "slack" | "gmail" | "github";
@@ -179,24 +179,13 @@ export function FinalizeModal({
       containerClassName="bg-card rounded-2xl shadow-xl max-w-lg w-full p-5 sm:p-6 my-auto"
       disableEscape={running}
     >
-      <div className="flex items-start justify-between gap-4 mb-4">
-        <div>
-          <h2 id="finalize-modal-title" className="font-heading text-lg font-bold text-foreground">
-            Finalize {projectName}
-          </h2>
-          <p className="text-xs text-muted-foreground mt-0.5">
-            Run the selected automations. Safe to re-run.
-          </p>
-        </div>
-        <button
-          type="button"
-          onClick={onClose}
-          disabled={running}
-          className="text-muted-foreground hover:text-foreground text-sm px-2 py-1 rounded hover:bg-muted disabled:opacity-50"
-        >
-          Close
-        </button>
-      </div>
+      <ModalHeader
+        titleId="finalize-modal-title"
+        title={`Finalize ${projectName}`}
+        subtitle="Run the selected automations. Safe to re-run."
+        onClose={onClose}
+        hideClose={running}
+      />
 
       {error && (
         <div className="bg-destructive/10 border border-destructive/30 text-destructive text-sm rounded-md px-3 py-2 mb-3">

--- a/dali-api/app/projects/components/SlotAdvancedSettingsModal.tsx
+++ b/dali-api/app/projects/components/SlotAdvancedSettingsModal.tsx
@@ -5,7 +5,7 @@
 // management) can still open it to see the current binding/columns
 // read-only — both inner components already render that way when canManage
 // is false.
-import { Modal } from "~/components/Modal";
+import { Modal, ModalHeader } from "~/components/Modal";
 import { SlotFormPicker } from "./SlotFormPicker";
 import { SlotColumnMapper } from "./SlotColumnMapper";
 import type { Slot } from "~/projects/lib/form-slots";
@@ -57,28 +57,13 @@ export function SlotAdvancedSettingsModal({
       labelledBy={titleId}
       containerClassName="bg-card rounded-2xl shadow-xl w-full max-w-3xl p-5 sm:p-6 my-auto"
     >
-      <div className="flex items-start justify-between gap-3 mb-3">
-        <div>
-          <h2
-            id={titleId}
-            className="font-heading text-lg font-semibold text-foreground"
-          >
-            {slotLabel} settings
-          </h2>
-          <p className="text-xs text-muted-foreground mt-0.5">
-            Connect the form members fill, then map its questions to the
-            columns shown on the board.
-          </p>
-        </div>
-        <button
-          type="button"
-          onClick={onClose}
-          aria-label="Close settings"
-          className="text-muted-foreground hover:text-foreground text-xl leading-none px-1"
-        >
-          ×
-        </button>
-      </div>
+      <ModalHeader
+        titleId={titleId}
+        title={`${slotLabel} settings`}
+        subtitle="Connect the form members fill, then map its questions to the columns shown on the board."
+        onClose={onClose}
+        closeLabel="Close settings"
+      />
 
       <div className="flex flex-col gap-4 max-h-[70vh] overflow-y-auto pr-1">
         <SlotFormPicker

--- a/dali-api/app/projects/components/TaskModal.tsx
+++ b/dali-api/app/projects/components/TaskModal.tsx
@@ -5,6 +5,7 @@
 // it collects the full set of fields and hands them to onCreate on submit.
 
 import { useEffect, useState } from "react";
+import { X } from "lucide-react";
 import { Modal } from "~/components/Modal";
 import { Button } from "~/components/ui/Button";
 import type { TaskBoardOptions, TaskCardModel, Priority } from "../lib/task-board";
@@ -149,10 +150,10 @@ export function TaskModal({
           <button
             type="button"
             onClick={onClose}
-            className="text-muted-foreground hover:text-foreground text-sm px-2 py-1"
+            className="text-muted-foreground/70 hover:text-foreground rounded p-1 hover:bg-muted"
             aria-label="Close"
           >
-            ✕
+            <X className="w-5 h-5" aria-hidden />
           </button>
         </div>
 

--- a/dali-api/app/projects/routes/projects.$id.tsx
+++ b/dali-api/app/projects/routes/projects.$id.tsx
@@ -11,7 +11,7 @@ import {
   useSubmit,
 } from "react-router";
 import { Check, Pencil, X, Settings } from "lucide-react";
-import { Modal } from "~/components/Modal";
+import { Modal, ModalHeader } from "~/components/Modal";
 import { EditableSection } from "~/components/EditableSection";
 import { TagPicker } from "~/components/TagPicker";
 import { PresenceProvider } from "~/components/collab/PresenceProvider";
@@ -914,25 +914,13 @@ export default function ProjectDetail() {
           labelledBy="scope-settings-title"
           containerClassName="bg-card rounded-2xl shadow-xl w-full max-w-4xl p-5 sm:p-6 my-auto max-h-[85vh] overflow-y-auto"
         >
-          <div className="flex items-start justify-between gap-3 mb-4">
-            <div>
-              <h2 id="scope-settings-title" className="font-heading text-lg font-bold text-foreground">
-                Domain settings
-              </h2>
-              <p className="text-xs text-muted-foreground mt-0.5">
-                Declared domains, planned terms, and the per-domain challenge
-                for each term.
-              </p>
-            </div>
-            <button
-              type="button"
-              onClick={() => setScopeSettingsOpen(false)}
-              aria-label="Close scope settings"
-              className="text-muted-foreground hover:text-foreground text-xl leading-none px-1"
-            >
-              ×
-            </button>
-          </div>
+          <ModalHeader
+            titleId="scope-settings-title"
+            title="Domain settings"
+            subtitle="Declared domains, planned terms, and the per-domain challenge for each term."
+            onClose={() => setScopeSettingsOpen(false)}
+            closeLabel="Close scope settings"
+          />
           <ScopeTab
             project={project}
             allDomainOptions={allDomainOptions}

--- a/dali-api/app/projects/routes/projects.level-up.tsx
+++ b/dali-api/app/projects/routes/projects.level-up.tsx
@@ -17,6 +17,7 @@ import { SubmissionFilters } from "../components/SubmissionFilters";
 import { SlotAdvancedSettingsModal } from "../components/SlotAdvancedSettingsModal";
 import { DomainFilter } from "../components/DomainFilter";
 import { TermFilter } from "~/components/TermFilter";
+import { Modal, ModalHeader } from "~/components/Modal";
 import { resolveTermFilter } from "~/lib/terms";
 import {
   parseColumnMapping,
@@ -688,16 +689,20 @@ function LevelUpConfirmDialog({
   }, [fetcher.data, onClose]);
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
-      onClick={(e) => {
-        if (e.target === e.currentTarget) onClose();
-      }}
+    <Modal
+      open
+      onClose={onClose}
+      labelledBy="level-up-confirm-title"
+      disableEscape={pending}
+      containerClassName="bg-card border border-border rounded-lg shadow-lg w-full max-w-sm p-6 flex flex-col gap-4 my-auto"
     >
-      <div className="bg-card border border-border rounded-lg shadow-lg w-full max-w-sm mx-4 p-6 flex flex-col gap-4">
-        <h2 className="font-heading text-lg font-bold text-foreground">
-          Confirm Level Up
-        </h2>
+      <>
+        <ModalHeader
+          titleId="level-up-confirm-title"
+          title="Confirm Level Up"
+          onClose={onClose}
+          className="mb-0"
+        />
         <p className="text-sm text-foreground">
           Promote{" "}
           <span className="font-semibold">{row.name}</span> to{" "}
@@ -735,8 +740,8 @@ function LevelUpConfirmDialog({
             </button>
           </fetcher.Form>
         </div>
-      </div>
-    </div>
+      </>
+    </Modal>
   );
 }
 


### PR DESCRIPTION
## Summary (PR-05)

Implements the **Modal header/footer + overlay migration** plan (`implementation-plans/PR-05-modal-primitives.md`).

**This is primarily an accessibility fix.** Nine modals were previously hand-rolled `fixed inset-0 bg-black/40` overlays that bypassed the shared `Modal` entirely — they had **no focus-trap, no Escape-to-close, no body scroll-lock, and no focus-restore**. Migrating them onto `Modal` restores all four behaviors. It also standardizes ~4 inconsistent close glyphs (`✕`, `×`, `<X size={16}>`, `<X w-4 h-4>`) onto one (`<X className="w-5 h-5">`) with a mandatory `aria-label`.

## New primitives — `app/components/Modal.tsx`

- `ModalHeader` — title (renders `<h2 id={titleId}>` matching `Modal`'s `labelledBy`), optional subtitle, and one standardized close button (`aria-label` defaults to `"Close"`, overridable; `hideClose` for blocking flows).
- `ModalFooter` — right-aligned Cancel + primary action child.
- Unit tests added in `app/components/__tests__/Modal.test.tsx` (14 tests, all green).

## Hand-rolled overlays migrated onto `Modal` (the 9 a11y gaps)

Located by grepping current `origin/dev` (the plan's line numbers were stale after the merged Hiring/Staffing/Nav PRs):

1. `app/components/collab/VersionHistoryPanel.tsx` (was :136) — preserved bespoke 900px panel sizing via `containerClassName`; `disableEscape` while restoring.
2. `app/forms/components/FormsBrowser.tsx` (was :392) — now uses `ModalHeader` + `ModalFooter`.
3. `app/projects/routes/projects.level-up.tsx` (was :692) — confirm dialog; `disableEscape` while pending.
4. `app/hiring/routes/domain-lead.tsx` (was :2815) — removed a redundant hand-rolled Escape `useEffect`.
5. `app/hiring/routes/lead.tsx` (was :84).
6. `app/hiring/routes/lead.cycle.$id.tsx` ×2 (was :3307 email preview, :3445 complete-confirm).
7. `app/hiring/routes/lead.intern-to-full-cycle.$id.tsx` ×2 (was :730 shortform editor, :1643 email preview). The nested `ChallengePreviewModal` no longer needs the stop-propagation hack since `Modal` uses an `onMouseDown` target guard.

No `fixed inset-0 … bg-black/40` literal remains at any of the 9 sites.

## `ModalHeader` / `ModalFooter` adopted in existing `Modal` consumers

`BidModal`, `FinalizeModal` (`hideClose` while running), `SlotAdvancedSettingsModal`, `TaskModal` (glyph only — title is an editable input), `EpicSprintManager` (glyph only — header shares row with a Delete action), `projects.$id.tsx` (scope settings), `PhotoCropModal`, `members.groups.tsx`, `EmailTemplates`, `Library` (×3), `ChallengePreviewModal`.

**Intentionally left as-is** (already on `Modal`, no hand-built close glyph to dedupe, distinct portal visual language with disable-able rounded-full buttons that `ModalHeader`/`ModalFooter` would override): `delibs/ApplicantContextModal.tsx`, `portal.application.tsx`, `portal.apply.tsx` (×3). `CommentsRail.tsx`'s `✕` is a cancel-reply button, not a modal close — out of scope.

## Out of scope / follow-up

- **`Drawer` slide-over primitive** — not added (per plan). `VersionHistoryPanel` is still a centered card; re-homing it (and the comments rail) onto a future `Drawer` is the recommended follow-up.
- **File overlap with PR-01/03/07** — `domain-lead.tsx`, `projects.level-up.tsx`, `lead.cycle.$id.tsx` are also touched by those PRs; rebase before merge if they land first.

## Verification

- `npm run typecheck` — **0 errors in `app/`** (the 26 pre-existing errors in `scripts/` and `prisma/seeds/` are present on clean `origin/dev` and untouched here).
- `npm test` — **1293/1293 pass** (157 files).
- `npm run build` — succeeds (only pre-existing chunk-size warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/860"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784751454&installation_id=133523038&pr_number=860&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F860&signature=14cc84d42c5862cbdfde3cc4fecb2bf80c2b847f8699a20e241203dc53e9b93f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->