### PR TITLE
Promote to prod: roster → GitHub team sync (#876)

### DIFF
--- a/dali-api/app/lib/__tests__/github-slug.test.ts
+++ b/dali-api/app/lib/__tests__/github-slug.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { githubTeamSlug } from "~/lib/github-slug";
+
+describe("githubTeamSlug", () => {
+  it("lowercases and hyphenates spaces", () => {
+    expect(githubTeamSlug("Smart Microscope")).toBe("smart-microscope");
+  });
+
+  it("collapses runs of non-alphanumerics into a single hyphen", () => {
+    expect(githubTeamSlug("DALI OS 2.0")).toBe("dali-os-2-0");
+    expect(githubTeamSlug("a  &  b")).toBe("a-b");
+    expect(githubTeamSlug("Hello_World!")).toBe("hello-world");
+  });
+
+  it("trims leading and trailing hyphens", () => {
+    expect(githubTeamSlug("  Hello World  ")).toBe("hello-world");
+    expect(githubTeamSlug("!!Edge!!")).toBe("edge");
+  });
+
+  it("returns '' when the name has no alphanumerics", () => {
+    expect(githubTeamSlug("—")).toBe("");
+    expect(githubTeamSlug("   ")).toBe("");
+    expect(githubTeamSlug("🚀")).toBe("");
+  });
+});

--- a/dali-api/app/lib/audit.ts
+++ b/dali-api/app/lib/audit.ts
@@ -37,6 +37,7 @@ export const AUDIT_ACTIONS = [
   "staffing.assign",
   "staffing.finalize",
   "staffing.term_channel",
+  "staffing.sync_teams",
   "staffing.board-member.add",
   "staffing.board-member.remove",
   "staffing.reorder",

--- a/dali-api/app/lib/github-slug.ts
+++ b/dali-api/app/lib/github-slug.ts
@@ -1,0 +1,11 @@
+// GitHub team-slug derivation, kept in its own module with NO octokit / Node
+// imports so it can be pulled into client bundles (project-create routes render
+// on the client). Rule: lowercase, collapse runs of non-alphanumerics to a
+// single hyphen, trim leading/trailing hyphens. Returns "" when the name has no
+// alphanumeric characters — callers store null in that case.
+export function githubTeamSlug(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}

--- a/dali-api/app/lib/github.ts
+++ b/dali-api/app/lib/github.ts
@@ -99,13 +99,38 @@ export async function ensureTeam(slug: string): Promise<{ slug: string; created:
 
 // Add (or confirm) a member on a team. PUT is idempotent — re-adding an
 // existing member is a no-op that returns 200. Role defaults to "member".
-export async function addTeamMember(teamSlug: string, username: string): Promise<void> {
+// Returns the resulting membership state: "pending" when the user isn't yet an
+// org member (GitHub emails them an org invite) vs "active" once accepted.
+export async function addTeamMember(
+  teamSlug: string,
+  username: string,
+): Promise<{ state: "active" | "pending" }> {
   const org = requireOrg();
-  await githubAppClient().rest.teams.addOrUpdateMembershipForUserInOrg({
+  const res = await githubAppClient().rest.teams.addOrUpdateMembershipForUserInOrg({
     org,
     team_slug: teamSlug,
     username,
     role: "member",
+  });
+  return { state: res?.data?.state === "pending" ? "pending" : "active" };
+}
+
+// Grant a team a permission on a repo under GITHUB_ORG. PUT is idempotent —
+// re-granting (or changing) the permission overwrites and returns 204. A missing
+// repo or team surfaces as 404; callers decide whether to swallow it (isNotFound).
+export async function grantTeamRepo(
+  teamSlug: string,
+  owner: string,
+  repo: string,
+  permission: "pull" | "triage" | "push" | "maintain" | "admin" = "push",
+): Promise<void> {
+  const org = requireOrg();
+  await githubAppClient().rest.teams.addOrUpdateRepoPermissionsInOrg({
+    org,
+    team_slug: teamSlug,
+    owner,
+    repo,
+    permission,
   });
 }
 

--- a/dali-api/app/partners/routes/partners.applications.$id.tsx
+++ b/dali-api/app/partners/routes/partners.applications.$id.tsx
@@ -11,6 +11,7 @@ import {
 import { Pencil } from "lucide-react";
 import type { Route } from "./+types/partners.applications.$id";
 import { prisma } from "~/lib/db";
+import { githubTeamSlug } from "~/lib/github-slug";
 import { requireAuth } from "~/lib/auth";
 import { parseSessionCookie } from "~/lib/cookies";
 import { canViewStaffing, isCore } from "~/lib/roles";
@@ -245,6 +246,8 @@ export async function action({ request, params }: Route.ActionArgs) {
       const created = await tx.project.create({
         data: {
           name: app.title,
+          // Auto-derive the GitHub team slug from the title (editable later).
+          githubTeamSlug: githubTeamSlug(app.title) || null,
           description: app.summary,
           ...(firstTermId
             ? { projectTerms: { create: { termId: firstTermId } } }

--- a/dali-api/app/projects/components/StaffingBoard.tsx
+++ b/dali-api/app/projects/components/StaffingBoard.tsx
@@ -368,6 +368,7 @@ export function StaffingBoard({
   return (
     <div className="flex flex-col gap-3">
       {canManage && <TermChannelBanner termId={termId} termCode={termCode} />}
+      {canManage && <SyncTeamsBanner termId={termId} termCode={termCode} />}
       <div className="flex items-center justify-end gap-3 flex-wrap">
         {canManage && <AddMemberControl cycleId={cycleId} />}
         <DomainFilter
@@ -566,6 +567,110 @@ function TermChannelBanner({ termId, termCode }: { termId: string; termCode: str
         >
           {running ? "Creating…" : "Create + invite"}
         </Button>
+      </div>
+    </div>
+  );
+}
+
+// Full-width banner: add-only GitHub team sync for every project staffed this
+// term. Ensures each project's org team, adds its rostered members, and grants
+// the team push on its repos. Idempotent — safe to re-run. Two-click confirm
+// because it can send org invites in bulk.
+function SyncTeamsBanner({ termId, termCode }: { termId: string; termCode: string }) {
+  const [running, setRunning] = useState(false);
+  const [confirming, setConfirming] = useState(false);
+  const [result, setResult] = useState<{ ok: boolean; message: string; warnings?: string[] } | null>(
+    null,
+  );
+
+  // Reset when the selected term changes.
+  useEffect(() => {
+    setResult(null);
+    setConfirming(false);
+  }, [termCode]);
+
+  async function run() {
+    setRunning(true);
+    setResult(null);
+    setConfirming(false);
+    try {
+      const res = await fetch("/api/staffing/sync-teams", {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ termId }),
+      });
+      const json = (await res.json().catch(() => ({}))) as {
+        ok?: boolean;
+        message?: string;
+        error?: string;
+        warnings?: string[];
+      };
+      if (!res.ok) {
+        setResult({ ok: false, message: json.error ?? `Failed: ${res.status}` });
+        return;
+      }
+      setResult({ ok: json.ok ?? true, message: json.message ?? "Done.", warnings: json.warnings });
+    } catch (err) {
+      setResult({ ok: false, message: err instanceof Error ? err.message : "Network error" });
+    } finally {
+      setRunning(false);
+    }
+  }
+
+  return (
+    <div className="w-full rounded-lg border border-accent-coral/30 bg-accent-coral/10 px-4 py-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+      <div className="min-w-0">
+        <p className="text-sm font-heading font-semibold text-foreground">
+          Sync GitHub teams{termCode ? ` for ${termCode}` : ""}
+        </p>
+        <p className="text-xs text-muted-foreground break-words">
+          For every project staffed this term: ensure its org team, add rostered members, and grant
+          the team push on its repos. Add-only — never removes anyone. Safe to re-run.
+        </p>
+        {result && (
+          <>
+            <p className={`text-xs mt-1 break-words ${result.ok ? "text-accent-teal" : "text-destructive"}`}>
+              {result.ok ? "✓ " : "✗ "}
+              {result.message}
+            </p>
+            {result.warnings?.length ? (
+              <ul className="text-xs text-muted-foreground mt-1 list-disc pl-4 max-h-32 overflow-auto break-words">
+                {result.warnings.map((w, i) => (
+                  <li key={i}>{w}</li>
+                ))}
+              </ul>
+            ) : null}
+          </>
+        )}
+      </div>
+      <div className="flex items-center gap-2 flex-shrink-0">
+        {confirming ? (
+          <>
+            <Button
+              variant="primary"
+              size="sm"
+              disabled={running}
+              onClick={run}
+              className="whitespace-nowrap"
+            >
+              {running ? "Syncing…" : "Confirm sync"}
+            </Button>
+            <Button variant="ghost" size="sm" disabled={running} onClick={() => setConfirming(false)}>
+              Cancel
+            </Button>
+          </>
+        ) : (
+          <Button
+            variant="primary"
+            size="sm"
+            disabled={running}
+            onClick={() => setConfirming(true)}
+            className="whitespace-nowrap"
+          >
+            Sync all current-term teams
+          </Button>
+        )}
       </div>
     </div>
   );

--- a/dali-api/app/projects/lib/__tests__/github-team-sync.test.ts
+++ b/dali-api/app/projects/lib/__tests__/github-team-sync.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+vi.mock("~/lib/db");
+
+import { prisma } from "~/lib/db";
+import { __setGitHubClientForTests } from "~/lib/github";
+import { syncProjectTeam } from "~/projects/lib/github-team-sync";
+import type { Octokit } from "@octokit/rest";
+
+const mockPrisma = prisma as unknown as {
+  project: { findUnique: ReturnType<typeof vi.fn> };
+};
+
+const TERM = "term-26x";
+const notFound = Object.assign(new Error("Not Found"), { status: 404 });
+
+function fakeOctokit(o: {
+  getByName?: ReturnType<typeof vi.fn>;
+  create?: ReturnType<typeof vi.fn>;
+  addMembership?: ReturnType<typeof vi.fn>;
+  grantRepo?: ReturnType<typeof vi.fn>;
+  removeMembership?: ReturnType<typeof vi.fn>;
+  listMembers?: ReturnType<typeof vi.fn>;
+  removeRepo?: ReturnType<typeof vi.fn>;
+}) {
+  return {
+    rest: {
+      teams: {
+        getByName: o.getByName ?? vi.fn().mockResolvedValue({ data: { slug: "proj" } }),
+        create: o.create ?? vi.fn().mockResolvedValue({ data: { slug: "proj" } }),
+        addOrUpdateMembershipForUserInOrg:
+          o.addMembership ?? vi.fn().mockResolvedValue({ data: { state: "active" } }),
+        addOrUpdateRepoPermissionsInOrg: o.grantRepo ?? vi.fn().mockResolvedValue({}),
+        // Guardrail spies — the add-only invariant means these must NEVER fire.
+        removeMembershipForUserInOrg: o.removeMembership ?? vi.fn(),
+        listMembersInOrg: o.listMembers ?? vi.fn(),
+        removeRepoInOrg: o.removeRepo ?? vi.fn(),
+      },
+    },
+  } as unknown as Octokit;
+}
+
+function assignment(id: string, first: string, last: string, gh: string | null) {
+  return { user: { id, firstName: first, lastName: last, githubUsername: gh } };
+}
+
+function projectRow(over: Partial<{ githubTeamSlug: string | null; repoUrls: string[]; assignments: unknown[] }> = {}) {
+  return {
+    id: "p1",
+    name: "Proj",
+    githubTeamSlug: "proj",
+    repoUrls: [],
+    assignments: [],
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  process.env.GITHUB_ORG = "dali-test-org";
+  mockPrisma.project = { findUnique: vi.fn() };
+});
+afterEach(() => {
+  __setGitHubClientForTests(null);
+  delete process.env.GITHUB_ORG;
+  vi.clearAllMocks();
+});
+
+describe("syncProjectTeam", () => {
+  it("happy path: ensures team, adds handles (active + pending), grants parseable repos, reports missing", async () => {
+    mockPrisma.project.findUnique.mockResolvedValue(
+      projectRow({
+        repoUrls: ["https://github.com/dali-lab/foo", "dali-lab/bar", "garbage"],
+        assignments: [
+          assignment("u1", "Ada", "Byte", "ada"),
+          assignment("u2", "Grace", "Hop", "gracep"),
+          assignment("u3", "No", "Handle", null),
+        ],
+      }),
+    );
+    const addMembership = vi.fn().mockImplementation(({ username }: { username: string }) =>
+      Promise.resolve({ data: { state: username === "gracep" ? "pending" : "active" } }),
+    );
+    const grantRepo = vi.fn().mockResolvedValue({});
+    __setGitHubClientForTests(fakeOctokit({ addMembership, grantRepo }));
+
+    const r = await syncProjectTeam("p1", TERM);
+
+    expect(r.status).toBe("ok");
+    expect(r.teamCreated).toBe(false);
+    expect(r.membersEnsured).toBe(2);
+    expect(r.membersPending).toBe(1);
+    expect(r.missingHandles).toEqual(["No Handle"]);
+    expect(addMembership).toHaveBeenCalledTimes(2);
+    // parseable repos granted with push, garbage skipped (not an error).
+    expect(grantRepo).toHaveBeenCalledWith(
+      expect.objectContaining({ owner: "dali-lab", repo: "foo", permission: "push" }),
+    );
+    expect(grantRepo).toHaveBeenCalledWith(
+      expect.objectContaining({ owner: "dali-lab", repo: "bar", permission: "push" }),
+    );
+    expect(grantRepo).toHaveBeenCalledTimes(2);
+    expect(r.repos.find((x) => x.repo === "garbage")?.status).toBe("skipped");
+  });
+
+  it("dedupes a member assigned in two domains to a single membership PUT", async () => {
+    mockPrisma.project.findUnique.mockResolvedValue(
+      projectRow({
+        assignments: [assignment("u1", "Ada", "Byte", "ada"), assignment("u1", "Ada", "Byte", "ada")],
+      }),
+    );
+    const addMembership = vi.fn().mockResolvedValue({ data: { state: "active" } });
+    __setGitHubClientForTests(fakeOctokit({ addMembership }));
+
+    const r = await syncProjectTeam("p1", TERM);
+    expect(addMembership).toHaveBeenCalledTimes(1);
+    expect(r.membersEnsured).toBe(1);
+  });
+
+  it("skips (no octokit calls) when the project has no slug", async () => {
+    mockPrisma.project.findUnique.mockResolvedValue(projectRow({ githubTeamSlug: null }));
+    const getByName = vi.fn();
+    const addMembership = vi.fn();
+    __setGitHubClientForTests(fakeOctokit({ getByName, addMembership }));
+
+    const r = await syncProjectTeam("p1", TERM);
+    expect(r.status).toBe("skipped");
+    expect(getByName).not.toHaveBeenCalled();
+    expect(addMembership).not.toHaveBeenCalled();
+  });
+
+  it("errors (no member/repo calls) when ensureTeam fails", async () => {
+    mockPrisma.project.findUnique.mockResolvedValue(
+      projectRow({
+        repoUrls: ["dali-lab/foo"],
+        assignments: [assignment("u1", "Ada", "Byte", "ada")],
+      }),
+    );
+    const getByName = vi.fn().mockRejectedValue(Object.assign(new Error("boom"), { status: 500 }));
+    const addMembership = vi.fn();
+    const grantRepo = vi.fn();
+    __setGitHubClientForTests(fakeOctokit({ getByName, addMembership, grantRepo }));
+
+    const r = await syncProjectTeam("p1", TERM);
+    expect(r.status).toBe("error");
+    expect(addMembership).not.toHaveBeenCalled();
+    expect(grantRepo).not.toHaveBeenCalled();
+  });
+
+  it("isolates a failing member add — other members still ensured, status error", async () => {
+    mockPrisma.project.findUnique.mockResolvedValue(
+      projectRow({
+        assignments: [assignment("u1", "A", "A", "aaa"), assignment("u2", "B", "B", "bbb")],
+      }),
+    );
+    const addMembership = vi.fn().mockImplementation(({ username }: { username: string }) =>
+      username === "aaa" ? Promise.reject(notFound) : Promise.resolve({ data: { state: "active" } }),
+    );
+    __setGitHubClientForTests(fakeOctokit({ addMembership }));
+
+    const r = await syncProjectTeam("p1", TERM);
+    expect(r.status).toBe("error");
+    expect(r.memberErrors).toHaveLength(1);
+    expect(r.memberErrors[0].handle).toBe("aaa");
+    expect(r.membersEnsured).toBe(1);
+  });
+
+  it("isolates a failing repo grant — others granted, status error, actionable 404 message", async () => {
+    mockPrisma.project.findUnique.mockResolvedValue(
+      projectRow({ repoUrls: ["dali-lab/ok", "dali-lab/missing"] }),
+    );
+    const grantRepo = vi.fn().mockImplementation(({ repo }: { repo: string }) =>
+      repo === "missing" ? Promise.reject(notFound) : Promise.resolve({}),
+    );
+    __setGitHubClientForTests(fakeOctokit({ grantRepo }));
+
+    const r = await syncProjectTeam("p1", TERM);
+    expect(r.status).toBe("error");
+    const bad = r.repos.find((x) => x.repo === "dali-lab/missing");
+    expect(bad?.status).toBe("error");
+    expect(bad?.message).toContain("not found");
+    expect(r.repos.find((x) => x.repo === "dali-lab/ok")?.status).toBe("granted");
+  });
+
+  it("is idempotent on re-run: existing team, no create call", async () => {
+    mockPrisma.project.findUnique.mockResolvedValue(
+      projectRow({ assignments: [assignment("u1", "A", "A", "aaa")] }),
+    );
+    const getByName = vi.fn().mockResolvedValue({ data: { slug: "proj" } });
+    const create = vi.fn();
+    __setGitHubClientForTests(fakeOctokit({ getByName, create }));
+
+    const r = await syncProjectTeam("p1", TERM);
+    expect(r.status).toBe("ok");
+    expect(r.teamCreated).toBe(false);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it("strips a stored leading '@' from a handle", async () => {
+    mockPrisma.project.findUnique.mockResolvedValue(
+      projectRow({ assignments: [assignment("u1", "A", "A", "@ada")] }),
+    );
+    const addMembership = vi.fn().mockResolvedValue({ data: { state: "active" } });
+    __setGitHubClientForTests(fakeOctokit({ addMembership }));
+
+    await syncProjectTeam("p1", TERM);
+    expect(addMembership).toHaveBeenCalledWith(expect.objectContaining({ username: "ada" }));
+  });
+
+  it("skips when the project is not found", async () => {
+    mockPrisma.project.findUnique.mockResolvedValue(null);
+    __setGitHubClientForTests(fakeOctokit({}));
+
+    const r = await syncProjectTeam("nope", TERM);
+    expect(r.status).toBe("skipped");
+    expect(r.message).toContain("not found");
+  });
+
+  it("is add-only: never removes members/repos or lists membership, even on re-run", async () => {
+    mockPrisma.project.findUnique.mockResolvedValue(
+      projectRow({
+        repoUrls: ["dali-lab/foo"],
+        assignments: [assignment("u1", "A", "A", "aaa"), assignment("u2", "B", "B", "bbb")],
+      }),
+    );
+    const removeMembership = vi.fn();
+    const listMembers = vi.fn();
+    const removeRepo = vi.fn();
+    __setGitHubClientForTests(fakeOctokit({ removeMembership, listMembers, removeRepo }));
+
+    await syncProjectTeam("p1", TERM);
+    await syncProjectTeam("p1", TERM); // re-run: still no removal/reconcile
+    expect(removeMembership).not.toHaveBeenCalled();
+    expect(listMembers).not.toHaveBeenCalled();
+    expect(removeRepo).not.toHaveBeenCalled();
+  });
+});

--- a/dali-api/app/projects/lib/github-team-sync.ts
+++ b/dali-api/app/projects/lib/github-team-sync.ts
@@ -1,0 +1,181 @@
+import { prisma } from "~/lib/db";
+import { ensureTeam, addTeamMember, grantTeamRepo, isNotFound } from "~/lib/github";
+import { normalizeRepo } from "~/projects/lib/github-task-sync";
+import { currentTerm } from "~/lib/roles";
+import { slackErrorMessage } from "~/slack/lib/slack-client";
+
+// Add-only, idempotent sync of ONE project's current-term roster into its GitHub
+// org team, plus a push grant for each of its repos. Never lists or removes
+// members/repos (add-only per design — departures are handled by org-level
+// offboarding). Safe to re-run: ensureTeam get-or-creates, addTeamMember PUTs,
+// grantTeamRepo PUTs. Per-member and per-repo failures are isolated so one bad
+// handle or repo never aborts the rest — the whole thing converges on re-run.
+
+export type RepoSyncResult = {
+  repo: string; // "owner/repo", or the raw entry when unparseable
+  status: "granted" | "skipped" | "error";
+  message?: string;
+};
+
+export type MemberError = { handle: string; message: string };
+
+export type ProjectTeamSyncReport = {
+  projectId: string;
+  projectName: string;
+  status: "ok" | "skipped" | "error";
+  slug: string | null;
+  teamCreated: boolean;
+  membersEnsured: number; // handles PUT to the team (idempotent — "ensured", not "newly added")
+  membersPending: number; // subset returned state:"pending" (GitHub emailed an org invite)
+  missingHandles: string[]; // rostered member display names with no githubUsername (reported, not skipped silently)
+  memberErrors: MemberError[];
+  repos: RepoSyncResult[];
+  message: string;
+};
+
+function emptyReport(
+  projectId: string,
+  projectName: string,
+  slug: string | null,
+  status: ProjectTeamSyncReport["status"],
+  message: string,
+): ProjectTeamSyncReport {
+  return {
+    projectId,
+    projectName,
+    status,
+    slug,
+    teamCreated: false,
+    membersEnsured: 0,
+    membersPending: 0,
+    missingHandles: [],
+    memberErrors: [],
+    repos: [],
+    message,
+  };
+}
+
+export async function syncProjectTeam(
+  projectId: string,
+  termId?: string,
+): Promise<ProjectTeamSyncReport> {
+  let tid = termId;
+  if (!tid) {
+    const t = await currentTerm();
+    if (!t) return emptyReport(projectId, projectId, null, "skipped", "No current term.");
+    tid = t.id;
+  }
+
+  const project = await prisma.project.findUnique({
+    where: { id: projectId },
+    select: {
+      id: true,
+      name: true,
+      githubTeamSlug: true,
+      repoUrls: true,
+      // Project.assignments == ProjectAssignment (live, term-scoped roster).
+      assignments: {
+        where: { termId: tid },
+        select: {
+          user: { select: { id: true, firstName: true, lastName: true, githubUsername: true } },
+        },
+      },
+    },
+  });
+  if (!project) return emptyReport(projectId, projectId, null, "skipped", "Project not found.");
+
+  const slug = project.githubTeamSlug?.trim() || null;
+  if (!slug) {
+    return emptyReport(
+      project.id,
+      project.name,
+      null,
+      "skipped",
+      "No GitHub team slug — set one on the project page.",
+    );
+  }
+
+  // Desired member set: dedupe by user id (a user holds one ProjectAssignment
+  // row per domain). Strip a stray leading "@" so a stored "@foo" doesn't error.
+  const byUser = new Map<string, { name: string; handle: string | null }>();
+  for (const a of project.assignments) {
+    byUser.set(a.user.id, {
+      name: `${a.user.firstName} ${a.user.lastName}`.trim(),
+      handle: a.user.githubUsername?.trim().replace(/^@/, "") || null,
+    });
+  }
+  const members = [...byUser.values()];
+  const handles = [...new Set(members.map((m) => m.handle).filter((h): h is string => !!h))];
+  const missingHandles = members.filter((m) => !m.handle).map((m) => m.name);
+
+  const report = emptyReport(project.id, project.name, slug, "ok", "");
+  report.missingHandles = missingHandles;
+
+  // ensureTeam is the only project-fatal step — without a team nothing else can proceed.
+  let team: { slug: string; created: boolean };
+  try {
+    team = await ensureTeam(slug);
+  } catch (err) {
+    return { ...report, status: "error", message: slackErrorMessage(err) };
+  }
+  report.slug = team.slug;
+  report.teamCreated = team.created;
+
+  // Members — sequential (avoids GitHub secondary-rate-limit bursts), isolated.
+  for (const handle of handles) {
+    try {
+      const { state } = await addTeamMember(team.slug, handle);
+      report.membersEnsured += 1;
+      if (state === "pending") report.membersPending += 1;
+    } catch (err) {
+      report.memberErrors.push({ handle, message: slackErrorMessage(err) });
+    }
+  }
+
+  // Repos — per-repo isolation; unparseable entries are "skipped", not errors.
+  for (const raw of project.repoUrls ?? []) {
+    const norm = normalizeRepo(raw);
+    if (!norm) {
+      report.repos.push({ repo: raw, status: "skipped", message: "Not a parseable owner/repo." });
+      continue;
+    }
+    const [owner, repo] = norm.split("/");
+    try {
+      await grantTeamRepo(team.slug, owner, repo, "push");
+      report.repos.push({ repo: norm, status: "granted" });
+    } catch (err) {
+      report.repos.push({
+        repo: norm,
+        status: "error",
+        message: isNotFound(err)
+          ? `${norm}: not found — check the repo exists in the org and the App has access.`
+          : slackErrorMessage(err),
+      });
+    }
+  }
+
+  const failed = report.memberErrors.length > 0 || report.repos.some((r) => r.status === "error");
+  report.status = failed ? "error" : "ok";
+  report.message = summarize(report);
+  return report;
+}
+
+function summarize(r: ProjectTeamSyncReport): string {
+  const parts = [
+    `${r.teamCreated ? "created" : "found"} team "${r.slug}"`,
+    `ensured ${r.membersEnsured} member${r.membersEnsured === 1 ? "" : "s"}${
+      r.membersPending ? ` (${r.membersPending} pending invite)` : ""
+    }`,
+  ];
+  const granted = r.repos.filter((x) => x.status === "granted").length;
+  parts.push(`granted ${granted} repo${granted === 1 ? "" : "s"}`);
+  if (r.missingHandles.length) {
+    parts.push(`${r.missingHandles.length} without a GitHub username (${r.missingHandles.join(", ")})`);
+  }
+  if (r.memberErrors.length) {
+    parts.push(`${r.memberErrors.length} member error${r.memberErrors.length === 1 ? "" : "s"}`);
+  }
+  const repoProblems = r.repos.filter((x) => x.status === "error").length;
+  if (repoProblems) parts.push(`${repoProblems} repo error${repoProblems === 1 ? "" : "s"}`);
+  return `${parts.join("; ")}.`;
+}

--- a/dali-api/app/projects/routes/__tests__/api.staffing.sync-teams.test.ts
+++ b/dali-api/app/projects/routes/__tests__/api.staffing.sync-teams.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("~/lib/auth", () => ({
+  requireAuth: vi.fn(),
+  forbidden: vi.fn(() => new Response("forbidden", { status: 403 })),
+}));
+vi.mock("~/lib/db");
+vi.mock("~/lib/roles", () => ({ canManageStaffing: vi.fn(), currentTerm: vi.fn() }));
+vi.mock("~/lib/audit", () => ({ logAuditEvent: vi.fn() }));
+vi.mock("~/lib/cors", () => ({
+  withCors: (_req: Request, res: Response) => res,
+  handlePreflight: (req: Request) =>
+    req.method === "OPTIONS" ? new Response(null, { status: 204 }) : null,
+}));
+vi.mock("~/slack/lib/slack-client", () => ({
+  slackErrorMessage: (e: unknown) => (e instanceof Error ? e.message : String(e)),
+}));
+vi.mock("~/projects/lib/github-team-sync", () => ({ syncProjectTeam: vi.fn() }));
+
+import { requireAuth } from "~/lib/auth";
+import { prisma } from "~/lib/db";
+import { canManageStaffing, currentTerm } from "~/lib/roles";
+import { logAuditEvent } from "~/lib/audit";
+import { syncProjectTeam } from "~/projects/lib/github-team-sync";
+import { action } from "~/projects/routes/api.staffing.sync-teams";
+import type { ProjectTeamSyncReport } from "~/projects/lib/github-team-sync";
+
+const TERM = { id: "term-26x", code: "26X" };
+
+const mockPrisma = prisma as unknown as {
+  project: { findMany: ReturnType<typeof vi.fn> };
+};
+
+function report(over: Partial<ProjectTeamSyncReport> = {}): ProjectTeamSyncReport {
+  return {
+    projectId: "p",
+    projectName: "P",
+    status: "ok",
+    slug: "p",
+    teamCreated: false,
+    membersEnsured: 0,
+    membersPending: 0,
+    missingHandles: [],
+    memberErrors: [],
+    repos: [],
+    message: "ok",
+    ...over,
+  };
+}
+
+function req(opts: { method?: string; body?: unknown; raw?: string } = {}) {
+  const { method = "POST", body, raw } = opts;
+  return new Request("http://localhost/api/staffing/sync-teams", {
+    method,
+    headers: { "Content-Type": "application/json" },
+    body: raw !== undefined ? raw : body !== undefined ? JSON.stringify(body) : undefined,
+  });
+}
+
+function call(request: Request) {
+  return action({ request } as any);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.GITHUB_ORG = "dali-test-org";
+  vi.mocked(requireAuth).mockResolvedValue({ ok: true, user: { sub: "u1" } } as any);
+  vi.mocked(canManageStaffing).mockResolvedValue(true);
+  vi.mocked(currentTerm).mockResolvedValue(TERM as any);
+  vi.mocked(syncProjectTeam).mockResolvedValue(report());
+  mockPrisma.project = { findMany: vi.fn().mockResolvedValue([]) };
+});
+
+describe("POST /api/staffing/sync-teams", () => {
+  it("204s on OPTIONS preflight", async () => {
+    const res = await call(req({ method: "OPTIONS" }));
+    expect(res.status).toBe(204);
+  });
+
+  it("401s when unauthenticated", async () => {
+    vi.mocked(requireAuth).mockResolvedValue({
+      ok: false,
+      response: new Response(null, { status: 401 }),
+    } as any);
+    const res = await call(req({ body: { termId: TERM.id } }));
+    expect(res.status).toBe(401);
+  });
+
+  it("405s on non-POST", async () => {
+    const res = await call(req({ method: "GET" }));
+    expect(res.status).toBe(405);
+  });
+
+  it("403s when the user can't manage staffing", async () => {
+    vi.mocked(canManageStaffing).mockResolvedValue(false);
+    const res = await call(req({ body: { termId: TERM.id } }));
+    expect(res.status).toBe(403);
+  });
+
+  it("400s on invalid JSON", async () => {
+    const res = await call(req({ raw: "{not json" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("400s when termId is missing", async () => {
+    const res = await call(req({ body: {} }));
+    expect(res.status).toBe(400);
+  });
+
+  it("400s when GITHUB_ORG is unset", async () => {
+    delete process.env.GITHUB_ORG;
+    const res = await call(req({ body: { termId: TERM.id } }));
+    expect(res.status).toBe(400);
+  });
+
+  it("400s when there is no current term", async () => {
+    vi.mocked(currentTerm).mockResolvedValue(null as any);
+    const res = await call(req({ body: { termId: TERM.id } }));
+    expect(res.status).toBe(400);
+  });
+
+  it("409s when the posted term isn't the current term", async () => {
+    const res = await call(req({ body: { termId: "some-old-term" } }));
+    expect(res.status).toBe(409);
+    expect(syncProjectTeam).not.toHaveBeenCalled();
+  });
+
+  it("enumerates current-term, non-archived projects", async () => {
+    await call(req({ body: { termId: TERM.id } }));
+    expect(mockPrisma.project.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          assignments: { some: { termId: TERM.id } },
+          status: { not: "Archived" },
+        }),
+      }),
+    );
+  });
+
+  it("skips duplicate-slug projects without merging teams", async () => {
+    mockPrisma.project.findMany.mockResolvedValue([
+      { id: "a", name: "A", githubTeamSlug: "dup" },
+      { id: "b", name: "B", githubTeamSlug: "dup" },
+    ]);
+    const res = await call(req({ body: { termId: TERM.id } }));
+    const json = (await res.json()) as { reports: ProjectTeamSyncReport[]; warnings: string[] };
+    expect(syncProjectTeam).not.toHaveBeenCalled();
+    expect(json.reports.every((r) => r.status === "skipped")).toBe(true);
+    expect(json.warnings.join(" ")).toContain("collides");
+  });
+
+  it("syncs each project with the current term id and returns ok", async () => {
+    mockPrisma.project.findMany.mockResolvedValue([
+      { id: "a", name: "A", githubTeamSlug: "a" },
+      { id: "b", name: "B", githubTeamSlug: "b" },
+    ]);
+    const res = await call(req({ body: { termId: TERM.id } }));
+    const json = (await res.json()) as { ok: boolean; reports: ProjectTeamSyncReport[] };
+    expect(syncProjectTeam).toHaveBeenCalledWith("a", TERM.id);
+    expect(syncProjectTeam).toHaveBeenCalledWith("b", TERM.id);
+    expect(json.ok).toBe(true);
+    expect(json.reports).toHaveLength(2);
+    expect(logAuditEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "staffing.sync_teams" }),
+    );
+  });
+
+  it("returns 200 with ok:false when a project errors (partial failure isolation)", async () => {
+    mockPrisma.project.findMany.mockResolvedValue([
+      { id: "a", name: "A", githubTeamSlug: "a" },
+      { id: "b", name: "B", githubTeamSlug: "b" },
+    ]);
+    vi.mocked(syncProjectTeam).mockImplementation(async (id: string) =>
+      id === "a" ? report({ projectId: "a", status: "error", message: "boom" }) : report({ projectId: "b" }),
+    );
+    const res = await call(req({ body: { termId: TERM.id } }));
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { ok: boolean };
+    expect(json.ok).toBe(false);
+  });
+});

--- a/dali-api/app/projects/routes/api.staffing.finalize.ts
+++ b/dali-api/app/projects/routes/api.staffing.finalize.ts
@@ -509,6 +509,17 @@ export async function action({ request }: Route.ActionArgs) {
         status: "skipped",
         message: "No GitHub team slug provided — enter one in the Finalize modal.",
       };
+    } else if (
+      (await prisma.project.count({
+        where: { id: { not: project.id }, githubTeamSlug: { equals: slug, mode: "insensitive" } },
+      })) > 0
+    ) {
+      // Another project already owns this slug — ensureTeam would merge their
+      // rosters into one team. Skip, matching the sync-teams sweep's guard.
+      results.github = {
+        status: "skipped",
+        message: `GitHub team slug "${slug}" is used by another project — skipped to avoid merging teams. Set a unique slug.`,
+      };
     } else {
       try {
         const roster = await prisma.staffingAssignment.findMany({

--- a/dali-api/app/projects/routes/api.staffing.sync-teams.ts
+++ b/dali-api/app/projects/routes/api.staffing.sync-teams.ts
@@ -1,0 +1,196 @@
+import type { Route } from "./+types/api.staffing.sync-teams";
+import { prisma } from "~/lib/db";
+import { requireAuth, forbidden } from "~/lib/auth";
+import { canManageStaffing, currentTerm } from "~/lib/roles";
+import { withCors, handlePreflight } from "~/lib/cors";
+import { slackErrorMessage } from "~/slack/lib/slack-client";
+import { logAuditEvent } from "~/lib/audit";
+import { syncProjectTeam, type ProjectTeamSyncReport } from "~/projects/lib/github-team-sync";
+
+// POST /api/staffing/sync-teams
+//
+// Add-only GitHub team sync for EVERY project staffed this term: ensure each
+// project's org team, add its rostered members (by githubUsername), and grant
+// the team push on each of its repos. Idempotent — safe to re-run. Never removes
+// members. The current term is resolved server-side; a stale/selected non-current
+// term is rejected so a past term's roster can't re-invite offboarded alumni.
+//
+// Body: { termId: string } — must equal the current term.
+
+type Body = { termId: string };
+
+function isBody(x: unknown): x is Body {
+  return !!x && typeof x === "object" && typeof (x as Record<string, unknown>).termId === "string";
+}
+
+export async function action({ request }: Route.ActionArgs) {
+  const preflight = handlePreflight(request);
+  if (preflight) return preflight;
+
+  const auth = await requireAuth(request);
+  if (!auth.ok) return withCors(request, auth.response);
+  if (request.method !== "POST") {
+    return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));
+  }
+  if (!(await canManageStaffing(auth.user.sub))) {
+    return forbidden(request);
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return withCors(request, Response.json({ error: "Invalid JSON" }, { status: 400 }));
+  }
+  if (!isBody(body)) {
+    return withCors(request, Response.json({ error: "Invalid body" }, { status: 400 }));
+  }
+
+  if (!process.env.GITHUB_ORG) {
+    return withCors(request, Response.json({ error: "GITHUB_ORG not set." }, { status: 400 }));
+  }
+
+  // Resolve the current term server-side and reject any other term. Prevents
+  // syncing a past term (re-inviting offboarded members) or a future one.
+  const term = await currentTerm();
+  if (!term) {
+    return withCors(request, Response.json({ error: "No current term." }, { status: 400 }));
+  }
+  if (body.termId !== term.id) {
+    return withCors(
+      request,
+      Response.json(
+        {
+          error: `Sync only runs for the current term (${term.code}). Switch the board to the current term and try again.`,
+        },
+        { status: 409 },
+      ),
+    );
+  }
+
+  try {
+    // Current-term projects with a live roster, excluding archived.
+    const projects = await prisma.project.findMany({
+      where: { assignments: { some: { termId: term.id } }, status: { not: "Archived" } },
+      select: { id: true, name: true, githubTeamSlug: true },
+      orderBy: { name: "asc" },
+    });
+
+    // githubTeamSlug is NOT @unique — detect duplicates across the sweep so two
+    // projects that resolve to the same team aren't merged into one. Normalized
+    // to lowercase because GitHub resolves team slugs case-insensitively
+    // ("MyApp" and "myapp" are the same team).
+    const slugCounts = new Map<string, number>();
+    for (const p of projects) {
+      const s = p.githubTeamSlug?.trim().toLowerCase();
+      if (s) slugCounts.set(s, (slugCounts.get(s) ?? 0) + 1);
+    }
+
+    const reports: ProjectTeamSyncReport[] = [];
+    for (const p of projects) {
+      const s = p.githubTeamSlug?.trim().toLowerCase();
+      if (s && (slugCounts.get(s) ?? 0) > 1) {
+        reports.push({
+          projectId: p.id,
+          projectName: p.name,
+          status: "skipped",
+          slug: s,
+          teamCreated: false,
+          membersEnsured: 0,
+          membersPending: 0,
+          missingHandles: [],
+          memberErrors: [],
+          repos: [],
+          message: `Slug "${s}" collides with another project — skipped to avoid merging teams. Set a unique slug.`,
+        });
+        continue;
+      }
+      // syncProjectTeam never throws, but guard belt-and-suspenders.
+      const r = await syncProjectTeam(p.id, term.id).catch(
+        (err): ProjectTeamSyncReport => ({
+          projectId: p.id,
+          projectName: p.name,
+          status: "error",
+          slug: s ?? null,
+          teamCreated: false,
+          membersEnsured: 0,
+          membersPending: 0,
+          missingHandles: [],
+          memberErrors: [],
+          repos: [],
+          message: slackErrorMessage(err),
+        }),
+      );
+      reports.push(r);
+    }
+
+    const okCount = reports.filter((r) => r.status === "ok").length;
+    const skippedCount = reports.filter((r) => r.status === "skipped").length;
+    const erroredCount = reports.filter((r) => r.status === "error").length;
+    const membersEnsured = reports.reduce((n, r) => n + r.membersEnsured, 0);
+    const membersPending = reports.reduce((n, r) => n + r.membersPending, 0);
+    const missing = reports.reduce((n, r) => n + r.missingHandles.length, 0);
+
+    // Per-project warnings the banner renders inline.
+    const warnings = reports.flatMap((r) => {
+      const w: string[] = [];
+      if (r.status === "skipped") w.push(`${r.projectName}: ${r.message}`);
+      if (r.missingHandles.length) {
+        w.push(`${r.projectName}: no GitHub username for ${r.missingHandles.join(", ")}`);
+      }
+      for (const me of r.memberErrors) w.push(`${r.projectName}: @${me.handle} — ${me.message}`);
+      for (const re of r.repos) {
+        if (re.status === "error") w.push(`${r.projectName}: repo ${re.repo} — ${re.message}`);
+      }
+      return w;
+    });
+
+    await logAuditEvent({
+      action: "staffing.sync_teams",
+      userId: auth.user.sub,
+      metadata: {
+        termId: term.id,
+        projectCount: projects.length,
+        okCount,
+        skippedCount,
+        erroredCount,
+        membersEnsured,
+        membersPending,
+        missing,
+        // Bounded per-project counts only — no member names/arrays (keeps the
+        // audit JSON small and free of PII; full detail is in the response body).
+        projects: reports.map((r) => ({
+          projectId: r.projectId,
+          slug: r.slug,
+          status: r.status,
+          membersEnsured: r.membersEnsured,
+          missingCount: r.missingHandles.length,
+          memberErrorCount: r.memberErrors.length,
+          repoErrorCount: r.repos.filter((x) => x.status === "error").length,
+        })),
+      },
+    });
+
+    const parts = [
+      `synced ${okCount}/${projects.length} team${projects.length === 1 ? "" : "s"} for ${term.code}`,
+      `ensured ${membersEnsured} member${membersEnsured === 1 ? "" : "s"}${
+        membersPending ? ` (${membersPending} pending)` : ""
+      }`,
+    ];
+    if (missing) parts.push(`${missing} without a GitHub username`);
+    if (skippedCount) parts.push(`${skippedCount} skipped`);
+    if (erroredCount) parts.push(`${erroredCount} with errors`);
+
+    return withCors(
+      request,
+      Response.json({
+        ok: erroredCount === 0, // partial failure => false => banner renders red
+        message: `${parts.join("; ")}.`,
+        warnings,
+        reports,
+      }),
+    );
+  } catch (err) {
+    return withCors(request, Response.json({ error: slackErrorMessage(err) }, { status: 500 }));
+  }
+}

--- a/dali-api/app/projects/routes/projects.list.tsx
+++ b/dali-api/app/projects/routes/projects.list.tsx
@@ -12,6 +12,7 @@ import { requireAuth, redirectApplicantToPortal } from "~/lib/auth";
 import { isCore } from "~/lib/roles";
 import { requestOpenTabIfEmbedded } from "~/components/workspace-link";
 import { prisma } from "~/lib/db";
+import { githubTeamSlug } from "~/lib/github-slug";
 import { ensureProjectGroup } from "~/lib/groups";
 import { ViewToggle, useViewPreference } from "~/components/ViewToggle";
 import { TermFilter } from "~/components/TermFilter";
@@ -139,6 +140,9 @@ export async function action({ request }: Route.ActionArgs) {
   const created = await prisma.project.create({
     data: {
       name,
+      // Auto-derive the GitHub team slug from the name (editable later on the
+      // project page). Enables the roster→team sync without a manual step.
+      githubTeamSlug: githubTeamSlug(name) || null,
       description: description === "" ? null : description,
       status: status as ProjectStatus,
       // Seed the initial term into the project's term set (if chosen).

--- a/dali-api/app/routes.ts
+++ b/dali-api/app/routes.ts
@@ -231,6 +231,7 @@ export default [
   route("api/staffing/assign", "projects/routes/api.staffing.assign.ts"),
   route("api/staffing/finalize", "projects/routes/api.staffing.finalize.ts"),
   route("api/staffing/term-channel", "projects/routes/api.staffing.term-channel.ts"),
+  route("api/staffing/sync-teams", "projects/routes/api.staffing.sync-teams.ts"),
   route("api/staffing/board-member", "projects/routes/api.staffing.board-member.ts"),
   route("api/staffing/events", "projects/routes/api.staffing.events.ts"),
   route("api/staffing/reorder", "projects/routes/api.staffing.reorder.ts"),

--- a/dali-api/app/slack/lib/__tests__/github-teams.test.ts
+++ b/dali-api/app/slack/lib/__tests__/github-teams.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
   ensureTeam,
   addTeamMember,
+  grantTeamRepo,
   __setGitHubClientForTests,
 } from "~/lib/github";
 import type { Octokit } from "@octokit/rest";
@@ -11,6 +12,7 @@ function fakeOctokit(overrides: {
   getByName?: ReturnType<typeof vi.fn>;
   create?: ReturnType<typeof vi.fn>;
   addMembership?: ReturnType<typeof vi.fn>;
+  grantRepo?: ReturnType<typeof vi.fn>;
 }) {
   return {
     rest: {
@@ -18,6 +20,7 @@ function fakeOctokit(overrides: {
         getByName: overrides.getByName ?? vi.fn(),
         create: overrides.create ?? vi.fn(),
         addOrUpdateMembershipForUserInOrg: overrides.addMembership ?? vi.fn(),
+        addOrUpdateRepoPermissionsInOrg: overrides.grantRepo ?? vi.fn(),
       },
     },
   } as unknown as Octokit;
@@ -79,12 +82,64 @@ describe("addTeamMember", () => {
     const addMembership = vi.fn().mockResolvedValue({});
     __setGitHubClientForTests(fakeOctokit({ addMembership }));
 
-    await addTeamMember("alpha", "octocat");
+    const res = await addTeamMember("alpha", "octocat");
     expect(addMembership).toHaveBeenCalledWith({
       org: "dali-test-org",
       team_slug: "alpha",
       username: "octocat",
       role: "member",
     });
+    // No data.state on the response → defaults to "active" (backward-compatible).
+    expect(res).toEqual({ state: "active" });
+  });
+
+  it("reports state:'pending' when the user isn't yet an org member", async () => {
+    const addMembership = vi.fn().mockResolvedValue({ data: { state: "pending" } });
+    __setGitHubClientForTests(fakeOctokit({ addMembership }));
+    expect(await addTeamMember("alpha", "invitee")).toEqual({ state: "pending" });
+  });
+
+  it("reports state:'active' for an accepted membership", async () => {
+    const addMembership = vi.fn().mockResolvedValue({ data: { state: "active" } });
+    __setGitHubClientForTests(fakeOctokit({ addMembership }));
+    expect(await addTeamMember("alpha", "member")).toEqual({ state: "active" });
+  });
+});
+
+describe("grantTeamRepo", () => {
+  it("grants push by default with the right params", async () => {
+    const grantRepo = vi.fn().mockResolvedValue({});
+    __setGitHubClientForTests(fakeOctokit({ grantRepo }));
+
+    await grantTeamRepo("alpha", "dali-lab", "foo");
+    expect(grantRepo).toHaveBeenCalledWith({
+      org: "dali-test-org",
+      team_slug: "alpha",
+      owner: "dali-lab",
+      repo: "foo",
+      permission: "push",
+    });
+  });
+
+  it("honors an explicit permission", async () => {
+    const grantRepo = vi.fn().mockResolvedValue({});
+    __setGitHubClientForTests(fakeOctokit({ grantRepo }));
+
+    await grantTeamRepo("alpha", "dali-lab", "bar", "admin");
+    expect(grantRepo).toHaveBeenCalledWith(
+      expect.objectContaining({ owner: "dali-lab", repo: "bar", permission: "admin" }),
+    );
+  });
+
+  it("throws when GITHUB_ORG is unset", async () => {
+    delete process.env.GITHUB_ORG;
+    __setGitHubClientForTests(fakeOctokit({}));
+    await expect(grantTeamRepo("alpha", "dali-lab", "foo")).rejects.toThrow("GITHUB_ORG");
+  });
+
+  it("propagates a 404 (missing repo/team)", async () => {
+    const grantRepo = vi.fn().mockRejectedValue(notFound);
+    __setGitHubClientForTests(fakeOctokit({ grantRepo }));
+    await expect(grantTeamRepo("alpha", "dali-lab", "nope")).rejects.toBe(notFound);
   });
 });

--- a/dali-api/scripts/backfill-github-team-slugs.ts
+++ b/dali-api/scripts/backfill-github-team-slugs.ts
@@ -1,0 +1,118 @@
+/**
+ * Backfill Project.githubTeamSlug for existing projects that don't have one, so
+ * the roster→GitHub team sync (staffing board "Sync all current-term teams") can
+ * act on them. New projects already get an auto-derived slug on create; this is
+ * the one-off pass for projects that predate that.
+ *
+ * GUIDED, never blind — three buckets:
+ *  - ADOPT: the name-derived candidate slug matches a team that ALREADY exists
+ *    in GITHUB_ORG → safe to write (only under --commit).
+ *  - FLAG-missing: no team with the candidate slug exists — likely a real team
+ *    under a different name (e.g. "Smart Microscope" → real team "smart-scope-26x").
+ *    Printed for a human to map by hand; never written.
+ *  - FLAG-collision: the candidate collides with another project's candidate or
+ *    an already-taken slug. Never written (avoids merging two projects into one team).
+ *
+ * Read-only against GitHub (teams.getByName only — never ensureTeam), so a dry
+ * run creates nothing. Excludes archived projects.
+ *
+ * Dry-run by default. Requires DATABASE_URL, GITHUB_ORG, and GITHUB_APP_* env.
+ *
+ * Usage:
+ *   npx tsx --env-file .env scripts/backfill-github-team-slugs.ts          # dry run
+ *   npx tsx --env-file .env scripts/backfill-github-team-slugs.ts --commit # write ADOPT bucket
+ */
+import { PrismaClient } from "../app/generated/prisma/client.js";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { githubAppClient, isNotFound } from "../app/lib/github.js";
+import { githubTeamSlug } from "../app/lib/github-slug.js";
+
+const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL! });
+const prisma = new PrismaClient({ adapter });
+
+const COMMIT = process.argv.includes("--commit");
+const ORG = process.env.GITHUB_ORG;
+
+async function teamExists(slug: string): Promise<boolean> {
+  try {
+    await githubAppClient().rest.teams.getByName({ org: ORG!, team_slug: slug });
+    return true;
+  } catch (err) {
+    if (isNotFound(err)) return false;
+    throw err;
+  }
+}
+
+async function main() {
+  if (!ORG) throw new Error("GITHUB_ORG is not set");
+  console.log(
+    COMMIT
+      ? "▶ COMMIT mode — the ADOPT bucket WILL be written.\n"
+      : "▶ DRY RUN — no changes will be written. Re-run with --commit to apply.\n",
+  );
+
+  const projects = await prisma.project.findMany({
+    where: { githubTeamSlug: null, status: { not: "Archived" } },
+    select: { id: true, name: true },
+    orderBy: { name: "asc" },
+  });
+
+  // Slugs already claimed by other projects — never reuse.
+  const taken = new Set(
+    (
+      await prisma.project.findMany({
+        where: { githubTeamSlug: { not: null } },
+        select: { githubTeamSlug: true },
+      })
+    ).map((p) => p.githubTeamSlug!),
+  );
+
+  // Count candidate slugs so two null-slug projects that derive to the same
+  // slug both land in FLAG-collision.
+  const candidateCount = new Map<string, number>();
+  for (const p of projects) {
+    const c = githubTeamSlug(p.name);
+    if (c) candidateCount.set(c, (candidateCount.get(c) ?? 0) + 1);
+  }
+
+  const adopt: string[] = [];
+  const flagMissing: string[] = [];
+  const flagCollision: string[] = [];
+
+  for (const p of projects) {
+    const c = githubTeamSlug(p.name);
+    if (!c) {
+      flagMissing.push(`${p.name} → (empty slug — name has no alphanumerics)`);
+      continue;
+    }
+    if (taken.has(c) || (candidateCount.get(c) ?? 0) > 1) {
+      flagCollision.push(`${p.name} → ${c} (collides — resolve by hand)`);
+      continue;
+    }
+    if (await teamExists(c)) {
+      adopt.push(`${p.name} → ${c}`);
+      if (COMMIT) {
+        await prisma.project.update({ where: { id: p.id }, data: { githubTeamSlug: c } });
+      }
+    } else {
+      flagMissing.push(`${p.name} → ${c} (no such team — map to the real slug by hand)`);
+    }
+  }
+
+  console.log(`ADOPT (${adopt.length})${COMMIT ? " — written" : " — would write"}:`);
+  console.log(adopt.length ? "  " + adopt.join("\n  ") : "  (none)");
+  console.log(`\nFLAG missing (${flagMissing.length}) — set manually on the project page:`);
+  console.log(flagMissing.length ? "  " + flagMissing.join("\n  ") : "  (none)");
+  console.log(`\nFLAG collision (${flagCollision.length}) — needs a unique slug:`);
+  console.log(flagCollision.length ? "  " + flagCollision.join("\n  ") : "  (none)");
+  if (!COMMIT && adopt.length > 0) {
+    console.log("\nRe-run with --commit to write the ADOPT bucket.");
+  }
+}
+
+main()
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());


### PR DESCRIPTION
Promotes **staging → prod**: the roster→GitHub team sync (#876, #875). Staging is deployed and smoke-tested (page loads, banner renders). One commit; nothing else queued.

**Review/CI vehicle — do not click "Merge."** An authorized reviewer approves, then comments **`/push`** to fast-forward `prod` and deploy `dali-api-prod`.

### After prod deploys
1. Backfill slugs for existing projects: `tsx --env-file .env scripts/backfill-github-team-slugs.ts` (dry run → `--commit`, resolve FLAG buckets by hand, e.g. `Smart Microscope` → `smart-scope-26x`).
2. On the prod staffing board, click **"Sync all current-term teams"** to clear the 26X backlog (the 16 member-adds + repo grants).

No migration. App perms already provisioned. Full detail in #876.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BBBGa6p4HMTdenGfryxuqC

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/878"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785524157&installation_id=133523038&pr_number=878&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F878&signature=bde486a7c466bd4ff30556b2c9ea6ab31e225cf3a6713e0d8b952036ef0dbf49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->