### PR TITLE
Desktop: native menu bar + on-demand updater + public /download page …

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -108,6 +108,9 @@ jobs:
 
           aws s3 cp "${TARGZ}" "${S3}/releases/${VERSION}/"
           aws s3 cp "${DMG}"   "${S3}/releases/${VERSION}/"
+          # Stable, version-less copy the website's /download page links to, so
+          # that page never depends on the version/filename. Overwritten each release.
+          aws s3 cp "${DMG}" "${S3}/DALI-OS-macos.dmg" --content-type application/x-apple-diskimage
 
           # Universal build: both arch keys point at the one universal artifact.
           cat > latest.json <<EOF

--- a/dali-api/app/routes.ts
+++ b/dali-api/app/routes.ts
@@ -129,6 +129,10 @@ export default [
   route("privacy", "routes/privacy.tsx"),
   route("terms", "routes/terms.tsx"),
 
+  // Public, shareable desktop download page (OS auto-detect). Not linked from
+  // anywhere yet — reachable by direct URL.
+  route("download", "routes/download.tsx"),
+
   // Login (no layout)
   route("login", "routes/login.tsx"),
   route("dev-login", "routes/dev-login.ts"),

--- a/dali-api/app/routes/download.tsx
+++ b/dali-api/app/routes/download.tsx
@@ -1,0 +1,118 @@
+// Public, shareable desktop-download page. No auth, no app layout (like
+// /privacy and /terms) so the link works anywhere. Detects the visitor's OS
+// client-side and surfaces the macOS build. The download target is derived from
+// the live updater feed (latest.json), so it always points at the current
+// release with no per-release edit here. Not linked from anywhere yet — reachable
+// only by visiting /download directly.
+
+import { useEffect, useState } from "react";
+import { Download } from "lucide-react";
+import type { Route } from "./+types/download";
+
+const RELEASES_BASE = "https://dali-os-desktop-releases.s3.us-east-1.amazonaws.com";
+// Stable, version-less artifact published by the release workflow each release —
+// the download link never has to know the version or filename, so it can't drift.
+const STABLE_DMG_URL = `${RELEASES_BASE}/DALI-OS-macos.dmg`;
+const VERSION_TTL_MS = 5 * 60 * 1000;
+
+// Small server-side memo so a popular share link doesn't hit S3 on every render.
+let versionCache: { version: string | null; at: number } | null = null;
+
+async function getLatestVersion(): Promise<string | null> {
+  const now = Date.now();
+  if (versionCache && now - versionCache.at < VERSION_TTL_MS) {
+    return versionCache.version;
+  }
+  let version: string | null = null;
+  try {
+    const res = await fetch(`${RELEASES_BASE}/latest.json`, {
+      signal: AbortSignal.timeout(4000),
+    });
+    if (res.ok) {
+      const data = (await res.json()) as { version?: string };
+      if (typeof data.version === "string") version = data.version;
+    }
+  } catch {
+    // Feed unavailable — render the page without a live download link.
+  }
+  versionCache = { version, at: now };
+  return version;
+}
+
+export const meta: Route.MetaFunction = () => {
+  const title = "Download DALI OS for Mac";
+  const description =
+    "The DALI OS desktop app — a native window with menu bar, dock, and background notifications even when it's closed.";
+  return [
+    { title },
+    { name: "description", content: description },
+    { property: "og:title", content: title },
+    { property: "og:description", content: description },
+  ];
+};
+
+export async function loader(_: Route.LoaderArgs) {
+  // Version is cosmetic (a label); the download target is the stable URL.
+  const version = await getLatestVersion();
+  return { version, dmgUrl: STABLE_DMG_URL };
+}
+
+export default function DownloadPage({ loaderData }: Route.ComponentProps) {
+  const { version, dmgUrl } = loaderData;
+  const [os, setOs] = useState<"mac" | "windows" | "other" | null>(null);
+
+  useEffect(() => {
+    const ua = navigator.userAgent;
+    if (/Mac/i.test(ua)) setOs("mac");
+    else if (/Windows/i.test(ua)) setOs("windows");
+    else setOs("other");
+  }, []);
+
+  const notMac = os === "windows" || os === "other";
+
+  return (
+    <div className="min-h-screen bg-zinc-50 flex items-center justify-center px-4 py-12">
+      <main className="w-full max-w-lg text-center">
+        <img src="/logo-blue.svg" alt="DALI Lab" className="mx-auto h-12 w-auto" />
+        <h1 className="mt-8 text-3xl font-semibold text-zinc-900">
+          DALI OS for desktop
+        </h1>
+        <p className="mt-3 text-zinc-600">
+          A native window for DALI OS — menu bar, dock, and background
+          notifications even when it&apos;s closed.
+        </p>
+
+        <div className="mt-8 rounded-2xl border border-zinc-200 bg-white p-8 shadow-sm">
+          <a
+            href={dmgUrl}
+            className="inline-flex items-center justify-center gap-2 rounded-xl bg-zinc-900 px-6 py-3.5 text-base font-semibold text-white transition hover:bg-zinc-700"
+          >
+            <Download className="h-5 w-5" />
+            Download for macOS
+          </a>
+          {version ? (
+            <p className="mt-3 text-xs text-zinc-500">
+              Version {version} · Universal (Apple Silicon &amp; Intel)
+            </p>
+          ) : null}
+          {notMac ? (
+            <p className="mt-4 rounded-lg bg-amber-50 px-4 py-2 text-xs text-amber-800">
+              DALI OS desktop is macOS-only for now. Windows is coming later.
+            </p>
+          ) : null}
+
+          <div className="mt-6 border-t border-zinc-100 pt-5 text-left">
+            <p className="text-xs font-semibold text-zinc-700">Installing</p>
+            <p className="mt-1 text-xs text-zinc-500">
+              Open the downloaded{" "}
+              <code className="rounded bg-zinc-100 px-1">.dmg</code> and drag DALI
+              OS to your Applications folder, then open it from there.
+            </p>
+          </div>
+        </div>
+
+        <p className="mt-6 text-xs text-zinc-400">Requires macOS 12 or later.</p>
+      </main>
+    </div>
+  );
+}

--- a/desktop/src-tauri/src/config.rs
+++ b/desktop/src-tauri/src/config.rs
@@ -25,3 +25,6 @@ pub fn notifications_url() -> String {
 pub fn logout_url() -> String {
     format!("{PROD_ORIGIN}/logout")
 }
+pub fn help_url() -> String {
+    format!("{PROD_ORIGIN}/help")
+}

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -15,6 +15,7 @@ mod pairing;
 mod poller;
 mod state;
 mod tray;
+mod updater;
 mod window;
 
 use tauri::{Manager, WindowEvent};
@@ -87,6 +88,26 @@ pub fn run() {
                     let _ = window.hide();
                 }
             }
+        })
+        // App menu bar actions (menu.rs). Predefined items (Cut/Copy/Quit/…) are
+        // handled by macOS directly and need no arm here.
+        .on_menu_event(|app, event| match event.id().as_ref() {
+            "reload" => {
+                if let Some(w) = app.get_webview_window("main") {
+                    let _ = w.eval("location.reload()");
+                }
+            }
+            "help" => {
+                window::navigate_main(app, &config::help_url());
+                window::show_main(app);
+            }
+            "sign-out" => {
+                tauri::async_runtime::spawn(commands::do_sign_out(app.clone()));
+            }
+            "check-update" => {
+                tauri::async_runtime::spawn(updater::check_now(app.clone()));
+            }
+            _ => {}
         })
         .run(tauri::generate_context!())
         .expect("error while running DALI OS desktop");

