### PR TITLE
Show desktop app version on Settings when running in the shell

### DIFF
--- a/dali-api/app/lib/__tests__/desktop.test.ts
+++ b/dali-api/app/lib/__tests__/desktop.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { desktopVersion } from "../desktop";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("desktopVersion", () => {
+  it("reads the shell global from the top frame", () => {
+    const top = { __DALI_DESKTOP: { version: "0.1.2" } };
+    vi.stubGlobal("window", { top });
+    expect(desktopVersion()).toBe("0.1.2");
+  });
+
+  it("returns null in a plain browser", () => {
+    const top = {};
+    vi.stubGlobal("window", { top });
+    expect(desktopVersion()).toBeNull();
+  });
+
+  it("returns null when top is cross-origin and throws", () => {
+    vi.stubGlobal("window", {
+      get top(): Window {
+        throw new Error("cross-origin");
+      },
+    });
+    expect(desktopVersion()).toBeNull();
+  });
+});

--- a/dali-api/app/lib/desktop.ts
+++ b/dali-api/app/lib/desktop.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from "react";
+
+type DesktopGlobal = { __DALI_DESKTOP?: { version?: string } };
+
+// The desktop shell (desktop/src-tauri/src/window.rs) injects
+// window.__DALI_DESKTOP into the top frame via a webview initialization
+// script — the remote page has no IPC access, so a frozen global is the
+// handoff. Workspace tabs render in same-origin iframes and read the top
+// frame's copy.
+export function desktopVersion(): string | null {
+  try {
+    const top = window.top as (Window & DesktopGlobal) | null;
+    return top?.__DALI_DESKTOP?.version ?? null;
+  } catch {
+    return null; // cross-origin top — not our shell
+  }
+}
+
+// null on the server and the first client render (effect-based so SSR markup
+// matches hydration), then the shell version, or stays null in a browser.
+export function useDesktopVersion(): string | null {
+  const [version, setVersion] = useState<string | null>(null);
+  useEffect(() => {
+    setVersion(desktopVersion());
+  }, []);
+  return version;
+}

--- a/dali-api/app/routes/settings._index.tsx
+++ b/dali-api/app/routes/settings._index.tsx
@@ -1,6 +1,7 @@
 import { Link, redirect } from "react-router";
 import { CalendarDays, Cable, KeyRound, Slack, UserCircle2 } from "lucide-react";
 import { requireAuth, redirectPartnerToPortal } from "~/lib/auth";
+import { useDesktopVersion } from "~/lib/desktop";
 import type { Route } from "./+types/settings._index";
 
 export const meta: Route.MetaFunction = () => [{ title: "Settings · DALI OS" }];
@@ -48,6 +49,7 @@ const CARDS = [
 ];
 
 export default function SettingsIndex() {
+  const desktopVersion = useDesktopVersion();
   return (
     <main className="max-w-3xl p-8">
       <h1 className="text-2xl font-semibold">Settings</h1>
@@ -72,6 +74,9 @@ export default function SettingsIndex() {
           </li>
         ))}
       </ul>
+      {desktopVersion && (
+        <p className="mt-8 text-xs text-zinc-400">DALI OS Desktop v{desktopVersion}</p>
+      )}
     </main>
   );
 }

--- a/desktop/src-tauri/src/window.rs
+++ b/desktop/src-tauri/src/window.rs
@@ -27,11 +27,20 @@ pub fn ensure_main(app: &AppHandle, initial_url: &str) -> tauri::Result<WebviewW
     }
     let url = Url::parse(initial_url).unwrap_or_else(|_| Url::parse(PROD_ORIGIN).unwrap());
     let nav_handle = app.clone();
+    // The remote page has no IPC, so the shell hands its version over as a
+    // frozen global re-injected on every top-frame navigation. Workspace-tab
+    // iframes read it via window.top (same origin). The web app renders it on
+    // Settings (app/lib/desktop.ts in dali-api).
+    let version_script = format!(
+        "window.__DALI_DESKTOP = Object.freeze({{ version: '{}' }});",
+        app.package_info().version
+    );
     WebviewWindowBuilder::new(app, "main", WebviewUrl::External(url))
         .title("DALI OS")
         .inner_size(1280.0, 832.0)
         .min_inner_size(900.0, 600.0)
         .visible(false)
+        .initialization_script(&version_script)
         .on_navigation(move |u| crate::nav::on_navigation(&nav_handle, u))
         .build()
 }


### PR DESCRIPTION
## What

Displays the running desktop shell version in the app UI — a muted "DALI OS Desktop v0.1.2" line under the Settings cards, visible only inside the desktop app.

## How

- **Shell** (`window.rs`): the main window gets a webview initialization script that sets `window.__DALI_DESKTOP = Object.freeze({ version })` (from `package_info`, i.e. `tauri.conf.json`). The remote origin has no IPC access by design, so a frozen top-frame global is the handoff; init scripts re-run on every navigation, so it survives reloads. **No capability, signing, or route changes.**
- **Web app**: new `~/lib/desktop.ts` — `desktopVersion()` reads the global from `window.top` (workspace tabs render in same-origin iframes) with a cross-origin guard, and `useDesktopVersion()` is effect-based so SSR markup matches hydration. Settings index renders the footer line when present.

## Testing

- Unit tests for the lib (top-frame read, plain browser, cross-origin throw).
- Live verification against the dev server in WebKit: injected the global into the top frame only (matching the shell's behavior), opened Settings via the sidebar → version line renders inside the tab iframe; a second session without the global shows nothing. Screenshot-verified.
- `cargo check --locked` green. Typecheck: no errors in touched files (dev has 115 pre-existing errors in `scripts/update-submitted-file.ts` and elsewhere, unrelated).

Note: session labels on Settings → Your devices still show pairing-time versions; this line reflects the currently running shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/907"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786590204&installation_id=133523038&pr_number=907&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F907&signature=de860d236be219eb1df98d976361bfe35c7ce58fa133acb8ebd23227de41be13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->