### PR TITLE
Payroll reconcile: budget module (PATEO, revenue merge, budget tab)

### DIFF
--- a/dali-api/app/admin-console/__tests__/admin-console.payroll.budget.route.test.ts
+++ b/dali-api/app/admin-console/__tests__/admin-console.payroll.budget.route.test.ts
@@ -1,0 +1,344 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("~/lib/auth", () => ({
+  requireAuth: vi.fn(),
+  forbidden: vi.fn((_req: Request) =>
+    Response.json({ error: "Forbidden" }, { status: 403 }),
+  ),
+}));
+vi.mock("~/lib/roles", () => ({ isAdmin: vi.fn() }));
+vi.mock("~/lib/terms", () => ({ resolveTermFilter: vi.fn() }));
+// Mutation helpers + the loader's data source are stubbed so this stays a pure
+// gating/validation/dispatch test.
+vi.mock("~/admin-console/lib/budget", async () => {
+  const actual = await vi.importActual<typeof import("~/admin-console/lib/budget")>(
+    "~/admin-console/lib/budget",
+  );
+  return {
+    ...actual,
+    getBudgetData: vi.fn(),
+    upsertRevenue: vi.fn(),
+    deleteEntry: vi.fn(),
+    updateChartString: vi.fn(),
+    upsertNote: vi.fn(),
+    updateProjectType: vi.fn(),
+  };
+});
+
+import { requireAuth } from "~/lib/auth";
+import { isAdmin } from "~/lib/roles";
+import { resolveTermFilter } from "~/lib/terms";
+import {
+  getBudgetData,
+  upsertRevenue,
+  deleteEntry,
+  updateChartString,
+  upsertNote,
+  updateProjectType,
+} from "~/admin-console/lib/budget";
+import {
+  loader,
+  action,
+} from "~/admin-console/routes/admin-console.payroll.budget";
+
+const ADMIN_ID = "admin-1";
+
+const EMPTY_BUDGET = {
+  groups: [],
+  grandTotalRevenue: 0,
+  grandTotalAdjustedRevenue: 0,
+  grandTotalExpense: 0,
+  grandTotalNet: 0,
+};
+
+function asAdmin() {
+  vi.mocked(requireAuth).mockResolvedValue({
+    ok: true,
+    user: { sub: ADMIN_ID, email: "a@x.com", type: "user" },
+  } as any);
+  vi.mocked(isAdmin).mockResolvedValue(true);
+}
+function asNonAdmin() {
+  vi.mocked(requireAuth).mockResolvedValue({
+    ok: true,
+    user: { sub: "rando-1", email: "r@x.com", type: "user" },
+  } as any);
+  vi.mocked(isAdmin).mockResolvedValue(false);
+}
+function asAnon() {
+  vi.mocked(requireAuth).mockResolvedValue({
+    ok: false,
+    response: Response.json({ error: "Unauthorized" }, { status: 401 }),
+    reason: "no_session",
+  } as any);
+}
+
+function getReq() {
+  return new Request("http://localhost/admin-console/payroll/budget?term=term-25f");
+}
+function postReq(fields: Record<string, string>) {
+  const fd = new FormData();
+  for (const [k, v] of Object.entries(fields)) fd.append(k, v);
+  return new Request("http://localhost/admin-console/payroll/budget", {
+    method: "POST",
+    body: fd,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(resolveTermFilter).mockResolvedValue({
+    terms: [{ id: "term-25f", code: "25F" }],
+    selected: "term-25f",
+    termId: "term-25f",
+    isAll: false,
+  } as any);
+  vi.mocked(getBudgetData).mockResolvedValue(EMPTY_BUDGET as any);
+});
+
+describe("budget loader — auth gate", () => {
+  it("redirects anonymous users to /login", async () => {
+    asAnon();
+    const res = (await loader({ request: getReq(), params: {}, context: {} } as any)) as Response;
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe("/login");
+    expect(getBudgetData).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 for non-admins (forbidden)", async () => {
+    asNonAdmin();
+    const res = (await loader({ request: getReq(), params: {}, context: {} } as any)) as Response;
+    expect(res.status).toBe(403);
+    expect(getBudgetData).not.toHaveBeenCalled();
+  });
+
+  it("returns budget data for an admin", async () => {
+    asAdmin();
+    const res = (await loader({ request: getReq(), params: {}, context: {} } as any)) as Response;
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.termId).toBe("term-25f");
+    expect(getBudgetData).toHaveBeenCalledWith("term-25f");
+  });
+});
+
+describe("budget action — auth gate", () => {
+  it("returns the auth response for anonymous callers (no mutation)", async () => {
+    asAnon();
+    const res = await action({
+      request: postReq({ intent: "upsert-revenue", projectId: "", chartString: "cs", termId: "t", revenue: "10" }),
+      params: {},
+      context: {},
+    } as any);
+    expect(res.status).toBe(401);
+    expect(upsertRevenue).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 for non-admin callers (no mutation)", async () => {
+    asNonAdmin();
+    const res = await action({
+      request: postReq({ intent: "upsert-revenue", projectId: "", chartString: "cs", termId: "t", revenue: "10" }),
+      params: {},
+      context: {},
+    } as any);
+    expect(res.status).toBe(403);
+    expect(upsertRevenue).not.toHaveBeenCalled();
+  });
+});
+
+describe("budget action — intent dispatch + validation", () => {
+  beforeEach(() => asAdmin());
+
+  it("upsert-revenue: coerces revenue and passes a null projectId through", async () => {
+    const res = await action({
+      request: postReq({
+        intent: "upsert-revenue",
+        projectId: "",
+        chartString: "cs-core",
+        termId: "term-25f",
+        revenue: "1234.50",
+      }),
+      params: {},
+      context: {},
+    } as any);
+    expect(res.status).toBe(200);
+    expect(upsertRevenue).toHaveBeenCalledWith(
+      { projectId: null, chartString: "cs-core", termId: "term-25f" },
+      1234.5,
+    );
+  });
+
+  it("upsert-revenue: rejects a non-numeric revenue with 400 (no mutation)", async () => {
+    const res = await action({
+      request: postReq({
+        intent: "upsert-revenue",
+        projectId: "p1",
+        chartString: "cs",
+        termId: "t",
+        revenue: "not-a-number",
+      }),
+      params: {},
+      context: {},
+    } as any);
+    expect(res.status).toBe(400);
+    expect(upsertRevenue).not.toHaveBeenCalled();
+  });
+
+  it("upsert-revenue: rejects a blank chartString with 400", async () => {
+    const res = await action({
+      request: postReq({
+        intent: "upsert-revenue",
+        projectId: "p1",
+        chartString: "",
+        termId: "t",
+        revenue: "10",
+      }),
+      params: {},
+      context: {},
+    } as any);
+    expect(res.status).toBe(400);
+    expect(upsertRevenue).not.toHaveBeenCalled();
+  });
+
+  it("delete-entry: calls deleteEntry with the id", async () => {
+    const res = await action({
+      request: postReq({ intent: "delete-entry", entryId: "e1" }),
+      params: {},
+      context: {},
+    } as any);
+    expect(res.status).toBe(200);
+    expect(deleteEntry).toHaveBeenCalledWith("e1");
+  });
+
+  it("delete-entry: rejects a missing id with 400", async () => {
+    const res = await action({
+      request: postReq({ intent: "delete-entry", entryId: "" }),
+      params: {},
+      context: {},
+    } as any);
+    expect(res.status).toBe(400);
+    expect(deleteEntry).not.toHaveBeenCalled();
+  });
+
+  it("update-chartstring: passes key + newChartString", async () => {
+    const res = await action({
+      request: postReq({
+        intent: "update-chartstring",
+        projectId: "p1",
+        chartString: "cs-old",
+        termId: "t",
+        newChartString: "cs-new",
+      }),
+      params: {},
+      context: {},
+    } as any);
+    expect(res.status).toBe(200);
+    expect(updateChartString).toHaveBeenCalledWith(
+      { projectId: "p1", chartString: "cs-old", termId: "t" },
+      "cs-new",
+    );
+  });
+
+  it("update-chartstring: surfaces a collision error as 400", async () => {
+    vi.mocked(updateChartString).mockRejectedValueOnce(
+      new Error("A budget entry already exists for that chart string"),
+    );
+    const res = await action({
+      request: postReq({
+        intent: "update-chartstring",
+        projectId: "p1",
+        chartString: "cs-old",
+        termId: "t",
+        newChartString: "cs-new",
+      }),
+      params: {},
+      context: {},
+    } as any);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/already exists/i);
+  });
+
+  it("upsert-note: accepts an empty note (clear path)", async () => {
+    const res = await action({
+      request: postReq({
+        intent: "upsert-note",
+        projectId: "",
+        chartString: "cs",
+        termId: "t",
+        note: "",
+      }),
+      params: {},
+      context: {},
+    } as any);
+    expect(res.status).toBe(200);
+    expect(upsertNote).toHaveBeenCalledWith(
+      { projectId: null, chartString: "cs", termId: "t" },
+      "",
+    );
+  });
+
+  it("update-project-type: accepts a valid type", async () => {
+    const res = await action({
+      request: postReq({
+        intent: "update-project-type",
+        projectId: "p1",
+        chartString: "cs",
+        termId: "t",
+        projectType: "DALI PATEO",
+      }),
+      params: {},
+      context: {},
+    } as any);
+    expect(res.status).toBe(200);
+    expect(updateProjectType).toHaveBeenCalledWith(
+      { projectId: "p1", chartString: "cs", termId: "t" },
+      "DALI PATEO",
+    );
+  });
+
+  it("update-project-type: coerces an empty string to null (clear type)", async () => {
+    const res = await action({
+      request: postReq({
+        intent: "update-project-type",
+        projectId: "p1",
+        chartString: "cs",
+        termId: "t",
+        projectType: "",
+      }),
+      params: {},
+      context: {},
+    } as any);
+    expect(res.status).toBe(200);
+    expect(updateProjectType).toHaveBeenCalledWith(
+      { projectId: "p1", chartString: "cs", termId: "t" },
+      null,
+    );
+  });
+
+  it("update-project-type: rejects an unknown type with 400", async () => {
+    const res = await action({
+      request: postReq({
+        intent: "update-project-type",
+        projectId: "p1",
+        chartString: "cs",
+        termId: "t",
+        projectType: "Bogus GL",
+      }),
+      params: {},
+      context: {},
+    } as any);
+    expect(res.status).toBe(400);
+    expect(updateProjectType).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unknown intent with 400", async () => {
+    const res = await action({
+      request: postReq({ intent: "nonsense" }),
+      params: {},
+      context: {},
+    } as any);
+    expect(res.status).toBe(400);
+  });
+});