--- a/desktop/src-tauri/src/menu.rs
+++ b/desktop/src-tauri/src/menu.rs
@@ -1,10 +1,20 @@
-// Native menu bar. The Edit submenu (Cut/Copy/Paste/Select All) is required or
-// Cmd-C/Cmd-V won't work inside the WKWebView — easy to forget.
+// Native macOS menu bar (NSApplication.mainMenu). Standard roles use
+// PredefinedMenuItem so macOS wires up labels, shortcuts, and behavior (e.g.
+// Cut/Copy/Paste work in the WKWebView via the responder chain — no handler
+// needed). App-specific items use MenuItem::with_id and are dispatched by the
+// Builder::on_menu_event handler in lib.rs. Custom ids are kept distinct from the
+// tray ids (open/signout/quit in tray.rs).
 
-use tauri::menu::{Menu, PredefinedMenuItem, Submenu};
+use tauri::menu::{Menu, MenuItem, PredefinedMenuItem, Submenu};
 use tauri::{AppHandle, Wry};
 
 pub fn build(app: &AppHandle) -> tauri::Result<Menu<Wry>> {
+    // App-handled items (see lib.rs on_menu_event).
+    let check_update = MenuItem::with_id(app, "check-update", "Check for Updates…", true, None::<&str>)?;
+    let sign_out = MenuItem::with_id(app, "sign-out", "Sign Out", true, None::<&str>)?;
+    let reload = MenuItem::with_id(app, "reload", "Reload", true, Some("CmdOrCtrl+R"))?;
+    let help_item = MenuItem::with_id(app, "help", "DALI OS Help", true, None::<&str>)?;
+
     let app_menu = Submenu::with_items(
         app,
         "DALI OS",
@@ -12,9 +22,15 @@ pub fn build(app: &AppHandle) -> tauri::Result<Menu<Wry>> {
         &[
             &PredefinedMenuItem::about(app, None, None)?,
             &PredefinedMenuItem::separator(app)?,
+            &check_update,
+            &PredefinedMenuItem::separator(app)?,
+            &PredefinedMenuItem::services(app, None)?,
+            &PredefinedMenuItem::separator(app)?,
             &PredefinedMenuItem::hide(app, None)?,
             &PredefinedMenuItem::hide_others(app, None)?,
             &PredefinedMenuItem::show_all(app, None)?,
+            &PredefinedMenuItem::separator(app)?,
+            &sign_out,
             &PredefinedMenuItem::separator(app)?,
             &PredefinedMenuItem::quit(app, None)?,
         ],
@@ -35,5 +51,33 @@ pub fn build(app: &AppHandle) -> tauri::Result<Menu<Wry>> {
         ],
     )?;
 
-    Menu::with_items(app, &[&app_menu, &edit_menu])
+    let view_menu = Submenu::with_items(
+        app,
+        "View",
+        true,
+        &[
+            &reload,
+            &PredefinedMenuItem::separator(app)?,
+            &PredefinedMenuItem::fullscreen(app, None)?,
+        ],
+    )?;
+
+    let window_menu = Submenu::with_items(
+        app,
+        "Window",
+        true,
+        &[
+            &PredefinedMenuItem::minimize(app, None)?,
+            &PredefinedMenuItem::maximize(app, None)?,
+            &PredefinedMenuItem::separator(app)?,
+            &PredefinedMenuItem::close_window(app, None)?,
+        ],
+    )?;
+
+    let help_menu = Submenu::with_items(app, "Help", true, &[&help_item])?;
+
+    Menu::with_items(
+        app,
+        &[&app_menu, &edit_menu, &view_menu, &window_menu, &help_menu],
+    )
 }

--- a/desktop/src-tauri/src/updater.rs
+++ b/desktop/src-tauri/src/updater.rs
@@ -1,0 +1,36 @@
+// On-demand "Check for Updates…" from the menu bar. Uses tauri-plugin-updater —
+// the same minisign-verified S3 feed the background auto-update path uses — and
+// surfaces the result as a native notification.
+
+use tauri::AppHandle;
+use tauri_plugin_updater::UpdaterExt;
+
+use crate::notify;
+
+pub async fn check_now(app: AppHandle) {
+    let updater = match app.updater() {
+        Ok(u) => u,
+        Err(e) => {
+            notify::raise(&app, "Update check failed", &e.to_string(), None);
+            return;
+        }
+    };
+
+    match updater.check().await {
+        Ok(Some(update)) => {
+            notify::raise(
+                &app,
+                "Updating DALI OS",
+                "Downloading the latest version…",
+                None,
+            );
+            match update.download_and_install(|_chunk, _total| {}, || {}).await {
+                // Relaunch into the new version (diverges).
+                Ok(_) => app.restart(),
+                Err(e) => notify::raise(&app, "Update failed", &e.to_string(), None),
+            }
+        }
+        Ok(None) => notify::raise(&app, "DALI OS", "You're up to date.", None),
+        Err(e) => notify::raise(&app, "Update check failed", &e.to_string(), None),
+    }
+}


### PR DESCRIPTION
…(#869)

* Expand native macOS menu bar + on-demand updater

Full App/Edit/View/Window/Help bar (Figma/Notion-style) so the wrapped web app feels native. App-specific items dispatched via Builder::on_menu_event: Reload (⌘R, page eval), DALI OS Help (→ /help), Sign Out, and Check for Updates… (new updater.rs over tauri-plugin-updater). Predefined roles (Cut/Copy/Quit/Full Screen/Minimize/…) are handled by macOS through the responder chain. Shell-only — no web/server changes, remote-window IPC lockdown untouched.



* Public /download page + stable release artifact

Shareable, OS-detecting /download page (public, no layout) that links to a stable version-less DALI-OS-macos.dmg, so the link never drifts with version or filename. The release workflow now publishes that stable copy each release alongside the versioned artifacts; the page shows the live version from latest.json as a label. Not linked from anywhere yet.



---------

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/871"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785129712&installation_id=133523038&pr_number=871&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F871&signature=71e237706f5d8e805239749c9d38dedccb2689533c483302275d2eac103b8c31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->