### PR TITLE
Desktop release CI: upload Tauri v2 updater artifacts

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -206,21 +206,21 @@ jobs:
           S3="s3://dali-os-desktop-releases"
           PUBLIC_BASE="https://dali-os-desktop-releases.s3.us-east-1.amazonaws.com/releases/${VERSION}"
 
-          TARGZ="$(ls "${BUNDLE}"/appimage/*.AppImage.tar.gz | head -n1)"
-          APPIMAGE="$(ls "${BUNDLE}"/appimage/*.AppImage | grep -v '\.tar\.gz' | head -n1)"
+          # Tauri v2's Linux updater artifact is the AppImage itself + .sig —
+          # the .AppImage.tar.gz format was v1 and is no longer produced.
+          APPIMAGE="$(ls "${BUNDLE}"/appimage/*.AppImage | head -n1)"
 
-          aws s3 cp "${TARGZ}"     "${S3}/releases/${VERSION}/"
           aws s3 cp "${APPIMAGE}"  "${S3}/releases/${VERSION}/"
           # Stable, version-less copy the website's /download page links to.
           aws s3 cp "${APPIMAGE}"  "${S3}/DALI-OS-linux.AppImage"
 
-          echo "linux_url=${PUBLIC_BASE}/$(basename "${TARGZ}")" >> "$GITHUB_OUTPUT"
+          echo "linux_url=${PUBLIC_BASE}/$(basename "${APPIMAGE}" | sed 's/ /%20/g')" >> "$GITHUB_OUTPUT"
 
       - name: Save sig for publish job
         uses: actions/upload-artifact@v4
         with:
           name: linux-sig
-          path: desktop/src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/appimage/*.AppImage.tar.gz.sig
+          path: desktop/src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/appimage/*.AppImage.sig
 
   build-windows:
     needs: decide
@@ -269,21 +269,21 @@ jobs:
           S3="s3://dali-os-desktop-releases"
           PUBLIC_BASE="https://dali-os-desktop-releases.s3.us-east-1.amazonaws.com/releases/${VERSION}"
 
-          TARGZ="$(ls "${BUNDLE}"/nsis/*.nsis.zip | head -n1)"
+          # Tauri v2's Windows updater artifact is the -setup.exe itself +
+          # .sig — the .nsis.zip format was v1 and is no longer produced.
           EXE="$(ls "${BUNDLE}"/nsis/*-setup.exe | head -n1)"
 
-          aws s3 cp "${TARGZ}" "${S3}/releases/${VERSION}/"
-          aws s3 cp "${EXE}"   "${S3}/releases/${VERSION}/"
+          aws s3 cp "${EXE}" "${S3}/releases/${VERSION}/"
           # Stable, version-less copy the website's /download page links to.
           aws s3 cp "${EXE}" "${S3}/DALI-OS-windows.exe"
 
-          echo "windows_url=${PUBLIC_BASE}/$(basename "${TARGZ}")" >> "$GITHUB_OUTPUT"
+          echo "windows_url=${PUBLIC_BASE}/$(basename "${EXE}" | sed 's/ /%20/g')" >> "$GITHUB_OUTPUT"
 
       - name: Save sig for publish job
         uses: actions/upload-artifact@v4
         with:
           name: windows-sig
-          path: desktop/src-tauri/target/x86_64-pc-windows-msvc/release/bundle/nsis/*.nsis.zip.sig
+          path: desktop/src-tauri/target/x86_64-pc-windows-msvc/release/bundle/nsis/*-setup.exe.sig
 
   # Merge all platform artifacts into latest.json and tag the release. Runs only
   # after all three builds succeed so the feed is never partially updated.


### PR DESCRIPTION
## What

Third and final piece of the 0.1.2 release fix. After #904, the Linux and Windows **builds** succeed (verified in [run 29300879913](https://github.com/dali-lab/dali-os/actions/runs/29300879913): correct triple paths, icon OK, updater sigs emitted) — but both **upload steps** still expect Tauri v1 updater formats that v2 doesn't produce:

| Platform | Workflow expected (v1) | v2 actually produces |
|---|---|---|
| Linux | `*.AppImage.tar.gz` (+`.sig`) | `*.AppImage` + `*.AppImage.sig` |
| Windows | `*.nsis.zip` (+`.sig`) | `*-setup.exe` + `*-setup.exe.sig` |
| macOS | `*.app.tar.gz` ✓ | same — why macOS kept passing |

The `.tar.gz`/`.nsis.zip` paths in the logs were the action's *candidate* list, not real files — that made the first failure look like a path issue (fixed in #904, still needed) when there were actually two bugs stacked.

Changes: point the S3 uploads, `latest.json` URLs, and sig-artifact paths at the v2 names, and percent-encode spaces in the updater URLs (`DALI OS_…` filenames; the live 0.1.1 feed carries a raw space that the url crate tolerates, but encoded is unambiguous).

## After merging

This PR doesn't touch `tauri.conf.json`, so it won't auto-trigger the release. Kick it manually:

```
gh workflow run desktop-release.yml --ref dev
```

`desktop-v0.1.2` is still untagged, so `decide` will re-release 0.1.2; the macOS re-upload is idempotent. When all three go green, `publish` flips `latest.json` to 0.1.2 and clients auto-update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/906"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786588505&installation_id=133523038&pr_number=906&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F906&signature=feb9953a654e6accded8751394be3661c666de2f20e681c24878689253a430b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->