--- a/dali-api/app/admin-console/__tests__/admin-console.payroll.budget.route.test.ts
+++ b/dali-api/app/admin-console/__tests__/admin-console.payroll.budget.route.test.ts
@@ -9,21 +9,18 @@ vi.mock("~/lib/auth", () => ({
 vi.mock("~/lib/roles", () => ({ isAdmin: vi.fn() }));
 vi.mock("~/lib/terms", () => ({ resolveTermFilter: vi.fn() }));
 // Mutation helpers + the loader's data source are stubbed so this stays a pure
-// gating/validation/dispatch test.
-vi.mock("~/admin-console/lib/budget", async () => {
-  const actual = await vi.importActual<typeof import("~/admin-console/lib/budget")>(
-    "~/admin-console/lib/budget",
-  );
-  return {
-    ...actual,
-    getBudgetData: vi.fn(),
-    upsertRevenue: vi.fn(),
-    deleteEntry: vi.fn(),
-    updateChartString: vi.fn(),
-    upsertNote: vi.fn(),
-    updateProjectType: vi.fn(),
-  };
-});
+// gating/validation/dispatch test. Plain factory only — no importActual: the
+// real budget.ts imports ~/lib/db, and loading it here would require the
+// generated Prisma client (absent in CI, where prisma generate never runs).
+// The route gets the real PROJECT_TYPES from budget.shared (client-safe).
+vi.mock("~/admin-console/lib/budget", () => ({
+  getBudgetData: vi.fn(),
+  upsertRevenue: vi.fn(),
+  deleteEntry: vi.fn(),
+  updateChartString: vi.fn(),
+  upsertNote: vi.fn(),
+  updateProjectType: vi.fn(),
+}));
 
 import { requireAuth } from "~/lib/auth";
 import { isAdmin } from "~/lib/roles";

--- a/dali-api/app/admin-console/__tests__/budget.test.ts
+++ b/dali-api/app/admin-console/__tests__/budget.test.ts
@@ -1,0 +1,286 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("~/lib/db");
+// The expense seam is exercised on its own in the reconcile tests — here we
+// stub it so the budget merge/PATEO/grouping logic is tested in isolation.
+vi.mock("~/admin-console/lib/payroll-reconcile.server", () => ({
+  computeExpensesByProjectChartTerm: vi.fn(),
+}));
+
+import { prisma } from "~/lib/db";
+import { computeExpensesByProjectChartTerm } from "~/admin-console/lib/payroll-reconcile.server";
+import {
+  getBudgetData,
+  upsertRevenue,
+  updateChartString,
+  upsertNote,
+  updateProjectType,
+  PATEO_EFFECTIVE_RATE,
+} from "~/admin-console/lib/budget";
+
+const TERM = "term-25f";
+
+type EntryStub = {
+  id: string;
+  projectId: string | null;
+  chartString: string;
+  termId: string;
+  revenue: number;
+  projectType: string | null;
+};
+
+function setup(opts: {
+  entries?: EntryStub[];
+  notes?: Array<{ id: string; projectId: string | null; chartString: string; note: string }>;
+  expenses?: Array<{ projectId: string | null; chartString: string; earnings: number }>;
+  projects?: Array<{ id: string; name: string }>;
+}) {
+  (prisma.budgetEntry.findMany as any).mockResolvedValue(opts.entries ?? []);
+  (prisma.budgetNote.findMany as any).mockResolvedValue(opts.notes ?? []);
+  (prisma.project.findMany as any).mockResolvedValue(opts.projects ?? []);
+  vi.mocked(computeExpensesByProjectChartTerm).mockResolvedValue(opts.expenses ?? []);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("getBudgetData — PATEO adjustment", () => {
+  it("scales revenue ONLY for DALI PATEO; other types pass through", async () => {
+    setup({
+      projects: [
+        { id: "p1", name: "Alpha" },
+        { id: "p2", name: "Beta" },
+        { id: "p3", name: "Gamma" },
+        { id: "p4", name: "Delta" },
+      ],
+      entries: [
+        { id: "e1", projectId: "p1", chartString: "cs-1", termId: TERM, revenue: 1000, projectType: "DALI PATEO" },
+        { id: "e2", projectId: "p2", chartString: "cs-2", termId: TERM, revenue: 1000, projectType: "Other PATEO" },
+        { id: "e3", projectId: "p3", chartString: "cs-3", termId: TERM, revenue: 1000, projectType: "DALI GL" },
+        { id: "e4", projectId: "p4", chartString: "cs-4", termId: TERM, revenue: 1000, projectType: null },
+      ],
+    });
+
+    const data = await getBudgetData(TERM);
+    const byProject = Object.fromEntries(
+      data.groups.map((g) => [g.projectName, g.rows[0]]),
+    );
+
+    // DALI PATEO: 1000 * PATEO_EFFECTIVE_RATE
+    expect(byProject["Alpha"].adjustedRevenue).toBeCloseTo(1000 * PATEO_EFFECTIVE_RATE, 2);
+    expect(byProject["Alpha"].isPateo).toBe(true);
+    // Everything else: unscaled.
+    expect(byProject["Beta"].adjustedRevenue).toBe(1000);
+    expect(byProject["Gamma"].adjustedRevenue).toBe(1000);
+    expect(byProject["Delta"].adjustedRevenue).toBe(1000);
+    expect(byProject["Beta"].isPateo).toBe(false);
+  });
+
+  it("the constant carries the documented provenance value", () => {
+    expect(PATEO_EFFECTIVE_RATE).toBeCloseTo(1.47625 / 1.635, 10);
+    expect(PATEO_EFFECTIVE_RATE).toBeCloseTo(0.9029, 3);
+  });
+});
+
+describe("getBudgetData — merge of revenue + expense", () => {
+  it("produces both-sided, revenue-only, and expense-only rows", async () => {
+    setup({
+      projects: [
+        { id: "p1", name: "Alpha" },
+        { id: "p2", name: "Beta" },
+      ],
+      entries: [
+        // both: has revenue AND an expense
+        { id: "e1", projectId: "p1", chartString: "cs-both", termId: TERM, revenue: 500, projectType: "DALI GL" },
+        // revenue-only: no matching expense
+        { id: "e2", projectId: "p2", chartString: "cs-rev", termId: TERM, revenue: 300, projectType: "DALI GL" },
+      ],
+      expenses: [
+        { projectId: "p1", chartString: "cs-both", earnings: 200 },
+        // expense-only: no budget entry (attributes to project p1)
+        { projectId: "p1", chartString: "cs-exp", earnings: 150 },
+      ],
+    });
+
+    const data = await getBudgetData(TERM);
+    const alpha = data.groups.find((g) => g.projectName === "Alpha")!;
+    const both = alpha.rows.find((r) => r.chartString === "cs-both")!;
+    const exp = alpha.rows.find((r) => r.chartString === "cs-exp")!;
+    const beta = data.groups.find((g) => g.projectName === "Beta")!;
+    const rev = beta.rows.find((r) => r.chartString === "cs-rev")!;
+
+    expect(both.revenue).toBe(500);
+    expect(both.expense).toBe(200);
+    expect(both.net).toBe(300);
+    expect(both.entryId).toBe("e1");
+
+    expect(rev.revenue).toBe(300);
+    expect(rev.expense).toBe(0);
+    expect(rev.net).toBe(300);
+
+    expect(exp.revenue).toBe(0);
+    expect(exp.expense).toBe(150);
+    expect(exp.net).toBe(-150);
+    expect(exp.entryId).toBeNull();
+  });
+
+  it("groups null-project expense lines into the non-project bucket, sorted last", async () => {
+    setup({
+      projects: [{ id: "p1", name: "Alpha" }],
+      expenses: [
+        { projectId: "p1", chartString: "cs-p1", earnings: 100 },
+        { projectId: null, chartString: "cs-core", earnings: 40 },
+        { projectId: null, chartString: "cs-ext", earnings: 60 },
+      ],
+    });
+
+    const data = await getBudgetData(TERM);
+    expect(data.groups).toHaveLength(2);
+    // Non-project bucket is always last.
+    const last = data.groups[data.groups.length - 1];
+    expect(last.projectId).toBeNull();
+    expect(last.rows).toHaveLength(2);
+    expect(last.totalExpense).toBe(100);
+  });
+
+  it("attaches notes to the matching (projectId, chartString) row, including null-project", async () => {
+    setup({
+      projects: [{ id: "p1", name: "Alpha" }],
+      entries: [
+        { id: "e1", projectId: "p1", chartString: "cs-1", termId: TERM, revenue: 100, projectType: null },
+      ],
+      notes: [
+        { id: "n1", projectId: "p1", chartString: "cs-1", note: "budgeted line" },
+        { id: "n2", projectId: null, chartString: "cs-core", note: "lab overhead" },
+      ],
+      expenses: [{ projectId: null, chartString: "cs-core", earnings: 10 }],
+    });
+
+    const data = await getBudgetData(TERM);
+    const alphaRow = data.groups.find((g) => g.projectId === "p1")!.rows[0];
+    const bucketRow = data.groups.find((g) => g.projectId === null)!.rows[0];
+    expect(alphaRow.note).toBe("budgeted line");
+    expect(alphaRow.noteId).toBe("n1");
+    expect(bucketRow.note).toBe("lab overhead");
+  });
+});
+
+describe("getBudgetData — totals", () => {
+  it("computes per-group and grand totals", async () => {
+    setup({
+      projects: [
+        { id: "p1", name: "Alpha" },
+        { id: "p2", name: "Beta" },
+      ],
+      entries: [
+        { id: "e1", projectId: "p1", chartString: "cs-1", termId: TERM, revenue: 1000, projectType: "DALI PATEO" },
+        { id: "e2", projectId: "p1", chartString: "cs-2", termId: TERM, revenue: 500, projectType: "DALI GL" },
+        { id: "e3", projectId: "p2", chartString: "cs-3", termId: TERM, revenue: 800, projectType: "DALI GL" },
+      ],
+      expenses: [
+        { projectId: "p1", chartString: "cs-1", earnings: 300 },
+        { projectId: "p2", chartString: "cs-3", earnings: 900 },
+      ],
+    });
+
+    const data = await getBudgetData(TERM);
+    const alpha = data.groups.find((g) => g.projectName === "Alpha")!;
+    const beta = data.groups.find((g) => g.projectName === "Beta")!;
+
+    const alphaAdj = 1000 * PATEO_EFFECTIVE_RATE + 500;
+    expect(alpha.totalRevenue).toBe(1500);
+    expect(alpha.totalAdjustedRevenue).toBeCloseTo(alphaAdj, 2);
+    expect(alpha.totalExpense).toBe(300);
+    expect(alpha.totalNet).toBeCloseTo(alphaAdj - 300, 2);
+
+    expect(beta.totalNet).toBe(800 - 900); // -100
+
+    expect(data.grandTotalRevenue).toBe(2300);
+    expect(data.grandTotalAdjustedRevenue).toBeCloseTo(alphaAdj + 800, 2);
+    expect(data.grandTotalExpense).toBe(1200);
+    expect(data.grandTotalNet).toBeCloseTo(alphaAdj + 800 - 1200, 2);
+  });
+
+  it("returns zeroed totals and no groups for an empty term (no throw)", async () => {
+    setup({});
+    const data = await getBudgetData(TERM);
+    expect(data.groups).toHaveLength(0);
+    expect(data.grandTotalRevenue).toBe(0);
+    expect(data.grandTotalAdjustedRevenue).toBe(0);
+    expect(data.grandTotalExpense).toBe(0);
+    expect(data.grandTotalNet).toBe(0);
+  });
+});
+
+describe("mutation helpers — null-project findFirst-before-write", () => {
+  it("upsertRevenue creates when no null-project row exists (findFirst, no upsert)", async () => {
+    (prisma.budgetEntry.findFirst as any).mockResolvedValue(null);
+    await upsertRevenue({ projectId: null, chartString: "cs-core", termId: TERM }, 250);
+
+    expect(prisma.budgetEntry.findFirst).toHaveBeenCalledWith({
+      where: { projectId: null, chartString: "cs-core", termId: TERM },
+    });
+    expect(prisma.budgetEntry.create).toHaveBeenCalledWith({
+      data: { projectId: null, chartString: "cs-core", termId: TERM, revenue: 250 },
+    });
+    expect(prisma.budgetEntry.upsert).not.toHaveBeenCalled();
+  });
+
+  it("upsertRevenue updates the existing null-project row (dedupes — no second create)", async () => {
+    (prisma.budgetEntry.findFirst as any).mockResolvedValue({ id: "e-null" });
+    await upsertRevenue({ projectId: null, chartString: "cs-core", termId: TERM }, 999);
+
+    expect(prisma.budgetEntry.update).toHaveBeenCalledWith({
+      where: { id: "e-null" },
+      data: { revenue: 999 },
+    });
+    expect(prisma.budgetEntry.create).not.toHaveBeenCalled();
+  });
+
+  it("updateProjectType creates an entry (revenue 0) when none exists yet", async () => {
+    (prisma.budgetEntry.findFirst as any).mockResolvedValue(null);
+    await updateProjectType({ projectId: "p1", chartString: "cs-1", termId: TERM }, "DALI PATEO");
+    expect(prisma.budgetEntry.create).toHaveBeenCalledWith({
+      data: { projectId: "p1", chartString: "cs-1", termId: TERM, revenue: 0, projectType: "DALI PATEO" },
+    });
+  });
+
+  it("upsertNote deletes the note when the text is blank", async () => {
+    (prisma.budgetNote.findFirst as any).mockResolvedValue({ id: "n1" });
+    await upsertNote({ projectId: null, chartString: "cs-core", termId: TERM }, "   ");
+    expect(prisma.budgetNote.delete).toHaveBeenCalledWith({ where: { id: "n1" } });
+    expect(prisma.budgetNote.create).not.toHaveBeenCalled();
+  });
+
+  it("updateChartString guards against a colliding target chart string", async () => {
+    (prisma.budgetEntry.findFirst as any)
+      .mockResolvedValueOnce({ id: "e1" }) // the source row
+      .mockResolvedValueOnce({ id: "e2" }); // a different row already at the target
+    await expect(
+      updateChartString({ projectId: "p1", chartString: "cs-old", termId: TERM }, "cs-new"),
+    ).rejects.toThrow(/already exists/i);
+  });
+
+  it("updateChartString moves the entry (and its note) inside a transaction", async () => {
+    (prisma.budgetEntry.findFirst as any)
+      .mockResolvedValueOnce({ id: "e1" }) // source
+      .mockResolvedValueOnce(null); // no collision at target
+    const txEntry = { update: vi.fn() };
+    const txNote = { findFirst: vi.fn().mockResolvedValue({ id: "n1" }), update: vi.fn() };
+    (prisma.$transaction as any).mockImplementation(async (cb: any) =>
+      cb({ budgetEntry: txEntry, budgetNote: txNote }),
+    );
+
+    await updateChartString({ projectId: "p1", chartString: "cs-old", termId: TERM }, "cs-new");
+
+    expect(txEntry.update).toHaveBeenCalledWith({
+      where: { id: "e1" },
+      data: { chartString: "cs-new" },
+    });
+    expect(txNote.update).toHaveBeenCalledWith({
+      where: { id: "n1" },
+      data: { chartString: "cs-new" },
+    });
+  });
+});

--- a/dali-api/app/admin-console/components/PayrollBudgetPanel.tsx
+++ b/dali-api/app/admin-console/components/PayrollBudgetPanel.tsx
@@ -1,0 +1,402 @@
+import { useEffect, useRef, useState } from "react";
+import { useFetcher } from "react-router";
+import { Trash2, StickyNote } from "lucide-react";
+import { Card } from "~/components/ui/Card";
+import { formatUsd } from "~/lib/money";
+import { cn } from "~/lib/cn";
+import { PROJECT_TYPES } from "~/admin-console/lib/budget.shared";
+import type {
+  BudgetData,
+  BudgetGroup,
+  BudgetRow,
+} from "~/admin-console/lib/budget.shared";
+import type { BudgetLoaderData } from "~/admin-console/routes/admin-console.payroll.budget";
+
+// Budget tab. Data is fetched lazily on first activation via a GET fetcher to
+// /admin-console/payroll/budget; mutations post back to the same route through
+// per-row hidden-`intent` fetcher Forms (the repo's inline-edit pattern).
+
+const TABLE_WRAP = "bg-card border border-border rounded-lg overflow-x-auto";
+const TH = "text-left px-3 py-2 font-medium text-muted-foreground whitespace-nowrap";
+const TH_NUM = "text-right px-3 py-2 font-medium text-muted-foreground whitespace-nowrap";
+const TD = "px-3 py-2 text-muted-foreground";
+const TD_NUM = "px-3 py-2 text-right text-muted-foreground tabular-nums";
+
+const BUDGET_ROUTE = "/admin-console/payroll/budget";
+
+export function PayrollBudgetPanel({ term }: { term: string }) {
+  const fetcher = useFetcher<BudgetLoaderData>();
+
+  // Lazy-load on first mount / when the term changes.
+  useEffect(() => {
+    fetcher.load(`${BUDGET_ROUTE}?term=${encodeURIComponent(term)}`);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [term]);
+
+  if (fetcher.state === "loading" && !fetcher.data) {
+    return <Card className="p-8 text-center text-sm text-muted-foreground">Loading budget…</Card>;
+  }
+  if (!fetcher.data) {
+    return <Card className="p-8 text-center text-sm text-muted-foreground">Loading budget…</Card>;
+  }
+  if (!fetcher.data.ok) {
+    return (
+      <Card className="p-8 text-center text-sm text-muted-foreground">
+        {fetcher.data.error}
+      </Card>
+    );
+  }
+
+  const { budget, termId } = fetcher.data;
+  return <BudgetTable budget={budget} termId={termId} />;
+}
+
+function BudgetTable({ budget, termId }: { budget: BudgetData; termId: string }) {
+  const anyPateo = budget.groups.some((g) => g.rows.some((r) => r.isPateo));
+
+  if (budget.groups.length === 0) {
+    return (
+      <Card className="p-8 text-center text-sm text-muted-foreground">
+        No budget lines for this term yet. Revenue and expense appear here once
+        timesheets are uploaded or revenue is entered.
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className={TABLE_WRAP}>
+        <table className="w-full text-sm min-w-[900px]">
+          <thead>
+            <tr className="border-b border-border bg-muted/50">
+              <th className={TH}>Project</th>
+              <th className={TH}>Chart String</th>
+              <th className={TH}>Type</th>
+              <th className={TH_NUM}>Revenue</th>
+              <th className={TH_NUM}>Adj. Revenue</th>
+              <th className={TH_NUM}>Expense</th>
+              <th className={TH_NUM}>Net</th>
+              <th className={TH}>Notes</th>
+              <th className="px-3 py-2"></th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border">
+            {budget.groups.map((g) => (
+              <GroupRows key={g.projectId ?? "__none__"} group={g} termId={termId} />
+            ))}
+            <tr className="border-t-2 border-foreground font-bold text-foreground">
+              <td className="px-3 py-2" colSpan={3}>
+                Grand total
+              </td>
+              <td className={cn(TD_NUM, "text-foreground font-bold")}>
+                {formatUsd(budget.grandTotalRevenue)}
+              </td>
+              <td className={cn(TD_NUM, "text-foreground font-bold")}>
+                {formatUsd(budget.grandTotalAdjustedRevenue)}
+              </td>
+              <td className={cn(TD_NUM, "text-foreground font-bold")}>
+                {formatUsd(budget.grandTotalExpense)}
+              </td>
+              <td className={cn(TD_NUM, netClass(budget.grandTotalNet), "font-bold")}>
+                {formatNet(budget.grandTotalNet)}
+              </td>
+              <td colSpan={2}></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      {anyPateo && (
+        <p className="text-xs text-muted-foreground">
+          * DALI PATEO revenue adjusted at 90.29% (Dartmouth F&amp;A 63.5%, 75%
+          recovery). The adjustment applies to DALI PATEO rows only; all other
+          types carry revenue through unchanged.
+        </p>
+      )}
+    </div>
+  );
+}
+
+function GroupRows({ group, termId }: { group: BudgetGroup; termId: string }) {
+  const isBucket = group.projectId === null;
+  return (
+    <>
+      <tr className="bg-muted/30">
+        <td className="px-3 py-1.5 text-xs font-semibold text-foreground" colSpan={9}>
+          {group.projectName}
+        </td>
+      </tr>
+      {group.rows.map((row) => (
+        <BudgetRowView
+          key={`${group.projectId ?? ""}-${row.chartString}`}
+          row={row}
+          termId={termId}
+          isBucket={isBucket}
+        />
+      ))}
+      <tr className="bg-muted/20 text-foreground">
+        <td className="px-3 py-1.5 text-xs italic" colSpan={3}>
+          {group.projectName} subtotal
+        </td>
+        <td className={cn(TD_NUM, "text-xs font-semibold")}>
+          {formatUsd(group.totalRevenue)}
+        </td>
+        <td className={cn(TD_NUM, "text-xs font-semibold")}>
+          {formatUsd(group.totalAdjustedRevenue)}
+        </td>
+        <td className={cn(TD_NUM, "text-xs font-semibold")}>
+          {formatUsd(group.totalExpense)}
+        </td>
+        <td className={cn(TD_NUM, "text-xs font-semibold", netClass(group.totalNet))}>
+          {formatNet(group.totalNet)}
+        </td>
+        <td colSpan={2}></td>
+      </tr>
+    </>
+  );
+}
+
+function BudgetRowView({
+  row,
+  termId,
+  isBucket,
+}: {
+  row: BudgetRow;
+  termId: string;
+  isBucket: boolean;
+}) {
+  const [notesOpen, setNotesOpen] = useState(false);
+  const keyInputs = (
+    <>
+      <input type="hidden" name="projectId" value={row.projectId ?? ""} />
+      <input type="hidden" name="chartString" value={row.chartString} />
+      <input type="hidden" name="termId" value={termId} />
+    </>
+  );
+
+  return (
+    <>
+      <tr className="hover:bg-muted/50">
+        {/* Project name lives in the group header; the per-row cell stays blank. */}
+        <td className={cn(TD, isBucket && "text-xs italic")}></td>
+        <td className="px-3 py-2 font-mono text-xs text-foreground">
+          {row.chartString}
+        </td>
+        <td className="px-3 py-2">
+          <ProjectTypeSelect row={row} termId={termId} keyInputs={keyInputs} />
+        </td>
+        <td className="px-3 py-1.5 text-right">
+          <RevenueEdit row={row} termId={termId} keyInputs={keyInputs} />
+        </td>
+        <td className={TD_NUM}>
+          {row.adjustedRevenue > 0 || row.revenue > 0 ? (
+            <>
+              {formatUsd(row.adjustedRevenue)}
+              {row.isPateo && <span className="ml-0.5 text-accent-coral">*</span>}
+            </>
+          ) : (
+            "—"
+          )}
+        </td>
+        <td className={TD_NUM}>{formatUsd(row.expense)}</td>
+        <td className={cn(TD_NUM, netClass(row.net), "font-semibold")}>
+          {formatNet(row.net)}
+        </td>
+        <td className="px-3 py-2">
+          <button
+            type="button"
+            onClick={() => setNotesOpen((o) => !o)}
+            aria-label={`${row.note ? "Edit" : "Add"} note for ${row.chartString}`}
+            className={cn(
+              "text-muted-foreground hover:text-foreground",
+              row.note && "text-accent-coral",
+            )}
+          >
+            <StickyNote className="w-4 h-4" />
+          </button>
+        </td>
+        <td className="px-3 py-2 text-right">
+          {row.entryId && <DeleteButton entryId={row.entryId} />}
+        </td>
+      </tr>
+      {notesOpen && (
+        <tr className="bg-muted/20">
+          <td colSpan={9} className="px-3 py-2">
+            <NoteEditor
+              row={row}
+              termId={termId}
+              keyInputs={keyInputs}
+              onDone={() => setNotesOpen(false)}
+            />
+          </td>
+        </tr>
+      )}
+    </>
+  );
+}
+
+// ─── inline editors ──────────────────────────────────────────────────────────
+
+function RevenueEdit({
+  row,
+  termId: _termId,
+  keyInputs,
+}: {
+  row: BudgetRow;
+  termId: string;
+  keyInputs: React.ReactNode;
+}) {
+  const fetcher = useFetcher();
+  const [value, setValue] = useState(row.revenue.toFixed(2));
+  const submitting = fetcher.state !== "idle";
+  const wasSubmitting = useRef(false);
+
+  // Re-sync the input when the server value changes after a save.
+  useEffect(() => {
+    if (submitting) wasSubmitting.current = true;
+    else if (wasSubmitting.current) {
+      wasSubmitting.current = false;
+      setValue(row.revenue.toFixed(2));
+    }
+  }, [submitting, row.revenue]);
+
+  return (
+    <fetcher.Form method="post" action={BUDGET_ROUTE} className="inline-flex">
+      <input type="hidden" name="intent" value="upsert-revenue" />
+      {keyInputs}
+      <input
+        type="text"
+        inputMode="decimal"
+        name="revenue"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onBlur={(e) => {
+          if (e.target.value !== row.revenue.toFixed(2)) {
+            fetcher.submit(e.target.form);
+          }
+        }}
+        aria-label={`Revenue for ${row.chartString}`}
+        className="w-24 rounded border border-border bg-card px-2 py-1 text-right text-xs tabular-nums text-foreground focus:border-accent-coral focus:outline-none"
+      />
+    </fetcher.Form>
+  );
+}
+
+function ProjectTypeSelect({
+  row,
+  termId: _termId,
+  keyInputs,
+}: {
+  row: BudgetRow;
+  termId: string;
+  keyInputs: React.ReactNode;
+}) {
+  const fetcher = useFetcher();
+  return (
+    <fetcher.Form method="post" action={BUDGET_ROUTE}>
+      <input type="hidden" name="intent" value="update-project-type" />
+      {keyInputs}
+      <select
+        name="projectType"
+        defaultValue={row.projectType ?? ""}
+        aria-label={`Project type for ${row.chartString}`}
+        onChange={(e) => fetcher.submit(e.target.form)}
+        className="rounded border border-border bg-card px-2 py-1 text-xs text-foreground focus:border-accent-coral focus:outline-none"
+      >
+        <option value="">—</option>
+        {PROJECT_TYPES.map((t) => (
+          <option key={t} value={t}>
+            {t}
+          </option>
+        ))}
+      </select>
+    </fetcher.Form>
+  );
+}
+
+function NoteEditor({
+  row,
+  termId: _termId,
+  keyInputs,
+  onDone,
+}: {
+  row: BudgetRow;
+  termId: string;
+  keyInputs: React.ReactNode;
+  onDone: () => void;
+}) {
+  const fetcher = useFetcher();
+  const submitting = fetcher.state !== "idle";
+  const wasSubmitting = useRef(false);
+
+  useEffect(() => {
+    if (submitting) wasSubmitting.current = true;
+    else if (wasSubmitting.current) {
+      wasSubmitting.current = false;
+      onDone();
+    }
+  }, [submitting, onDone]);
+
+  return (
+    <fetcher.Form
+      method="post"
+      action={BUDGET_ROUTE}
+      className="flex items-center gap-2"
+    >
+      <input type="hidden" name="intent" value="upsert-note" />
+      {keyInputs}
+      <input
+        type="text"
+        name="note"
+        defaultValue={row.note ?? ""}
+        placeholder="Add a note…"
+        autoFocus
+        aria-label={`Note for ${row.chartString}`}
+        className="flex-1 rounded border border-border bg-card px-2 py-1 text-xs text-foreground focus:border-accent-coral focus:outline-none"
+      />
+      <button
+        type="submit"
+        className="rounded bg-accent-coral px-2 py-1 text-xs font-semibold text-white"
+      >
+        Save
+      </button>
+    </fetcher.Form>
+  );
+}
+
+function DeleteButton({ entryId }: { entryId: string }) {
+  const fetcher = useFetcher();
+  return (
+    <fetcher.Form
+      method="post"
+      action={BUDGET_ROUTE}
+      className="inline"
+      onSubmit={(e) => {
+        if (!confirm("Delete this budget line? Expense will still show as an unbudgeted row.")) {
+          e.preventDefault();
+        }
+      }}
+    >
+      <input type="hidden" name="intent" value="delete-entry" />
+      <input type="hidden" name="entryId" value={entryId} />
+      <button
+        type="submit"
+        aria-label="Delete budget line"
+        className="text-muted-foreground hover:text-red-600"
+      >
+        <Trash2 className="w-4 h-4" />
+      </button>
+    </fetcher.Form>
+  );
+}
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+function netClass(net: number): string {
+  if (net > 0) return "text-green-600";
+  if (net < 0) return "text-red-600";
+  return "text-muted-foreground";
+}
+
+function formatNet(net: number): string {
+  return net < 0 ? `−${formatUsd(Math.abs(net))}` : formatUsd(net);
+}

--- a/dali-api/app/admin-console/lib/budget.shared.ts
+++ b/dali-api/app/admin-console/lib/budget.shared.ts
@@ -1,0 +1,56 @@
+// Client-safe budget surface: the project-type constant + serialized row/group
+// shapes. Kept free of any server-only import so the Budget tab component can
+// pull the type list without dragging Prisma / the reconcile server module into
+// the client bundle. budget.ts (server) re-exports these for its callers.
+
+// DALI PATEO funds are discounted for Dartmouth's indirect-cost recovery.
+// Effective rate = 1.47625 / 1.635 ≈ 0.9029, derived from an F&A rate of 63.5%
+// with 75% recovery. Applied ONLY to revenue on rows whose projectType is
+// "DALI PATEO"; every other type carries revenue through unchanged.
+export const PATEO_EFFECTIVE_RATE = 1.47625 / 1.635;
+
+/** The four project-type values the UI offers (empty = unset). */
+export const PROJECT_TYPES = [
+  "DALI GL",
+  "Transfer GL",
+  "DALI PATEO",
+  "Other PATEO",
+] as const;
+export type ProjectType = (typeof PROJECT_TYPES)[number];
+
+export type BudgetRow = {
+  /** BudgetEntry id, or null when this row exists only because of expense. */
+  entryId: string | null;
+  /** BudgetNote id, or null when no note is attached. */
+  noteId: string | null;
+  projectId: string | null;
+  chartString: string;
+  projectType: string | null;
+  revenue: number;
+  adjustedRevenue: number;
+  expense: number;
+  net: number;
+  note: string | null;
+  /** True when projectType is "DALI PATEO" (revenue was scaled). */
+  isPateo: boolean;
+};
+
+export type BudgetGroup = {
+  /** Project id, or null for the non-project (Core/Instructor/External/unmatched) bucket. */
+  projectId: string | null;
+  /** Display name for the group. */
+  projectName: string;
+  rows: BudgetRow[];
+  totalRevenue: number;
+  totalAdjustedRevenue: number;
+  totalExpense: number;
+  totalNet: number;
+};
+
+export type BudgetData = {
+  groups: BudgetGroup[];
+  grandTotalRevenue: number;
+  grandTotalAdjustedRevenue: number;
+  grandTotalExpense: number;
+  grandTotalNet: number;
+};

--- a/dali-api/app/admin-console/lib/budget.ts
+++ b/dali-api/app/admin-console/lib/budget.ts
@@ -1,0 +1,316 @@
+// Budget module: revenue (admin-entered) vs computed payroll expense per
+// project / chart-string / term, with Dartmouth PATEO indirect-cost
+// discounting. Ported from dali-hr/app/services/budget.server.ts with dali-os
+// substitutions (projectId-keyed expense seam, cuid ids, Decimal → number at
+// this boundary — React Router single-fetch can't serialize Prisma Decimal).
+
+import { prisma } from "~/lib/db";
+import { decimalToNumber, roundCents } from "~/lib/money";
+import { computeExpensesByProjectChartTerm } from "~/admin-console/lib/payroll-reconcile.server";
+import {
+  PATEO_EFFECTIVE_RATE,
+  PROJECT_TYPES,
+  type ProjectType,
+  type BudgetRow,
+  type BudgetGroup,
+  type BudgetData,
+} from "~/admin-console/lib/budget.shared";
+
+// The client-safe budget surface (PATEO constant, project-type list, and the
+// serialized row/group/data shapes) lives in budget.shared.ts so the Budget tab
+// component can import it without pulling this server module into the client
+// bundle. Re-exported here for server callers, tests, and the CSV route.
+export {
+  PATEO_EFFECTIVE_RATE,
+  PROJECT_TYPES,
+  type ProjectType,
+  type BudgetRow,
+  type BudgetGroup,
+  type BudgetData,
+};
+
+function adjustRevenue(revenue: number, projectType: string | null): number {
+  return projectType === "DALI PATEO"
+    ? roundCents(revenue * PATEO_EFFECTIVE_RATE)
+    : revenue;
+}
+
+// ─── getBudgetData ───────────────────────────────────────────────────────────
+
+const NON_PROJECT_GROUP_NAME = "Non-project (Core / Instructor / External / unmatched)";
+
+/**
+ * Full budget breakdown for a term. Reads BudgetEntry/BudgetNote, merges with
+ * the payroll expense seam on (projectId, chartString), applies the PATEO
+ * adjustment, and groups by project (+ one non-project bucket). Expense-only
+ * lines (no BudgetEntry) appear with revenue 0. An empty term returns zeroed
+ * totals with no groups — never throws.
+ */
+export async function getBudgetData(termId: string): Promise<BudgetData> {
+  const [entries, notes, expenses, projects] = await Promise.all([
+    prisma.budgetEntry.findMany({ where: { termId } }),
+    prisma.budgetNote.findMany({ where: { termId } }),
+    computeExpensesByProjectChartTerm(termId),
+    prisma.project.findMany({ select: { id: true, name: true } }),
+  ]);
+
+  const projectName = new Map(projects.map((p) => [p.id, p.name]));
+
+  // Note lookup keyed by (projectId, chartString). NULL projectId → "" sentinel.
+  const noteByKey = new Map<string, { id: string; note: string }>();
+  for (const n of notes) {
+    noteByKey.set(mergeKey(n.projectId, n.chartString), { id: n.id, note: n.note });
+  }
+
+  // Merge budget entries + expenses into one row per (projectId, chartString).
+  const rowByKey = new Map<string, BudgetRow>();
+
+  for (const e of entries) {
+    const revenue = decimalToNumber(e.revenue);
+    const adjustedRevenue = adjustRevenue(revenue, e.projectType);
+    const key = mergeKey(e.projectId, e.chartString);
+    const note = noteByKey.get(key) ?? null;
+    rowByKey.set(key, {
+      entryId: e.id,
+      noteId: note?.id ?? null,
+      projectId: e.projectId,
+      chartString: e.chartString,
+      projectType: e.projectType,
+      revenue,
+      adjustedRevenue,
+      expense: 0,
+      net: adjustedRevenue,
+      note: note?.note ?? null,
+      isPateo: e.projectType === "DALI PATEO",
+    });
+  }
+
+  for (const x of expenses) {
+    const key = mergeKey(x.projectId, x.chartString);
+    const existing = rowByKey.get(key);
+    if (existing) {
+      existing.expense = x.earnings;
+      existing.net = roundCents(existing.adjustedRevenue - x.earnings);
+    } else {
+      const note = noteByKey.get(key) ?? null;
+      rowByKey.set(key, {
+        entryId: null,
+        noteId: note?.id ?? null,
+        projectId: x.projectId,
+        chartString: x.chartString,
+        projectType: null,
+        revenue: 0,
+        adjustedRevenue: 0,
+        expense: x.earnings,
+        net: roundCents(-x.earnings),
+        note: note?.note ?? null,
+        isPateo: false,
+      });
+    }
+  }
+
+  // Group by project; null projectId → the shared non-project bucket.
+  const groupByProject = new Map<string | null, BudgetRow[]>();
+  for (const row of rowByKey.values()) {
+    const list = groupByProject.get(row.projectId) ?? [];
+    list.push(row);
+    groupByProject.set(row.projectId, list);
+  }
+
+  const groups: BudgetGroup[] = [];
+  for (const [projectId, rows] of groupByProject) {
+    rows.sort((a, b) => a.chartString.localeCompare(b.chartString));
+    const totalRevenue = roundCents(rows.reduce((s, r) => s + r.revenue, 0));
+    const totalAdjustedRevenue = roundCents(
+      rows.reduce((s, r) => s + r.adjustedRevenue, 0),
+    );
+    const totalExpense = roundCents(rows.reduce((s, r) => s + r.expense, 0));
+    groups.push({
+      projectId,
+      projectName:
+        projectId === null
+          ? NON_PROJECT_GROUP_NAME
+          : (projectName.get(projectId) ?? "Unknown project"),
+      rows,
+      totalRevenue,
+      totalAdjustedRevenue,
+      totalExpense,
+      totalNet: roundCents(totalAdjustedRevenue - totalExpense),
+    });
+  }
+
+  // Real projects sorted by name; the non-project bucket always last.
+  groups.sort((a, b) => {
+    if (a.projectId === null) return 1;
+    if (b.projectId === null) return -1;
+    return a.projectName.localeCompare(b.projectName);
+  });
+
+  const grandTotalRevenue = roundCents(
+    groups.reduce((s, g) => s + g.totalRevenue, 0),
+  );
+  const grandTotalAdjustedRevenue = roundCents(
+    groups.reduce((s, g) => s + g.totalAdjustedRevenue, 0),
+  );
+  const grandTotalExpense = roundCents(
+    groups.reduce((s, g) => s + g.totalExpense, 0),
+  );
+
+  return {
+    groups,
+    grandTotalRevenue,
+    grandTotalAdjustedRevenue,
+    grandTotalExpense,
+    grandTotalNet: roundCents(grandTotalAdjustedRevenue - grandTotalExpense),
+  };
+}
+
+/** Merge key for a budget line. NULL projectId collapses to "" so the sentinel
+ * is stable across the note map, the row map, and the expense seam. */
+function mergeKey(projectId: string | null, chartString: string): string {
+  return `${projectId ?? ""}::${chartString}`;
+}
+
+// ─── mutation helpers ────────────────────────────────────────────────────────
+
+// Postgres treats NULLs as distinct in a unique index, so `upsert` on the
+// composite (projectId, chartString, termId) does NOT dedupe when projectId is
+// null. Every mutation therefore does a findFirst-before-write on the exact
+// key, using Prisma's native `upsert` only as a fast path for the non-null case.
+
+type BudgetKey = {
+  projectId: string | null;
+  chartString: string;
+  termId: string;
+};
+
+async function findEntry(key: BudgetKey) {
+  return prisma.budgetEntry.findFirst({
+    where: {
+      projectId: key.projectId,
+      chartString: key.chartString,
+      termId: key.termId,
+    },
+  });
+}
+
+async function findNote(key: BudgetKey) {
+  return prisma.budgetNote.findFirst({
+    where: {
+      projectId: key.projectId,
+      chartString: key.chartString,
+      termId: key.termId,
+    },
+  });
+}
+
+/** Create or update the revenue on a budget line. */
+export async function upsertRevenue(key: BudgetKey, revenue: number): Promise<void> {
+  const existing = await findEntry(key);
+  if (existing) {
+    await prisma.budgetEntry.update({
+      where: { id: existing.id },
+      data: { revenue },
+    });
+  } else {
+    await prisma.budgetEntry.create({
+      data: {
+        projectId: key.projectId,
+        chartString: key.chartString,
+        termId: key.termId,
+        revenue,
+      },
+    });
+  }
+}
+
+/** Delete a budget entry by id (its note, if any, is left as-is). */
+export async function deleteEntry(id: string): Promise<void> {
+  await prisma.budgetEntry.delete({ where: { id } });
+}
+
+/**
+ * Move a budget line to a new chart string. Because chartString is part of the
+ * unique key we can't just update in place if the target already exists, so we
+ * guard against a collision, then update. The note (if any) moves with it.
+ */
+export async function updateChartString(
+  key: BudgetKey,
+  newChartString: string,
+): Promise<void> {
+  const existing = await findEntry(key);
+  if (!existing) {
+    throw new Error("Budget entry not found");
+  }
+  const collision = await findEntry({ ...key, chartString: newChartString });
+  if (collision && collision.id !== existing.id) {
+    throw new Error("A budget entry already exists for that chart string");
+  }
+  await prisma.$transaction(async (tx) => {
+    await tx.budgetEntry.update({
+      where: { id: existing.id },
+      data: { chartString: newChartString },
+    });
+    const note = await tx.budgetNote.findFirst({
+      where: {
+        projectId: key.projectId,
+        chartString: key.chartString,
+        termId: key.termId,
+      },
+    });
+    if (note) {
+      await tx.budgetNote.update({
+        where: { id: note.id },
+        data: { chartString: newChartString },
+      });
+    }
+  });
+}
+
+/** Create/update a note on a budget line, or delete it when the text is empty. */
+export async function upsertNote(key: BudgetKey, note: string): Promise<void> {
+  const existing = await findNote(key);
+  if (!note.trim()) {
+    if (existing) await prisma.budgetNote.delete({ where: { id: existing.id } });
+    return;
+  }
+  if (existing) {
+    await prisma.budgetNote.update({ where: { id: existing.id }, data: { note } });
+  } else {
+    await prisma.budgetNote.create({
+      data: {
+        projectId: key.projectId,
+        chartString: key.chartString,
+        termId: key.termId,
+        note,
+      },
+    });
+  }
+}
+
+/**
+ * Set (or clear) the project type on a budget line, creating the entry with
+ * revenue 0 if it doesn't exist yet (so an expense-only row can be typed).
+ */
+export async function updateProjectType(
+  key: BudgetKey,
+  projectType: string | null,
+): Promise<void> {
+  const existing = await findEntry(key);
+  if (existing) {
+    await prisma.budgetEntry.update({
+      where: { id: existing.id },
+      data: { projectType },
+    });
+  } else {
+    await prisma.budgetEntry.create({
+      data: {
+        projectId: key.projectId,
+        chartString: key.chartString,
+        termId: key.termId,
+        revenue: 0,
+        projectType,
+      },
+    });
+  }
+}

--- a/dali-api/app/admin-console/routes/admin-console.payroll.budget.ts
+++ b/dali-api/app/admin-console/routes/admin-console.payroll.budget.ts
@@ -1,0 +1,151 @@
+import type { Route } from "./+types/admin-console.payroll.budget";
+import { redirect } from "react-router";
+import { z } from "zod";
+import { requireAuth, forbidden } from "~/lib/auth";
+import { isAdmin } from "~/lib/roles";
+import { resolveTermFilter } from "~/lib/terms";
+import {
+  getBudgetData,
+  upsertRevenue,
+  deleteEntry,
+  updateChartString,
+  upsertNote,
+  updateProjectType,
+  PROJECT_TYPES,
+  type BudgetData,
+} from "~/admin-console/lib/budget";
+
+// Resource route (GET + action) for the Budget tab. Loaded lazily by the page
+// via useFetcher().load('/admin-console/payroll/budget?term=…') on first tab
+// activation. Same admin gate as the page — on BOTH loader and action.
+
+export type BudgetLoaderData =
+  | { ok: true; budget: BudgetData; termId: string }
+  | { ok: false; error: string };
+
+export async function loader({ request }: Route.LoaderArgs) {
+  const auth = await requireAuth(request);
+  if (!auth.ok) return redirect("/login");
+  if (!(await isAdmin(auth.user.sub))) return forbidden(request);
+
+  const { termId } = await resolveTermFilter(request);
+  if (!termId) {
+    return Response.json({ ok: false, error: "No term selected" } satisfies BudgetLoaderData, {
+      status: 400,
+    });
+  }
+
+  const budget = await getBudgetData(termId);
+  return Response.json({ ok: true, budget, termId } satisfies BudgetLoaderData);
+}
+
+// ─── action ──────────────────────────────────────────────────────────────────
+
+const nullableProjectId = z
+  .string()
+  .transform((v) => (v === "" ? null : v))
+  .nullable()
+  .transform((v) => v ?? null);
+
+const keyFields = {
+  projectId: nullableProjectId,
+  chartString: z.string().min(1),
+  termId: z.string().min(1),
+};
+
+const upsertRevenueSchema = z.object({
+  intent: z.literal("upsert-revenue"),
+  ...keyFields,
+  revenue: z.coerce.number().finite(),
+});
+
+const deleteEntrySchema = z.object({
+  intent: z.literal("delete-entry"),
+  entryId: z.string().min(1),
+});
+
+const updateChartStringSchema = z.object({
+  intent: z.literal("update-chartstring"),
+  ...keyFields,
+  newChartString: z.string().min(1),
+});
+
+const upsertNoteSchema = z.object({
+  intent: z.literal("upsert-note"),
+  ...keyFields,
+  note: z.string(),
+});
+
+const updateProjectTypeSchema = z.object({
+  intent: z.literal("update-project-type"),
+  ...keyFields,
+  projectType: z
+    .string()
+    .transform((v) => v.trim())
+    .refine((v) => v === "" || (PROJECT_TYPES as readonly string[]).includes(v), {
+      message: "Invalid project type",
+    })
+    .transform((v) => (v === "" ? null : v)),
+});
+
+function jsonError(message: string, status: number): Response {
+  return Response.json({ ok: false, error: message }, { status });
+}
+
+export async function action({ request }: Route.ActionArgs): Promise<Response> {
+  const auth = await requireAuth(request);
+  if (!auth.ok) return auth.response;
+  if (!(await isAdmin(auth.user.sub))) return forbidden(request);
+
+  const form = Object.fromEntries(await request.formData());
+  const intent = form.intent;
+
+  try {
+    switch (intent) {
+      case "upsert-revenue": {
+        const p = upsertRevenueSchema.parse(form);
+        await upsertRevenue(
+          { projectId: p.projectId, chartString: p.chartString, termId: p.termId },
+          p.revenue,
+        );
+        return Response.json({ ok: true });
+      }
+      case "delete-entry": {
+        const p = deleteEntrySchema.parse(form);
+        await deleteEntry(p.entryId);
+        return Response.json({ ok: true });
+      }
+      case "update-chartstring": {
+        const p = updateChartStringSchema.parse(form);
+        await updateChartString(
+          { projectId: p.projectId, chartString: p.chartString, termId: p.termId },
+          p.newChartString,
+        );
+        return Response.json({ ok: true });
+      }
+      case "upsert-note": {
+        const p = upsertNoteSchema.parse(form);
+        await upsertNote(
+          { projectId: p.projectId, chartString: p.chartString, termId: p.termId },
+          p.note,
+        );
+        return Response.json({ ok: true });
+      }
+      case "update-project-type": {
+        const p = updateProjectTypeSchema.parse(form);
+        await updateProjectType(
+          { projectId: p.projectId, chartString: p.chartString, termId: p.termId },
+          p.projectType,
+        );
+        return Response.json({ ok: true });
+      }
+      default:
+        return jsonError("Unknown intent", 400);
+    }
+  } catch (e) {
+    if (e instanceof z.ZodError) {
+      return jsonError(e.issues[0]?.message ?? "Invalid input", 400);
+    }
+    return jsonError(e instanceof Error ? e.message : "Budget update failed", 400);
+  }
+}

--- a/dali-api/app/admin-console/routes/admin-console.payroll.budget.ts
+++ b/dali-api/app/admin-console/routes/admin-console.payroll.budget.ts
@@ -11,9 +11,13 @@ import {
   updateChartString,
   upsertNote,
   updateProjectType,
+} from "~/admin-console/lib/budget";
+// PROJECT_TYPES comes from the client-safe shared module (not budget.ts) so
+// tests can fully mock budget.ts without the zod schema losing the real list.
+import {
   PROJECT_TYPES,
   type BudgetData,
-} from "~/admin-console/lib/budget";
+} from "~/admin-console/lib/budget.shared";
 
 // Resource route (GET + action) for the Budget tab. Loaded lazily by the page
 // via useFetcher().load('/admin-console/payroll/budget?term=…') on first tab

--- a/dali-api/app/admin-console/routes/admin-console.payroll.csv.ts
+++ b/dali-api/app/admin-console/routes/admin-console.payroll.csv.ts
@@ -6,6 +6,7 @@ import { rowsToCsv, csvResponse } from "~/lib/csv";
 import { resolveTermFilter } from "~/lib/terms";
 import { getReconciliation } from "~/admin-console/lib/payroll-reconcile.server";
 import type { CollatedResult } from "~/admin-console/lib/payroll-collation";
+import { getBudgetData } from "~/admin-console/lib/budget";
 
 // Resource route (GET) — one CSV per reconcile view. Registered OUTSIDE the app
 // layout so the Response streams a bare CSV body. Uses the shared
@@ -19,6 +20,7 @@ const VIEWS = [
   "chart-strings",
   "discrepancies",
   "external",
+  "budget",
 ] as const;
 type View = (typeof VIEWS)[number];
 
@@ -146,7 +148,43 @@ function buildRows(view: View, r: CollatedResult): unknown[][] {
         rows.push([j.netId, j.name, j.jobId, j.jobTitle, j.hours, j.pay]);
       return rows;
     }
+
+    case "budget":
+      // Budget has its own data source (getBudgetData); handled in the loader,
+      // not from the CollatedResult. Unreachable here.
+      return [];
   }
+}
+
+function buildBudgetRows(
+  budget: Awaited<ReturnType<typeof getBudgetData>>,
+): unknown[][] {
+  const rows: unknown[][] = [
+    ["Project", "Chart String", "Type", "Revenue", "Adj. Revenue", "Expense", "Net"],
+  ];
+  for (const g of budget.groups) {
+    for (const row of g.rows) {
+      rows.push([
+        g.projectName,
+        row.chartString,
+        row.projectType ?? "",
+        row.revenue,
+        row.adjustedRevenue,
+        row.expense,
+        row.net,
+      ]);
+    }
+  }
+  rows.push([
+    "Grand total",
+    "",
+    "",
+    budget.grandTotalRevenue,
+    budget.grandTotalAdjustedRevenue,
+    budget.grandTotalExpense,
+    budget.grandTotalNet,
+  ]);
+  return rows;
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
@@ -165,8 +203,10 @@ export async function loader({ request }: Route.LoaderArgs) {
     return new Response("No term selected", { status: 404 });
   }
 
-  const result = await getReconciliation(termId);
-  const rows = buildRows(viewParam, result);
+  const rows =
+    viewParam === "budget"
+      ? buildBudgetRows(await getBudgetData(termId))
+      : buildRows(viewParam, await getReconciliation(termId));
   const csv = rowsToCsv(rows);
 
   const termCode = terms.find((t) => t.id === selected)?.code ?? "term";

--- a/dali-api/app/admin-console/routes/admin-console.payroll.tsx
+++ b/dali-api/app/admin-console/routes/admin-console.payroll.tsx
@@ -39,6 +39,7 @@ import { formatUsd } from "~/lib/money";
 import { cn } from "~/lib/cn";
 import { useChartColors } from "~/hiring/components/analytics/useChartColors";
 import { PayrollUploadModal } from "~/admin-console/components/PayrollUploadModal";
+import { PayrollBudgetPanel } from "~/admin-console/components/PayrollBudgetPanel";
 
 export const handle = { areaPills: true };
 
@@ -117,7 +118,8 @@ type TabKey =
   | "projects"
   | "chart-strings"
   | "discrepancies"
-  | "external";
+  | "external"
+  | "budget";
 
 export default function PayrollReconcile() {
   const data = useLoaderData<typeof loader>();
@@ -156,6 +158,7 @@ export default function PayrollReconcile() {
       badge: rec && rec.external.totalHours > 0 ? `${rec.external.totalHours} hrs` : undefined,
       badgeTone: "muted",
     },
+    { key: "budget", label: "Budget" },
   ];
 
   return (
@@ -249,6 +252,7 @@ export default function PayrollReconcile() {
             {tab === "chart-strings" && <ChartStringsPanel rec={rec!} />}
             {tab === "discrepancies" && <DiscrepanciesPanel rec={rec!} />}
             {tab === "external" && <ExternalPanel rec={rec!} />}
+            {tab === "budget" && <PayrollBudgetPanel term={data.selected} />}
           </div>
         </>
       )}

--- a/dali-api/app/routes.ts
+++ b/dali-api/app/routes.ts
@@ -341,6 +341,7 @@ export default [
   // Payroll reconcile — upload (multipart action) + per-view CSV export.
   // Resource routes registered OUTSIDE the app layout (bare bodies, no shell).
   route("admin-console/payroll/upload", "admin-console/routes/admin-console.payroll.upload.ts"),
+  route("admin-console/payroll/budget", "admin-console/routes/admin-console.payroll.budget.ts"),
   route("admin-console/payroll.csv", "admin-console/routes/admin-console.payroll.csv.ts"),
 
   // Partner application status (board drag-and-drop) + domain scope


### PR DESCRIPTION
PR4 of the Payroll: Reconcile feature. **Stacked on #902**.

## What
- `budget.ts` — `PATEO_EFFECTIVE_RATE = 1.47625/1.635` (provenance-commented; applied ONLY to "DALI PATEO" rows); `getBudgetData(termId)` merges BudgetEntry/BudgetNote with actual payroll expense (`computeExpensesByProjectChartTerm`) on `(projectId, chartString)`; per-group + grand totals; null-projectId bucket (Core/Instructor/External/unmatched) grouped last; Decimals→numbers at the boundary.
- `budget.shared.ts` — client-safe constants/types split (required: importing the server lib from the tab component broke the client bundle).
- `/admin-console/payroll/budget` resource route — GET + 5 zod-validated intents (`upsert-revenue`, `delete-entry`, `update-chartstring`, `upsert-note`, `update-project-type`), admin-gated on loader AND action; all writes `findFirst`-before-write to dedupe NULL-distinct `(projectId, chartString, termId)` uniques.
- Budget tab UI (inline revenue edit, project-type select, notes, delete-with-confirm, green/red net, PATEO footnote, grand totals) + `view=budget` CSV export.

## Verification
- 30 new tests (PATEO-only scaling, 3-way merge, null-project dedupe, totals, 403s, every intent) — **1607 total, all pass**; typecheck at baseline; build ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BBBGa6p4HMTdenGfryxuqC

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/903"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786586204&installation_id=133523038&pr_number=903&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F903&signature=dc973eee051a2fd30524cd2fda22076483500b2d4b926a3915537a5c1b4b7240"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->