### PR TITLE
Payroll reconcile: e2e coverage, notes surfacing, seed job codes, polish

### DIFF
--- a/dali-api/app/admin-console/__tests__/admin-console.payroll.route.test.ts
+++ b/dali-api/app/admin-console/__tests__/admin-console.payroll.route.test.ts
@@ -45,6 +45,7 @@ const EMPTY_RECONCILIATION = {
     daliStudentCount: 0,
     medianPay: 0,
   },
+  notesByJobKey: {},
 };
 
 function asAdmin() {

--- a/dali-api/app/admin-console/__tests__/payroll-reconcile.notes.test.ts
+++ b/dali-api/app/admin-console/__tests__/payroll-reconcile.notes.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi } from "vitest";
+
+// payroll-reconcile.server imports ~/lib/db at module load, which eagerly
+// instantiates a PrismaClient the unit-test job doesn't generate. Mock it so the
+// (pure) groupNotesByJobKey import resolves — same convention as the other
+// server-edge tests.
+vi.mock("~/lib/db");
+
+import { groupNotesByJobKey } from "~/admin-console/lib/payroll-reconcile.server";
+
+// Pure notes-join logic (no Prisma). Synthetic rows only — f00fake* netids and
+// invented note text. Verifies the `${netId}::${jobId}` keying that the Payroll
+// Data tab uses to surface notes + the count indicator.
+
+type RawNote = Parameters<typeof groupNotesByJobKey>[0][number];
+
+function note(o: Partial<RawNote> = {}): RawNote {
+  return {
+    netId: "f00fake1",
+    jobId: "4834",
+    note: "Adjusted a shift.",
+    validatedChartstring: null,
+    linkToTimesheet: null,
+    payPeriod: { name: "09/14/2025 - 09/27/2025" },
+    ...o,
+  };
+}
+
+describe("groupNotesByJobKey", () => {
+  it("keys notes by netId::jobId", () => {
+    const map = groupNotesByJobKey([note()]);
+    expect(Object.keys(map)).toEqual(["f00fake1::4834"]);
+    expect(map["f00fake1::4834"]).toHaveLength(1);
+    expect(map["f00fake1::4834"][0]).toEqual({
+      note: "Adjusted a shift.",
+      validatedChartstring: null,
+      linkToTimesheet: null,
+      payPeriodName: "09/14/2025 - 09/27/2025",
+    });
+  });
+
+  it("groups multiple notes for the same (netId, jobId)", () => {
+    const map = groupNotesByJobKey([
+      note({ note: "First." }),
+      note({ note: "Second." }),
+    ]);
+    expect(map["f00fake1::4834"]).toHaveLength(2);
+    expect(map["f00fake1::4834"].map((n) => n.note)).toEqual(["First.", "Second."]);
+  });
+
+  it("separates notes across different jobs and people", () => {
+    const map = groupNotesByJobKey([
+      note({ netId: "f00fake1", jobId: "4834" }),
+      note({ netId: "f00fake1", jobId: "4889" }),
+      note({ netId: "f00fake2", jobId: "4834" }),
+    ]);
+    expect(Object.keys(map).sort()).toEqual([
+      "f00fake1::4834",
+      "f00fake1::4889",
+      "f00fake2::4834",
+    ]);
+    for (const key of Object.keys(map)) expect(map[key]).toHaveLength(1);
+  });
+
+  it("lowercases the netId so it matches the lowercased timesheet entries", () => {
+    const map = groupNotesByJobKey([note({ netId: "F00Fake1" })]);
+    expect(map["f00fake1::4834"]).toHaveLength(1);
+    expect(map["F00Fake1::4834"]).toBeUndefined();
+  });
+
+  it("preserves chart string and timesheet link when present", () => {
+    const map = groupNotesByJobKey([
+      note({
+        validatedChartstring: "18.722.161028.128512.4000",
+        linkToTimesheet: "https://timesheetx.example/ts/1",
+      }),
+    ]);
+    const entry = map["f00fake1::4834"][0];
+    expect(entry.validatedChartstring).toBe("18.722.161028.128512.4000");
+    expect(entry.linkToTimesheet).toBe("https://timesheetx.example/ts/1");
+  });
+
+  it("returns an empty map for no notes", () => {
+    expect(groupNotesByJobKey([])).toEqual({});
+  });
+});

