### PR TITLE
Desktop 0.1.1: auto-update/zoom/launch-at-login + auto-release CI (#872)

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -1,6 +1,8 @@
-# Builds, signs, notarizes, and publishes the macOS desktop shell. Separate from
-# the web app's test.yml / build-check.yml — it only runs when a desktop release
-# tag is pushed, so cutting a web deploy never builds the desktop binary.
+# Builds, signs, notarizes, and publishes the macOS desktop shell — separate from
+# the web app's CI/deploy. It auto-releases when desktop/src-tauri/tauri.conf.json's
+# version changes on `dev` (a version-bump merge IS the release), and also accepts
+# a manual `desktop-v*` tag or a workflow_dispatch as a fallback. Re-runs for an
+# already-released version are skipped (idempotent).
 #
 # REQUIRES secrets the repo owner must provision (the build can't create them):
 #   Apple (Gatekeeper):  APPLE_CERTIFICATE, APPLE_CERTIFICATE_PASSWORD,
@@ -15,26 +17,55 @@ name: Desktop Release (macOS)
 
 on:
   push:
+    branches: [dev]
+    paths:
+      - "desktop/src-tauri/tauri.conf.json"
     tags:
       - "desktop-v*"
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write # needed to push the release tag
+
+concurrency:
+  group: desktop-release
+  cancel-in-progress: false
 
 jobs:
+  # Decide the version + whether there's actually a new release to cut. On a
+  # `desktop-v*` tag the version comes from the tag; otherwise from tauri.conf.json,
+  # and we skip if that version was already released (its tag exists).
+  decide:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.v.outputs.version }}
+      release: ${{ steps.v.outputs.release }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: v
+        run: |
+          set -euo pipefail
+          if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+            VERSION="${GITHUB_REF_NAME#desktop-v}"
+            echo "release=true" >> "$GITHUB_OUTPUT"
+          else
+            VERSION="$(jq -r .version desktop/src-tauri/tauri.conf.json)"
+            if git ls-remote --exit-code --tags origin "refs/tags/desktop-v${VERSION}" >/dev/null 2>&1; then
+              echo "desktop-v${VERSION} already released — skipping."
+              echo "release=false" >> "$GITHUB_OUTPUT"
+            else
+              echo "New version ${VERSION} — releasing."
+              echo "release=true" >> "$GITHUB_OUTPUT"
+            fi
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
   build-macos:
+    needs: decide
+    if: ${{ needs.decide.outputs.release == 'true' }}
     runs-on: macos-14 # Apple silicon
     steps:
       - uses: actions/checkout@v4
-
-      - name: Derive version from tag
-        id: ver
-        run: |
-          REF="${GITHUB_REF_NAME}"
-          VERSION="${REF#desktop-v}"
-          if [ -z "$VERSION" ] || [ "$VERSION" = "$REF" ]; then VERSION="0.0.0-dev"; fi
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -95,7 +126,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.DESKTOP_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.DESKTOP_AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: us-east-1
-          VERSION: ${{ steps.ver.outputs.version }}
+          VERSION: ${{ needs.decide.outputs.version }}
         run: |
           set -euo pipefail
           BUNDLE="src-tauri/target/universal-apple-darwin/release/bundle"
@@ -125,3 +156,15 @@ jobs:
           EOF
 
           aws s3 cp latest.json "${S3}/latest.json"
+
+      # Record the release as a tag (only when we weren't already triggered by one).
+      # Pushed with GITHUB_TOKEN, which intentionally does NOT re-trigger this
+      # workflow — so no release loop. The tag is what makes future re-runs idempotent.
+      - name: Tag the release
+        if: ${{ github.ref_type != 'tag' }}
+        env:
+          VERSION: ${{ needs.decide.outputs.version }}
+        run: |
+          set -euo pipefail
+          git tag "desktop-v${VERSION}"
+          git push origin "desktop-v${VERSION}"

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dali-os-desktop",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "description": "Native macOS desktop shell for DALI OS (Tauri v2).",
   "scripts": {

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -686,7 +686,7 @@ checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
 name = "dali-os-desktop"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "keyring",
  "reqwest 0.12.28",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dali-os-desktop"
-version = "0.1.0"
+version = "0.1.1"
 description = "DALI OS desktop shell"
 authors = ["DALI Lab"]
 edition = "2021"

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -78,6 +78,9 @@ pub fn run() {
                 window::show_pairing(&handle);
             }
 
+            // Check for a newer signed release at launch (silent if up to date).
+            tauri::async_runtime::spawn(updater::check_on_launch(handle.clone()));
+
             Ok(())
         })
         .on_window_event(|window, event| {
@@ -106,6 +109,27 @@ pub fn run() {
             }
             "check-update" => {
                 tauri::async_runtime::spawn(updater::check_now(app.clone()));
+            }
+            "zoom-in" => {
+                let z = app.state::<AppState>().bump_zoom(0.1);
+                window::apply_zoom(app, z);
+            }
+            "zoom-out" => {
+                let z = app.state::<AppState>().bump_zoom(-0.1);
+                window::apply_zoom(app, z);
+            }
+            "zoom-reset" => {
+                let z = app.state::<AppState>().reset_zoom();
+                window::apply_zoom(app, z);
+            }
+            "open-at-login" => {
+                use tauri_plugin_autostart::ManagerExt;
+                let al = app.autolaunch();
+                let _ = if al.is_enabled().unwrap_or(false) {
+                    al.disable()
+                } else {
+                    al.enable()
+                };
             }
             _ => {}
         })

