### PR TITLE
Allow claude.ai web connector to register (MCP OAuth redirect URIs)

### DIFF
--- a/dali-api/app/routes/__tests__/oauth.register.test.ts
+++ b/dali-api/app/routes/__tests__/oauth.register.test.ts
@@ -82,6 +82,83 @@ describe("POST /oauth/register", () => {
     expect(createArgs.name).toBe("MCP Client");
   });
 
+  it("registers a Claude hosted-https client (claude.ai) with exact-match matching", async () => {
+    const req = makeRequest({
+      redirect_uris: ["https://claude.ai/api/mcp/auth_callback"],
+      client_name: "Claude",
+      token_endpoint_auth_method: "none",
+    });
+    const res = await action({ request: req } as any);
+    expect(res.status).toBe(200);
+    const createArgs = mockCreate.mock.calls[0]![0].data;
+    expect(createArgs.redirectUris).toEqual([
+      "https://claude.ai/api/mcp/auth_callback",
+    ]);
+    // Hosted https callbacks are NOT loopback — they must exact-match only.
+    expect(createArgs.isLoopback).toBe(false);
+    expect(createArgs.requireMembership).toBe(true);
+  });
+
+  it("accepts the claude.com host and its subdomains", async () => {
+    for (const uri of [
+      "https://claude.com/api/mcp/auth_callback",
+      "https://foo.claude.ai/api/mcp/auth_callback",
+    ]) {
+      vi.clearAllMocks();
+      mockCreate.mockImplementation(async ({ data }: any) => ({
+        id: "cuid-abc",
+        ...data,
+        createdAt: new Date("2026-05-14T18:00:00Z"),
+      }));
+      const res = await action({ request: makeRequest({ redirect_uris: [uri] }) } as any);
+      expect(res.status).toBe(200);
+      expect(mockCreate.mock.calls[0]![0].data.isLoopback).toBe(false);
+    }
+  });
+
+  it("rejects an https callback on an untrusted host", async () => {
+    const req = makeRequest({
+      redirect_uris: ["https://evil.example.com/api/mcp/auth_callback"],
+    });
+    const res = await action({ request: req } as any);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("invalid_redirect_uri");
+  });
+
+  it("does not treat a lookalike host (claude.ai.evil.com) as trusted", async () => {
+    const req = makeRequest({
+      redirect_uris: ["https://claude.ai.evil.com/api/mcp/auth_callback"],
+    });
+    const res = await action({ request: req } as any);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("invalid_redirect_uri");
+  });
+
+  it("honors MCP_ALLOWED_REDIRECT_HOSTS override", async () => {
+    process.env.MCP_ALLOWED_REDIRECT_HOSTS = "connectors.example.org";
+    try {
+      const res = await action({
+        request: makeRequest({
+          redirect_uris: ["https://connectors.example.org/cb"],
+        }),
+      } as any);
+      expect(res.status).toBe(200);
+      expect(mockCreate.mock.calls[0]![0].data.isLoopback).toBe(false);
+      // A default host is no longer trusted once the override is set.
+      vi.clearAllMocks();
+      const rejected = await action({
+        request: makeRequest({
+          redirect_uris: ["https://claude.ai/api/mcp/auth_callback"],
+        }),
+      } as any);
+      expect(rejected.status).toBe(400);
+    } finally {
+      delete process.env.MCP_ALLOWED_REDIRECT_HOSTS;
+    }
+  });
+
   it("rejects https loopback as invalid_redirect_uri", async () => {
     const req = makeRequest({
       redirect_uris: ["https://127.0.0.1/callback"],

--- a/dali-api/app/routes/oauth.register.ts
+++ b/dali-api/app/routes/oauth.register.ts
@@ -4,8 +4,10 @@
 // so the spec requires a registration endpoint they can POST to. We accept
 // the minimal request shape, but the resulting OAuthClient row is locked to
 // the MCP-only policy: google-only IDP, member-only accountType, membership
-// required, mcp:read/mcp:write scopes, loopback redirects only. None of the
-// client-supplied policy fields are honored — only redirect_uris + client_name.
+// required, mcp:read/mcp:write scopes. Redirect URIs are limited to http
+// loopback (Claude Code / Desktop-local) or an https callback on an allowed
+// Claude host (claude.ai web / mobile). None of the client-supplied policy
+// fields are honored — only redirect_uris + client_name.
 
 import type { Route } from "./+types/oauth.register";
 import { prisma } from "~/lib/db";
@@ -49,6 +51,38 @@ function isLoopbackRedirect(uri: string): boolean {
   return true;
 }
 
+// Claude's hosted MCP surfaces (claude.ai web, mobile, desktop connectors)
+// register a fixed https callback rather than a loopback URI — the loopback
+// model only fits locally-run clients (Claude Code / Desktop-local). Accept an
+// https redirect whose host is an Anthropic-controlled registrable domain, or a
+// subdomain of one. Overridable via MCP_ALLOWED_REDIRECT_HOSTS (comma-separated)
+// so a new Claude surface host can be allowed without a redeploy.
+const DEFAULT_TRUSTED_REDIRECT_HOSTS = ["claude.ai", "claude.com"];
+
+function trustedRedirectHosts(): string[] {
+  const raw = process.env.MCP_ALLOWED_REDIRECT_HOSTS;
+  if (!raw) return DEFAULT_TRUSTED_REDIRECT_HOSTS;
+  const hosts = raw
+    .split(",")
+    .map((h) => h.trim().toLowerCase())
+    .filter(Boolean);
+  return hosts.length ? hosts : DEFAULT_TRUSTED_REDIRECT_HOSTS;
+}
+
+function isTrustedHttpsRedirect(uri: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(uri);
+  } catch {
+    return false;
+  }
+  if (parsed.protocol !== "https:") return false;
+  const host = parsed.hostname.toLowerCase();
+  return trustedRedirectHosts().some(
+    (allowed) => host === allowed || host.endsWith(`.${allowed}`),
+  );
+}
+
 export async function action({ request }: Route.ActionArgs) {
   const preflight = handlePreflight(request);
   if (preflight) return preflight;
@@ -76,17 +110,24 @@ export async function action({ request }: Route.ActionArgs) {
   }
   const redirectUris: string[] = [];
   for (const uri of body.redirect_uris) {
-    if (typeof uri !== "string" || !isLoopbackRedirect(uri)) {
+    if (
+      typeof uri !== "string" ||
+      !(isLoopbackRedirect(uri) || isTrustedHttpsRedirect(uri))
+    ) {
       return withCors(
         request,
         badRequest(
           "invalid_redirect_uri",
-          "redirect_uris must be http loopback (127.0.0.1 or localhost)",
+          "redirect_uris must be http loopback (127.0.0.1 or localhost) or an https callback on an allowed Claude host",
         ),
       );
     }
     redirectUris.push(uri);
   }
+
+  // Loopback clients get RFC 8252 port-agnostic matching at authorize time;
+  // hosted-https clients (Claude's web/mobile surfaces) get exact-match only.
+  const isLoopback = redirectUris.every(isLoopbackRedirect);
 
   // token_endpoint_auth_method: only "none" (public client) is supported.
   const authMethod = body.token_endpoint_auth_method ?? "none";
@@ -150,7 +191,7 @@ export async function action({ request }: Route.ActionArgs) {
       clientId: "pending",
       name: clientName,
       redirectUris,
-      isLoopback: true,
+      isLoopback,
       isFirstParty: false,
       allowedScopes: ALLOWED_SCOPES,
       allowedProviders: ["google"],


### PR DESCRIPTION
## Problem

Connecting **claude.ai** (web) to the dali-os MCP server (`https://os.dali.dartmouth.edu/mcp`) hangs at **"checking connection"** and never connects. Claude Code and Claude Desktop connect fine.

Confirmed against prod with live claude.ai traffic — the OAuth discovery chain works, but Dynamic Client Registration is rejected:

```
POST /mcp                                       401  ← challenge (ok)
GET  /.well-known/oauth-protected-resource/mcp  200  ← discovery (ok)
GET  /.well-known/oauth-authorization-server    200  ← discovery (ok)
POST /oauth/register                            400  ← DCR REJECTED
POST /oauth/register                            400  ← claude.ai retries, same
```

## Root cause

`oauth/register.ts` only accepted **http loopback** redirect URIs (`127.0.0.1` / `localhost`). That fits locally-run clients (Claude Code, Claude Desktop), which use `http://127.0.0.1:PORT/callback`. But **claude.ai web / mobile** register a fixed *hosted https callback* (e.g. `https://claude.ai/api/mcp/auth_callback`), which the endpoint rejected with `400 invalid_redirect_uri` → claude.ai can't obtain a `client_id` → connector stalls.

## Fix

Registration now accepts a redirect URI that is **http loopback** *(unchanged)* **or** an **https callback on an Anthropic-controlled host** (`claude.ai` / `claude.com` or a subdomain). Overridable via `MCP_ALLOWED_REDIRECT_HOSTS` (comma-separated) so a new Claude surface host can be allowed without a redeploy — the default needs no env change in prod.

### Claude Code / Desktop remain unaffected
- The new check is **additive** and evaluated first: `isLoopbackRedirect(uri) || isTrustedHttpsRedirect(uri)`. The loopback branch is the exact prior logic.
- The stored `isLoopback` flag is now `redirectUris.every(isLoopbackRedirect)` — `true` for a pure-loopback client (same as the old hardcoded `true`), so **RFC 8252 port-agnostic matching** at authorize time is preserved for the random-port loopback callback.
- Hosted-https clients get `isLoopback: false` → **exact-match only** (`isAllowedRedirectUri` already exact-matches a registered URI before any loopback logic), which is correct for a fixed callback.

No downstream change needed in `authorize` / `token`.

## Tests

Extended `oauth.register.test.ts`:
- registers a claude.ai hosted-https client (`isLoopback: false`, membership policy intact)
- accepts `claude.com` and a subdomain of an allowed host
- rejects an https callback on an untrusted host
- rejects a lookalike host (`claude.ai.evil.com`)
- honors the `MCP_ALLOWED_REDIRECT_HOSTS` override (and stops trusting defaults once set)
- existing loopback / policy / rate-limit tests unchanged and passing

Full unit suite green (1385 passed). Typecheck shows only pre-existing errors in unrelated `scripts/`, a `Modal.test.tsx`, and a prisma seed — none in the changed files.

## Rollout note

Ships to prod via the normal `dev → staging → prod` promotion. No env var required for claude.ai/claude.com. After deploy, retrying the claude.ai connector should show `POST /oauth/register 200` followed by the Google consent redirect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/885"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785673932&installation_id=133523038&pr_number=885&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F885&signature=5590944cdff202be9e255e69adbae56d73ab9df03a6f0f04bd0b0bd743cd8f52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->