--- a/dali-api/app/admin-console/lib/payroll-reconcile.server.ts
+++ b/dali-api/app/admin-console/lib/payroll-reconcile.server.ts
@@ -28,9 +28,30 @@ export type ReconciliationOptions = {
   payPeriodIds?: string[];
 };
 
+/** One surfaced timesheet note, JSON-safe, attached to a (netId, jobId) row. */
+export type TimesheetNoteView = {
+  note: string;
+  validatedChartstring: string | null;
+  linkToTimesheet: string | null;
+  payPeriodName: string;
+};
+
+/**
+ * The reconciliation breakdown plus surfaced notes. Notes live at the server
+ * edge (the pure collation core is deliberately Prisma-free) keyed by
+ * `${netId}::${jobId}` so the Payroll Data rows — which carry both — can look
+ * up their notes and show a count indicator.
+ */
+export type ReconciliationResult = CollatedResult & {
+  notesByJobKey: Record<string, TimesheetNoteView[]>;
+};
+
+const noteKey = (netId: string, jobId: string) => `${netId}::${jobId}`;
+
 /**
  * Full reconciliation breakdown for a term. Optionally scope to specific pay
- * periods. Returns the plain (JSON-safe) CollatedResult the page consumes.
+ * periods. Returns the plain (JSON-safe) result the page consumes, with any
+ * TimesheetNotes for the term's pay periods attached under `notesByJobKey`.
  *
  * Rate-mismatch discrepancies are only computed when the term is the currently
  * active term (there's no wage history, so comparing a past term against
@@ -39,7 +60,7 @@ export type ReconciliationOptions = {
 export async function getReconciliation(
   termId: string,
   options: ReconciliationOptions = {},
-): Promise<CollatedResult> {
+): Promise<ReconciliationResult> {
   const { payPeriodIds } = options;
 
   // Pay periods in this term (optionally narrowed to a chosen subset).
@@ -56,17 +77,20 @@ export async function getReconciliation(
 
   // Short-circuit: no periods → empty collation (still shape-valid).
   if (periodIds.length === 0) {
-    return collate({
-      entries: [],
-      lookups: [],
-      users: [],
-      assignments: [],
-      projects: [],
-      isActiveTerm: await isActiveTerm(termId),
-    });
+    return {
+      ...collate({
+        entries: [],
+        lookups: [],
+        users: [],
+        assignments: [],
+        projects: [],
+        isActiveTerm: await isActiveTerm(termId),
+      }),
+      notesByJobKey: {},
+    };
   }
 
-  const [entryRows, lookupRows, assignmentRows, projectRows, activeTerm] =
+  const [entryRows, lookupRows, assignmentRows, projectRows, noteRows, activeTerm] =
     await Promise.all([
       prisma.timesheetEntry.findMany({
         where: { payPeriodId: { in: periodIds } },
@@ -100,6 +124,17 @@ export async function getReconciliation(
       }),
       prisma.project.findMany({
         select: { id: true, name: true, chartString: true },
+      }),
+      prisma.timesheetNote.findMany({
+        where: { payPeriodId: { in: periodIds } },
+        select: {
+          netId: true,
+          jobId: true,
+          note: true,
+          validatedChartstring: true,
+          linkToTimesheet: true,
+          payPeriod: { select: { name: true } },
+        },
       }),
       isActiveTerm(termId),
     ]);
@@ -159,14 +194,45 @@ export async function getReconciliation(
     chartString: p.chartString,
   }));
 
-  return collate({
-    entries,
-    lookups,
-    users,
-    assignments,
-    projects,
-    isActiveTerm: activeTerm,
-  });
+  return {
+    ...collate({
+      entries,
+      lookups,
+      users,
+      assignments,
+      projects,
+      isActiveTerm: activeTerm,
+    }),
+    notesByJobKey: groupNotesByJobKey(noteRows),
+  };
+}
+
+/**
+ * Group note rows by `${netId}::${jobId}` for row-level lookup on the Payroll
+ * Data tab. netId is lowercased to match the entries' lowercased netIds. Pure
+ * (no Prisma) so the join is unit-testable against synthetic rows.
+ */
+export function groupNotesByJobKey(
+  notes: Array<{
+    netId: string;
+    jobId: string;
+    note: string;
+    validatedChartstring: string | null;
+    linkToTimesheet: string | null;
+    payPeriod: { name: string };
+  }>,
+): Record<string, TimesheetNoteView[]> {
+  const map: Record<string, TimesheetNoteView[]> = {};
+  for (const n of notes) {
+    const key = noteKey(n.netId.toLowerCase(), n.jobId);
+    (map[key] ??= []).push({
+      note: n.note,
+      validatedChartstring: n.validatedChartstring,
+      linkToTimesheet: n.linkToTimesheet,
+      payPeriodName: n.payPeriod.name,
+    });
+  }
+  return map;
 }
 
 // ─── computeExpensesByProjectChartTerm ───────────────────────────────────────

