### PR TITLE
Desktop: find-in-page (Cmd+F) with cross-frame search

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dali-os-desktop",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "description": "Native macOS desktop shell for DALI OS (Tauri v2).",
   "scripts": {

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -686,7 +686,7 @@ checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
 name = "dali-os-desktop"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "keyring",
  "reqwest 0.12.28",
@@ -2053,9 +2053,12 @@ version = "3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
 dependencies = [
+ "byteorder",
+ "linux-keyutils",
  "log",
  "security-framework 2.11.1",
  "security-framework 3.7.0",
+ "windows-sys 0.60.2",
  "zeroize",
 ]
 
@@ -2114,6 +2117,16 @@ version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "linux-keyutils"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83270a18e9f90d0707c41e9f35efada77b64c0e6f3f1810e71c8368a864d5590"
+dependencies = [
+ "bitflags 2.13.0",
  "libc",
 ]
 

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dali-os-desktop"
-version = "0.1.1"
+version = "0.1.2"
 description = "DALI OS desktop shell"
 authors = ["DALI Lab"]
 edition = "2021"

--- a/desktop/src-tauri/src/find.js
+++ b/desktop/src-tauri/src/find.js
@@ -1,0 +1,331 @@
+// In-page find bar (Edit → Find, Cmd+F). The main window loads the remote app
+// with zero IPC access, so the whole feature lives in page JS: Rust evals this
+// file on each menu action (window.rs find_action) and calls the API it
+// defines. The define is guarded, so re-eval after a page reload just works.
+//
+// The app renders each workspace tab in a same-origin <iframe>
+// (TabWorkspace.tsx) with background tabs display:none, so search covers the
+// top document plus every *rendered* iframe document. Highlight registries,
+// ::highlight styles, and key listeners are all per-document — everything
+// here tracks the set of documents it touched.
+//
+// Matching is per-text-node and case-insensitive (no cross-element matches).
+// All-match highlighting uses the CSS Custom Highlight API where the system
+// webview has it; elsewhere the current match is shown via the document
+// selection instead.
+(function () {
+  'use strict';
+  if (window.__daliFindBar) return;
+
+  const MAX_MATCHES = 500;
+  const canHighlight =
+    typeof Highlight === 'function' && typeof CSS !== 'undefined' && !!CSS.highlights;
+
+  let matches = []; // Range[] across documents — stale after rerenders/tab switches
+  let index = -1;
+  let query = '';
+  let debounce = 0;
+  let pending = false; // a debounced search is scheduled but hasn't run yet
+  const litDocs = new Set(); // documents currently holding our highlights
+  let litEls = []; // container elements of the painted ranges (for repaint nudges)
+  let selDoc = null; // document holding the fallback selection, if any
+
+  // Closed shadow root so page CSS can't restyle the bar; the host hangs off
+  // <html>, not <body>, so the text walker below never sees the bar itself.
+  const host = document.createElement('div');
+  const root = host.attachShadow({ mode: 'closed' });
+  root.innerHTML = `
+    <style>
+      :host { all: initial; position: fixed; top: 12px; right: 16px; z-index: 2147483647; }
+      .bar { display: flex; align-items: center; gap: 4px; padding: 6px 8px; background: #fff; border: 1px solid #d2d2d7; border-radius: 8px; box-shadow: 0 4px 16px rgba(0, 0, 0, 0.18); font: 13px -apple-system, system-ui, sans-serif; color: #1d1d1f; }
+      input { width: 170px; margin-right: 4px; border: none; outline: none; background: transparent; font: inherit; color: inherit; }
+      .count { color: #86868b; font-variant-numeric: tabular-nums; white-space: nowrap; }
+      button { border: none; background: none; padding: 2px 6px; border-radius: 4px; font: inherit; font-size: 14px; color: inherit; }
+      button:hover { background: rgba(0, 0, 0, 0.08); }
+      @media (prefers-color-scheme: dark) {
+        .bar { background: #323236; border-color: #48484d; color: #f5f5f7; }
+        .count { color: #98989d; }
+        button:hover { background: rgba(255, 255, 255, 0.12); }
+      }
+    </style>
+    <div class="bar">
+      <input type="text" placeholder="Find in page" aria-label="Find in page" />
+      <span class="count"></span>
+      <button class="prev" aria-label="Previous match">&#x2039;</button>
+      <button class="next" aria-label="Next match">&#x203A;</button>
+      <button class="close" aria-label="Close">&#x2715;</button>
+    </div>`;
+
+  const input = root.querySelector('input');
+  const count = root.querySelector('.count');
+
+  function barVisible() {
+    return host.isConnected && host.style.display !== 'none';
+  }
+
+  // The top document and every laid-out same-origin iframe document, in DOM
+  // order. display:none iframes (background workspace tabs) have no rects and
+  // are skipped, which scopes the search to what the user can actually see.
+  function docsOf() {
+    const docs = [];
+    (function add(doc) {
+      if (!doc || !doc.body) return;
+      docs.push(doc);
+      for (const f of doc.querySelectorAll('iframe')) {
+        if (!f.getClientRects().length) continue;
+        try {
+          add(f.contentDocument);
+        } catch (_) {
+          // cross-origin frame — not searchable
+        }
+      }
+    })(document);
+    return docs;
+  }
+
+  // Per-document setup. The flag lives on the Document object, so a reloaded
+  // frame (new document) gets hooked again on the next search.
+  function hookDoc(doc) {
+    if (doc.__daliFindHooked) return;
+    doc.__daliFindHooked = true;
+    if (canHighlight) {
+      // ::highlight() rules only apply in the tree scope they're declared in.
+      // Highlight pseudos only support a few properties — shorthands like
+      // `background` are dropped, so spell out background-color.
+      const sheet = doc.createElement('style');
+      sheet.textContent =
+        '::highlight(dali-find) { background-color: #ffdf60; color: #1d1d1f; }' +
+        '::highlight(dali-find-current) { background-color: #ff9330; color: #1d1d1f; }';
+      (doc.head || doc.documentElement).appendChild(sheet);
+    }
+    // Esc closes the bar no matter which document has focus — key events
+    // inside an iframe never bubble to the parent document.
+    doc.addEventListener(
+      'keydown',
+      (e) => {
+        if (e.key === 'Escape' && barVisible()) {
+          e.preventDefault();
+          e.stopPropagation();
+          close();
+        }
+      },
+      true,
+    );
+  }
+
+  // Keys typed into the bar must not reach the app's global shortcut handlers
+  // (events retarget to the host but still bubble into the document).
+  for (const type of ['keydown', 'keyup', 'keypress']) {
+    host.addEventListener(type, (e) => e.stopPropagation());
+  }
+
+  function collect() {
+    matches = [];
+    for (const doc of docsOf()) {
+      hookDoc(doc);
+      const walker = doc.createTreeWalker(doc.body, NodeFilter.SHOW_TEXT, {
+        acceptNode(node) {
+          const tag = node.parentElement && node.parentElement.tagName;
+          return tag && tag !== 'SCRIPT' && tag !== 'STYLE' && tag !== 'NOSCRIPT' && tag !== 'TEXTAREA'
+            ? NodeFilter.FILTER_ACCEPT
+            : NodeFilter.FILTER_REJECT;
+        },
+      });
+      let node;
+      while ((node = walker.nextNode()) && matches.length < MAX_MATCHES) {
+        const text = node.nodeValue.toLowerCase();
+        let at = text.indexOf(query);
+        while (at !== -1 && matches.length < MAX_MATCHES) {
+          const range = doc.createRange();
+          range.setStart(node, at);
+          range.setEnd(node, at + query.length);
+          if (range.getClientRects().length) matches.push(range); // skips display:none text
+          at = text.indexOf(query, at + query.length);
+        }
+      }
+      if (matches.length >= MAX_MATCHES) break;
+    }
+  }
+
+  // The system WebKit defers highlight repaints in parts of this app (e.g.
+  // the fixed sidebar): registry changes take effect but pixels only update
+  // when the containing ELEMENT's own style changes — highlights appear late
+  // and linger after clearing. Toggling a visually-inert text-shadow directly
+  // on each match's container forces the repaint. Two constraints found
+  // empirically: it must be the element itself (an inherited toggle on the
+  // root does nothing), and it only works once the engine has committed the
+  // registry change, which lags by more than a frame. So the toggle runs in
+  // several delayed rounds; each round reads the then-current registry, so
+  // this both paints and unpaints correctly.
+  function nudgeEls(els) {
+    const byWin = new Map();
+    for (const el of els) {
+      if (!el) continue;
+      const win = el.ownerDocument.defaultView;
+      if (!win) continue;
+      if (!byWin.has(win)) byWin.set(win, []);
+      byWin.get(win).push(el);
+    }
+    for (const [win, list] of byWin) {
+      const toggle = () => {
+        for (const el of list) if (el.isConnected) el.style.textShadow = '0 0 transparent';
+        win.requestAnimationFrame(() => {
+          for (const el of list) el.style.textShadow = '';
+        });
+      };
+      // The engine commits registry changes to the paintable state with up to
+      // ~1-2s of lag here; only a post-commit invalidation paints. Rounds
+      // straddle that window — early ones cover fast paths, late ones the lag.
+      win.requestAnimationFrame(toggle);
+      for (const ms of [150, 500, 1100, 2200]) win.setTimeout(toggle, ms);
+    }
+  }
+
+  function clearMarks() {
+    for (const doc of litDocs) {
+      const win = doc.defaultView;
+      if (win && win.CSS && win.CSS.highlights) {
+        win.CSS.highlights.delete('dali-find');
+        win.CSS.highlights.delete('dali-find-current');
+      }
+    }
+    litDocs.clear();
+    nudgeEls(litEls);
+    litEls = [];
+    if (selDoc) {
+      try {
+        selDoc.getSelection().removeAllRanges();
+      } catch (_) {}
+      selDoc = null;
+    }
+  }
+
+  function render() {
+    count.textContent = !query
+      ? ''
+      : matches.length
+        ? `${index + 1}/${matches.length}${matches.length === MAX_MATCHES ? '+' : ''}`
+        : '0/0';
+    clearMarks();
+    if (!canHighlight || !matches.length) return;
+    const byDoc = new Map();
+    for (const r of matches) {
+      const doc = r.startContainer.ownerDocument;
+      if (!byDoc.has(doc)) byDoc.set(doc, []);
+      byDoc.get(doc).push(r);
+    }
+    for (const [doc, ranges] of byDoc) {
+      const win = doc.defaultView;
+      if (!win || !win.CSS || !win.CSS.highlights || typeof win.Highlight !== 'function') continue;
+      win.CSS.highlights.set('dali-find', new win.Highlight(...ranges));
+      litDocs.add(doc);
+    }
+    litEls = matches.map((r) => r.startContainer.parentElement).filter(Boolean);
+    nudgeEls(litEls); // first paint lags just like clearing (see nudgeEls)
+    const cur = matches[index];
+    if (cur) {
+      const win = cur.startContainer.ownerDocument.defaultView;
+      if (win && win.CSS && win.CSS.highlights && typeof win.Highlight === 'function') {
+        const h = new win.Highlight(cur);
+        h.priority = 1; // paint over the all-matches highlight
+        win.CSS.highlights.set('dali-find-current', h);
+      }
+    }
+  }
+
+  function goTo(i) {
+    index = i;
+    render();
+    const range = matches[index];
+    if (!range) return;
+    if (!canHighlight) {
+      // No highlight API (older webview): show the current match via its
+      // document's selection. Skipped otherwise — moving the selection can
+      // move carets in the app's collaborative editors.
+      const doc = range.startContainer.ownerDocument;
+      try {
+        const sel = doc.getSelection();
+        sel.removeAllRanges();
+        sel.addRange(range.cloneRange());
+        selDoc = doc;
+      } catch (_) {}
+    }
+    const el = range.startContainer.parentElement;
+    if (el) el.scrollIntoView({ block: 'center', inline: 'nearest' });
+  }
+
+  function search() {
+    if (!barVisible()) return; // a pending debounce must never re-light a closed bar
+    query = input.value.toLowerCase();
+    matches = [];
+    index = -1;
+    if (!query) return render();
+    collect();
+    if (matches.length) goTo(0);
+    else render();
+  }
+
+  function advance(dir) {
+    if (!query) return open();
+    show();
+    // Rerenders and tab switches pull the DOM out from under saved ranges —
+    // if the current one no longer draws, redo the search from scratch.
+    if (matches[index] && !matches[index].getClientRects().length) matches = [];
+    if (!matches.length) {
+      collect();
+      index = -1;
+    }
+    if (!matches.length) return render();
+    goTo((index + dir + matches.length) % matches.length);
+  }
+
+  function show() {
+    if (!host.isConnected) document.documentElement.appendChild(host);
+    host.style.display = '';
+  }
+
+  function open() {
+    show();
+    for (const doc of docsOf()) hookDoc(doc); // Esc must work even before the first search
+    input.focus();
+    input.select();
+  }
+
+  function close() {
+    clearTimeout(debounce); // Esc can land inside the debounce window — cancel, or the
+    pending = false; // pending search re-lights highlights with the bar closed
+    host.style.display = 'none'; // hiding the focused input returns focus to the page
+    clearMarks();
+    matches = [];
+    index = -1;
+  }
+
+  input.addEventListener('input', () => {
+    clearTimeout(debounce);
+    pending = true;
+    debounce = setTimeout(() => {
+      pending = false;
+      search();
+    }, 50);
+  });
+  input.addEventListener('keydown', (e) => {
+    if (e.key !== 'Enter') return;
+    e.preventDefault();
+    if (pending) {
+      // Enter right after typing: run the not-yet-fired search (landing on
+      // match 1) instead of stepping through the stale previous results.
+      clearTimeout(debounce);
+      pending = false;
+      search();
+      return;
+    }
+    advance(e.shiftKey ? -1 : 1);
+  });
+  for (const [cls, fn] of [['prev', () => advance(-1)], ['next', () => advance(1)], ['close', close]]) {
+    const btn = root.querySelector('.' + cls);
+    btn.addEventListener('mousedown', (e) => e.preventDefault()); // keep focus in the input
+    btn.addEventListener('click', fn);
+  }
+
+  window.__daliFindBar = { open, next: () => advance(1), prev: () => advance(-1) };
+})();

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -104,6 +104,9 @@ pub fn run() {
                 window::navigate_main(app, &config::help_url());
                 window::show_main(app);
             }
+            "find" => window::find_action(app, "open"),
+            "find-next" => window::find_action(app, "next"),
+            "find-previous" => window::find_action(app, "prev"),
             "sign-out" => {
                 tauri::async_runtime::spawn(commands::do_sign_out(app.clone()));
             }

--- a/desktop/src-tauri/src/menu.rs
+++ b/desktop/src-tauri/src/menu.rs
@@ -15,6 +15,15 @@ pub fn build(app: &AppHandle) -> tauri::Result<Menu<Wry>> {
     let sign_out = MenuItem::with_id(app, "sign-out", "Sign Out", true, None::<&str>)?;
     let reload = MenuItem::with_id(app, "reload", "Reload", true, Some("CmdOrCtrl+R"))?;
     let help_item = MenuItem::with_id(app, "help", "DALI OS Help", true, None::<&str>)?;
+    let find = MenuItem::with_id(app, "find", "Find…", true, Some("CmdOrCtrl+F"))?;
+    let find_next = MenuItem::with_id(app, "find-next", "Find Next", true, Some("CmdOrCtrl+G"))?;
+    let find_prev = MenuItem::with_id(
+        app,
+        "find-previous",
+        "Find Previous",
+        true,
+        Some("Shift+CmdOrCtrl+G"),
+    )?;
     let zoom_in = MenuItem::with_id(app, "zoom-in", "Zoom In", true, Some("CmdOrCtrl+="))?;
     let zoom_out = MenuItem::with_id(app, "zoom-out", "Zoom Out", true, Some("CmdOrCtrl+-"))?;
     let zoom_reset = MenuItem::with_id(app, "zoom-reset", "Actual Size", true, Some("CmdOrCtrl+0"))?;
@@ -82,6 +91,8 @@ pub fn build(app: &AppHandle) -> tauri::Result<Menu<Wry>> {
             &PredefinedMenuItem::copy(app, None)?,
             &PredefinedMenuItem::paste(app, None)?,
             &PredefinedMenuItem::select_all(app, None)?,
+            &PredefinedMenuItem::separator(app)?,
+            &Submenu::with_items(app, "Find", true, &[&find, &find_next, &find_prev])?,
         ],
     )?;
 

--- a/desktop/src-tauri/src/window.rs
+++ b/desktop/src-tauri/src/window.rs
@@ -80,3 +80,17 @@ pub fn apply_zoom(app: &AppHandle, factor: f64) {
         let _ = w.set_zoom(factor);
     }
 }