--- a/desktop/src-tauri/src/menu.rs
+++ b/desktop/src-tauri/src/menu.rs
@@ -5,8 +5,9 @@
 // Builder::on_menu_event handler in lib.rs. Custom ids are kept distinct from the
 // tray ids (open/signout/quit in tray.rs).
 
-use tauri::menu::{Menu, MenuItem, PredefinedMenuItem, Submenu};
+use tauri::menu::{CheckMenuItem, Menu, MenuItem, PredefinedMenuItem, Submenu};
 use tauri::{AppHandle, Wry};
+use tauri_plugin_autostart::ManagerExt;
 
 pub fn build(app: &AppHandle) -> tauri::Result<Menu<Wry>> {
     // App-handled items (see lib.rs on_menu_event).
@@ -14,6 +15,18 @@ pub fn build(app: &AppHandle) -> tauri::Result<Menu<Wry>> {
     let sign_out = MenuItem::with_id(app, "sign-out", "Sign Out", true, None::<&str>)?;
     let reload = MenuItem::with_id(app, "reload", "Reload", true, Some("CmdOrCtrl+R"))?;
     let help_item = MenuItem::with_id(app, "help", "DALI OS Help", true, None::<&str>)?;
+    let zoom_in = MenuItem::with_id(app, "zoom-in", "Zoom In", true, Some("CmdOrCtrl+="))?;
+    let zoom_out = MenuItem::with_id(app, "zoom-out", "Zoom Out", true, Some("CmdOrCtrl+-"))?;
+    let zoom_reset = MenuItem::with_id(app, "zoom-reset", "Actual Size", true, Some("CmdOrCtrl+0"))?;
+    // Reflects the current launch-at-login state; toggled in lib.rs on_menu_event.
+    let open_at_login = CheckMenuItem::with_id(
+        app,
+        "open-at-login",
+        "Open at Login",
+        true,
+        app.autolaunch().is_enabled().unwrap_or(false),
+        None::<&str>,
+    )?;
 
     let app_menu = Submenu::with_items(
         app,
@@ -29,6 +42,8 @@ pub fn build(app: &AppHandle) -> tauri::Result<Menu<Wry>> {
             &PredefinedMenuItem::hide(app, None)?,
             &PredefinedMenuItem::hide_others(app, None)?,
             &PredefinedMenuItem::show_all(app, None)?,
+            &PredefinedMenuItem::separator(app)?,
+            &open_at_login,
             &PredefinedMenuItem::separator(app)?,
             &sign_out,
             &PredefinedMenuItem::separator(app)?,
@@ -57,6 +72,10 @@ pub fn build(app: &AppHandle) -> tauri::Result<Menu<Wry>> {
         true,
         &[
             &reload,
+            &PredefinedMenuItem::separator(app)?,
+            &zoom_in,
+            &zoom_out,
+            &zoom_reset,
             &PredefinedMenuItem::separator(app)?,
             &PredefinedMenuItem::fullscreen(app, None)?,
         ],

--- a/desktop/src-tauri/src/state.rs
+++ b/desktop/src-tauri/src/state.rs
@@ -26,6 +26,8 @@ pub struct AppState {
     // Notification ids already surfaced this session — dedupe so a steady poll
     // doesn't re-alert the same item.
     pub seen_notifs: Mutex<HashSet<String>>,
+    // Webview zoom factor (View → Zoom). In-memory; resets to 1.0 on restart.
+    pub zoom: Mutex<f64>,
 }
 
 impl AppState {
@@ -35,6 +37,7 @@ impl AppState {
             auth: Mutex::new(AuthState::Unpaired),
             pairing_cancel: AtomicBool::new(false),
             seen_notifs: Mutex::new(HashSet::new()),
+            zoom: Mutex::new(1.0),
         }
     }
 
@@ -46,6 +49,20 @@ impl AppState {
 
     pub fn auth(&self) -> AuthState {
         self.auth.lock().map(|g| *g).unwrap_or(AuthState::Unpaired)
+    }
+
+    /// Adjust the webview zoom by `delta`, clamped to a sane range; returns the
+    /// new factor.
+    pub fn bump_zoom(&self, delta: f64) -> f64 {
+        let mut g = self.zoom.lock().unwrap_or_else(|e| e.into_inner());
+        *g = (*g + delta).clamp(0.5, 3.0);
+        *g
+    }
+
+    pub fn reset_zoom(&self) -> f64 {
+        let mut g = self.zoom.lock().unwrap_or_else(|e| e.into_inner());
+        *g = 1.0;
+        *g
     }
 }
 

--- a/desktop/src-tauri/src/updater.rs
+++ b/desktop/src-tauri/src/updater.rs
@@ -34,3 +34,26 @@ pub async fn check_now(app: AppHandle) {
         Err(e) => notify::raise(&app, "Update check failed", &e.to_string(), None),
     }
 }
+
+/// Silent check at launch: if a newer signed release exists, download + stage it
+/// and notify the user to reopen. Quiet on up-to-date / errors so a flaky network
+/// never nags. No forced restart — the staged bundle applies on the next launch.
+pub async fn check_on_launch(app: AppHandle) {
+    let Ok(updater) = app.updater() else {
+        return;
+    };
+    if let Ok(Some(update)) = updater.check().await {
+        if update
+            .download_and_install(|_chunk, _total| {}, || {})
+            .await
+            .is_ok()
+        {
+            notify::raise(
+                &app,
+                "DALI OS updated",
+                "Reopen DALI OS to finish updating.",
+                None,
+            );
+        }
+    }
+}

--- a/desktop/src-tauri/src/window.rs
+++ b/desktop/src-tauri/src/window.rs
@@ -74,3 +74,9 @@ pub fn set_badge(app: &AppHandle, count: i64) {
         let _ = w.set_badge_count(if count > 0 { Some(count) } else { None });
     }
 }
+
+pub fn apply_zoom(app: &AppHandle, factor: f64) {
+    if let Some(w) = app.get_webview_window("main") {
+        let _ = w.set_zoom(factor);
+    }
+}

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "DALI OS",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "identifier": "edu.dartmouth.dali.os",
   "build": {
     "frontendDist": "../frontend"


### PR DESCRIPTION
* Desktop 0.1.1: auto-update on launch, zoom, launch-at-login

- Auto-update: silent updater check at launch (updater::check_on_launch) — stages a newer signed release and notifies to reopen; quiet when up to date.
- Zoom: View → Zoom In/Out/Actual Size (⌘=/⌘-/⌘0) via WebviewWindow::set_zoom, level tracked in AppState (clamped 0.5–3.0).
- Launch at login: App-menu "Open at Login" CheckMenuItem backed by the autostart plugin.
- Bump version to 0.1.1 (tauri.conf.json / Cargo.toml / package.json).



* CI: auto-release desktop on version bump

The release workflow now also triggers on a push to dev that changes desktop/src-tauri/tauri.conf.json: a `decide` job reads the version, skips if that version was already released (its desktop-v* tag exists), otherwise builds
+ publishes and tags desktop-v<version>. So bumping the version in a merged PR IS the release — no manual tag push. Manual `desktop-v*` tags and workflow_dispatch still work as fallbacks; the auto-created tag uses GITHUB_TOKEN so it doesn't re-trigger the workflow.



---------

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/873"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785131129&installation_id=133523038&pr_number=873&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F873&signature=7a1f653b950446e7f63437df2f961472b92e52e44aae8adeea0fdb8fd5bbbcae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->