### PR TITLE
Forms: duplicate a form from the card menu

### DIFF
--- a/dali-api/app/forms/components/FormsBrowser.tsx
+++ b/dali-api/app/forms/components/FormsBrowser.tsx
@@ -1,5 +1,5 @@
-import { useMemo, useState } from "react";
-import { Link, useFetcher } from "react-router";
+import { useEffect, useMemo, useState } from "react";
+import { Link, useFetcher, useNavigate } from "react-router";
 import {
   DndContext,
   PointerSensor,
@@ -79,10 +79,21 @@ export function FormsBrowser({
   allForms: FormRef[];
 }) {
   const fetcher = useFetcher();
+  const navigate = useNavigate();
   const [dialog, setDialog] = useState<Dialog | null>(null);
   const [move, setMove] = useState<MoveSubject | null>(null);
   const [dragging, setDragging] = useState<DragItem | null>(null);
   const [query, setQuery] = useState("");
+
+  // duplicate-form returns the new copy's id — jump straight to its editor
+  // so the user lands in the seeded draft instead of hunting for the card.
+  const duplicatedId =
+    fetcher.data && typeof fetcher.data === "object" && "formId" in fetcher.data
+      ? (fetcher.data as { formId?: string }).formId
+      : undefined;
+  useEffect(() => {
+    if (duplicatedId) navigate(`/forms/edit/${duplicatedId}`);
+  }, [duplicatedId, navigate]);
 
   // 6px activation distance disambiguates click (navigate) from drag on the
   // Link cards — same pattern as KanbanBoard.
@@ -183,6 +194,13 @@ export function FormsBrowser({
       fetcher.submit(dialog.submit, { method: "post" });
     }
     setDialog(null);
+  }
+
+  function duplicateForm(f: { id: string }) {
+    fetcher.submit(
+      { intent: "duplicate-form", id: f.id },
+      { method: "post" },
+    );
   }
 
   function submitMove(item: DragItem, destinationId: string | null) {
@@ -324,6 +342,7 @@ export function FormsBrowser({
                       locationId: f.folderId,
                     })
                   }
+                  onDuplicate={() => duplicateForm(f)}
                   onDelete={() => deleteForm(f)}
                 />
               </div>
@@ -387,6 +406,7 @@ export function FormsBrowser({
                     locationId: folderId,
                   })
                 }
+                onDuplicate={() => duplicateForm(f)}
               />
             ))}
           </div>