--- a/dali-api/app/admin-console/routes/admin-console.payroll.tsx
+++ b/dali-api/app/admin-console/routes/admin-console.payroll.tsx
@@ -18,16 +18,18 @@ import {
   StickyNote,
   AlertTriangle,
   Info,
+  X,
 } from "lucide-react";
 import { requireAuth } from "~/lib/auth";
 import { isAdmin } from "~/lib/roles";
 import { prisma } from "~/lib/db";
 import { resolveTermFilter } from "~/lib/terms";
-import { getReconciliation } from "~/admin-console/lib/payroll-reconcile.server";
-import type {
-  CollatedResult,
-  JobBreakdown,
-} from "~/admin-console/lib/payroll-collation";
+import {
+  getReconciliation,
+  type ReconciliationResult,
+  type TimesheetNoteView,
+} from "~/admin-console/lib/payroll-reconcile.server";
+import type { JobBreakdown } from "~/admin-console/lib/payroll-collation";
 import { adminPills } from "~/admin-console/adminPills";
 import { AreaPillNav } from "~/components/AreaPillNav";
 import { TermFilter } from "~/components/TermFilter";
@@ -67,12 +69,13 @@ export async function loader({ request }: Route.LoaderArgs) {
   if (!termId) {
     return {
       ...termFilter,
-      reconciliation: null as CollatedResult | null,
+      reconciliation: null as ReconciliationResult | null,
       periods: [] as PeriodSummary[],
+      missingChartStrings: [] as string[],
     };
   }
 
-  const [reconciliation, periodRows] = await Promise.all([
+  const [reconciliation, periodRows, missingChartRows] = await Promise.all([
     getReconciliation(termId),
     prisma.payPeriod.findMany({
       where: { termId },
@@ -93,7 +96,19 @@ export async function loader({ request }: Route.LoaderArgs) {
         },
       },
     }),
+    // DALI projects staffed this term whose chart string is missing/blank: the
+    // chart-string tie-break can't attribute their hours to one project, so
+    // warn staff to fill it in.
+    prisma.project.findMany({
+      where: {
+        assignments: { some: { termId } },
+        OR: [{ chartString: null }, { chartString: "" }],
+      },
+      orderBy: { name: "asc" },
+      select: { name: true },
+    }),
   ]);
+  const missingChartStrings = missingChartRows.map((p) => p.name);
 
   const periods: PeriodSummary[] = periodRows.map((p) => {
     const imp = p.imports[0];
@@ -109,7 +124,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     };
   });
 
-  return { ...termFilter, reconciliation, periods };
+  return { ...termFilter, reconciliation, periods, missingChartStrings };
 }
 
 type TabKey =