+
+/// Find-in-page (Edit → Find). The remote page has no IPC access, so the bar
+/// is driven by eval: the script defines `window.__daliFindBar` once (its own
+/// guard makes re-eval a no-op) and each menu action calls into it. `action`
+/// is one of open/next/prev.
+pub fn find_action(app: &AppHandle, action: &str) {
+    if let Some(w) = app.get_webview_window("main") {
+        let _ = w.eval(&format!(
+            "{}\nwindow.__daliFindBar.{}();",
+            include_str!("find.js"),
+            action
+        ));
+    }
+}

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "DALI OS",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "identifier": "edu.dartmouth.dali.os",
   "build": {
     "frontendDist": "../frontend"


### PR DESCRIPTION
## What

Adds native find-in-page to the desktop shell: **Edit → Find** with **Find… (⌘F)**, **Find Next (⌘G)**, **Find Previous (⇧⌘G)**.

The main window loads the remote origin with zero IPC access (by design), so the feature is an in-page find bar (`desktop/src-tauri/src/find.js`) injected via webview `eval` from the native menu handlers — the same pattern as the existing ⌘R reload item. **No capability files or signing config touched; no server route changes.**

## How it works

- Self-contained bar in a closed shadow root (page CSS can't restyle it; its own text is never searched). Incremental search with a match counter, Enter/⇧Enter stepping, Esc closes from any document, ✕ button.
- The web app renders each workspace tab in a same-origin iframe, so search covers the top document plus every *rendered* iframe document — background (`display:none`) tabs are naturally excluded; both panes of a split are included.
- Highlighting uses the CSS Custom Highlight API, registered per document (registries are per-window), with a selection fallback for older webviews. Clearing sweeps every document that was lit.
- The debounced search cancels on close and refuses to run while the bar is hidden (a pending search re-lighting highlights after close was an early bug), and Enter inside the debounce window flushes the new query instead of stepping stale results.

## System-WebKit paint workaround

Two quirks found empirically on the shipped WKWebView (documented in `find.js`): highlight repaints in composited regions (e.g. the fixed sidebar) only land after the match's **container element** gets its own style change, and only once the engine has **committed** the registry change (~1–2s lag worst case). Handled with visually-inert per-element `text-shadow` toggles in delayed rounds after every set/clear. Known residual: sidebar highlights can appear/clear up to ~1–2s late when the app is idle; tab content paints immediately.

## Testing

- Playwright WebKit suites against the real app (local dev server + seeded DB): match collection across nav/tab-iframes/tables/contenteditable/nested scrollers, all close paths (Esc in bar, Esc in iframe, ✕, type-then-instant-Esc race), pixel-verified clean against pre-search baselines.
- Native Swift WKWebView harnesses (same engine + eval path as the shell) driving the real app with synthesized keystrokes: type → delete-to-empty → Esc ends byte-identical to baseline; long-horizon no-eval probe confirms sidebar paint lands within ~2.2s.
- `cargo check --locked` green; `node --check` on the injected script.

## Notes for review

- Matching is per-text-node (no cross-element matches) and capped at 500 matches (counter shows `500+`).
- Esc only closes from documents the bar has hooked (top doc at open, iframes on search) — the ✕ always works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/899"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786576820&installation_id=133523038&pr_number=899&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F899&signature=d10e01fe6b968128df7a26df3d5cad987d72d46200f6f7d6fa80b767df64b231"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->