@@ -452,11 +472,14 @@ function CardMenu({
   busy,
   onRename,
   onMove,
+  onDuplicate,
   onDelete,
 }: {
   busy: boolean;
   onRename: () => void;
   onMove: () => void;
+  // Forms only — duplicating a folder (deep copy) isn't supported.
+  onDuplicate?: () => void;
   onDelete: () => void;
 }) {
   const [open, setOpen] = useState(false);
@@ -516,6 +539,20 @@ function CardMenu({
             >
               Move to…
             </button>
+            {onDuplicate && (
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  setOpen(false);
+                  onDuplicate();
+                }}
+                className="text-left px-2 py-1.5 rounded hover:bg-muted/50 text-foreground"
+              >
+                Duplicate
+              </button>
+            )}
             <button
               type="button"
               onClick={(e) => {
@@ -623,12 +660,14 @@ function FormCardView({
   onRename,
   onDelete,
   onMove,
+  onDuplicate,
 }: {
   form: FormCard;
   busy: boolean;
   onRename: () => void;
   onDelete: () => void;
   onMove: () => void;
+  onDuplicate: () => void;
 }) {
   const drag = useDraggable({
     id: `form:${form.id}`,
@@ -671,6 +710,7 @@ function FormCardView({
         busy={busy}
         onRename={onRename}
         onMove={onMove}
+        onDuplicate={onDuplicate}
         onDelete={onDelete}
       />
     </div>

--- a/dali-api/app/forms/lib/__tests__/forms-data.duplicate.test.ts
+++ b/dali-api/app/forms/lib/__tests__/forms-data.duplicate.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("~/lib/db");
+
+import { prisma } from "~/lib/db";
+import { runFormsAction } from "~/forms/lib/forms-data";
+
+const mockPrisma = prisma as unknown as {
+  form: {
+    findUnique: ReturnType<typeof vi.fn>;
+    create: ReturnType<typeof vi.fn>;
+  };
+};
+
+function fd(entries: Record<string, string>): FormData {
+  const f = new FormData();
+  for (const [k, v] of Object.entries(entries)) f.set(k, v);
+  return f;
+}
+
+const DRAFT_QUESTIONS = [
+  { key: "d1", type: "text", required: false, data: { label: "Draft Q" } },
+];
+const VERSION_QUESTIONS = [
+  { key: "v1", type: "text", required: false, data: { label: "Version Q" } },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockPrisma.form.create.mockResolvedValue({ id: "copy-1" });
+});
+
+describe("runFormsAction duplicate-form", () => {
+  it("copies the draft (when present) into a new form's draft and returns its id", async () => {
+    mockPrisma.form.findUnique.mockResolvedValue({
+      name: "Snack Poll",
+      folderId: "folder-1",
+      draftQuestions: DRAFT_QUESTIONS,
+      draftIntro: "draft intro",
+      versions: [{ questions: VERSION_QUESTIONS, intro: "version intro" }],
+    });
+
+    const res = await runFormsAction(
+      fd({ intent: "duplicate-form", id: "form-1" }),
+      "user-1",
+    );
+
+    expect(res).toEqual({ ok: true, formId: "copy-1" });
+    expect(mockPrisma.form.create).toHaveBeenCalledWith({
+      data: {
+        name: "Copy of Snack Poll",
+        folderId: "folder-1",
+        createdById: "user-1",
+        draftQuestions: DRAFT_QUESTIONS,
+        draftIntro: "draft intro",
+      },
+      select: { id: true },
+    });
+  });
+
+  it("falls back to the latest version when there is no draft", async () => {
+    mockPrisma.form.findUnique.mockResolvedValue({
+      name: "Snack Poll",
+      folderId: null,
+      draftQuestions: null,
+      draftIntro: null,
+      versions: [{ questions: VERSION_QUESTIONS, intro: "version intro" }],
+    });
+
+    const res = await runFormsAction(
+      fd({ intent: "duplicate-form", id: "form-1" }),
+      "user-1",
+    );
+
+    expect(res).toEqual({ ok: true, formId: "copy-1" });
+    expect(mockPrisma.form.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          draftQuestions: VERSION_QUESTIONS,
+          draftIntro: "version intro",
+        }),
+      }),
+    );
+  });
+
+  it("copies an empty form as an empty draft", async () => {
+    mockPrisma.form.findUnique.mockResolvedValue({
+      name: "Blank",
+      folderId: null,
+      draftQuestions: null,
+      draftIntro: null,
+      versions: [],
+    });
+
+    const res = await runFormsAction(
+      fd({ intent: "duplicate-form", id: "form-1" }),
+      "user-1",
+    );
+
+    expect(res).toEqual({ ok: true, formId: "copy-1" });
+    const data = mockPrisma.form.create.mock.calls[0][0].data;
+    expect(data.draftQuestions).toBeUndefined();
+  });
+
+  it("never copies publish/listing/audience state — the copy uses column defaults", async () => {
+    mockPrisma.form.findUnique.mockResolvedValue({
+      name: "Live Form",
+      folderId: null,
+      draftQuestions: DRAFT_QUESTIONS,
+      draftIntro: null,
+      versions: [],
+    });
+
+    await runFormsAction(fd({ intent: "duplicate-form", id: "form-1" }), "user-1");
+
+    const data = mockPrisma.form.create.mock.calls[0][0].data;
+    for (const key of [
+      "published",
+      "publicToken",
+      "listed",
+      "audience",
+      "audienceGroupIds",
+      "oneResponsePerMember",
+      "notifyOnSubmission",
+    ]) {
+      expect(data).not.toHaveProperty(key);
+    }
+  });
+
+  it("404s an unknown source form", async () => {
+    mockPrisma.form.findUnique.mockResolvedValue(null);
+    const res = await runFormsAction(
+      fd({ intent: "duplicate-form", id: "ghost" }),
+      "user-1",
+    );
+    expect(res).toEqual({ error: "Not found", status: 404 });
+    expect(mockPrisma.form.create).not.toHaveBeenCalled();
+  });
+});

--- a/dali-api/app/forms/lib/forms-data.ts
+++ b/dali-api/app/forms/lib/forms-data.ts
@@ -319,6 +319,7 @@ export const ActionSchema = z.discriminatedUnion("intent", [
     id: z.string().min(1),
     folderId: z.string().optional(), // "" = top level
   }),
+  z.object({ intent: z.literal("duplicate-form"), id: z.string().min(1) }),
   z.object({
     // "Save" — persist the editable working copy. Lenient: a draft may hold a
     // work-in-progress question set, so it isn't held to save-version's rules.
@@ -374,7 +375,8 @@ function newPublicToken(): string {
 }
 
 export type FormsActionResult =
-  | { ok: true }
+  // `formId` is set by duplicate-form so the UI can jump to the new copy.
+  | { ok: true; formId?: string }
   | { error: string; status: number };
 
 export async function runFormsAction(
@@ -397,6 +399,46 @@ export async function runFormsAction(
         },
       });
       return { ok: true };
+    }
+    case "duplicate-form": {
+      const source = await prisma.form.findUnique({
+        where: { id: input.id },
+        select: {
+          name: true,
+          folderId: true,
+          draftQuestions: true,
+          draftIntro: true,
+          versions: {
+            orderBy: { versionNumber: "desc" },
+            take: 1,
+            select: { questions: true, intro: true },
+          },
+        },
+      });
+      if (!source) return { error: "Not found", status: 404 };
+
+      // Seed the copy's DRAFT from the source's draft when one exists (the
+      // author's newest thinking), else its latest version. The copy starts
+      // unpublished/unlisted with default settings and audience — a copy must
+      // never silently inherit a Public audience or live link — and belongs
+      // to the duplicating user.
+      const latest = source.versions[0] ?? null;
+      const questions = source.draftQuestions ?? latest?.questions ?? null;
+      const intro = source.draftQuestions
+        ? source.draftIntro
+        : (latest?.intro ?? null);
+
+      const created = await prisma.form.create({
+        data: {
+          name: `Copy of ${source.name}`.slice(0, 120),
+          folderId: source.folderId,
+          createdById: userId,
+          draftQuestions: questions === null ? undefined : (questions as object),
+          draftIntro: intro,
+        },
+        select: { id: true },
+      });
+      return { ok: true, formId: created.id };
     }
     case "move-form": {
       const exists = await prisma.form.findUnique({


### PR DESCRIPTION
Follow-up to #910 (this commit was pushed just after the squash merge and missed it).

Adds a **Duplicate** item to form card menus (grid and search results; not folders). It creates "Copy of \<name\>" in the same folder:

- The copy's **draft** is seeded from the source's draft when one exists (the author's newest thinking), otherwise its latest version — so "reuse last term's form" is Duplicate → tweak → Save as version → publish.
- The copy deliberately starts from column defaults: **unpublished, unlisted, Members audience, no public token, settings off** — a copy can never silently inherit a Public audience or a live fill link.
- The browser navigates straight to the copy's editor, which opens into the seeded builder.

Note on reuse: hiring's "Duplicate to New Version" is a different operation (in-place version seeding via the shared FormBuilderTab, which forms already expose as "New version") — cross-entity copy needed its own small `duplicate-form` intent rather than an abstraction.

## Testing
5 unit tests (draft-wins seeding, latest-version fallback, empty-form copy, no publish/listing/audience/settings fields ever copied, 404). Forms suites + typecheck green on this branch; browser-verified the menu, the created row's defaults, and the editor landing seeded with the source's questions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/911"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786677051&installation_id=133523038&pr_number=911&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F911&signature=c6ba480eca3bcdaab1c196bc44f8a8c21adf9ea8676a82de3824d85551b3e68d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->