@@ -125,6 +140,7 @@ export default function PayrollReconcile() {
   const data = useLoaderData<typeof loader>();
   const [tab, setTab] = useState<TabKey>("summary");
   const [uploadOpen, setUploadOpen] = useState(false);
+  const [chartWarningDismissed, setChartWarningDismissed] = useState(false);
 
   const rec = data.reconciliation;
   const discrepancyCount = rec
@@ -203,6 +219,13 @@ export default function PayrollReconcile() {
         Reconcile TimesheetX actuals against DALI OS staffing. Headline totals
         are DALI-only; External (non-DALI job IDs) is reported but excluded.
       </p>
+
+      {data.missingChartStrings.length > 0 && !chartWarningDismissed && (
+        <ChartStringWarning
+          projects={data.missingChartStrings}
+          onDismiss={() => setChartWarningDismissed(true)}
+        />
+      )}
 
       {!hasData ? (
         <EmptyState onUpload={() => setUploadOpen(true)} />
@@ -286,6 +309,43 @@ function EmptyState({ onUpload }: { onUpload: () => void }) {
   );
 }
 
+// ─── Chart-string-missing warning ────────────────────────────────────────────
+
+function ChartStringWarning({
+  projects,
+  onDismiss,
+}: {
+  projects: string[];
+  onDismiss: () => void;
+}) {
+  return (
+    <div
+      role="alert"
+      className="flex items-start gap-3 rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-900"
+    >
+      <AlertTriangle className="mt-0.5 w-4 h-4 flex-shrink-0 text-amber-600" aria-hidden />
+      <div className="flex-1">
+        <p className="font-medium">
+          {projects.length} staffed project{projects.length === 1 ? "" : "s"} missing a
+          chart string
+        </p>
+        <p className="mt-0.5 text-amber-800">
+          Hours can't be tie-broken to {projects.length === 1 ? "it" : "them"} by chart
+          string — set one on {projects.join(", ")} in the project settings.
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={onDismiss}
+        aria-label="Dismiss chart string warning"
+        className="text-amber-600 hover:text-amber-900"
+      >
+        <X className="w-4 h-4" />
+      </button>
+    </div>
+  );
+}
+
 // ─── Shared table chrome ─────────────────────────────────────────────────────
 
 const TABLE_WRAP = "bg-card border border-border rounded-lg overflow-x-auto";
@@ -301,7 +361,7 @@ function SummaryPanel({
   rec,
   periods,
 }: {
-  rec: CollatedResult;
+  rec: ReconciliationResult;
   periods: PeriodSummary[];
 }) {
   const colors = useChartColors();
@@ -473,10 +533,14 @@ type SortKey = "name" | "hours" | "pay";
 
 type FlatJob = JobBreakdown & { projects: string };
 
-function PayrollDataPanel({ rec }: { rec: CollatedResult }) {
+function PayrollDataPanel({ rec }: { rec: ReconciliationResult }) {
   const [query, setQuery] = useState("");
   const [sortKey, setSortKey] = useState<SortKey>("hours");
   const [notesFor, setNotesFor] = useState<FlatJob | null>(null);
+
+  const notesByJobKey = rec.notesByJobKey;
+  const notesForJob = (j: { netId: string; jobId: string }): TimesheetNoteView[] =>
+    notesByJobKey[`${j.netId}::${j.jobId}`] ?? [];
 
   const jobs = useMemo<FlatJob[]>(() => {
     const flat: FlatJob[] = [];
@@ -568,14 +632,27 @@ function PayrollDataPanel({ rec }: { rec: CollatedResult }) {
                 <td className={TD_NUM}>{j.hours.toLocaleString()}</td>
                 <td className={TD_NUM}>{formatUsd(j.pay)}</td>
                 <td className="px-3 py-2 text-right">
-                  <button
-                    type="button"
-                    onClick={() => setNotesFor(j)}
-                    aria-label={`View notes for ${j.name}`}
-                    className="text-muted-foreground hover:text-foreground"
-                  >
-                    <StickyNote className="w-4 h-4" />
-                  </button>
+                  {(() => {
+                    const count = notesForJob(j).length;
+                    return (
+                      <button
+                        type="button"
+                        onClick={() => setNotesFor(j)}
+                        aria-label={`View notes for ${j.name}`}
+                        className={cn(
+                          "inline-flex items-center gap-1",
+                          count > 0
+                            ? "text-accent-coral hover:text-accent-coral/80"
+                            : "text-muted-foreground/40 hover:text-foreground",
+                        )}
+                      >
+                        <StickyNote className="w-4 h-4" />
+                        {count > 0 && (
+                          <span className="text-[10px] font-bold tabular-nums">{count}</span>
+                        )}
+                      </button>
+                    );
+                  })()}
                 </td>
               </tr>
             ))}
@@ -587,12 +664,24 @@ function PayrollDataPanel({ rec }: { rec: CollatedResult }) {
         wage is display-only.
       </p>
 
-      <NotesModal job={notesFor} onClose={() => setNotesFor(null)} />
+      <NotesModal
+        job={notesFor}
+        notes={notesFor ? notesForJob(notesFor) : []}
+        onClose={() => setNotesFor(null)}
+      />
     </div>
   );
 }
 
-function NotesModal({ job, onClose }: { job: FlatJob | null; onClose: () => void }) {
+function NotesModal({
+  job,
+  notes,
+  onClose,
+}: {
+  job: FlatJob | null;
+  notes: TimesheetNoteView[];
+  onClose: () => void;
+}) {
   const open = job !== null;
   return (
     <Modal open={open} onClose={onClose} labelledBy="notes-modal-title">
@@ -602,16 +691,45 @@ function NotesModal({ job, onClose }: { job: FlatJob | null; onClose: () => void
         subtitle={job ? `${job.name} · ${job.jobId}` : undefined}
         onClose={onClose}
       />
-      <p className="text-sm text-muted-foreground">
-        No notes recorded for this person-job.
-      </p>
+      {notes.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          No notes recorded for this person-job.
+        </p>
+      ) : (
+        <ul className="space-y-3">
+          {notes.map((n, i) => (
+            <li
+              key={i}
+              className="rounded-md border border-border bg-muted/40 px-3 py-2.5 text-sm"
+            >
+              <p className="whitespace-pre-wrap text-foreground">{n.note}</p>
+              <div className="mt-1.5 flex flex-wrap items-center gap-2 text-[11px] text-muted-foreground">
+                <span className="font-mono">{n.payPeriodName}</span>
+                {n.validatedChartstring && (
+                  <span className="font-mono">· {n.validatedChartstring}</span>
+                )}
+                {n.linkToTimesheet && (
+                  <a
+                    href={n.linkToTimesheet}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="text-accent-coral underline hover:text-accent-coral/80"
+                  >
+                    timesheet
+                  </a>
+                )}
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
     </Modal>
   );
 }
 
 // ─── Project Summaries ───────────────────────────────────────────────────────
 
-function ProjectsPanel({ rec }: { rec: CollatedResult }) {
+function ProjectsPanel({ rec }: { rec: ReconciliationResult }) {
   const projects = [...rec.projects].sort((a, b) => b.totalHours - a.totalHours);
   const totalStudents = new Set(
     projects.flatMap((p) => p.jobs.map((j) => j.netId)),
@@ -619,6 +737,15 @@ function ProjectsPanel({ rec }: { rec: CollatedResult }) {
   const totalHours = projects.reduce((s, p) => s + p.totalHours, 0);
   const totalShared = projects.reduce((s, p) => s + p.sharedHours, 0);
   const totalPay = projects.reduce((s, p) => s + p.totalPay, 0);
+
+  if (projects.length === 0) {
+    return (
+      <Card className="p-8 text-center text-sm text-muted-foreground">
+        No project-attributed hours this term. Uploaded hours may be Core,
+        Instructor, or External — see those tabs.
+      </Card>
+    );
+  }
 
   return (
     <div className="space-y-3">
@@ -673,7 +800,7 @@ function ProjectsPanel({ rec }: { rec: CollatedResult }) {
 
 // ─── Chart Strings ───────────────────────────────────────────────────────────
 
-function ChartStringsPanel({ rec }: { rec: CollatedResult }) {
+function ChartStringsPanel({ rec }: { rec: ReconciliationResult }) {
   const [open, setOpen] = useState<Set<string>>(new Set());
   const toggle = (cs: string) => {
     const next = new Set(open);
@@ -681,6 +808,14 @@ function ChartStringsPanel({ rec }: { rec: CollatedResult }) {
     else next.add(cs);
     setOpen(next);
   };
+
+  if (rec.chartStrings.length === 0) {
+    return (
+      <Card className="p-8 text-center text-sm text-muted-foreground">
+        No chart strings charged this term.
+      </Card>
+    );
+  }
 
   return (
     <div className="space-y-3">
@@ -779,7 +914,7 @@ function ChartStringsPanel({ rec }: { rec: CollatedResult }) {
 
 // ─── Discrepancies ───────────────────────────────────────────────────────────
 
-function DiscrepanciesPanel({ rec }: { rec: CollatedResult }) {
+function DiscrepanciesPanel({ rec }: { rec: ReconciliationResult }) {
   const d = rec.discrepancies;
   const total =
     d.assignedNoHours.length +
@@ -941,7 +1076,7 @@ function DiscCard({
 
 // ─── External ────────────────────────────────────────────────────────────────
 
-function ExternalPanel({ rec }: { rec: CollatedResult }) {
+function ExternalPanel({ rec }: { rec: ReconciliationResult }) {
   const [open, setOpen] = useState(false);
   const ext = rec.external;
   const people = new Set(ext.jobs.map((j) => j.netId)).size;

--- a/dali-api/e2e/payroll-reconcile.spec.ts
+++ b/dali-api/e2e/payroll-reconcile.spec.ts
@@ -1,0 +1,159 @@
+import { test, expect } from './fixtures';
+
+// Payroll: Reconcile — admin uploads a synthetic TimesheetX CSV, sees the
+// reconciled Payroll Data row, edits a Budget revenue cell (totals update),
+// exports a CSV, and confirms a non-admin is bounced to /admin-console/members.
+//
+// PII rule: every name/netid here is synthetic (Ada Lovelace / f00pay01, the
+// seed's payroll fixture student). No real export is ever read.
+//
+// The page is admin-only and renders standalone via ?embed=1 (client-side nav
+// would wrap it in the TabWorkspace iframe — see education.spec.ts).
+
+const ADMIN_EMAIL = 'admin@dali.dartmouth.edu';
+
+// Seed fixture (prisma/seed.ts): student f00pay01 is assigned to project-dali-os
+// (chart string below) in the active term, and jobId 4834 is a DALI Project code.
+const STUDENT_NETID = 'f00pay01';
+const JOB_ID = '4834';
+const CHART_STRING = '18.722.161028.128512.4000';
+
+/**
+ * A valid biweekly pay-period label (Sunday start, Saturday end, 14 days
+ * inclusive) whose end date lands inside the seeded active term. The seed
+ * anchors term "26S" to [now-30d, now+60d], so a period ending on the most
+ * recent Saturday is always inside that window — keeping the test
+ * date-independent (the seed dates move with the clock).
+ */
+function activePayPeriodName(): string {
+  const now = new Date();
+  // Most recent Saturday at/ before today (UTC day 6).
+  const end = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+  end.setUTCDate(end.getUTCDate() - ((end.getUTCDay() + 1) % 7)); // back up to Saturday
+  const start = new Date(end);
+  start.setUTCDate(start.getUTCDate() - 13); // Sunday, 14 days inclusive
+  const fmt = (d: Date) =>
+    `${String(d.getUTCMonth() + 1).padStart(2, '0')}/${String(d.getUTCDate()).padStart(2, '0')}/${d.getUTCFullYear()}`;
+  return `${fmt(start)} - ${fmt(end)}`;
+}
+
+/** Build a one-row synthetic TimesheetX timesheet CSV (real header set). */
+function timesheetCsv(payPeriod: string): string {
+  const headers = [
+    'Pay_Period_Name',
+    'Employee_Name',
+    'Employee_NetID',
+    'Job_Title',
+    'JobID',
+    'Shift_Start_Time',
+    'Shift_End_Time',
+    'Total_Shift_Time',
+    'Hourly_Pay_Rate',
+    'Total_Earnings',
+    'Overtime_Hours',
+    'Overtime_Earnings',
+    'Pay_Code',
+    'Department',
+    'Supervisor_First_Name',
+    'Supervisor_Last_Name',
+    'Timesheet_Status',
+    'Chart_String',
+  ];
+  const row = [
+    payPeriod,
+    'Lovelace, Ada',
+    STUDENT_NETID,
+    'DALI Lab Student Employee',
+    JOB_ID,
+    '09/15/2025 09:00',
+    '09/15/2025 12:00',
+    '3',
+    '16.25',
+    '48.75',
+    '',
+    '',
+    'REG',
+    'DALI Lab',
+    'Admin',
+    'User',
+    'Approved',
+    CHART_STRING,
+  ];
+  return `${headers.join(',')}\n${row.map((c) => (c.includes(',') ? `"${c}"` : c)).join(',')}\n`;
+}
+
+test.describe('payroll: reconcile', () => {
+  test('admin uploads a timesheet, reconciles, edits budget, and exports', async ({
+    page,
+    loginAs,
+  }) => {
+    const payPeriod = activePayPeriodName();
+
+    await loginAs({ daliEmail: ADMIN_EMAIL });
+    await page.goto('/admin-console/payroll?embed=1');
+
+    // Header + empty state before any upload for this term.
+    await expect(
+      page.getByRole('heading', { name: 'Payroll: Reconcile' }),
+    ).toBeVisible();
+    await expect(
+      page.getByText('No timesheet data for this term yet'),
+    ).toBeVisible();
+
+    // Open the upload modal and submit the synthetic timesheet.
+    await page.getByRole('button', { name: 'Upload CSV' }).first().click();
+    await page.locator('input[name="timesheet"]').setInputFiles({
+      name: 'timesheet.csv',
+      mimeType: 'text/csv',
+      buffer: Buffer.from(timesheetCsv(payPeriod)),
+    });
+    await page.getByRole('button', { name: 'Upload', exact: true }).click();
+
+    // Success summary shows the import counts, then the page revalidates.
+    await expect(page.getByText('Import complete')).toBeVisible();
+    await expect(page.getByText(/1 created/)).toBeVisible();
+
+    // Close the modal (it stays open showing the summary) before touching tabs.
+    // Two "Close" controls exist — the header X (aria-label) and the footer
+    // button; the footer one is last in DOM order.
+    await page.getByRole('button', { name: 'Close' }).last().click();
+    await expect(page.getByRole('dialog')).toBeHidden();
+
+    // Payroll Data tab: the reconciled row for our student appears.
+    await page.getByRole('tab', { name: 'Payroll Data' }).click();
+    const dataRow = page.getByRole('row', { name: new RegExp(STUDENT_NETID) });
+    await expect(dataRow).toBeVisible();
+    await expect(dataRow.getByText('Ada Lovelace')).toBeVisible();
+
+    // Budget tab: edit the revenue cell for our chart string on blur.
+    await page.getByRole('tab', { name: 'Budget' }).click();
+    const revenue = page.getByLabel(`Revenue for ${CHART_STRING}`);
+    await expect(revenue).toBeVisible();
+    await revenue.fill('1000.00');
+    await revenue.blur();
+
+    // Adj. Revenue / Net / grand totals update once the mutation revalidates.
+    // Grand-total revenue reflects the entered $1,000.00.
+    const grandTotal = page.getByRole('row', { name: /Grand total/ });
+    await expect(grandTotal).toContainText('$1,000.00');
+
+    // Export CSV downloads for the active tab.
+    const [download] = await Promise.all([
+      page.waitForEvent('download'),
+      page.getByRole('link', { name: 'Export CSV' }).click(),
+    ]);
+    expect(download.suggestedFilename()).toMatch(/\.csv$/);
+  });
+
+  test('non-admin is redirected to /admin-console/members', async ({
+    page,
+    loginAs,
+  }) => {
+    // jordan.taylor is Core (can reach admin-console/members) but not Admin, so
+    // the admin-only payroll page bounces them there.
+    await loginAs({ daliEmail: 'jordan.taylor@dali.dartmouth.edu' });
+    await page.goto('/admin-console/payroll');
+    await expect(page).toHaveURL(/\/admin-console\/members/);
+    await expect(page).not.toHaveURL(/\/admin-console\/payroll/);
+  });
+});

--- a/dali-api/prisma/seed.ts
+++ b/dali-api/prisma/seed.ts
@@ -3943,16 +3943,67 @@ async function main() {
         },
       });
 
-      // JobCodeLookup: a couple of payroll mappings (wildcards allowed).
+      // JobCodeLookup: the real Dartmouth Job IDs used on TimesheetX exports, so
+      // the payroll-reconcile reverse-lookup (jobId → assignmentType/level/rate)
+      // resolves against the same identifiers prod carries. 4834 maps to BOTH P1
+      // and P2 (a Job ID is a category-level classifier — the precise level +
+      // wage come from the person's ProjectAssignment).
+      const jobCodeIds = ["4834", "4889", "4890", "7523"];
       await prisma.jobCodeLookup.deleteMany({
-        where: { jobCode: { in: ["DALI-PROJ-P1", "DALI-CORE"] } },
+        where: {
+          jobCode: { in: [...jobCodeIds, "DALI-PROJ-P1", "DALI-CORE"] },
+        },
       });
-      await prisma.jobCodeLookup.create({
-        data: { assignmentType: "Project", level: "P1", jobCode: "DALI-PROJ-P1" },
+      await prisma.jobCodeLookup.createMany({
+        data: [
+          { assignmentType: "Project", level: "P1", jobCode: "4834", payRateUsdHour: 16.25 },
+          { assignmentType: "Project", level: "P2", jobCode: "4834", payRateUsdHour: 17.0 },
+          { assignmentType: "Project", level: "P3", jobCode: "4889", payRateUsdHour: 18.0 },
+          { assignmentType: "Core", jobCode: "4890", payRateUsdHour: 20.0 },
+          { assignmentType: "Instructor", jobCode: "7523", payRateUsdHour: 19.0 },
+        ],
       });
-      await prisma.jobCodeLookup.create({
-        data: { assignmentType: "Core", jobCode: "DALI-CORE" },
-      });
+
+      // Payroll-reconcile fixture: a student with a netId, a chart string on the
+      // DALI OS project, and an explicit ProjectAssignment in the active term so
+      // an uploaded timesheet (netId + jobId 4834) reconciles to a Payroll Data
+      // row. The bid-derived assignments above are members-by-daliEmail (no
+      // netId), so the reconcile join needs this deterministic netId'd student.
+      const payrollChartString = "18.722.161028.128512.4000";
+      if (dali) {
+        await prisma.project.update({
+          where: { id: dali.id },
+          data: { chartString: payrollChartString },
+        });
+        const payrollStudent = await prisma.user.upsert({
+          where: { netId: "f00pay01" },
+          update: { firstName: "Ada", lastName: "Lovelace" },
+          create: {
+            netId: "f00pay01",
+            firstName: "Ada",
+            lastName: "Lovelace",
+            daliMember: { create: {} },
+          },
+        });
+        await prisma.projectAssignment.upsert({
+          where: {
+            userId_projectId_termId_domainId: {
+              userId: payrollStudent.id,
+              projectId: dali.id,
+              termId: term26S.id,
+              domainId: engDomain.id,
+            },
+          },
+          update: { level: "P1" },
+          create: {
+            userId: payrollStudent.id,
+            projectId: dali.id,
+            termId: term26S.id,
+            domainId: engDomain.id,
+            level: "P1",
+          },
+        });
+      }
 
       console.log(
         `  v0 demo rows: ${eligCount} eligibilities, ${assignCount} project assignments, ` +


### PR DESCRIPTION
PR5 (final) of the Payroll: Reconcile feature. **Stacked on #903**.

## What
- **Notes surfaced end-to-end**: `getReconciliation` now joins `TimesheetNote` at the server edge (collation core stays Prisma-free); Payroll Data rows show a note-count badge and the modal renders real notes (text, period, validated chart string, timesheet link). Additive `notesByJobKey` on the result — CSV route and Budget seam untouched.
- **Seed**: placeholder job codes replaced with the real Dartmouth Job IDs (4834/4889/4890/7523 with wages) + a deterministic e2e fixture (netId'd student, chart string on a seeded project, matching ProjectAssignment in the active term). No existing assertions referenced the placeholders.
- **E2E** (`e2e/payroll-reconcile.spec.ts`): admin full journey — empty state → synthetic-CSV upload → Payroll Data row appears → Budget revenue inline edit → grand total updates → CSV export downloads; plus non-admin redirect. Pay-period label computed at runtime so the test is date-independent. CSV content is synthetic (no real student data).
- **Polish**: dismissible warning banner for staffed DALI projects missing a chart string; empty-state cards for Projects/Chart Strings tabs.

## Verification
- Unit: **1613 passed / 188 files** (6 new notes tests); typecheck at baseline; build clean.
- E2E local: new spec 2/2 green; 4 unrelated pre-existing failures in the wider suite (scheduling date-drift, 2 shared-DB flakes that pass in isolation, partner-portal magic-link flake) — none touch payroll; CI is the arbiter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BBBGa6p4HMTdenGfryxuqC

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/905"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786587643&installation_id=133523038&pr_number=905&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F905&signature=dd0ff382800216886d312f1a4c02eb895475450eeb4711502e0709ef99ca2e32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->