### PR TITLE
Timesheet: per-role hours, required roles, typed time ranges, drag-to…

### DIFF
--- a/dali-api/app/admin-console/adminPills.tsx
+++ b/dali-api/app/admin-console/adminPills.tsx
@@ -1,6 +1,7 @@
 import {
   Activity,
   BarChart3,
+  ClipboardCheck,
   Globe,
   LayoutGrid,
   Megaphone,
@@ -11,9 +12,8 @@ import {
 import type { AreaPill } from "~/components/AreaPillNav";
 
 // The Admin area's tools (the sidebar entry is childless and lands on the
-// hub). Every admin page is already Core-gated, so the first four pills
-// always show; the last three are Admin-only, matching the old sidebar
-// section gates.
+// hub). Every admin page is already Core-gated, so Core tools always show;
+// Admin-only tools are appended when isAdmin.
 export function adminPills(args: {
   isAdmin: boolean;
   active:
@@ -21,6 +21,7 @@ export function adminPills(args: {
     | "members"
     | "domains"
     | "announcements"
+    | "attendance"
     | "activity"
     | "analytics"
     | "payroll"
@@ -45,6 +46,12 @@ export function adminPills(args: {
       to: "/admin-console/announcements",
       active: args.active === "announcements",
       icon: Megaphone,
+    },
+    {
+      label: "Attendance",
+      to: "/admin-console/attendance",
+      active: args.active === "attendance",
+      icon: ClipboardCheck,
     },
     ...(args.isAdmin
       ? [

--- a/dali-api/app/admin-console/routes/admin-console.attendance.tsx
+++ b/dali-api/app/admin-console/routes/admin-console.attendance.tsx
@@ -1,0 +1,345 @@
+import { useState } from "react";
+import { Link, redirect, useLoaderData } from "react-router";
+import type { Route } from "./+types/admin-console.attendance";
+import { adminPills } from "~/admin-console/adminPills";
+import { AreaPillNav } from "~/components/AreaPillNav";
+import { TermFilter } from "~/components/TermFilter";
+import { prisma } from "~/lib/db";
+import { requireAuth } from "~/lib/auth";
+import { isCore, isAdmin } from "~/lib/roles";
+import { resolveTermFilter } from "~/lib/terms";
+import { fullName, formatDateShort, formatDateTime } from "~/lib/display";
+import {
+  ClipboardCheck,
+  ChevronDown,
+  ChevronRight,
+  ExternalLink,
+  UserCheck,
+  UserX,
+} from "lucide-react";
+
+export const handle = { areaPills: true };
+
+export const meta: Route.MetaFunction = () => [
+  { title: "Attendance · Admin · DALI OS" },
+];
+
+export async function loader({ request }: Route.LoaderArgs) {
+  const auth = await requireAuth(request);
+  if (!auth.ok) return redirect("/login");
+  if (!(await isCore(auth.user.sub))) return redirect("/");
+
+  const { terms, selected, termId, isAll } = await resolveTermFilter(request);
+
+  // Term window for selectedAt filtering. Meetings without a start time are
+  // only included in the All-terms view so a half-planned event doesn't
+  // vanish from every term.
+  let dateWhere: { gte?: Date; lte?: Date } | undefined;
+  if (!isAll && termId) {
+    const term = await prisma.term.findUnique({
+      where: { id: termId },
+      select: { startDate: true, endDate: true },
+    });
+    if (term) dateWhere = { gte: term.startDate, lte: term.endDate };
+  }
+
+  const meetings = await prisma.scheduledMeeting.findMany({
+    where: {
+      attendanceMode: "SelfCheckIn",
+      ...(dateWhere
+        ? { selectedAt: dateWhere }
+        : isAll
+          ? {}
+          : { selectedAt: { not: null } }),
+    },
+    orderBy: [{ selectedAt: "desc" }, { createdAt: "desc" }],
+    select: {
+      id: true,
+      title: true,
+      selectedAt: true,
+      meetingType: true,
+      meetingTypeLabel: true,
+      project: { select: { id: true, name: true } },
+      notePage: { select: { id: true } },
+      organizer: {
+        select: { firstName: true, lastName: true, daliEmail: true },
+      },
+      attendance: {
+        orderBy: { user: { lastName: "asc" } },
+        select: {
+          present: true,
+          markedAt: true,
+          user: {
+            select: {
+              id: true,
+              firstName: true,
+              lastName: true,
+              daliEmail: true,
+            },
+          },
+        },
+      },
+    },
+  });
+
+  return {
+    terms,
+    selected,
+    viewerIsAdmin: await isAdmin(auth.user.sub),
+    events: meetings.map((m) => {
+      const invited = m.attendance.length;
+      const checkedIn = m.attendance.filter((a) => a.present).length;
+      const typeLabel =
+        m.meetingType === "Other"
+          ? m.meetingTypeLabel || "Other"
+          : (m.meetingType ?? "Meeting");
+      return {
+        id: m.id,
+        title: m.title,
+        typeLabel,
+        startsAt: m.selectedAt?.toISOString() ?? null,
+        projectName: m.project?.name ?? null,
+        projectId: m.project?.id ?? null,
+        notePageId: m.notePage?.id ?? null,
+        organizerName: fullName(m.organizer) || m.organizer.daliEmail || "—",
+        invited,
+        checkedIn,
+        attendees: m.attendance.map((a) => ({
+          id: a.user.id,
+          name: fullName(a.user) || a.user.daliEmail || a.user.id,
+          present: a.present,
+          markedAt: a.markedAt?.toISOString() ?? null,
+        })),
+      };
+    }),
+  };
+}
+
+type Attendee = {
+  id: string;
+  name: string;
+  present: boolean;
+  markedAt: string | null;
+};
+
+export default function AdminAttendancePage() {
+  const { terms, selected, viewerIsAdmin, events } = useLoaderData<typeof loader>();
+  const [openId, setOpenId] = useState<string | null>(events[0]?.id ?? null);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <AreaPillNav
+        items={adminPills({ isAdmin: viewerIsAdmin, active: "attendance" })}
+      />
+
+      <header className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <p className="text-[11px] uppercase tracking-[0.14em] text-accent-coral font-medium">
+            Self check-in
+          </p>
+          <h1 className="font-heading text-2xl font-bold text-foreground mt-0.5">
+            Attendance
+          </h1>
+          <p className="text-sm text-muted-foreground mt-1 max-w-lg">
+            Who was invited to QR check-in events, and who actually checked in.
+          </p>
+        </div>
+        <TermFilter terms={terms} selected={selected} />
+      </header>
+
+      {events.length === 0 ? (
+        <div className="bg-card border border-border shadow-brand-1 rounded-lg p-10 text-center">
+          <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-accent-coral/10">
+            <ClipboardCheck className="w-6 h-6 text-accent-coral" aria-hidden />
+          </div>
+          <p className="font-heading font-semibold text-foreground">
+            No self check-in events this term
+          </p>
+          <p className="text-sm text-muted-foreground mt-1 max-w-md mx-auto">
+            In Calendar, create a meeting and turn on{" "}
+            <span className="text-foreground">Self check-in (QR)</span>. Add the
+            people or groups to invite under Participants — a project is optional.
+          </p>
+        </div>
+      ) : (
+        <ul className="flex flex-col gap-3">
+          {events.map((event) => {
+            const open = openId === event.id;
+            const pct =
+              event.invited > 0
+                ? Math.round((event.checkedIn / event.invited) * 100)
+                : 0;
+            const present = event.attendees.filter((a) => a.present);
+            const missing = event.attendees.filter((a) => !a.present);
+            return (
+              <li
+                key={event.id}
+                className="bg-card border border-border shadow-brand-1 rounded-lg overflow-hidden"
+              >
+                <button
+                  type="button"
+                  onClick={() => setOpenId(open ? null : event.id)}
+                  aria-expanded={open}
+                  className="w-full text-left px-4 py-3.5 flex items-start gap-3 hover:bg-muted/30 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent-coral/40"
+                >
+                  <span className="mt-1 text-muted-foreground flex-shrink-0" aria-hidden>
+                    {open ? (
+                      <ChevronDown className="w-4 h-4" />
+                    ) : (
+                      <ChevronRight className="w-4 h-4" />
+                    )}
+                  </span>
+                  <div className="min-w-0 flex-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <h2 className="font-heading font-semibold text-foreground truncate">
+                        {event.title}
+                      </h2>
+                      <span className="text-[11px] rounded-md px-2 py-0.5 bg-accent-coral/10 text-accent-coral font-medium">
+                        {event.typeLabel}
+                      </span>
+                    </div>
+                    <p className="text-xs text-muted-foreground mt-1">
+                      {[
+                        event.startsAt
+                          ? formatDateShort(new Date(event.startsAt))
+                          : "No start time",
+                        event.projectName ?? "No project",
+                        `Organizer ${event.organizerName}`,
+                      ].join(" · ")}
+                    </p>
+                    <div className="mt-2.5 flex items-center gap-3">
+                      <div className="flex-1 h-1.5 rounded-full bg-muted overflow-hidden max-w-xs">
+                        <div
+                          className="h-full bg-accent-teal rounded-full transition-[width] duration-300"
+                          style={{ width: `${pct}%` }}
+                        />
+                      </div>
+                      <span className="text-xs text-muted-foreground tabular-nums flex-shrink-0">
+                        {event.checkedIn}/{event.invited} checked in
+                      </span>
+                    </div>
+                  </div>
+                  {event.notePageId && (
+                    <Link
+                      to={`/documents/${event.notePageId}`}
+                      onClick={(e) => e.stopPropagation()}
+                      className="flex-shrink-0 p-1.5 rounded-md text-muted-foreground hover:text-accent-coral hover:bg-accent-coral/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-coral/40"
+                      title="Open meeting note"
+                      aria-label="Open meeting note"
+                    >
+                      <ExternalLink className="w-4 h-4" />
+                    </Link>
+                  )}
+                </button>
+
+                {open && (
+                  <div className="border-t border-border bg-muted/15">
+                    <div className="grid grid-cols-3 gap-2 px-4 py-3 border-b border-border">
+                      <EventStat label="Invited" value={String(event.invited)} />
+                      <EventStat label="Checked in" value={String(event.checkedIn)} />
+                      <EventStat
+                        label="Rate"
+                        value={event.invited ? `${pct}%` : "—"}
+                      />
+                    </div>
+                    {event.attendees.length === 0 ? (
+                      <p className="px-4 py-4 text-sm text-muted-foreground italic">
+                        No invitees on this event.
+                      </p>
+                    ) : (
+                      <div className="grid sm:grid-cols-2 divide-y sm:divide-y-0 sm:divide-x divide-border">
+                        <RosterColumn
+                          icon={UserCheck}
+                          title="Checked in"
+                          count={present.length}
+                          tone="present"
+                          attendees={present}
+                          empty="Nobody has checked in yet."
+                        />
+                        <RosterColumn
+                          icon={UserX}
+                          title="Not submitted"
+                          count={missing.length}
+                          tone="missing"
+                          attendees={missing}
+                          empty="Everyone checked in."
+                        />
+                      </div>
+                    )}
+                  </div>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function RosterColumn({
+  icon: Icon,
+  title,
+  count,
+  tone,
+  attendees,
+  empty,
+}: {
+  icon: typeof UserCheck;
+  title: string;
+  count: number;
+  tone: "present" | "missing";
+  attendees: Attendee[];
+  empty: string;
+}) {
+  return (
+    <div className="min-w-0">
+      <div className="px-4 py-2.5 flex items-center gap-2 border-b border-border/80">
+        <Icon
+          className={`w-3.5 h-3.5 ${
+            tone === "present" ? "text-accent-teal" : "text-muted-foreground"
+          }`}
+          aria-hidden
+        />
+        <h3 className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          {title}
+        </h3>
+        <span className="ml-auto text-xs tabular-nums text-foreground font-medium">
+          {count}
+        </span>
+      </div>
+      {attendees.length === 0 ? (
+        <p className="px-4 py-3 text-sm text-muted-foreground italic">{empty}</p>
+      ) : (
+        <ul className="max-h-72 overflow-y-auto divide-y divide-border/60">
+          {attendees.map((a) => (
+            <li
+              key={a.id}
+              className="px-4 py-2.5 flex items-baseline justify-between gap-3 text-sm"
+            >
+              <span className="text-foreground truncate">{a.name}</span>
+              {a.present && a.markedAt && (
+                <span className="text-[11px] text-muted-foreground tabular-nums flex-shrink-0">
+                  {formatDateTime(a.markedAt)}
+                </span>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function EventStat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="min-w-0">
+      <div className="text-[10px] uppercase tracking-wide text-muted-foreground">
+        {label}
+      </div>
+      <div className="font-heading text-base font-semibold text-foreground tabular-nums">
+        {value}
+      </div>
+    </div>
+  );
+}

--- a/dali-api/app/admin-console/routes/admin-console.tsx
+++ b/dali-api/app/admin-console/routes/admin-console.tsx
@@ -37,6 +37,12 @@ export default function AdminHub() {
       description:
         "Send an announcement to the lab, with an optional due date and attached form.",
     },
+    {
+      to: "/admin-console/attendance",
+      title: "Attendance",
+      description:
+        "Self check-in events — see who was invited and who checked in.",
+    },
     ...(admin
       ? [
           {
@@ -77,7 +83,7 @@ export default function AdminHub() {
           <Link
             key={t.to}
             to={t.to}
-            className="bg-card border border-border rounded-lg p-4 hover:border-accent-coral/60 hover:shadow-sm transition-all"
+            className="bg-card border border-border shadow-brand-1 rounded-lg p-4 hover:border-accent-coral/60 hover:shadow-brand-2 transition-all"
           >
             <h2 className="font-heading font-semibold text-foreground">{t.title}</h2>
             <p className="text-sm text-muted-foreground mt-1">{t.description}</p>

--- a/dali-api/app/calendar/routes/api.scheduled-meetings.ts
+++ b/dali-api/app/calendar/routes/api.scheduled-meetings.ts
@@ -2,6 +2,7 @@ import type { Route } from "./+types/api.scheduled-meetings";
 import { z } from "zod";
 import { requireAuth, forbidden } from "~/lib/auth";
 import { withCors, handlePreflight } from "~/lib/cors";
+import { canViewForms } from "~/lib/roles";
 import { parseJson } from "~/lib/validate";
 import {
   createScheduledMeeting,
@@ -16,9 +17,9 @@ const Base = {
   organizerCalendarLinkId: z.string().min(1).optional(),
   meetingType: z.enum(["Team", "Partner", "Other"]).optional(),
   meetingTypeLabel: z.string().trim().min(1).max(80).optional(),
-  // Project-less meetingType meetings (e.g. an all-lab Group event) get a
-  // Lab-workspace note page instead of a project one — see
-  // createScheduledMeeting in ~/lib/scheduled-meeting.
+  // Project-less meetingType meetings get a Lab-workspace note page instead of
+  // a project one — see createScheduledMeeting in ~/lib/scheduled-meeting.
+  // Invites still come only from the meeting's participant scope.
   projectId: z.string().min(1).optional(),
   // SelfCheckIn only makes sense alongside meetingType (that's what creates
   // MeetingAttendance rows at all) — enforced by the refine below.
@@ -59,6 +60,11 @@ export async function action({ request }: Route.ActionArgs) {
 
   const body = await parseJson(request, CreateSchema);
   if (body instanceof Response) return withCors(request, body);
+
+  // Self check-in is Core / Admin / Instructor only (same gate as Forms).
+  if (body.attendanceMode === "SelfCheckIn" && !(await canViewForms(auth.user.sub))) {
+    return forbidden(request);
+  }
 
   let scope: ScheduledMeetingScope;
   if (body.scopeType === "Group") {

--- a/dali-api/app/calendar/routes/calendar.tsx
+++ b/dali-api/app/calendar/routes/calendar.tsx
@@ -25,12 +25,13 @@ import { fullName } from "~/lib/display";
 import { prisma } from "~/lib/db";
 import { listVisibleGroupsForUser } from "~/lib/groups";
 import {
+  canViewForms,
   currentTermMemberWhere,
   getUserRoleInstances,
   resolveRoleRef,
   type RoleInstance,
 } from "~/lib/roles";
-import { CalendarActionSchema } from "~/lib/calendar-schemas";
+import { CalendarActionSchema, validateTimeEntryRange } from "~/lib/calendar-schemas";
 import { syncManualBlockTimeEntry } from "~/lib/time-entry-sync";
 import { fetchBusyEvents, listCalendarsForLink } from "~/lib/google-calendar";
 import { APPLICATION_TZ as DEFAULT_TIMEZONE, getZonedHourFraction, getZonedYMD, zonedDayStartUtc } from "~/lib/timezone";
@@ -158,6 +159,8 @@ type LoaderData = {
   myProjects: ProjectOption[];
   myRoles: RoleInstance[];
   timeEntries: TimeEntryDTO[];
+  /** Core, Admin, or Instructor — can enable Self check-in (QR) on meetings. */
+  canSetSelfCheckIn: boolean;
 };
 
 function defaultWorkingHours(): WhDay[] {
@@ -216,8 +219,18 @@ export async function loader({ request }: Route.LoaderArgs) {
   // applicants, partners, and alumni who happen to still have a User row.
   const memberWhere = await currentTermMemberWhere();
 
-  const [settings, whRows, blocks, links, groups, users, myProjects, myRoles, timeEntryRows] =
-    await Promise.all([
+  const [
+    settings,
+    whRows,
+    blocks,
+    links,
+    groups,
+    users,
+    myProjects,
+    myRoles,
+    timeEntryRows,
+    canSetSelfCheckIn,
+  ] = await Promise.all([
       prisma.userAvailabilitySettings.findUnique({ where: { userId } }),
       prisma.workingHoursDay.findMany({ where: { userId } }),
       prisma.manualBlock.findMany({
@@ -270,6 +283,8 @@ export async function loader({ request }: Route.LoaderArgs) {
           meeting: { select: { notePage: { select: { id: true } } } },
         },
       }),
+      // Same gate as Forms: Core, Admin, or Instructor.
+      canViewForms(userId),
     ]);
 
   const timezone = settings?.timezone ?? DEFAULT_TIMEZONE;
@@ -402,6 +417,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     currentUserId: userId,
     myProjects,
     myRoles,
+    canSetSelfCheckIn,
     timeEntries: timeEntryRows.map((t) => ({
       id: t.id,
       source: t.source,
@@ -693,24 +709,23 @@ export async function action({ request }: Route.ActionArgs) {
     }
 
     case "add-time-entry": {
-      let projectId: string | null = null;
-      if (input.assignmentType && input.roleRefId) {
-        const resolved = await resolveRoleRef(userId, input.assignmentType, input.roleRefId);
-        if (!resolved) return Response.json({ error: "Invalid role" }, { status: 400 });
-        projectId = resolved.projectId;
-      }
+      const rangeError = validateTimeEntryRange(input);
+      if (rangeError) return Response.json({ error: rangeError }, { status: 400 });
+      const resolved = await resolveRoleRef(userId, input.assignmentType, input.roleRefId);
+      if (!resolved) return Response.json({ error: "Invalid role" }, { status: 400 });
+      const projectId = resolved.projectId;
       await prisma.timeEntry.create({
         data: {
           userId,
           source: "Manual",
           date: new Date(input.date),
           hours: input.hours,
-          assignmentType: input.assignmentType ?? null,
-          roleRefId: input.roleRefId ?? null,
+          assignmentType: input.assignmentType,
+          roleRefId: input.roleRefId,
           projectId,
           note: input.note ?? null,
-          startTime: input.startTime ? new Date(input.startTime) : null,
-          endTime: input.endTime ? new Date(input.endTime) : null,
+          startTime: new Date(input.startTime),
+          endTime: new Date(input.endTime),
         },
       });
       return null;
@@ -729,35 +744,40 @@ export async function action({ request }: Route.ActionArgs) {
       const roleRefId = input.roleRefId === undefined ? existing.roleRefId : input.roleRefId;
       let projectId = existing.projectId;
       if (input.assignmentType !== undefined || input.roleRefId !== undefined) {
-        if (assignmentType && roleRefId) {
-          const resolved = await resolveRoleRef(userId, assignmentType, roleRefId);
-          if (!resolved) return Response.json({ error: "Invalid role" }, { status: 400 });
-          projectId = resolved.projectId;
-        } else {
-          projectId = null;
+        // A patch that touches either half must land on a complete, real role
+        // — this is the path that used to allow clearing back to unassigned.
+        if (!assignmentType || !roleRefId) {
+          return Response.json({ error: "A role is required" }, { status: 400 });
         }
+        const resolved = await resolveRoleRef(userId, assignmentType, roleRefId);
+        if (!resolved) return Response.json({ error: "Invalid role" }, { status: 400 });
+        projectId = resolved.projectId;
       }
+
+      const startTime =
+        input.startTime === undefined ? existing.startTime : new Date(input.startTime);
+      const endTime = input.endTime === undefined ? existing.endTime : new Date(input.endTime);
+      const hours = input.hours ?? existing.hours;
+      // Validate the MERGED result, not just the patch: a partial update that
+      // moves only `end` earlier than the stored `start` is still invalid.
+      const rangeError = validateTimeEntryRange({
+        startTime: startTime ? startTime.toISOString() : null,
+        endTime: endTime ? endTime.toISOString() : null,
+        hours,
+      });
+      if (rangeError) return Response.json({ error: rangeError }, { status: 400 });
+
       await prisma.timeEntry.update({
         where: { id: input.id },
         data: {
           date: input.date ? new Date(input.date) : existing.date,
-          hours: input.hours ?? existing.hours,
+          hours,
           assignmentType,
           roleRefId,
           projectId,
           note: input.note === undefined ? existing.note : input.note,
-          startTime:
-            input.startTime === undefined
-              ? existing.startTime
-              : input.startTime
-                ? new Date(input.startTime)
-                : null,
-          endTime:
-            input.endTime === undefined
-              ? existing.endTime
-              : input.endTime
-                ? new Date(input.endTime)
-                : null,
+          startTime,
+          endTime,
         },
       });
       return null;
@@ -2120,6 +2140,11 @@ function roleColor(key: string): (typeof ROLE_COLOR_PALETTE)[number] {
 
 const UNASSIGNED_ROLE_KEY = "unassigned";
 
+// Shown wherever time can be logged but the user holds no paid role. Every
+// entry must attribute to one, so there's nothing valid to submit.
+const NO_ROLES_MESSAGE =
+  "You have no paid roles this term, so there's nothing to log hours against.";
+
 function timeEntryRoleKey(t: TimeEntryDTO): string {
   return t.assignmentType && t.roleRefId ? `${t.assignmentType}:${t.roleRefId}` : UNASSIGNED_ROLE_KEY;
 }
@@ -2133,11 +2158,14 @@ function RoleFilterRow({
   excludedKeys,
   onToggle,
 }: {
-  buckets: { key: string; label: string }[];
+  buckets: { key: string; label: string; hours: number }[];
   excludedKeys: Set<string>;
   onToggle: (key: string) => void;
 }) {
-  if (buckets.length < 2) return null;
+  // Single-bucket weeks still get the row: the chip doubles as this week's
+  // per-role hours readout, which is useful even when there's nothing to
+  // filter against.
+  if (buckets.length === 0) return null;
   return (
     <div className="flex flex-wrap items-center gap-1.5 px-1 pb-2">
       {buckets.map((b) => {
@@ -2148,6 +2176,8 @@ function RoleFilterRow({
             key={b.key}
             type="button"
             onClick={() => onToggle(b.key)}
+            aria-pressed={active}
+            title={`${b.label} — ${b.hours.toFixed(2)} hrs this week${active ? "" : " (hidden)"}`}
             className={`flex items-center gap-1.5 px-2 py-1 rounded-full border text-xs transition-colors ${
               active
                 ? "border-border bg-muted/60 text-foreground"
@@ -2156,6 +2186,7 @@ function RoleFilterRow({
           >
             <span className="w-2 h-2 rounded-full flex-shrink-0" style={{ backgroundColor: color.dot }} />
             {b.label}
+            <span className={active ? "text-muted-foreground" : ""}>· {b.hours.toFixed(2)}h</span>
           </button>
         );
       })}
@@ -2184,27 +2215,38 @@ function parseRoleOptionKey(
 // Role picker for a plain (non-fetch, name-attribute-driven) <Form> — pairs a
 // controlled <select> with hidden assignmentType/roleRefId inputs so native
 // FormData submission carries both halves of the encoded role key.
+// Controlled by the parent so submit can be gated on a role actually being
+// picked (the disabled placeholder below is not a submittable choice).
 function RoleSelectField({
   id,
   myRoles,
-  defaultValue,
+  value,
+  onChange,
 }: {
   id: string;
   myRoles: RoleInstance[];
-  defaultValue: string;
+  value: string;
+  onChange: (next: string) => void;
 }) {
-  const [roleKey, setRoleKey] = useState(defaultValue);
-  const parsed = parseRoleOptionKey(roleKey);
+  const parsed = parseRoleOptionKey(value);
   return (
     <label htmlFor={id} className="text-xs text-muted-foreground flex flex-col gap-1">
       Role
       <select
         id={id}
-        value={roleKey}
-        onChange={(e) => setRoleKey(e.target.value)}
-        className="px-2 py-1.5 text-sm border border-border rounded-md bg-background text-foreground"
+        required
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className={`px-2 py-1.5 text-sm border rounded-md bg-background text-foreground ${
+          value ? "border-border" : "border-red-500"
+        }`}
       >
-        <option value="">Unassigned</option>
+        {/* Placeholder, not a choice: every logged hour bills to a real role,
+            so this is disabled and can't be submitted (unlike the old
+            "Unassigned" option, which silently created unattributable time). */}
+        <option value="" disabled>
+          Select a role…
+        </option>
         {myRoles.map((r) => (
           <option key={roleOptionKey(r)} value={roleOptionKey(r)}>
             {r.label}
@@ -2483,6 +2525,7 @@ function ScheduleView({ data }: { data: LoaderData }) {
         users={data.users}
         calendarLinks={data.calendarLinks}
         myProjects={data.myProjects}
+        canSetSelfCheckIn={data.canSetSelfCheckIn}
         startLocal={startLocal}
         onStartLocalChange={setStartLocal}
         endLocal={endLocal}
@@ -2542,15 +2585,67 @@ function nominalDayRange(
   return { startIso: start.toISOString(), endIso: end.toISOString() };
 }
 
+// Combine a "YYYY-MM-DD" day and a "HH:MM" wall-clock time into the real UTC
+// instant for that moment in `timezone`, so a typed entry lands on the grid
+// exactly where a dragged one would.
+function localDayTimeToIso(date: string, time: string, timezone: string): string | null {
+  const [y, m, d] = date.split("-").map(Number);
+  const [hh, mm] = time.split(":").map(Number);
+  if (!y || !m || !d || hh === undefined || mm === undefined) return null;
+  if (!Number.isFinite(hh) || !Number.isFinite(mm)) return null;
+  const dayStart = zonedDayStartUtc(y, m, d, timezone);
+  return new Date(dayStart.getTime() + (hh * 60 + mm) * 60_000).toISOString();
+}
+
+function todayDateInputValue(timezone: string): string {
+  const { year, month, day } = getZonedYMD(new Date(), timezone);
+  return `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+}
+
 function TimesheetView({ data }: { data: LoaderData }) {
   const totalHours = data.timeEntries.reduce((sum, t) => sum + t.hours, 0);
-  const addFetcher = useFetcher();
+  const addFetcher = useFetcher<{ error?: string } | null>();
   const adding = addFetcher.state !== "idle";
-  const [date, setDate] = useState(() => new Date().toISOString().slice(0, 10));
-  const [hours, setHours] = useState("");
-  const parsedHours = Number(hours);
-  const range =
-    date && hours && parsedHours > 0 ? nominalDayRange(date, parsedHours, data.timezone) : null;
+  const [date, setDate] = useState(() => todayDateInputValue(data.timezone));
+  const [startTime, setStartTime] = useState("09:00");
+  const [endTime, setEndTime] = useState("10:00");
+  const [note, setNote] = useState("");
+  const hasRoles = data.myRoles.length > 0;
+  // Preselect only when there's exactly one role — otherwise force a choice
+  // rather than defaulting to an arbitrary one.
+  const [roleKey, setRoleKey] = useState(
+    data.myRoles.length === 1 ? roleOptionKey(data.myRoles[0]!) : "",
+  );
+
+  function resetAddForm() {
+    setDate(todayDateInputValue(data.timezone));
+    setStartTime("09:00");
+    setEndTime("10:00");
+    setNote("");
+    setRoleKey(data.myRoles.length === 1 ? roleOptionKey(data.myRoles[0]!) : "");
+  }
+
+  const startIso = date && startTime ? localDayTimeToIso(date, startTime, data.timezone) : null;
+  const endIso = date && endTime ? localDayTimeToIso(date, endTime, data.timezone) : null;
+  const hours =
+    startIso && endIso
+      ? Math.round(((new Date(endIso).getTime() - new Date(startIso).getTime()) / 3_600_000) * 100) /
+        100
+      : 0;
+  // Mirror the server's rules (validateTimeEntryRange) so the button is only
+  // live for something that will actually save.
+  const rangeError =
+    !startIso || !endIso
+      ? "Enter a date, start and end time."
+      : hours <= 0
+        ? "End time must be after start time."
+        : hours > 24
+          ? "An entry can't be longer than 24 hours."
+          : !roleKey
+            ? "Pick a role to log this time against."
+            : null;
+  const canSubmit = hasRoles && !rangeError && !adding;
+  const serverError = addFetcher.data?.error ?? null;
 
   return (
     <div className="flex flex-col gap-4 w-full max-w-full min-w-0">
@@ -2562,72 +2657,117 @@ function TimesheetView({ data }: { data: LoaderData }) {
         <p className="text-xs text-muted-foreground mb-3">
           Meeting-sourced entries are added automatically when someone checks you present on a
           meeting note's attendance checklist. Every entry shows up as a block on the calendar
-          below — drag a range there for precise timing, or quick-add here. Click a block on the
-          calendar to edit or delete it.
+          below — add one here, or drag a range on the calendar. Click a block on the calendar to
+          edit or delete it.
         </p>
 
-        <addFetcher.Form
-          method="post"
-          onSubmit={(e) => {
-            const form = e.currentTarget;
-            queueMicrotask(() => {
-              form.reset();
-              setDate(new Date().toISOString().slice(0, 10));
-              setHours("");
-            });
-          }}
-          className="grid grid-cols-1 sm:grid-cols-[1fr_1fr_120px_2fr_auto] gap-2 items-end"
-        >
-          <input type="hidden" name="intent" value="add-time-entry" />
-          <input type="hidden" name="startTime" value={range?.startIso ?? ""} />
-          <input type="hidden" name="endTime" value={range?.endIso ?? ""} />
-          <label className="text-xs text-muted-foreground flex flex-col gap-1">
-            Date
-            <input
-              type="date"
-              name="date"
-              required
-              value={date}
-              onChange={(e) => setDate(e.target.value)}
-              className="px-2 py-1.5 text-sm border border-border rounded-md bg-background text-foreground"
-            />
-          </label>
-          <RoleSelectField
-            id="add-time-entry-role"
-            myRoles={data.myRoles}
-            defaultValue={data.myRoles.length === 1 ? roleOptionKey(data.myRoles[0]!) : ""}
-          />
-          <label className="text-xs text-muted-foreground flex flex-col gap-1">
-            Hours
-            <input
-              type="number"
-              name="hours"
-              min="0.25"
-              max="24"
-              step="0.25"
-              required
-              value={hours}
-              onChange={(e) => setHours(e.target.value)}
-              className="px-2 py-1.5 text-sm border border-border rounded-md bg-background text-foreground"
-            />
-          </label>
-          <label className="text-xs text-muted-foreground flex flex-col gap-1">
-            Note
-            <input
-              type="text"
-              name="note"
-              placeholder="Optional"
-              className="px-2 py-1.5 text-sm border border-border rounded-md bg-background text-foreground"
-            />
-          </label>
-          <button
-            type="submit"
-            disabled={adding || !range}
-            className="px-3 py-1.5 text-xs font-semibold rounded-md bg-accent-coral text-white hover:bg-accent-coral/90 disabled:opacity-50"
+        {!hasRoles ? (
+          <p className="text-xs text-red-600">{NO_ROLES_MESSAGE}</p>
+        ) : (
+          <addFetcher.Form
+            method="post"
+            onSubmit={(e) => {
+              if (!canSubmit) {
+                e.preventDefault();
+                return;
+              }
+              // Defer so the fetcher can read current field values first.
+              queueMicrotask(() => resetAddForm());
+            }}
+            className="grid grid-cols-1 sm:grid-cols-[1fr_110px_110px_1.4fr_1.6fr_auto] gap-2 items-end"
           >
-            Add
-          </button>
-        </addFetcher.Form>
+            <input type="hidden" name="intent" value="add-time-entry" />
+            {/* Hours is derived from the range, never typed — the server
+                re-derives and rejects any mismatch. */}
+            <input type="hidden" name="hours" value={hours > 0 ? String(hours) : ""} />
+            <input type="hidden" name="startTime" value={startIso ?? ""} />
+            <input type="hidden" name="endTime" value={endIso ?? ""} />
+            <label className="text-xs text-muted-foreground flex flex-col gap-1">
+              Date
+              <input
+                type="date"
+                name="date"
+                required
+                value={date}
+                onChange={(e) => setDate(e.target.value)}
+                className="px-2 py-1.5 text-sm border border-border rounded-md bg-background text-foreground"
+              />
+            </label>
+            <label className="text-xs text-muted-foreground flex flex-col gap-1">
+              Start
+              <input
+                type="time"
+                required
+                step="900"
+                value={startTime}
+                onChange={(e) => setStartTime(e.target.value)}
+                className="px-2 py-1.5 text-sm border border-border rounded-md bg-background text-foreground"
+              />
+            </label>
+            <label className="text-xs text-muted-foreground flex flex-col gap-1">
+              End
+              <input
+                type="time"
+                required
+                step="900"
+                value={endTime}
+                onChange={(e) => setEndTime(e.target.value)}
+                aria-invalid={!!rangeError}
+                className={`px-2 py-1.5 text-sm border rounded-md bg-background text-foreground ${
+                  rangeError ? "border-red-500" : "border-border"
+                }`}
+              />
+            </label>
+            <RoleSelectField
+              id="add-time-entry-role"
+              myRoles={data.myRoles}
+              value={roleKey}
+              onChange={setRoleKey}
+            />
+            <label className="text-xs text-muted-foreground flex flex-col gap-1">
+              Note
+              <input
+                type="text"
+                name="note"
+                value={note}
+                onChange={(e) => setNote(e.target.value)}
+                placeholder="Optional"
+                className="px-2 py-1.5 text-sm border border-border rounded-md bg-background text-foreground"
+              />
+            </label>
+            <div className="flex items-center gap-1.5">
+              <button
+                type="submit"
+                disabled={!canSubmit}
+                className="px-3 py-1.5 text-xs font-semibold rounded-md bg-accent-coral text-white hover:bg-accent-coral/90 disabled:opacity-50"
+              >
+                Add
+              </button>
+              <button
+                type="button"
+                onClick={resetAddForm}
+                className="inline-flex items-center gap-1 px-2.5 py-1.5 text-xs font-semibold rounded-md border border-border text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+              >
+                <RotateCcw className="w-3 h-3" aria-hidden />
+                Reset
+              </button>
+            </div>
+          </addFetcher.Form>
+        )}
+
+        {hasRoles && (
+          <p
+            className={`mt-2 text-xs ${rangeError ? "text-red-600" : "text-muted-foreground"}`}
+            role={rangeError ? "alert" : undefined}
+          >
+            {rangeError ?? `${hours.toFixed(2)} hrs`}
+          </p>
+        )}
+        {serverError && (
+          <p className="mt-1 text-xs text-red-600" role="alert">
+            {serverError}
+          </p>
+        )}
       </section>
 
       <TimesheetWeekGrid data={data} />
@@ -2713,43 +2853,44 @@ function TimesheetWeekGrid({ data }: { data: LoaderData }) {
     });
   };
 
-  // Context blocks from other calendars first (so timesheet entries render on
-  // top of them), then this user's TimeEntry rows — timed ones at their real
-  // time; untimed ones (e.g. attendance on a meeting with no confirmed start
-  // time yet) at a nominal 9am slot so every entry is still visible somewhere.
-  // Manual entries are clickable to edit/delete; Meeting entries open their
-  // note in a new tab.
+  // The Timesheet grid shows logged work ONLY — it's a record of paid hours,
+  // so an ordinary calendar event (a linked Google event, or a personal block
+  // not marked as work) has no place on it and is deliberately not drawn.
+  // Blocks that ARE marked as work already surface here via their synced
+  // source:"Block" TimeEntry (see syncManualBlockTimeEntry), so rendering
+  // data.manualBlocks too would double-draw them. Availability's grid still
+  // shows the full picture — that's the tab for "when am I busy".
+  //
+  // Below: this user's TimeEntry rows — timed ones at their real time; untimed
+  // ones (e.g. attendance on a meeting with no confirmed start time yet) at a
+  // nominal 9am slot so every entry is still visible somewhere. Manual entries
+  // are clickable to edit/delete; Meeting entries open their note in a new tab.
   const eventsByDay: Record<number, EventBlock[]> = {};
-  for (const e of data.externalEvents) {
-    placeBlock(
-      e.startIso,
-      e.endIso,
-      {
-        label: e.title,
-        className: e.color ? "" : EVENT_CORAL,
-        bgColor: e.color ?? undefined,
-        borderClassName: e.color ? undefined : "border-accent-coral-light",
-        location: e.location,
-        description: e.description,
-      },
-      eventsByDay,
-    );
-  }
-  for (const b of data.manualBlocks) {
-    placeBlock(
-      b.startTime,
-      b.endTime,
-      { label: b.title || "Busy", className: EVENT_CORAL, borderClassName: "border-accent-coral-light" },
-      eventsByDay,
-    );
-  }
   // One filter chip per role bucket actually present among this week's
   // entries (plus "Unassigned"), so every visible block always has a
   // matching chip — even for a role no longer in data.myRoles.
-  const roleBuckets = new Map<string, { key: string; label: string }>();
+  // The loader sends the last 200 entries, not just this week's, so resolve
+  // each entry's grid range once and keep only those landing on a visible day
+  // (dayIdx < 0 = outside this week — exactly what placeBlock drops). That
+  // keeps the chips' hours honest: they total what's actually drawn.
+  const weekEntries: { t: TimeEntryDTO; startIso: string; endIso: string }[] = [];
   for (const t of data.timeEntries) {
+    const { startIso, endIso } =
+      t.startTime && t.endTime
+        ? { startIso: t.startTime, endIso: t.endTime }
+        : nominalDayRange(t.date, t.hours, data.timezone);
+    if (toGridRange(startIso, endIso).dayIdx < 0) continue;
+    weekEntries.push({ t, startIso, endIso });
+  }
+
+  const roleBuckets = new Map<string, { key: string; label: string; hours: number }>();
+  for (const { t } of weekEntries) {
     const key = timeEntryRoleKey(t);
-    if (roleBuckets.has(key)) continue;
+    const existing = roleBuckets.get(key);
+    if (existing) {
+      existing.hours += t.hours;
+      continue;
+    }
     const known =
       t.assignmentType && t.roleRefId
         ? data.myRoles.find((r) => r.assignmentType === t.assignmentType && r.roleRefId === t.roleRefId)
@@ -2757,16 +2898,13 @@ function TimesheetWeekGrid({ data }: { data: LoaderData }) {
     roleBuckets.set(key, {
       key,
       label: known?.label ?? (key === UNASSIGNED_ROLE_KEY ? "Unassigned" : "Other role"),
+      hours: t.hours,
     });
   }
 
-  for (const t of data.timeEntries) {
+  for (const { t, startIso, endIso } of weekEntries) {
     const roleKey = timeEntryRoleKey(t);
     if (excludedRoleKeys.has(roleKey)) continue;
-    const { startIso, endIso } =
-      t.startTime && t.endTime
-        ? { startIso: t.startTime, endIso: t.endTime }
-        : nominalDayRange(t.date, t.hours, data.timezone);
     const color = roleColor(roleKey);
     placeBlock(
       startIso,
@@ -2775,9 +2913,15 @@ function TimesheetWeekGrid({ data }: { data: LoaderData }) {
         label: t.source === "Meeting" ? "Meeting" : t.note || "Time entry",
         className: color.className,
         borderClassName: color.borderClassName,
-        // Meeting/Block-sourced blocks are informational only — attendance /
-        // the linked calendar block drives them, so clicking one doesn't
-        // navigate or open anything.
+        // Only Manual entries are editable here — the server rejects edits to
+        // the others (they'd desync from their source), so instead of a dead
+        // click they explain where their hours actually come from.
+        description:
+          t.source === "Meeting"
+            ? "Logged from meeting attendance. Edit it via that meeting note's attendance checklist."
+            : t.source === "Block"
+              ? "Logged from a calendar block marked as work. Edit it in My Availability."
+              : undefined,
         onClick: t.source === "Manual" ? () => openEdit(t, startIso, endIso) : undefined,
       },
       eventsByDay,
@@ -2799,8 +2943,8 @@ function TimesheetWeekGrid({ data }: { data: LoaderData }) {
         refreshing={revalidator.state !== "idle"}
       />
       <p className="px-1 pb-2 text-[11px] text-muted-foreground">
-        Drag a range to log time, or click an entry to edit/delete it. Coral blocks are context
-        from your linked/personal calendars.
+        Drag a range to log time, or click an entry to edit/delete it. Only logged work shows
+        here — see My Availability for your full calendar.
       </p>
       <RoleFilterRow
         buckets={Array.from(roleBuckets.values())}
@@ -2851,22 +2995,22 @@ function TimesheetWeekGrid({ data }: { data: LoaderData }) {
             : undefined
         }
         onSelectionDismiss={() => setSelection(null)}
-        onSelectionResize={
-          selection?.mode === "create"
-            ? (startHour, endHour) =>
-                setSelection((prev) => {
-                  if (!prev) return prev;
-                  const day = days[prev.dayIdx];
-                  if (!day) return prev;
-                  return {
-                    ...prev,
-                    startHour,
-                    endHour,
-                    startLocal: dayHourToLocal(day.dateUtc, startHour),
-                    endLocal: dayHourToLocal(day.dateUtc, endHour),
-                  };
-                })
-            : undefined
+        // Wired for both modes: a committed entry can be dragged/resized on the
+        // grid to retime it, not just a fresh drag-selection. The popover form
+        // follows the block live (both popovers sync off startLocal/endLocal).
+        onSelectionResize={(startHour, endHour) =>
+          setSelection((prev) => {
+            if (!prev) return prev;
+            const day = days[prev.dayIdx];
+            if (!day) return prev;
+            return {
+              ...prev,
+              startHour,
+              endHour,
+              startLocal: dayHourToLocal(day.dateUtc, startHour),
+              endLocal: dayHourToLocal(day.dateUtc, endHour),
+            };
+          })
         }
       />
     </section>
@@ -2901,7 +3045,7 @@ function TimesheetDragPopover({
   const hours = startEndValid
     ? Math.round(((new Date(end).getTime() - new Date(start).getTime()) / 3_600_000) * 100) / 100
     : 0;
-  const canSubmit = startEndValid && hours > 0 && !submitting;
+  const canSubmit = startEndValid && hours > 0 && !!roleKey && !submitting;
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -2999,26 +3143,33 @@ function TimesheetDragPopover({
           <p className="text-xs text-muted-foreground">{hours.toFixed(2)} hrs</p>
         )}
 
-        {myRoles.length > 0 && (
-          <div>
-            <label htmlFor="ts-drag-role" className="block text-sm font-medium text-foreground mb-1">
-              Role
-            </label>
+        <div>
+          <label htmlFor="ts-drag-role" className="block text-sm font-medium text-foreground mb-1">
+            Role
+          </label>
+          {myRoles.length === 0 ? (
+            <p className="text-xs text-red-600">{NO_ROLES_MESSAGE}</p>
+          ) : (
             <select
               id="ts-drag-role"
+              required
               value={roleKey}
               onChange={(e) => setRoleKey(e.target.value)}
-              className="w-full px-3 py-2 text-sm border border-border rounded-md bg-background text-foreground"
+              className={`w-full px-3 py-2 text-sm border rounded-md bg-background text-foreground ${
+                roleKey ? "border-border" : "border-red-500"
+              }`}
             >
-              <option value="">Unassigned</option>
+              <option value="" disabled>
+                Select a role…
+              </option>
               {myRoles.map((r) => (
                 <option key={roleOptionKey(r)} value={roleOptionKey(r)}>
                   {r.label}
                 </option>
               ))}
             </select>
-          </div>
-        )}
+          )}
+        </div>
 
         <div>
           <label htmlFor="ts-drag-note" className="block text-sm font-medium text-foreground mb-1">
@@ -3075,6 +3226,13 @@ function TimesheetEditPopover({
   const revalidator = useRevalidator();
   const [start, setStart] = useState(startLocal);
   const [end, setEnd] = useState(endLocal);
+  // Follow the block while it's dragged/resized on the grid, so the form and
+  // the block never disagree (same as TimesheetDragPopover). Typing into the
+  // inputs still wins until the next grid drag.
+  useEffect(() => {
+    setStart(startLocal);
+    setEnd(endLocal);
+  }, [startLocal, endLocal]);
   const [roleKey, setRoleKey] = useState(
     entry.assignmentType && entry.roleRefId
       ? `${entry.assignmentType}:${entry.roleRefId}`
@@ -3090,7 +3248,7 @@ function TimesheetEditPopover({
     ? Math.round(((new Date(end).getTime() - new Date(start).getTime()) / 3_600_000) * 100) / 100
     : 0;
   const busy = submitting || deleting;
-  const canSubmit = startEndValid && hours > 0 && !busy;
+  const canSubmit = startEndValid && hours > 0 && !!roleKey && !busy;
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -3215,11 +3373,19 @@ function TimesheetEditPopover({
           </label>
           <select
             id="ts-edit-role"
+            required
             value={roleKey}
             onChange={(e) => setRoleKey(e.target.value)}
-            className="w-full px-3 py-2 text-sm border border-border rounded-md bg-background text-foreground"
+            className={`w-full px-3 py-2 text-sm border rounded-md bg-background text-foreground ${
+              roleKey ? "border-border" : "border-red-500"
+            }`}
           >
-            <option value="">Unassigned</option>
+            {/* Disabled placeholder rather than an "Unassigned" choice. A
+                legacy unattributed entry still opens here with nothing
+                selected — saving then forces a real role, which is the point. */}
+            <option value="" disabled>
+              Select a role…
+            </option>
             {roleKey &&
               !myRoles.some((r) => roleOptionKey(r) === roleKey) && (
                 <option value={roleKey}>Current role (no longer active)</option>
@@ -3230,6 +3396,7 @@ function TimesheetEditPopover({
               </option>
             ))}
           </select>
+          {!roleKey && <p className="mt-1 text-xs text-red-600">Pick a role to save this entry.</p>}
         </div>
 
         <div>
@@ -3283,6 +3450,7 @@ function CreateScheduledMeetingForm({
   users,
   calendarLinks,
   myProjects,
+  canSetSelfCheckIn,
   startLocal,
   onStartLocalChange,
   endLocal,
@@ -3297,6 +3465,7 @@ function CreateScheduledMeetingForm({
   users: UserOption[];
   calendarLinks: CalendarLinkDTO[];
   myProjects: ProjectOption[];
+  canSetSelfCheckIn: boolean;
   startLocal: string;
   onStartLocalChange: (v: string) => void;
   endLocal: string;
@@ -3313,9 +3482,10 @@ function CreateScheduledMeetingForm({
   const [organizerCalendarLinkId, setOrganizerCalendarLinkId] = useState<string>(
     googleLinks[0]?.id ?? "",
   );
-  const [meetingType, setMeetingType] = useState<"" | "Team" | "Partner" | "Other">("");
+  const [meetingType, setMeetingType] = useState<"Team" | "Partner" | "Other">("Other");
   const [meetingTypeLabel, setMeetingTypeLabel] = useState("");
   const [projectId, setProjectId] = useState("");
+  const [selfCheckIn, setSelfCheckIn] = useState(false);
   const [status, setStatus] = useState<
     | null
     | { ok: true; count: number; gcalError?: string | null; notePageId?: string | null }
@@ -3342,7 +3512,7 @@ function CreateScheduledMeetingForm({
   const startEndValid =
     !startLocal || !endLocal || new Date(endLocal).getTime() > new Date(startLocal).getTime();
   const meetingTypeValid =
-    !meetingType || (!!projectId && (meetingType !== "Other" || meetingTypeLabel.trim().length > 0));
+    meetingType !== "Other" || meetingTypeLabel.trim().length > 0;
 
   async function submit(e: React.FormEvent) {
     e.preventDefault();
@@ -3366,10 +3536,11 @@ function CreateScheduledMeetingForm({
       if (organizerCalendarLinkId) {
         payload.organizerCalendarLinkId = organizerCalendarLinkId;
       }
-      if (meetingType) {
-        payload.meetingType = meetingType;
-        payload.projectId = projectId;
-        if (meetingType === "Other") payload.meetingTypeLabel = meetingTypeLabel.trim();
+      payload.meetingType = meetingType;
+      if (meetingType === "Other") payload.meetingTypeLabel = meetingTypeLabel.trim();
+      if (projectId) payload.projectId = projectId;
+      if (canSetSelfCheckIn) {
+        payload.attendanceMode = selfCheckIn ? "SelfCheckIn" : "Roster";
       }
 
       // If exactly one group is picked and no extra people are added, record the
@@ -3406,9 +3577,10 @@ function CreateScheduledMeetingForm({
         onEndLocalChange("");
         onChangeSelectedUserIds([]);
         onChangeSelectedGroupIds([]);
-        setMeetingType("");
+        setMeetingType("Other");
         setMeetingTypeLabel("");
         setProjectId("");
+        setSelfCheckIn(false);
       }
     } catch (err) {
       setStatus({ ok: false, error: err instanceof Error ? err.message : "Network error" });
@@ -3536,7 +3708,7 @@ function CreateScheduledMeetingForm({
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
           <div>
             <label htmlFor="meeting-type" className="block text-sm font-medium text-foreground mb-1">
-              Meeting type <span className="text-muted-foreground font-normal">(optional)</span>
+              Meeting type
             </label>
             <select
               id="meeting-type"
@@ -3544,14 +3716,18 @@ function CreateScheduledMeetingForm({
               onChange={(e) => setMeetingType(e.target.value as typeof meetingType)}
               className="w-full px-3 py-2 text-sm border border-border rounded-md bg-background text-foreground"
             >
-              <option value="">No meeting note</option>
               <option value="Team">Team meeting</option>
               <option value="Partner">Partner meeting</option>
               <option value="Other">Other</option>
             </select>
             <p className="mt-1 text-xs text-muted-foreground">
-              Auto-creates a meeting note with an attendance checklist under the project's
-              shared documents.
+              Creates a meeting note with an attendance checklist
+              {canSetSelfCheckIn && selfCheckIn
+                ? " and a self check-in QR code."
+                : projectId
+                  ? " under the project's documents."
+                  : " in Lab documents."}{" "}
+              Invites go only to people and groups in Participants.
             </p>
           </div>
           {meetingType === "Other" && (
@@ -3573,28 +3749,38 @@ function CreateScheduledMeetingForm({
               />
             </div>
           )}
-          {meetingType && (
-            <div>
-              <label htmlFor="meeting-project" className="block text-sm font-medium text-foreground mb-1">
-                Project
-              </label>
-              <select
-                id="meeting-project"
-                value={projectId}
-                onChange={(e) => setProjectId(e.target.value)}
-                required
-                className="w-full px-3 py-2 text-sm border border-border rounded-md bg-background text-foreground"
-              >
-                <option value="">Select a project…</option>
-                {myProjects.map((p) => (
-                  <option key={p.id} value={p.id}>
-                    {p.name}
-                  </option>
-                ))}
-              </select>
-            </div>
-          )}
+          <div>
+            <label htmlFor="meeting-project" className="block text-sm font-medium text-foreground mb-1">
+              Project{" "}
+              <span className="text-muted-foreground font-normal">(optional)</span>
+            </label>
+            <select
+              id="meeting-project"
+              value={projectId}
+              onChange={(e) => setProjectId(e.target.value)}
+              className="w-full px-3 py-2 text-sm border border-border rounded-md bg-background text-foreground"
+            >
+              <option value="">No project</option>
+              {myProjects.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.name}
+                </option>
+              ))}
+            </select>
+          </div>
         </div>
+
+        {canSetSelfCheckIn && (
+          <label className="inline-flex items-center gap-2 text-sm text-foreground cursor-pointer">
+            <input
+              type="checkbox"
+              checked={selfCheckIn}
+              onChange={(e) => setSelfCheckIn(e.target.checked)}
+              className="h-3.5 w-3.5 rounded border-border"
+            />
+            Self check-in (QR)
+          </label>
+        )}
 
         <div className="flex items-center justify-between pt-1">
           <div className="text-sm">
@@ -4596,7 +4782,13 @@ function WeekGridEvent({ e }: { e: EventBlock }) {
         top: (e.startHour - bufferBefore - HOURS[0]) * HOUR_PX,
         height: totalHours * HOUR_PX,
       }}
-      onMouseDown={e.onClick ? (ev) => ev.stopPropagation() : undefined}
+      // Always swallow mousedown, even with no onClick. The day column starts
+      // a drag-to-create on any mousedown that reaches it, and its mouseup
+      // commits a selection even with zero movement — so without this, clicking
+      // an existing block opens a bogus "New entry" popover on top of it.
+      // Previously this was gated on `e.onClick`, which is why only the
+      // clickable (Manual) blocks were protected.
+      onMouseDown={(ev) => ev.stopPropagation()}
       onClick={e.onClick}
     >
       <div
@@ -4711,6 +4903,10 @@ function WeekGrid({
   const [resize, setResize] = useState<
     null | { edge: "start" | "end"; fixed: number }
   >(null);
+  // Dragging the committed selection's body to move it whole (duration fixed).
+  // `grabOffset` is how far into the block the pointer grabbed, so the block
+  // tracks the cursor instead of snapping its top edge under it.
+  const [move, setMove] = useState<null | { grabOffset: number; duration: number }>(null);
 
   // Column DOM refs so window-level mousemove can compute Y relative to the
   // column the drag started in, even when the cursor strays elsewhere.
@@ -4808,6 +5004,46 @@ function WeekGrid({
       window.removeEventListener("mouseup", onUp);
     };
   }, [resize, selection, onSelectionResize, MIN_HOUR, MAX_HOUR]);
+
+  // Moving the committed selection up/down as a whole. Duration is preserved:
+  // the range slides, and is clamped so neither edge leaves the visible day
+  // rather than being squashed at the boundary.
+  const startMove = (e: React.MouseEvent) => {
+    if (!selection || !onSelectionResize) return;
+    if (e.button !== 0) return;
+    e.preventDefault();
+    e.stopPropagation();
+    const col = columnRefs.current[selection.dayIdx];
+    if (!col) return;
+    const rect = col.getBoundingClientRect();
+    const pointerHour = hourFromY(e.clientY - rect.top);
+    setMove({
+      grabOffset: pointerHour - selection.startHour,
+      duration: selection.endHour - selection.startHour,
+    });
+  };
+
+  useEffect(() => {
+    if (!move || !selection || !onSelectionResize) return;
+    const col = columnRefs.current[selection.dayIdx];
+    const onMouseMove = (e: MouseEvent) => {
+      if (!col) return;
+      const rect = col.getBoundingClientRect();
+      const pointerHour = hourFromY(e.clientY - rect.top);
+      const start = Math.min(
+        Math.max(MIN_HOUR, pointerHour - move.grabOffset),
+        MAX_HOUR - move.duration,
+      );
+      onSelectionResize(start, start + move.duration);
+    };
+    const onUp = () => setMove(null);
+    window.addEventListener("mousemove", onMouseMove);
+    window.addEventListener("mouseup", onUp);
+    return () => {
+      window.removeEventListener("mousemove", onMouseMove);
+      window.removeEventListener("mouseup", onUp);
+    };
+  }, [move, selection, onSelectionResize, MIN_HOUR, MAX_HOUR]);
 
   return (
     <div className="relative">
@@ -4930,8 +5166,11 @@ function WeekGrid({
               return (
                 <div
                   ref={setAnchorEl}
+                  // Body drag moves the whole block; the edge handles below
+                  // resize it (they stopPropagation so they win over this).
+                  onMouseDown={resizable ? startMove : undefined}
                   className={`absolute left-0 right-0 border-2 border-accent-coral bg-accent-coral/15 rounded-sm z-30 ${
-                    resizable ? "" : "pointer-events-none"
+                    resizable ? (move ? "cursor-grabbing" : "cursor-grab") : "pointer-events-none"
                   }`}
                   style={{ top, height }}
                 >

--- a/dali-api/app/components/PhotoCropModal.tsx
+++ b/dali-api/app/components/PhotoCropModal.tsx
@@ -2,17 +2,27 @@ import { useCallback, useState } from "react";
 import Cropper, { type Area } from "react-easy-crop";
 import { Modal, ModalHeader } from "./Modal";
 
-const OUTPUT_SIZE = 512;
+// Short side of the output. The long side follows `aspect`, so a square avatar
+// and a wide banner come out at comparable resolution.
+const OUTPUT_SHORT_SIDE = 512;
 
-// Draw the selected square region of `imageSrc` onto a fixed-size canvas and
-// return it as a normalized image blob. `area` is in natural-image pixels, as
-// react-easy-crop reports it. WebP keeps avatars small; PNG is the fallback for
+// Draw the selected region of `imageSrc` onto a fixed-size canvas and return it
+// as a normalized image blob. `area` is in natural-image pixels, as
+// react-easy-crop reports it. WebP keeps the file small; PNG is the fallback for
 // the rare browser whose canvas can't encode WebP.
-async function getCroppedBlob(imageSrc: string, area: Area): Promise<Blob> {
+async function getCroppedBlob(
+  imageSrc: string,
+  area: Area,
+  aspect: number,
+): Promise<Blob> {
   const image = await loadImage(imageSrc);
   const canvas = document.createElement("canvas");
-  canvas.width = OUTPUT_SIZE;
-  canvas.height = OUTPUT_SIZE;
+  const width =
+    aspect >= 1 ? Math.round(OUTPUT_SHORT_SIDE * aspect) : OUTPUT_SHORT_SIDE;
+  const height =
+    aspect >= 1 ? OUTPUT_SHORT_SIDE : Math.round(OUTPUT_SHORT_SIDE / aspect);
+  canvas.width = width;
+  canvas.height = height;
   const ctx = canvas.getContext("2d");
   if (!ctx) throw new Error("Could not process image");
 
@@ -24,8 +34,8 @@ async function getCroppedBlob(imageSrc: string, area: Area): Promise<Blob> {
     area.height,
     0,
     0,
-    OUTPUT_SIZE,
-    OUTPUT_SIZE,
+    width,
+    height,
   );
 
   const blob = await canvasToBlob(canvas, "image/webp");
@@ -56,11 +66,16 @@ export function PhotoCropModal({
   imageSrc,
   onCancel,
   onConfirm,
+  aspect = 1,
+  cropShape = "round",
 }: {
   open: boolean;
   imageSrc: string | null;
   onCancel: () => void;
   onConfirm: (blob: Blob) => void;
+  /** Crop box width:height. Defaults to the square avatar crop. */
+  aspect?: number;
+  cropShape?: "round" | "rect";
 }) {
   const [crop, setCrop] = useState({ x: 0, y: 0 });
   const [zoom, setZoom] = useState(1);
@@ -77,7 +92,7 @@ export function PhotoCropModal({
     setError(null);
     setProcessing(true);
     try {
-      const blob = await getCroppedBlob(imageSrc, area);
+      const blob = await getCroppedBlob(imageSrc, area, aspect);
       onConfirm(blob);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Could not process image");
@@ -109,8 +124,8 @@ export function PhotoCropModal({
           image={imageSrc}
           crop={crop}
           zoom={zoom}
-          aspect={1}
-          cropShape="round"
+          aspect={aspect}
+          cropShape={cropShape}
           showGrid={false}
           onCropChange={setCrop}
           onZoomChange={setZoom}

--- a/dali-api/app/components/editor/shared.tsx
+++ b/dali-api/app/components/editor/shared.tsx
@@ -1,11 +1,15 @@
 import { forwardRef, type ReactNode } from "react";
 import Link from "@tiptap/extension-link";
 
+// `dark:prose-invert` is required, not cosmetic: @tailwindcss/typography's
+// `prose` sets its own body colour (--tw-prose-body, a dark grey) which wins
+// over an inherited text-foreground, so without the invert the text renders
+// dark-on-dark and is unreadable in dark mode.
 export const EDITOR_CONTENT_CLASS =
-  "prose prose-sm max-w-none focus:outline-none min-h-[6rem] px-3 py-2";
+  "prose prose-sm dark:prose-invert max-w-none focus:outline-none min-h-[6rem] px-3 py-2";
 // Viewer has no min-height/padding (RichTextViewer's read-only variant).
 export const EDITOR_VIEWER_CONTENT_CLASS =
-  "prose prose-sm max-w-none focus:outline-none";
+  "prose prose-sm dark:prose-invert max-w-none focus:outline-none";
 
 const LINK_HTML_ATTRIBUTES = {
   target: "_blank",

--- a/dali-api/app/education/components/CourseHub.tsx
+++ b/dali-api/app/education/components/CourseHub.tsx
@@ -133,7 +133,7 @@ export function CourseHub({ data, basePath }: { data: HubData; basePath: string 
           )}
           {data.offering.descriptionHtml && (
             <section
-              className="bg-card border border-border rounded-lg p-5 prose prose-sm max-w-none"
+              className="bg-card border border-border rounded-lg p-5 prose prose-sm dark:prose-invert max-w-none"
               dangerouslySetInnerHTML={{ __html: data.offering.descriptionHtml }}
             />
           )}

--- a/dali-api/app/education/routes/education.$offeringId.tsx
+++ b/dali-api/app/education/routes/education.$offeringId.tsx
@@ -183,7 +183,7 @@ export default function OfferingDetail() {
 
       {descriptionHtml && (
         <section
-          className="bg-card border border-border rounded-lg p-5 prose prose-sm max-w-none"
+          className="bg-card border border-border rounded-lg p-5 prose prose-sm dark:prose-invert max-w-none"
           dangerouslySetInnerHTML={{ __html: descriptionHtml }}
         />
       )}

--- a/dali-api/app/hiring/routes/lead.cycle.$id.tsx
+++ b/dali-api/app/hiring/routes/lead.cycle.$id.tsx
@@ -3357,7 +3357,7 @@ function DecisionEmailPreviewModal({ decision, binding, onClose }: {
               <div>
                 <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">Body</h3>
                 <div
-                  className="mt-1 prose prose-sm max-w-none text-foreground"
+                  className="mt-1 prose prose-sm dark:prose-invert max-w-none text-foreground"
                   // eslint-disable-next-line react/no-danger
                   dangerouslySetInnerHTML={{ __html: rendered?.html ?? '' }}
                 />

--- a/dali-api/app/hiring/routes/lead.intern-to-full-cycle.$id.tsx
+++ b/dali-api/app/hiring/routes/lead.intern-to-full-cycle.$id.tsx
@@ -1684,7 +1684,7 @@ function DecisionEmailPreviewModal({
               <div>
                 <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">Body</h3>
                 <div
-                  className="mt-1 prose prose-sm max-w-none text-foreground"
+                  className="mt-1 prose prose-sm dark:prose-invert max-w-none text-foreground"
                   dangerouslySetInnerHTML={{ __html: rendered?.html ?? "" }}
                 />
               </div>

--- a/dali-api/app/lib/__tests__/calendar-schemas.test.ts
+++ b/dali-api/app/lib/__tests__/calendar-schemas.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from "vitest";
+import {
+  AddTimeEntrySchema,
+  UpdateTimeEntrySchema,
+  validateTimeEntryRange,
+} from "~/lib/calendar-schemas";
+
+const START = "2026-05-12T13:00:00.000Z";
+const END = "2026-05-12T14:30:00.000Z"; // 1.5h after START
+
+describe("validateTimeEntryRange", () => {
+  it("accepts a range whose hours match the start/end span", () => {
+    expect(validateTimeEntryRange({ startTime: START, endTime: END, hours: 1.5 })).toBeNull();
+  });
+
+  it("rejects an end at or before the start", () => {
+    expect(validateTimeEntryRange({ startTime: END, endTime: START, hours: 1.5 })).toBe(
+      "End time must be after start time",
+    );
+    expect(validateTimeEntryRange({ startTime: START, endTime: START, hours: 0.5 })).toBe(
+      "End time must be after start time",
+    );
+  });
+
+  it("rejects hours that disagree with the range — a hand-rolled POST can't inflate time", () => {
+    expect(validateTimeEntryRange({ startTime: START, endTime: END, hours: 8 })).toBe(
+      "Hours must match the start/end range",
+    );
+  });
+
+  it("tolerates sub-minute rounding drift between derived and submitted hours", () => {
+    // 1.5h span submitted as 1.51 — within HOURS_TOLERANCE.
+    expect(validateTimeEntryRange({ startTime: START, endTime: END, hours: 1.51 })).toBeNull();
+  });
+
+  it("rejects a span longer than 24 hours", () => {
+    expect(
+      validateTimeEntryRange({
+        startTime: START,
+        endTime: "2026-05-14T13:00:00.000Z",
+        hours: 48,
+      }),
+    ).toBe("An entry can't be longer than 24 hours");
+  });
+
+  it("rejects unparseable timestamps", () => {
+    expect(validateTimeEntryRange({ startTime: "nonsense", endTime: END, hours: 1 })).toBe(
+      "Invalid start or end time",
+    );
+  });
+
+  it("skips the range checks when either side is absent (update patches)", () => {
+    expect(validateTimeEntryRange({ startTime: START, endTime: null, hours: 1.5 })).toBeNull();
+    expect(validateTimeEntryRange({ hours: 1.5 })).toBeNull();
+  });
+
+  it("validates the range even when hours aren't supplied", () => {
+    expect(validateTimeEntryRange({ startTime: END, endTime: START })).toBe(
+      "End time must be after start time",
+    );
+  });
+});
+
+describe("AddTimeEntrySchema", () => {
+  const valid = {
+    intent: "add-time-entry" as const,
+    date: "2026-05-12T00:00:00.000Z",
+    hours: 1.5,
+    assignmentType: "Project" as const,
+    roleRefId: "assignment-1",
+    startTime: START,
+    endTime: END,
+  };
+
+  it("accepts a fully attributed, time-ranged entry", () => {
+    expect(AddTimeEntrySchema.safeParse(valid).success).toBe(true);
+  });
+
+  // The "unassigned" bucket is legacy-read-only: nothing may create one.
+  it("rejects an entry with no role", () => {
+    const { assignmentType: _a, roleRefId: _r, ...noRole } = valid;
+    expect(AddTimeEntrySchema.safeParse(noRole).success).toBe(false);
+    expect(AddTimeEntrySchema.safeParse({ ...valid, assignmentType: null }).success).toBe(false);
+    expect(AddTimeEntrySchema.safeParse({ ...valid, roleRefId: null }).success).toBe(false);
+    expect(AddTimeEntrySchema.safeParse({ ...valid, roleRefId: "" }).success).toBe(false);
+  });
+
+  it("rejects an entry with no start/end time", () => {
+    const { startTime: _s, endTime: _e, ...noRange } = valid;
+    expect(AddTimeEntrySchema.safeParse(noRange).success).toBe(false);
+    expect(AddTimeEntrySchema.safeParse({ ...valid, startTime: null }).success).toBe(false);
+  });
+});
+
+describe("UpdateTimeEntrySchema", () => {
+  it("allows a partial patch that omits role and range", () => {
+    const res = UpdateTimeEntrySchema.safeParse({
+      intent: "update-time-entry",
+      id: "te-1",
+      note: "just a note change",
+    });
+    expect(res.success).toBe(true);
+  });
+
+  it("rejects clearing a role back to unassigned", () => {
+    expect(
+      UpdateTimeEntrySchema.safeParse({
+        intent: "update-time-entry",
+        id: "te-1",
+        assignmentType: null,
+        roleRefId: null,
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/dali-api/app/lib/__tests__/photo.test.ts
+++ b/dali-api/app/lib/__tests__/photo.test.ts
@@ -2,15 +2,17 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 
 vi.mock("~/lib/s3", () => ({
   getDownloadUrl: vi.fn(),
+  isS3Configured: vi.fn(),
 }));
 
-import { getDownloadUrl } from "~/lib/s3";
+import { getDownloadUrl, isS3Configured } from "~/lib/s3";
 import { resolvePhotoUrl } from "~/lib/photo";
 
 describe("resolvePhotoUrl", () => {
   beforeEach(() => {
     vi.mocked(getDownloadUrl).mockReset();
     vi.mocked(getDownloadUrl).mockResolvedValue("https://s3.example/signed");
+    vi.mocked(isS3Configured).mockReturnValue(true);
   });
 
   it("returns null for null/undefined/empty", async () => {
@@ -33,5 +35,11 @@ describe("resolvePhotoUrl", () => {
     const key = "uploads/avatars/user-1/abc.webp";
     expect(await resolvePhotoUrl(key)).toBe("https://s3.example/signed");
     expect(getDownloadUrl).toHaveBeenCalledWith(key);
+  });
+
+  it("omits S3-backed images when S3 is not configured", async () => {
+    vi.mocked(isS3Configured).mockReturnValue(false);
+    expect(await resolvePhotoUrl("uploads/projects/project-1/image.webp")).toBeNull();
+    expect(getDownloadUrl).not.toHaveBeenCalled();
   });
 });

--- a/dali-api/app/lib/calendar-schemas.ts
+++ b/dali-api/app/lib/calendar-schemas.ts
@@ -131,14 +131,15 @@ export const AddTimeEntrySchema = z.object({
   date: isoString,
   hours: z.number().positive().max(24),
   // Which concrete paid role this entry is attributed to (see assignmentType
-  // above). Both null = unattributed ("unassigned" bucket on export).
-  assignmentType: assignmentType.nullish(),
-  roleRefId: z.string().min(1).nullish(),
+  // above). Required: every logged hour bills to a real role, so there's no
+  // "unassigned" path in (legacy rows predating this may still be null).
+  assignmentType,
+  roleRefId: z.string().min(1),
   note: z.string().max(500).nullish(),
-  // Set when the entry was created by dragging on the Timesheet week grid;
-  // null for the plain date+hours form (no time-of-day picked).
-  startTime: isoString.nullish(),
-  endTime: isoString.nullish(),
+  // Required: manual entries always carry a real time-of-day range now,
+  // whether dragged on the grid or typed into the add form.
+  startTime: isoString,
+  endTime: isoString,
 });
 
 export const UpdateTimeEntrySchema = z.object({
@@ -146,12 +147,40 @@ export const UpdateTimeEntrySchema = z.object({
   id: z.string().min(1),
   date: isoString.optional(),
   hours: z.number().positive().max(24).optional(),
-  assignmentType: assignmentType.nullish(),
-  roleRefId: z.string().min(1).nullish(),
+  assignmentType: assignmentType.optional(),
+  roleRefId: z.string().min(1).optional(),
   note: z.string().max(500).nullish(),
-  startTime: isoString.nullish(),
-  endTime: isoString.nullish(),
+  startTime: isoString.optional(),
+  endTime: isoString.optional(),
 });
+
+// Cross-field rules for a manual TimeEntry's time range. Kept out of the
+// schemas themselves because CalendarActionSchema is a discriminatedUnion,
+// which needs plain ZodObjects to narrow on `intent`. Callers run this after
+// parsing and surface the message verbatim.
+//
+// `hours` is always derived from start/end on the client, but it's re-checked
+// rather than trusted: a hand-rolled POST could otherwise log 8h against a
+// 30-minute window.
+const HOURS_TOLERANCE = 0.02; // ~1 minute of float/rounding slack
+
+export function validateTimeEntryRange(v: {
+  startTime?: string | null;
+  endTime?: string | null;
+  hours?: number | null;
+}): string | null {
+  if (!v.startTime || !v.endTime) return null;
+  const start = new Date(v.startTime).getTime();
+  const end = new Date(v.endTime).getTime();
+  if (!Number.isFinite(start) || !Number.isFinite(end)) return "Invalid start or end time";
+  if (end <= start) return "End time must be after start time";
+  const derived = (end - start) / 3_600_000;
+  if (derived > 24) return "An entry can't be longer than 24 hours";
+  if (typeof v.hours === "number" && Math.abs(derived - v.hours) > HOURS_TOLERANCE) {
+    return "Hours must match the start/end range";
+  }
+  return null;
+}
 
 export const DeleteTimeEntrySchema = z.object({
   intent: z.literal("delete-time-entry"),

--- a/dali-api/app/lib/photo.ts
+++ b/dali-api/app/lib/photo.ts
@@ -1,4 +1,4 @@
-import { getDownloadUrl } from "./s3";
+import { getDownloadUrl, isS3Configured } from "./s3";
 
 // A stored User.photoUrl is one of:
 //   - an S3 object key under `uploads/` (avatars uploaded through this app), or
@@ -11,6 +11,12 @@ export async function resolvePhotoUrl(
   value: string | null | undefined,
 ): Promise<string | null> {
   if (!value) return null;
-  if (value.startsWith("uploads/")) return getDownloadUrl(value);
+  // Local development can legitimately run without S3. Stored upload keys
+  // then have no usable browser URL, so omit the image rather than failing
+  // the entire route loader while trying to presign it.
+  if (value.startsWith("uploads/")) {
+    if (!isS3Configured()) return null;
+    return getDownloadUrl(value);
+  }
   return value;
 }

--- a/dali-api/app/lib/s3.ts
+++ b/dali-api/app/lib/s3.ts
@@ -6,6 +6,15 @@ import { MAX_UPLOAD_BYTES } from './file-validation'
 const REGION = process.env.AWS_REGION
 const BUCKET = process.env.AWS_S3_BUCKET
 
+export function isS3Configured(): boolean {
+  return Boolean(
+    REGION &&
+      BUCKET &&
+      process.env.AWS_ACCESS_KEY_ID &&
+      process.env.AWS_SECRET_ACCESS_KEY,
+  )
+}
+
 // `responseChecksumValidation: "WHEN_REQUIRED"` opts out of the SDK's default
 // behavior of adding `x-amz-checksum-mode=ENABLED` to presigned GetObject URLs.
 // That extra query param breaks SigV4 (signed headers don't account for it),
@@ -45,6 +54,9 @@ export async function getUploadPost(
 
 // Generate a presigned URL for reading a private file.
 export async function getDownloadUrl(key: string, expiresIn = 3600) {
+  if (!isS3Configured()) {
+    throw new Error("AWS S3 is not configured")
+  }
   const command = new GetObjectCommand({ Bucket: BUCKET, Key: key })
   return getSignedUrl(s3, command, { expiresIn })
 }

--- a/dali-api/app/lib/scheduled-meeting.ts
+++ b/dali-api/app/lib/scheduled-meeting.ts
@@ -156,14 +156,14 @@ export async function createScheduledMeeting(
     }
   }
 
-  // MeetingAttendance fan-out only needs a meetingType — a project-less
-  // all-lab event (e.g. attendanceMode: SelfCheckIn on a scopeType: Group
-  // meeting) still gets attendance rows for every participant + organizer.
-  // Note-page creation branches on whether there's a project: project-scoped
-  // meetings get a Page under the project's shared documents (optionally
-  // nested in the Team/Partner meeting-notes folder); project-less meetings
-  // get a Lab-workspace page instead, so there's still somewhere to host the
-  // QR code / AttendanceChecklist.
+  // MeetingAttendance fan-out follows the meeting's participant scope only
+  // (plus the organizer) — never the whole lab. A project-less meeting still
+  // only invites whoever was listed; pick a Term group in Participants if you
+  // actually want every current-term member. Note-page creation branches on
+  // whether there's a project: project-scoped meetings get a Page under the
+  // project's shared documents (optionally nested in the Team/Partner
+  // meeting-notes folder); project-less meetings get a Lab-workspace page
+  // instead, so there's still somewhere to host the QR / AttendanceChecklist.
   let notePageId: string | null = null;
   if (input.meetingType) {
     const label =

--- a/dali-api/app/members/components/MemberProfileView.tsx
+++ b/dali-api/app/members/components/MemberProfileView.tsx
@@ -102,9 +102,11 @@ export function MemberProfileView({
 
   // Flat, card-stacked layout (no left nav, no collapsible chrome) — matches
   // the partner org detail page: an unboxed identity header up top, then each
-  // section as its own bordered card. Account is the exception — it stays
-  // embedded (no border) so it reads as a continuation of the identity
-  // header above it, same as AccountSettingsBlock does on /settings.
+  // section as its own bordered card. Name/pronouns edit inside Personal's
+  // own form (see PersonalSection's showIdentitySummary) rather than a
+  // separate Account card, so there's a single Edit control on this page —
+  // unlike /settings, which has no Personal section and so still renders
+  // AccountSettingsBlock (name/pronouns + major/class year) on its own.
   const page = (
     <div className="max-w-4xl w-full flex flex-col gap-6">
       <PresenceBar className="self-end" />
@@ -142,14 +144,6 @@ export function MemberProfileView({
           )}
         </div>
       </div>
-
-      <AccountSettingsSection
-        member={member}
-        roleLabels={roleLabels}
-        canEdit={canEdit}
-        embedded
-        showIdentitySummary={false}
-      />
 
       <PersonalSection
         member={member}
@@ -381,6 +375,23 @@ function PersonalSection({
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
               {showIdentitySummary && (
                 <>
+                  <FieldInput
+                    name="firstName"
+                    label="First name"
+                    defaultValue={member.firstName}
+                    required
+                  />
+                  <FieldInput
+                    name="lastName"
+                    label="Last name"
+                    defaultValue={member.lastName}
+                    required
+                  />
+                  <FieldInput
+                    name="pronouns"
+                    label="Pronouns"
+                    defaultValue={member.pronouns ?? ""}
+                  />
                   <FieldInput
                     name="major"
                     label="Major"
@@ -1032,10 +1043,12 @@ const PERSONAL_FIELDS = new Set<keyof ProfileMember>([
   "dietaryRestrictions",
 ]);
 
-// Personal's fields when it also hosts major/class year (the member/profile
-// view, where Account only edits name + pronouns).
+// Personal's fields when it also hosts name/pronouns + major/class year (the
+// member/profile view, which has no separate Account card — see
+// MemberProfileView's page layout comment).
 const PERSONAL_FIELDS_WITH_IDENTITY = new Set<keyof ProfileMember>([
   ...PERSONAL_FIELDS,
+  ...ACCOUNT_FIELDS_BASE,
   "major",
   "classYear",
 ]);

--- a/dali-api/app/partners/components/PartnerProjectHubView.tsx
+++ b/dali-api/app/partners/components/PartnerProjectHubView.tsx
@@ -1,9 +1,102 @@
 import { Link } from "react-router";
 import { termCodeLabel } from "~/lib/display";
-import type { PartnerProjectViewData } from "~/partners/lib/partner-project-view.server";
+import type {
+  PartnerProjectEpic,
+  PartnerProjectSprint,
+  PartnerProjectViewData,
+} from "~/partners/lib/partner-project-view.server";
 
 const fmtDate = (iso: string) =>
   new Date(iso).toLocaleDateString(undefined, { month: "short", day: "numeric" });
+
+const EPIC_STATUS_LABEL: Record<PartnerProjectEpic["status"], string> = {
+  Backlog: "Backlog",
+  Open: "Open",
+  InProgress: "In progress",
+  Done: "Done",
+  Cancelled: "Cancelled",
+};
+
+function SprintProgressCard({
+  s,
+  nested = false,
+}: {
+  s: PartnerProjectSprint;
+  nested?: boolean;
+}) {
+  const total = s.done + s.open;
+  const pct = total > 0 ? Math.round((s.done / total) * 100) : 0;
+  return (
+    <div
+      className={
+        nested ? "bg-muted/30 border border-border rounded-xl p-4" : undefined
+      }
+    >
+      <div className="flex items-center justify-between gap-3">
+        <span className="font-heading font-semibold text-dark-blue text-sm">
+          {s.name}
+        </span>
+        <span
+          className={`text-xs rounded-full px-2 py-0.5 ${
+            s.status === "Active"
+              ? "bg-accent-teal/15 text-accent-teal"
+              : "bg-muted text-muted-foreground"
+          }`}
+        >
+          {s.status === "Active" ? "In progress" : "Wrapped up"}
+        </span>
+      </div>
+      <p className="text-xs text-muted-foreground mt-1">
+        {fmtDate(s.startsAt)} – {fmtDate(s.endsAt)}
+      </p>
+      <div className="mt-3">
+        <div className="flex items-center justify-between text-xs text-muted-foreground mb-1">
+          <span>
+            {s.done} of {total} tasks done
+          </span>
+          <span>{pct}%</span>
+        </div>
+        <div className="h-2 rounded-full bg-muted overflow-hidden">
+          <div
+            className="h-full bg-accent-teal rounded-full"
+            style={{ width: `${pct}%` }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function EpicCard({ epic }: { epic: PartnerProjectEpic }) {
+  return (
+    <div className="bg-card border border-border rounded-2xl p-5 flex flex-col gap-4">
+      <div>
+        <div className="flex items-center justify-between gap-3">
+          <h3 className="font-heading font-semibold text-dark-blue text-base">
+            {epic.title}
+          </h3>
+          <span className="text-xs rounded-full px-2 py-0.5 bg-accent-coral/10 text-accent-coral flex-shrink-0">
+            {EPIC_STATUS_LABEL[epic.status]}
+          </span>
+        </div>
+        {epic.startsAt && epic.endsAt && (
+          <p className="text-xs text-muted-foreground mt-1">
+            {fmtDate(epic.startsAt)} – {fmtDate(epic.endsAt)}
+          </p>
+        )}
+      </div>
+      {epic.sprints.length > 0 && (
+        <div className="flex flex-col gap-3 pl-1 border-l-2 border-accent-coral/30 ml-0.5">
+          {epic.sprints.map((s) => (
+            <div key={s.id} className="pl-3">
+              <SprintProgressCard s={s} nested />
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
 
 // Renders the partner-facing read surface for a project. Shared by the real
 // partner portal (partner.projects.$id.tsx) and the in-app preview any
@@ -27,11 +120,14 @@ export function PartnerProjectHubView({
     partnerSince,
     currentTermCode,
     team,
-    sprints,
+    epics,
+    ungroupedSprints,
     nextSprint,
     recentlyDone,
     sharedPages,
   } = data;
+
+  const hasCurrentWork = epics.length > 0 || ungroupedSprints.length > 0;
 
   return (
     <div className="flex flex-col gap-8">
@@ -70,12 +166,12 @@ export function PartnerProjectHubView({
         </div>
       </div>
 
-      {/* What's going on right now */}
+      {/* What's going on right now — epics first, sprints nested under each */}
       <section>
         <h2 className="font-heading text-lg font-semibold text-dark-blue mb-3">
           Current work
         </h2>
-        {sprints.length === 0 ? (
+        {!hasCurrentWork ? (
           <div className="bg-card border border-border rounded-2xl p-6 text-sm text-muted-foreground">
             No sprint in flight right now.
             {nextSprint && (
@@ -85,46 +181,19 @@ export function PartnerProjectHubView({
             )}
           </div>
         ) : (
-          <div className="grid gap-4 sm:grid-cols-2">
-            {sprints.map((s) => {
-              const total = s.done + s.open;
-              const pct = total > 0 ? Math.round((s.done / total) * 100) : 0;
-              return (
-                <div key={s.id} className="bg-card border border-border rounded-2xl p-5">
-                  <div className="flex items-center justify-between gap-3">
-                    <span className="font-heading font-semibold text-dark-blue">
-                      {s.name}
-                    </span>
-                    <span
-                      className={`text-xs rounded-full px-2 py-0.5 ${
-                        s.status === "Active"
-                          ? "bg-accent-teal/15 text-accent-teal"
-                          : "bg-muted text-muted-foreground"
-                      }`}
-                    >
-                      {s.status === "Active" ? "In progress" : "Wrapped up"}
-                    </span>
+          <div className="flex flex-col gap-4">
+            {epics.map((epic) => (
+              <EpicCard key={epic.id} epic={epic} />
+            ))}
+            {ungroupedSprints.length > 0 && (
+              <div className="grid gap-4 sm:grid-cols-2">
+                {ungroupedSprints.map((s) => (
+                  <div key={s.id} className="bg-card border border-border rounded-2xl p-5">
+                    <SprintProgressCard s={s} />
                   </div>
-                  <p className="text-xs text-muted-foreground mt-1">
-                    {fmtDate(s.startsAt)} – {fmtDate(s.endsAt)}
-                  </p>
-                  <div className="mt-4">
-                    <div className="flex items-center justify-between text-xs text-muted-foreground mb-1">
-                      <span>
-                        {s.done} of {total} tasks done
-                      </span>
-                      <span>{pct}%</span>
-                    </div>
-                    <div className="h-2 rounded-full bg-muted overflow-hidden">
-                      <div
-                        className="h-full bg-accent-teal rounded-full"
-                        style={{ width: `${pct}%` }}
-                      />
-                    </div>
-                  </div>
-                </div>
-              );
-            })}
+                ))}
+              </div>
+            )}
             {nextSprint && (
               <div className="bg-card border border-dashed border-border rounded-2xl p-5 text-sm text-muted-foreground">
                 <span className="font-medium text-foreground">Next up:</span>{" "}

--- a/dali-api/app/partners/lib/partner-project-view.server.ts
+++ b/dali-api/app/partners/lib/partner-project-view.server.ts
@@ -13,6 +13,15 @@ export type PartnerProjectSprint = {
   open: number;
 };
 
+export type PartnerProjectEpic = {
+  id: string;
+  title: string;
+  status: "Backlog" | "Open" | "InProgress" | "Done" | "Cancelled";
+  startsAt: string | null;
+  endsAt: string | null;
+  sprints: PartnerProjectSprint[];
+};
+
 export type PartnerProjectViewData = {
   project: {
     id: string;
@@ -24,7 +33,10 @@ export type PartnerProjectViewData = {
   partnerSince: string | null;
   currentTermCode: string | null;
   team: { name: string; domains: string[] }[];
-  sprints: PartnerProjectSprint[];
+  // Current-work hierarchy: epic cards first, with their in-flight sprints
+  // nested under each. Sprints with no epic sit in ungroupedSprints.
+  epics: PartnerProjectEpic[];
+  ungroupedSprints: PartnerProjectSprint[];
   nextSprint: { name: string; startsAt: string; endsAt: string } | null;
   recentlyDone: {
     id: string;
@@ -40,7 +52,7 @@ export type PartnerProjectViewData = {
   }[];
 };
 
-// The whole partner read-surface for a project: current sprints, roster,
+// The whole partner read-surface for a project: current epics/sprints, roster,
 // recently-closed tasks, and partner-shared docs. Shared by the real partner
 // portal (partner.projects.$id.tsx, scoped to the signed-in partner's org)
 // and the in-app preview any signed-in member can open from the project page
@@ -97,7 +109,23 @@ export async function loadPartnerProjectView(
     prisma.sprint.findMany({
       where: { projectId: project.id, status: "Active" },
       orderBy: { startsAt: "asc" },
-      select: { id: true, name: true, startsAt: true, endsAt: true },
+      select: {
+        id: true,
+        name: true,
+        startsAt: true,
+        endsAt: true,
+        epicId: true,
+        epic: {
+          select: {
+            id: true,
+            title: true,
+            status: true,
+            startsAt: true,
+            endsAt: true,
+            position: true,
+          },
+        },
+      },
     }),
     prisma.sprint.findFirst({
       where: { projectId: project.id, status: "Planned" },
@@ -107,7 +135,23 @@ export async function loadPartnerProjectView(
     prisma.sprint.findFirst({
       where: { projectId: project.id, status: "Closed" },
       orderBy: { endsAt: "desc" },
-      select: { id: true, name: true, startsAt: true, endsAt: true },
+      select: {
+        id: true,
+        name: true,
+        startsAt: true,
+        endsAt: true,
+        epicId: true,
+        epic: {
+          select: {
+            id: true,
+            title: true,
+            status: true,
+            startsAt: true,
+            endsAt: true,
+            position: true,
+          },
+        },
+      },
     }),
     prisma.task.findMany({
       where: { projectId: project.id, status: "Done" },
@@ -150,7 +194,9 @@ export async function loadPartnerProjectView(
       })
     : [];
 
-  const sprints: PartnerProjectSprint[] = summarySprints.map((s) => {
+  function toSprintCard(
+    s: (typeof summarySprints)[number],
+  ): PartnerProjectSprint {
     const mine = counts.filter((c) => c.sprintId === s.id);
     const total = mine.reduce((sum, c) => sum + c._count._all, 0);
     const done = mine
@@ -168,7 +214,39 @@ export async function loadPartnerProjectView(
       done,
       open: Math.max(0, total - cancelled - done),
     };
-  });
+  }
+
+  // Group under epics (ordered by epic.position). Sprints with no epic stay
+  // in ungroupedSprints so they still surface on the partner view.
+  const epicMap = new Map<
+    string,
+    PartnerProjectEpic & { position: number }
+  >();
+  const ungroupedSprints: PartnerProjectSprint[] = [];
+  for (const s of summarySprints) {
+    const card = toSprintCard(s);
+    if (!s.epic) {
+      ungroupedSprints.push(card);
+      continue;
+    }
+    const existing = epicMap.get(s.epic.id);
+    if (existing) {
+      existing.sprints.push(card);
+    } else {
+      epicMap.set(s.epic.id, {
+        id: s.epic.id,
+        title: s.epic.title,
+        status: s.epic.status,
+        startsAt: s.epic.startsAt?.toISOString() ?? null,
+        endsAt: s.epic.endsAt?.toISOString() ?? null,
+        sprints: [card],
+        position: s.epic.position,
+      });
+    }
+  }
+  const epics: PartnerProjectEpic[] = [...epicMap.values()]
+    .sort((a, b) => a.position - b.position || a.title.localeCompare(b.title))
+    .map(({ position: _position, ...epic }) => epic);
 
   // Dedupe the roster: one row per person, domains joined.
   const roster = new Map<string, { name: string; domains: Set<string> }>();
@@ -197,7 +275,8 @@ export async function loadPartnerProjectView(
       name: r.name,
       domains: [...r.domains].sort(),
     })),
-    sprints,
+    epics,
+    ungroupedSprints,
     nextSprint: plannedSprint
       ? {
           name: plannedSprint.name,

--- a/dali-api/app/projects/components/EpicSprintManager.tsx
+++ b/dali-api/app/projects/components/EpicSprintManager.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState, type CSSProperties, type ReactNode } from "react";
 import { useRevalidator } from "react-router";
-import { X, GripVertical } from "lucide-react";
+import { X, GripVertical, Check, Trash2 } from "lucide-react";
 import {
   DndContext,
   PointerSensor,
@@ -73,17 +73,24 @@ function dateInputValue(iso: string): string {
   return new Date(iso).toISOString().slice(0, 10);
 }
 
-async function api(url: string, method: "POST" | "DELETE", body?: unknown): Promise<void> {
+// Same request/error handling as `api`, but hands back the parsed response.
+// Used by epic creation, which needs the new id to open its detail modal.
+async function apiJson<T>(url: string, method: "POST" | "DELETE", body?: unknown): Promise<T> {
   const res = await fetch(url, {
     method,
     credentials: "include",
     headers: body ? { "Content-Type": "application/json" } : undefined,
     body: body ? JSON.stringify(body) : undefined,
   });
+  const json = (await res.json().catch(() => null)) as (T & { error?: string }) | null;
   if (!res.ok) {
-    const b = (await res.json().catch(() => ({}))) as { error?: string };
-    throw new Error(b.error ?? `Request failed: ${res.status}`);
+    throw new Error(json?.error ?? `Request failed: ${res.status}`);
   }
+  return json as T;
+}
+
+async function api(url: string, method: "POST" | "DELETE", body?: unknown): Promise<void> {
+  await apiJson<unknown>(url, method, body);
 }
 
 export function EpicSprintManager({
@@ -116,6 +123,8 @@ export function EpicSprintManager({
   // When set, the detail panel opens with this sprint's edit form expanded
   // (entered by clicking a nested sprint row in the epic list).
   const [openSprintId, setOpenSprintId] = useState<string | null>(null);
+  // Opens the epic detail already scrolled to the Sprints section (e.g. "Add one").
+  const [openAddSprint, setOpenAddSprint] = useState(false);
   // Which epics are expanded to show their nested sprints in the list.
   const [expandedEpicIds, setExpandedEpicIds] = useState<Set<string>>(new Set());
 
@@ -128,9 +137,13 @@ export function EpicSprintManager({
     });
   }
 
-  function openEpic(epicId: string, opts?: { edit?: boolean; sprintId?: string }) {
+  function openEpic(
+    epicId: string,
+    opts?: { edit?: boolean; sprintId?: string; addSprint?: boolean },
+  ) {
     setOpenInEdit(opts?.edit ?? true);
     setOpenSprintId(opts?.sprintId ?? null);
+    setOpenAddSprint(opts?.addSprint ?? false);
     setOpenEpicId(epicId);
   }
 
@@ -138,6 +151,7 @@ export function EpicSprintManager({
     setOpenEpicId(null);
     setOpenInEdit(false);
     setOpenSprintId(null);
+    setOpenAddSprint(false);
   }
 
   function run(fn: () => Promise<void>) {
@@ -202,6 +216,54 @@ export function EpicSprintManager({
     <div className="flex flex-col gap-4">
       {errorBanner}
 
+      {/* New epic — a modal like the detail view, not inline inputs in the
+          list. On save we immediately reopen as the real detail modal for the
+          created epic (see onSubmit), so sprints/stories can be added right
+          away without hunting for the new row. */}
+      <Modal
+        open={newEpicOpen}
+        onClose={() => setNewEpicOpen(false)}
+        labelledBy="new-epic-title"
+        disableEscape={busy}
+        containerClassName="bg-card rounded-2xl shadow-xl max-w-2xl w-full p-5 sm:p-6 my-auto"
+      >
+        <div className="flex items-center justify-between gap-2 mb-4">
+          <h2 id="new-epic-title" className="font-heading text-lg font-semibold text-foreground">
+            New epic
+          </h2>
+          <button
+            type="button"
+            onClick={() => setNewEpicOpen(false)}
+            aria-label="Close"
+            className="p-1 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+        <p className="text-xs text-muted-foreground mb-3">
+          Name it and save — you can add sprints, stories and a description next.
+        </p>
+        <EpicForm
+          busy={busy}
+          onCancel={() => setNewEpicOpen(false)}
+          onSubmit={(values) =>
+            run(async () => {
+              const created = await apiJson<{ id: string }>(
+                `/api/projects/${projectId}/epics`,
+                "POST",
+                values,
+              );
+              setNewEpicOpen(false);
+              // Hand straight off to the detail modal, scrolled to Sprints —
+              // this is what makes "add sprints while creating the first epic"
+              // a single flow. `openEpic` only sets the id; the modal renders
+              // once the revalidate in `run` lands the new row in `epics`.
+              openEpic(created.id, { edit: false, addSprint: true });
+            })
+          }
+        />
+      </Modal>
+
       <Modal
         open={activeEpic != null}
         onClose={closeEpic}
@@ -218,6 +280,7 @@ export function EpicSprintManager({
             busy={busy}
             startInEdit={openInEdit}
             startEditSprintId={openSprintId}
+            startAddSprint={openAddSprint}
             run={run}
             api={api}
             collabToken={collabToken}
@@ -283,19 +346,6 @@ export function EpicSprintManager({
 
         {epicsOpen && (
           <>
-        {newEpicOpen && (
-          <EpicForm
-            busy={busy}
-            onCancel={() => setNewEpicOpen(false)}
-            onSubmit={(values) =>
-              run(async () => {
-                await api(`/api/projects/${projectId}/epics`, "POST", values);
-                setNewEpicOpen(false);
-              })
-            }
-          />
-        )}
-
         {visibleEpics.length === 0 && !newEpicOpen ? (
           <p className="text-sm text-muted-foreground italic">
             {filtering ? `No epics with status "${statusFilter}".` : "No epics yet."}
@@ -405,7 +455,9 @@ export function EpicSprintManager({
                           {canManage && (
                             <button
                               type="button"
-                              onClick={() => openEpic(epic.id)}
+                              onClick={() =>
+                                openEpic(epic.id, { edit: false, addSprint: true })
+                              }
                               className="text-accent-coral hover:underline"
                             >
                               Add one
@@ -511,6 +563,7 @@ function EpicDetail({
   busy,
   startInEdit,
   startEditSprintId,
+  startAddSprint,
   run,
   api,
   collabToken,
@@ -529,6 +582,8 @@ function EpicDetail({
   // When set, opens with this sprint's edit form already expanded (entered by
   // clicking a nested sprint row in the epic list).
   startEditSprintId: string | null;
+  // When true, scroll the Sprints block into view (from "Add one" in the list).
+  startAddSprint: boolean;
   run: (fn: () => Promise<void>) => void;
   api: (url: string, method: "POST" | "DELETE", body?: unknown) => Promise<void>;
   collabToken: string | null;
@@ -537,17 +592,25 @@ function EpicDetail({
   onDeleted: () => void;
 }) {
   // Editing a sprint takes precedence over the epic-edit form so opening from
-  // a nested sprint row lands directly on that sprint.
+  // a nested sprint row lands directly on that sprint. Opening to add a sprint
+  // skips the epic-edit form and scrolls to Sprints instead.
   const [editEpicOpen, setEditEpicOpen] = useState(
-    canManage && startInEdit && !startEditSprintId,
+    canManage && startInEdit && !startEditSprintId && !startAddSprint,
   );
-  const [newSprintOpen, setNewSprintOpen] = useState(false);
+  // startAddSprint opens the sprint form outright, not just a scroll: both of
+  // its entry points ("Add one" in the list, and landing here right after
+  // creating an epic) mean "I want to add a sprint now".
+  const [newSprintOpen, setNewSprintOpen] = useState(canManage && startAddSprint);
   const [sprintsOpen, setSprintsOpen] = useState(true);
   const [editSprintId, setEditSprintId] = useState<string | null>(
     canManage ? startEditSprintId : null,
   );
   const [newStoryOpen, setNewStoryOpen] = useState(false);
   const [editStoryId, setEditStoryId] = useState<string | null>(null);
+  // Draft title while editing details — lives in the header where the name
+  // normally sits (no second title field in the form below).
+  const [draftTitle, setDraftTitle] = useState(epic.title);
+  useEffect(() => setDraftTitle(epic.title), [epic.id, epic.title]);
   // The epic's collab room name. Already populated for epics that have been
   // opened in edit mode before; null otherwise (auto-provisioned on open if
   // the user has edit perms, via POST /api/epics/:id/description-doc).
@@ -584,34 +647,51 @@ function EpicDetail({
     };
   }, [descriptionDocId, canManage, epic.id]);
 
-  // When opened on a specific sprint, bring its (already-expanded) edit form
-  // into view — the Sprints block sits at the bottom of the scroll container.
+  // Sprints sit at the bottom of the scroll container — jump there when
+  // opening a specific sprint to edit, or when arriving via "Add one".
   const sprintsRef = useRef<HTMLElement | null>(null);
   useEffect(() => {
-    if (!startEditSprintId) return;
-    sprintsRef.current?.scrollIntoView({ block: "start" });
-  }, [startEditSprintId]);
+    if (!startEditSprintId && !startAddSprint) return;
+    // Defer one frame so the modal + collapsed sections have laid out.
+    const id = requestAnimationFrame(() => {
+      sprintsRef.current?.scrollIntoView({ block: "start", behavior: "smooth" });
+    });
+    return () => cancelAnimationFrame(id);
+  }, [startEditSprintId, startAddSprint]);
 
   return (
     <div className="flex flex-col gap-4 max-h-[80vh] overflow-y-auto">
       {/* Modal header */}
       <div className="flex items-start justify-between gap-3">
-        <div className="min-w-0">
-          <h2
-            id="epic-detail-title"
-            className="font-heading text-lg font-bold text-foreground truncate"
-          >
-            {epic.title}
-          </h2>
-          <p className="text-[11px] text-muted-foreground mt-0.5">
-            {epic.status}
-            {epic.startsAt && epic.endsAt && (
-              <>
-                {" · "}
-                {dateInputValue(epic.startsAt)} → {dateInputValue(epic.endsAt)}
-              </>
-            )}
-          </p>
+        <div className="min-w-0 flex-1">
+          {editEpicOpen ? (
+            <input
+              id="epic-detail-title"
+              autoFocus
+              value={draftTitle}
+              onChange={(e) => setDraftTitle(e.target.value)}
+              aria-label="Epic name"
+              className="w-full font-heading text-lg font-bold text-foreground bg-transparent border-b border-border focus:border-accent-coral focus:outline-none px-0 py-0.5"
+            />
+          ) : (
+            <h2
+              id="epic-detail-title"
+              className="font-heading text-lg font-bold text-foreground truncate"
+            >
+              {epic.title}
+            </h2>
+          )}
+          {!editEpicOpen && (
+            <p className="text-[11px] text-muted-foreground mt-0.5">
+              {epic.status}
+              {epic.startsAt && epic.endsAt && (
+                <>
+                  {" · "}
+                  {dateInputValue(epic.startsAt)} → {dateInputValue(epic.endsAt)}
+                </>
+              )}
+            </p>
+          )}
         </div>
         <div className="flex items-center gap-3 flex-shrink-0">
           {canManage && (
@@ -646,16 +726,19 @@ function EpicDetail({
         </div>
       </div>
 
-      {/* Epic details (title / status / dates) — Edit toggles the form. The
-          description is no longer part of this form; it has its own collab
-          editor below so it stays live and visible regardless of which
-          metadata-edit state we're in. */}
+      {/* Epic details (status / dates) — title edits in the header above.
+          Description is a separate collab editor below. */}
       <section className="bg-card border border-border rounded-lg p-4">
         {editEpicOpen ? (
           <EpicForm
             busy={busy}
             initial={epic}
-            onCancel={() => setEditEpicOpen(false)}
+            title={draftTitle}
+            hideTitle
+            onCancel={() => {
+              setDraftTitle(epic.title);
+              setEditEpicOpen(false);
+            }}
             onSubmit={(values) =>
               run(async () => {
                 await api(`/api/epics/${epic.id}`, "POST", values);
@@ -891,6 +974,18 @@ function EpicDetail({
                         setEditSprintId(null);
                       })
                     }
+                    onDelete={() => {
+                      if (
+                        !window.confirm(
+                          `Delete sprint "${sprint.name}"? Its tasks move back to the backlog.`,
+                        )
+                      )
+                        return;
+                      run(async () => {
+                        await api(`/api/sprints/${sprint.id}`, "DELETE");
+                        setEditSprintId(null);
+                      });
+                    }}
                   />
                 </div>
               ) : (
@@ -904,29 +999,16 @@ function EpicDetail({
                       {dateInputValue(sprint.startsAt)} → {dateInputValue(sprint.endsAt)}
                     </span>
                   </div>
-                  <div className="flex items-center gap-3 flex-shrink-0">
+                  <div className="flex items-center gap-2 flex-shrink-0">
                     <span className="text-[11px] text-muted-foreground">{sprint.status}</span>
                     {canManage && (
-                      <>
-                        <button
-                          type="button"
-                          onClick={() => setEditSprintId(sprint.id)}
-                          className="text-xs text-muted-foreground hover:text-foreground"
-                        >
-                          Edit
-                        </button>
-                        <button
-                          type="button"
-                          disabled={busy}
-                          onClick={() => {
-                            if (!window.confirm(`Delete sprint "${sprint.name}"? Its tasks move back to the backlog.`)) return;
-                            run(() => api(`/api/sprints/${sprint.id}`, "DELETE"));
-                          }}
-                          className="text-xs text-destructive hover:underline disabled:opacity-60"
-                        >
-                          Delete
-                        </button>
-                      </>
+                      <button
+                        type="button"
+                        onClick={() => setEditSprintId(sprint.id)}
+                        className="text-xs text-muted-foreground hover:text-foreground"
+                      >
+                        Edit
+                      </button>
                     )}
                   </div>
                 </div>
@@ -946,6 +1028,8 @@ function EpicForm({
   busy,
   onSubmit,
   onCancel,
+  hideTitle = false,
+  title: titleProp,
 }: {
   initial?: EditableEpic;
   busy: boolean;
@@ -956,8 +1040,12 @@ function EpicForm({
     endsAt: string | null;
   }) => void;
   onCancel: () => void;
+  /** When true, title is edited elsewhere (e.g. modal header) via `title`. */
+  hideTitle?: boolean;
+  title?: string;
 }) {
-  const [title, setTitle] = useState(initial?.title ?? "");
+  const [titleInternal, setTitleInternal] = useState(initial?.title ?? "");
+  const title = hideTitle ? (titleProp ?? "") : titleInternal;
   const [status, setStatus] = useState(initial?.status ?? "Open");
   const [startsAt, setStartsAt] = useState(
     initial?.startsAt ? dateInputValue(initial.startsAt) : "",
@@ -981,15 +1069,17 @@ function EpicForm({
       className="flex flex-col gap-2 mb-3"
     >
       <div className="flex flex-wrap items-end gap-2">
-        <label className="flex flex-col gap-1 text-xs flex-1 min-w-[200px]">
-          <span className="text-muted-foreground">Title</span>
-          <input
-            autoFocus
-            value={title}
-            onChange={(e) => setTitle(e.target.value)}
-            className="px-2 py-1.5 text-sm border border-border rounded-md bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-accent-coral/30"
-          />
-        </label>
+        {!hideTitle && (
+          <label className="flex flex-col gap-1 text-xs flex-1 min-w-[200px]">
+            <span className="text-muted-foreground">Title</span>
+            <input
+              autoFocus
+              value={titleInternal}
+              onChange={(e) => setTitleInternal(e.target.value)}
+              className="px-2 py-1.5 text-sm border border-border rounded-md bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-accent-coral/30"
+            />
+          </label>
+        )}
         <label className="flex flex-col gap-1 text-xs">
           <span className="text-muted-foreground">Status</span>
           <select
@@ -1055,6 +1145,7 @@ function SprintForm({
   busy,
   onSubmit,
   onCancel,
+  onDelete,
 }: {
   initial?: EditableSprint;
   busy: boolean;
@@ -1065,6 +1156,7 @@ function SprintForm({
     status: string;
   }) => void;
   onCancel: () => void;
+  onDelete?: () => void;
 }) {
   const [name, setName] = useState(initial?.name ?? "");
   const [startsAt, setStartsAt] = useState(
@@ -1131,21 +1223,36 @@ function SprintForm({
           ))}
         </select>
       </label>
-      <div className="flex gap-1.5">
-        <Button
+      <div className="flex items-center gap-1">
+        <button
           type="submit"
-          variant="primary"
-          size="sm"
           disabled={busy}
+          title="Save"
+          aria-label="Save"
+          className="p-1.5 rounded text-accent-coral hover:bg-accent-coral/10 disabled:opacity-60"
         >
-          Save
-        </Button>
+          <Check className="w-4 h-4" />
+        </button>
+        {onDelete && (
+          <button
+            type="button"
+            disabled={busy}
+            onClick={onDelete}
+            title="Delete sprint"
+            aria-label="Delete sprint"
+            className="p-1.5 rounded text-destructive hover:bg-destructive/10 disabled:opacity-60"
+          >
+            <Trash2 className="w-4 h-4" />
+          </button>
+        )}
         <button
           type="button"
           onClick={onCancel}
-          className="px-3 py-1.5 text-xs font-medium rounded-md border border-border hover:bg-muted transition-colors"
+          title="Cancel"
+          aria-label="Cancel"
+          className="p-1.5 rounded text-muted-foreground hover:text-foreground hover:bg-muted"
         >
-          Cancel
+          <X className="w-4 h-4" />
         </button>
       </div>
     </form>

--- a/dali-api/app/projects/components/EpicsTimeline.tsx
+++ b/dali-api/app/projects/components/EpicsTimeline.tsx
@@ -1,4 +1,13 @@
-import { useEffect, useMemo, useRef } from "react";
+import {
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type ReactNode,
+} from "react";
+import { createPortal } from "react-dom";
 
 export type EpicStatus = "Backlog" | "Open" | "InProgress" | "Done" | "Cancelled";
 export type SprintStatus = "Planned" | "Active" | "Closed";
@@ -21,27 +30,25 @@ export type TimelineEpic = {
   startsAt: string | null;
   endsAt: string | null;
   sprintCount: number;
-  // Sprints under this epic, ordered by startsAt. Each is its own bar row,
-  // matching the reference timeline (one row per sprint, connectors between
-  // consecutive sprints).
+  // Sprints under this epic, ordered by startsAt. Drawn as thinner bars
+  // directly under the epic bar on the same track.
   sprints: TimelineSprint[];
 };
 
-// Bar fills. Epics are the parent rows, so they get a saturated coral
-// gradient (the brand's heaviest accent) — distinctly bolder than their
-// teal sprint children, which keeps the hierarchy obvious at a glance.
+// Bar fills. Epics are the parent bars (coral / stronger fill so they stay
+// readable above the quieter sprint stack); sprints are subordinate teal.
 const EPIC_BAR: Record<EpicStatus, string> = {
-  Backlog: "bg-muted-foreground/40",
-  Open: "bg-gradient-to-b from-accent-coral to-accent-coral-light",
-  InProgress: "bg-gradient-to-b from-accent-coral to-accent-coral-light",
-  Done: "bg-accent-coral/45",
-  Cancelled: "bg-destructive/50",
+  Backlog: "bg-muted-foreground/70 ring-1 ring-inset ring-border",
+  Open: "bg-accent-coral",
+  InProgress: "bg-accent-coral",
+  Done: "bg-accent-coral/60",
+  Cancelled: "bg-destructive/70",
 };
 
 const SPRINT_BAR: Record<SprintStatus, string> = {
-  Planned: "bg-muted-foreground/40",
-  Active: "bg-gradient-to-b from-accent-teal to-accent-teal-light",
-  Closed: "bg-accent-teal/45",
+  Planned: "bg-muted-foreground/50 ring-1 ring-inset ring-border/60",
+  Active: "bg-accent-teal",
+  Closed: "bg-accent-teal/55",
 };
 
 const EPIC_LABEL: Record<EpicStatus, string> = {
@@ -58,10 +65,6 @@ const SPRINT_LABEL: Record<SprintStatus, string> = {
   Closed: "Done",
 };
 
-// Status pill — a small solid chip with a leading dot, sitting at the start
-// of each bar (like the "Done" / "In progress" chips in the reference). Solid
-// surface + white text so it stays legible on top of any bar fill, instead
-// of the old gray-on-gray chip that disappeared on muted bars.
 const EPIC_PILL: Record<EpicStatus, string> = {
   Backlog: "bg-card/90 text-muted-foreground ring-1 ring-black/5",
   Open: "bg-card/90 text-foreground ring-1 ring-black/5",
@@ -70,13 +73,6 @@ const EPIC_PILL: Record<EpicStatus, string> = {
   Cancelled: "bg-card/80 text-destructive",
 };
 
-const SPRINT_PILL: Record<SprintStatus, string> = {
-  Planned: "bg-card/90 text-muted-foreground ring-1 ring-black/5",
-  Active: "bg-card/90 text-foreground ring-1 ring-black/5",
-  Closed: "bg-card/80 text-muted-foreground",
-};
-
-// Dot color inside the pill — this is what carries the status hue now.
 const EPIC_DOT: Record<EpicStatus, string> = {
   Backlog: "bg-muted-foreground",
   Open: "bg-accent-coral",
@@ -85,17 +81,13 @@ const EPIC_DOT: Record<EpicStatus, string> = {
   Cancelled: "bg-destructive",
 };
 
-const SPRINT_DOT: Record<SprintStatus, string> = {
-  Planned: "bg-muted-foreground",
-  Active: "bg-accent-teal",
-  Closed: "bg-muted-foreground",
-};
-
 const DAY = 86_400_000;
 const LABEL_W = 176; // px — fixed left column for row titles (w-44)
-// Pixels per day. The axis scrolls horizontally rather than squashing, so a
-// fixed scale keeps long projects readable.
 const PX_PER_DAY = 22;
+const EPIC_BAR_H = 26;
+const SPRINT_BAR_H = 14;
+const BAR_GAP = 4;
+const ROW_PAD_Y = 10;
 
 function startOfDay(t: number): number {
   const d = new Date(t);
@@ -111,31 +103,124 @@ function fmtMonth(d: Date): string {
   return d.toLocaleDateString(undefined, { month: "long", year: "numeric" });
 }
 
-type Row =
-  | { kind: "epic"; epic: TimelineEpic }
-  | { kind: "sprint"; sprint: TimelineSprint; epicId: string; prevId: string | null };
+function rowHeight(sprintCount: number): number {
+  // Epic bar + optional stack of sprint bars underneath.
+  const sprintStack =
+    sprintCount > 0 ? BAR_GAP + sprintCount * SPRINT_BAR_H + (sprintCount - 1) * 3 : 0;
+  return ROW_PAD_Y * 2 + EPIC_BAR_H + sprintStack;
+}
+
+function TimelineBarHover({
+  open,
+  anchorEl,
+  title,
+  rows,
+}: {
+  open: boolean;
+  anchorEl: HTMLElement | null;
+  title: string;
+  rows: { label: string; value: string }[];
+}) {
+  const cardRef = useRef<HTMLDivElement | null>(null);
+  const [pos, setPos] = useState<{ left: number; top: number } | null>(null);
+
+  useLayoutEffect(() => {
+    if (!open || !anchorEl) {
+      setPos(null);
+      return;
+    }
+    const place = () => {
+      const card = cardRef.current;
+      if (!card) return;
+      const a = anchorEl.getBoundingClientRect();
+      const cw = card.offsetWidth;
+      const ch = card.offsetHeight;
+      const gap = 8;
+      const margin = 8;
+      const vw = window.innerWidth;
+      const vh = window.innerHeight;
+      let left = a.left + a.width / 2 - cw / 2;
+      left = Math.max(margin, Math.min(left, vw - cw - margin));
+      let top = a.bottom + gap;
+      if (top + ch + margin > vh) top = a.top - gap - ch;
+      top = Math.max(margin, top);
+      setPos((prev) =>
+        prev && prev.left === left && prev.top === top ? prev : { left, top },
+      );
+    };
+    place();
+    const ro = new ResizeObserver(place);
+    if (cardRef.current) ro.observe(cardRef.current);
+    window.addEventListener("resize", place);
+    window.addEventListener("scroll", place, true);
+    return () => {
+      ro.disconnect();
+      window.removeEventListener("resize", place);
+      window.removeEventListener("scroll", place, true);
+    };
+  }, [open, anchorEl, title]);
+
+  if (!open || typeof document === "undefined") return null;
+
+  return createPortal(
+    <div
+      ref={cardRef}
+      role="tooltip"
+      className="fixed z-50 w-64 max-w-[min(16rem,calc(100vw-1rem))] rounded-md border border-border bg-card shadow-lg p-2.5 text-xs pointer-events-none"
+      style={{
+        left: pos?.left ?? 0,
+        top: pos?.top ?? 0,
+        visibility: pos ? "visible" : "hidden",
+      }}
+    >
+      <div className="font-heading font-semibold text-foreground leading-snug break-words">
+        {title}
+      </div>
+      <dl className="mt-1.5 space-y-1">
+        {rows.map((r) => (
+          <div key={r.label} className="flex gap-2 justify-between">
+            <dt className="text-muted-foreground flex-shrink-0">{r.label}</dt>
+            <dd className="text-foreground text-right break-words">{r.value}</dd>
+          </div>
+        ))}
+      </dl>
+    </div>,
+    document.body,
+  );
+}
+
+function HoverBar({
+  className,
+  style,
+  title,
+  rows,
+  children,
+}: {
+  className: string;
+  style: CSSProperties;
+  title: string;
+  rows: { label: string; value: string }[];
+  children?: ReactNode;
+}) {
+  const [open, setOpen] = useState(false);
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  return (
+    <>
+      <div
+        ref={setAnchorEl}
+        className={className}
+        style={style}
+        onMouseEnter={() => setOpen(true)}
+        onMouseLeave={() => setOpen(false)}
+      >
+        {children}
+      </div>
+      <TimelineBarHover open={open} anchorEl={anchorEl} title={title} rows={rows} />
+    </>
+  );
+}
 
 export function EpicsTimeline({ epics }: { epics: TimelineEpic[] }) {
-  // Flatten epics → rows: an epic header row followed by one row per sprint.
-  // `prevId` links a sprint to the one before it in the same epic so we can
-  // draw a connector between them.
-  const rows = useMemo<Row[]>(() => {
-    const out: Row[] = [];
-    for (const epic of epics) {
-      out.push({ kind: "epic", epic });
-      let prevId: string | null = null;
-      for (const sprint of epic.sprints) {
-        out.push({ kind: "sprint", sprint, epicId: epic.id, prevId });
-        prevId = sprint.id;
-      }
-    }
-    return out;
-  }, [epics]);
-
-  // Global date window: the union of every scheduled epic/sprint span (and
-  // today), then padded out by 3 months on each side and snapped to month
-  // boundaries. The extra padding is empty grid you can scroll left/right
-  // into, so the axis never dead-ends right at the data.
   const bounds = useMemo(() => {
     const times: number[] = [startOfDay(Date.now())];
     for (const e of epics) {
@@ -148,8 +233,6 @@ export function EpicsTimeline({ epics }: { epics: TimelineEpic[] }) {
     }
     if (times.length === 0) return null;
 
-    // Snap to the 1st of (earliest month − 3) … 1st of (latest month + 4),
-    // so the window starts/ends on clean month boundaries.
     const lo = new Date(Math.min(...times));
     const hi = new Date(Math.max(...times));
     const minD = new Date(lo.getFullYear(), lo.getMonth() - 3, 1);
@@ -160,7 +243,6 @@ export function EpicsTimeline({ epics }: { epics: TimelineEpic[] }) {
     return { min, max, days, width: days * PX_PER_DAY };
   }, [epics]);
 
-  // One tick per day for the gridlines; group ticks by month for the header.
   const days = useMemo(() => {
     if (!bounds) return [];
     const out: { t: number; isMonthStart: boolean; isToday: boolean }[] = [];
@@ -181,10 +263,10 @@ export function EpicsTimeline({ epics }: { epics: TimelineEpic[] }) {
     const out: { label: string; left: number; width: number }[] = [];
     let i = 0;
     while (i < days.length) {
-      const start = days[i].t;
+      const start = days[i]!.t;
       let j = i;
-      while (j + 1 < days.length && !days[j + 1].isMonthStart) j++;
-      const end = days[j].t;
+      while (j + 1 < days.length && !days[j + 1]!.isMonthStart) j++;
+      const end = days[j]!.t;
       out.push({
         label: fmtMonth(new Date(start)),
         left: ((start - bounds.min) / DAY) * PX_PER_DAY,
@@ -204,50 +286,33 @@ export function EpicsTimeline({ epics }: { epics: TimelineEpic[] }) {
     return Math.max(((b - a) / DAY + 1) * PX_PER_DAY, PX_PER_DAY);
   }
 
-  if (epics.length === 0) {
-    return (
-      <div className="text-sm text-muted-foreground italic py-8 text-center border border-border rounded-lg bg-card">
-        No epics yet.
-      </div>
-    );
-  }
-
-  const ROW_H = 48; // px per row, kept in sync with the row container height
-  // Floor on visible rows so a short timeline still renders a tall, roomy
-  // grid: any rows beyond the real data are empty gridline-only filler.
-  const MIN_ROWS = 10;
-  const fillerRows = Math.max(MIN_ROWS - rows.length, 0);
+  const MIN_ROWS = 8;
+  const fillerRows = Math.max(MIN_ROWS - epics.length, 0);
+  const FILLER_H = 48;
   const todayLeft =
     bounds && startOfDay(Date.now()) >= bounds.min && startOfDay(Date.now()) <= bounds.max
       ? ((startOfDay(Date.now()) - bounds.min) / DAY) * PX_PER_DAY
       : null;
 
-  // The window now extends ~3 months of empty grid before the data, so on
-  // mount jump the scroll to "today" (fallback: the first scheduled item),
-  // sitting it a little in from the left edge rather than at column 0.
   const scrollerRef = useRef<HTMLDivElement>(null);
   const initialScroll = useMemo(() => {
     if (!bounds) return 0;
-    const anchor =
-      todayLeft != null
-        ? todayLeft
-        : rows.length
-          ? // earliest bar position across rows
-            Math.min(
-              ...rows.map((r) =>
-                r.kind === "epic"
-                  ? r.epic.startsAt
-                    ? ((startOfDay(new Date(r.epic.startsAt).getTime()) - bounds.min) /
-                        DAY) *
-                      PX_PER_DAY
-                    : Infinity
-                  : ((startOfDay(new Date(r.sprint.startsAt).getTime()) - bounds.min) /
-                      DAY) *
-                    PX_PER_DAY,
-              ),
-            )
-          : 0;
-    return Math.max(Number.isFinite(anchor) ? anchor - 7 * PX_PER_DAY : 0, 0);
+    const anchors: number[] = [];
+    if (todayLeft != null) anchors.push(todayLeft);
+    for (const e of epics) {
+      if (e.startsAt) {
+        anchors.push(
+          ((startOfDay(new Date(e.startsAt).getTime()) - bounds.min) / DAY) * PX_PER_DAY,
+        );
+      }
+      for (const s of e.sprints) {
+        anchors.push(
+          ((startOfDay(new Date(s.startsAt).getTime()) - bounds.min) / DAY) * PX_PER_DAY,
+        );
+      }
+    }
+    const anchor = anchors.length ? Math.min(...anchors) : 0;
+    return Math.max(anchor - 7 * PX_PER_DAY, 0);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [bounds]);
 
@@ -257,11 +322,23 @@ export function EpicsTimeline({ epics }: { epics: TimelineEpic[] }) {
     }
   }, [initialScroll]);
 
+  // Empty state is returned only AFTER every hook above has run. Bailing out
+  // earlier (as this did) changes the hook count between renders, so adding a
+  // project's first epic — 0 -> 1 — crashed the whole page with "Rendered more
+  // hooks than during the previous render". The hooks above all handle the
+  // empty case (bounds === null), so running them here is harmless.
+  if (epics.length === 0) {
+    return (
+      <div className="text-sm text-muted-foreground italic py-8 text-center border border-border rounded-lg bg-card">
+        No epics yet.
+      </div>
+    );
+  }
+
   return (
     <div className="border border-border rounded-lg bg-card overflow-hidden">
       <div ref={scrollerRef} className="overflow-x-auto">
         <div style={{ width: bounds ? LABEL_W + bounds.width : "100%" }}>
-          {/* Month + day header */}
           {bounds ? (
             <div className="sticky top-0 z-10 bg-card border-b border-border">
               <div className="flex">
@@ -270,7 +347,6 @@ export function EpicsTimeline({ epics }: { epics: TimelineEpic[] }) {
                   style={{ width: LABEL_W }}
                 />
                 <div className="relative" style={{ width: bounds.width, height: 44 }}>
-                  {/* Month band */}
                   <div className="relative h-6 border-b border-border/60">
                     {months.map((m) => (
                       <div
@@ -282,7 +358,6 @@ export function EpicsTimeline({ epics }: { epics: TimelineEpic[] }) {
                       </div>
                     ))}
                   </div>
-                  {/* Day numbers */}
                   <div className="relative h-[18px]">
                     {days.map((d) => (
                       <div
@@ -306,9 +381,7 @@ export function EpicsTimeline({ epics }: { epics: TimelineEpic[] }) {
             </div>
           ) : null}
 
-          {/* Rows */}
           <div className="relative">
-            {/* Vertical gridlines + month boundaries, behind the bars */}
             {bounds && (
               <div
                 className="absolute inset-y-0 pointer-events-none"
@@ -335,35 +408,58 @@ export function EpicsTimeline({ epics }: { epics: TimelineEpic[] }) {
               </div>
             )}
 
-            {rows.map((row) => {
-              if (row.kind === "epic") {
-                const e = row.epic;
-                const has = !!(e.startsAt && e.endsAt && bounds);
-                return (
+            {epics.map((e) => {
+              const h = rowHeight(e.sprints.length);
+              const has = !!(e.startsAt && e.endsAt && bounds);
+              const epicDateRange =
+                e.startsAt && e.endsAt
+                  ? `${fmtDay(new Date(e.startsAt))}–${fmtDay(new Date(e.endsAt))}`
+                  : "—";
+
+              return (
+                <div
+                  key={e.id}
+                  className="relative flex border-b border-border/40 bg-muted/10"
+                  style={{ height: h }}
+                >
                   <div
-                    key={`epic-${e.id}`}
-                    className="relative flex items-center border-b border-border/40 bg-muted/10"
-                    style={{ height: ROW_H }}
+                    className="flex-shrink-0 px-3 flex flex-col justify-center gap-0.5 border-r border-border min-w-0"
+                    style={{ width: LABEL_W }}
                   >
                     <div
-                      className="flex-shrink-0 px-3 text-sm font-semibold text-foreground truncate border-r border-border"
-                      style={{ width: LABEL_W }}
+                      className="text-sm font-semibold text-foreground truncate"
                       title={e.title}
                     >
                       {e.title}
                     </div>
-                    <div
-                      className="relative"
-                      style={{ width: bounds ? bounds.width : "100%", height: ROW_H }}
-                    >
-                      {has ? (
-                        <div
-                          className={`absolute top-1/2 -translate-y-1/2 h-6 rounded-md shadow-sm ${EPIC_BAR[e.status]} flex items-center gap-1.5 px-1.5`}
+                    {e.sprints.length > 0 && (
+                      <div className="text-[10px] text-muted-foreground truncate">
+                        {e.sprints.length} sprint{e.sprints.length === 1 ? "" : "s"}
+                      </div>
+                    )}
+                  </div>
+                  <div
+                    className="relative"
+                    style={{ width: bounds ? bounds.width : "100%", height: h }}
+                  >
+                    {has ? (
+                      <>
+                        {/* Parent epic bar — solid coral so it stays visible
+                            above the thinner sprint stack. */}
+                        <HoverBar
+                          className={`absolute rounded-md shadow-sm ${EPIC_BAR[e.status]} flex items-center gap-1.5 px-1.5 cursor-default min-w-[22px]`}
                           style={{
                             left: x(e.startsAt!),
                             width: w(e.startsAt!, e.endsAt!),
+                            top: ROW_PAD_Y,
+                            height: EPIC_BAR_H,
                           }}
-                          title={`${EPIC_LABEL[e.status]} · ${fmtDay(new Date(e.startsAt!))}–${fmtDay(new Date(e.endsAt!))}`}
+                          title={e.title}
+                          rows={[
+                            { label: "Status", value: EPIC_LABEL[e.status] },
+                            { label: "Dates", value: epicDateRange },
+                            { label: "Sprints", value: String(e.sprintCount) },
+                          ]}
                         >
                           <span
                             className={`flex-shrink-0 inline-flex items-center gap-1 text-[10px] font-semibold px-1.5 py-0.5 rounded-full ${EPIC_PILL[e.status]}`}
@@ -373,94 +469,52 @@ export function EpicsTimeline({ epics }: { epics: TimelineEpic[] }) {
                             />
                             {EPIC_LABEL[e.status]}
                           </span>
-                          <span className="text-[11px] font-medium text-white/95 truncate">
-                            {e.sprintCount} sprint{e.sprintCount === 1 ? "" : "s"}
-                          </span>
-                        </div>
-                      ) : (
-                        <span className="absolute left-2 top-1/2 -translate-y-1/2 text-[11px] text-muted-foreground italic">
-                          No dates yet
-                        </span>
-                      )}
-                    </div>
-                  </div>
-                );
-              }
+                        </HoverBar>
 
-              // Sprint row
-              const s = row.sprint;
-              const left = x(s.startsAt);
-              const width = w(s.startsAt, s.endsAt);
-              return (
-                <div
-                  key={`sprint-${s.id}`}
-                  className="relative flex items-center border-b border-border/30"
-                  style={{ height: ROW_H }}
-                >
-                  <div
-                    className="flex-shrink-0 pl-6 pr-3 text-[13px] text-muted-foreground truncate border-r border-border"
-                    style={{ width: LABEL_W }}
-                    title={s.name}
-                  >
-                    {s.name}
-                  </div>
-                  <div
-                    className="relative"
-                    style={{ width: bounds!.width, height: ROW_H }}
-                  >
-                    {/* Connector from the previous sprint's end (one row up)
-                        into this bar's start — an elbow like the reference. */}
-                    {row.prevId && (
-                      <svg
-                        className="absolute pointer-events-none overflow-visible"
-                        style={{ left: 0, top: -ROW_H / 2, width: left, height: ROW_H }}
-                        aria-hidden
+                        {/* Subordinate sprint bars stacked under the epic bar */}
+                        {e.sprints.map((s, i) => {
+                          const top =
+                            ROW_PAD_Y + EPIC_BAR_H + BAR_GAP + i * (SPRINT_BAR_H + 3);
+                          return (
+                            <HoverBar
+                              key={s.id}
+                              className={`absolute rounded-sm shadow-sm ${SPRINT_BAR[s.status]} cursor-default`}
+                              style={{
+                                left: x(s.startsAt),
+                                width: w(s.startsAt, s.endsAt),
+                                top,
+                                height: SPRINT_BAR_H,
+                              }}
+                              title={s.name}
+                              rows={[
+                                { label: "Status", value: SPRINT_LABEL[s.status] },
+                                {
+                                  label: "Dates",
+                                  value: `${fmtDay(new Date(s.startsAt))}–${fmtDay(new Date(s.endsAt))}`,
+                                },
+                              ]}
+                            />
+                          );
+                        })}
+                      </>
+                    ) : (
+                      <span
+                        className="absolute left-2 text-[11px] text-muted-foreground italic"
+                        style={{ top: ROW_PAD_Y + 4 }}
                       >
-                        <path
-                          d={`M ${Math.max(left - 14, 0)} ${ROW_H / 2}
-                              C ${left - 7} ${ROW_H / 2}, ${left - 7} ${ROW_H},
-                                ${left} ${ROW_H}`}
-                          fill="none"
-                          className="stroke-muted-foreground/40"
-                          strokeWidth={1.5}
-                        />
-                      </svg>
+                        No dates yet
+                      </span>
                     )}
-                    <div
-                      className={`absolute top-1/2 -translate-y-1/2 h-[26px] rounded-md ${SPRINT_BAR[s.status]} flex items-center gap-1.5 px-1.5 shadow-sm`}
-                      style={{ left, width }}
-                      title={`${s.name} · ${SPRINT_LABEL[s.status]} · ${fmtDay(new Date(s.startsAt))}–${fmtDay(new Date(s.endsAt))}`}
-                    >
-                      <span
-                        className={`truncate flex-1 min-w-0 text-[11px] ${
-                          s.status === "Planned"
-                            ? "text-foreground/80"
-                            : "text-white/95 font-medium"
-                        }`}
-                      >
-                        {s.name}
-                      </span>
-                      <span
-                        className={`flex-shrink-0 inline-flex items-center gap-1 text-[10px] font-semibold px-1.5 py-0.5 rounded-full ${SPRINT_PILL[s.status]}`}
-                      >
-                        <span
-                          className={`h-1.5 w-1.5 rounded-full ${SPRINT_DOT[s.status]}`}
-                        />
-                        {SPRINT_LABEL[s.status]}
-                      </span>
-                    </div>
                   </div>
                 </div>
               );
             })}
 
-            {/* Empty trailing rows: pure gridline background so a short
-                timeline still has a tall, open grid to plan into. */}
             {Array.from({ length: fillerRows }).map((_, i) => (
               <div
                 key={`filler-${i}`}
                 className="relative flex items-center border-b border-border/20"
-                style={{ height: ROW_H }}
+                style={{ height: FILLER_H }}
                 aria-hidden
               >
                 <div

--- a/dali-api/app/projects/components/ProjectImageBanner.tsx
+++ b/dali-api/app/projects/components/ProjectImageBanner.tsx
@@ -10,6 +10,11 @@ import { PhotoCropModal } from "~/components/PhotoCropModal";
 
 const ACCEPT = "image/png,image/jpeg,image/webp,image/gif";
 
+// Banner crop ratio. Sits between the detail page's wide hero box and the
+// hub card's shorter thumbnail; both use object-cover, so each trims a little
+// rather than either letterboxing.
+const BANNER_ASPECT = 3;
+
 // Full-width project banner that doubles as the image-upload control. When the
 // project has no image, a default gradient (with the project initial) shows
 // instead. Clicking the banner (or its camera button) picks → crops → uploads
@@ -193,6 +198,15 @@ export function ProjectImageBanner({
       />
 
       {error && <p className="text-xs text-red-500">{error}</p>}
+
+      <PhotoCropModal
+        open={cropSrc !== null}
+        imageSrc={cropSrc}
+        onCancel={closeCrop}
+        onConfirm={handleConfirm}
+        aspect={BANNER_ASPECT}
+        cropShape="rect"
+      />
     </div>
   );
 }

--- a/dali-api/app/projects/routes/projects.$id.tsx
+++ b/dali-api/app/projects/routes/projects.$id.tsx
@@ -10,7 +10,7 @@ import {
   useSearchParams,
   useSubmit,
 } from "react-router";
-import { Check, Handshake, Pencil, X, Settings, Folder, FolderPlus, ChevronRight, ChevronDown, FileText, Info, Users, Paperclip, Plus, Trash2 } from "lucide-react";
+import { Check, Handshake, Pencil, X, Settings, Folder, FolderPlus, ChevronRight, ChevronDown, FileText, Info, Users, Paperclip, Plus, Trash2, Upload } from "lucide-react";
 import { Modal, ModalHeader } from "~/components/Modal";
 import { EditableSection } from "~/components/EditableSection";
 import { PresenceProvider } from "~/components/collab/PresenceProvider";
@@ -326,23 +326,29 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   const userName = presenceUser?.name ?? fallbackName;
 
   // Timeline span: prefer the epic's explicit startsAt/endsAt; fall back to
-  // the min/max of its sprint dates when either is unset. Each epic also
-  // carries its own sprint rows (ordered by start) so the timeline can render
-  // one bar per sprint with connectors, not just a single epic bar.
+  // the min/max of its sprint dates when either is unset. When the epic has
+  // sprints, expand the bar to cover the sprint union so the parent epic bar
+  // never disappears while child sprint bars are visible.
   const epics: TimelineEpic[] = project.epics.map((e) => {
     const epicSprints = project.sprints
       .filter((s) => s.epicId === e.id)
       .sort((a, b) => a.startsAt.getTime() - b.startsAt.getTime());
-    const starts = epicSprints.map((s) => s.startsAt.getTime());
-    const ends = epicSprints.map((s) => s.endsAt.getTime());
-    const sprintStart = starts.length ? new Date(Math.min(...starts)).toISOString() : null;
-    const sprintEnd = ends.length ? new Date(Math.max(...ends)).toISOString() : null;
+    const sprintStarts = epicSprints.map((s) => s.startsAt.getTime());
+    const sprintEnds = epicSprints.map((s) => s.endsAt.getTime());
+    const sprintStartMs = sprintStarts.length ? Math.min(...sprintStarts) : null;
+    const sprintEndMs = sprintEnds.length ? Math.max(...sprintEnds) : null;
+
+    let startMs = e.startsAt?.getTime() ?? sprintStartMs;
+    let endMs = e.endsAt?.getTime() ?? sprintEndMs;
+    if (sprintStartMs != null && startMs != null) startMs = Math.min(startMs, sprintStartMs);
+    if (sprintEndMs != null && endMs != null) endMs = Math.max(endMs, sprintEndMs);
+
     return {
       id: e.id,
       title: e.title,
       status: e.status as EpicStatus,
-      startsAt: e.startsAt ? e.startsAt.toISOString() : sprintStart,
-      endsAt: e.endsAt ? e.endsAt.toISOString() : sprintEnd,
+      startsAt: startMs != null ? new Date(startMs).toISOString() : null,
+      endsAt: endMs != null ? new Date(endMs).toISOString() : null,
       sprintCount: epicSprints.length,
       sprints: epicSprints.map((s) => ({
         id: s.id,
@@ -2738,9 +2744,11 @@ function FilesBlock({
               versionForId.current = null;
               fileInputRef.current?.click();
             }}
-            className="text-xs font-medium text-accent-coral hover:underline disabled:opacity-60"
+            title={busy ? "Uploading…" : "Add file"}
+            aria-label={busy ? "Uploading…" : "Add file"}
+            className="p-1 rounded text-accent-coral hover:bg-accent-coral/10 disabled:opacity-60"
           >
-            {busy ? "Uploading…" : "+ Add file"}
+            <Plus className="w-3.5 h-3.5" />
           </button>
         )}
       </div>
@@ -2766,7 +2774,7 @@ function FilesBlock({
                 </span>
               </Link>
               {canEdit && (
-                <div className="flex items-center gap-3 flex-shrink-0">
+                <div className="flex items-center gap-2 flex-shrink-0">
                   <button
                     type="button"
                     disabled={busy}
@@ -2774,17 +2782,21 @@ function FilesBlock({
                       versionForId.current = f.id;
                       fileInputRef.current?.click();
                     }}
-                    className="text-xs text-muted-foreground hover:text-foreground disabled:opacity-60"
+                    title="New version"
+                    aria-label="New version"
+                    className="p-1 rounded text-muted-foreground hover:text-foreground hover:bg-muted disabled:opacity-60"
                   >
-                    New version
+                    <Upload className="w-3.5 h-3.5" />
                   </button>
                   <button
                     type="button"
                     disabled={busy}
                     onClick={() => void deleteFile(f.id, f.title)}
-                    className="text-xs text-destructive hover:underline disabled:opacity-60"
+                    title="Delete file"
+                    aria-label="Delete file"
+                    className="p-1 rounded text-destructive hover:text-destructive/80 disabled:opacity-60"
                   >
-                    Delete
+                    <Trash2 className="w-3.5 h-3.5" />
                   </button>
                 </div>
               )}

--- a/dali-api/app/projects/routes/projects.hub.tsx
+++ b/dali-api/app/projects/routes/projects.hub.tsx
@@ -14,6 +14,7 @@ import { projectsPills } from "../components/projectsPills";
 import { AreaPillNav } from "~/components/AreaPillNav";
 import { requestOpenTabIfEmbedded } from "~/components/workspace-link";
 import { prisma } from "~/lib/db";
+import { resolvePhotoUrl } from "~/lib/photo";
 import { githubTeamSlug } from "~/lib/github-slug";
 import { ensureProjectGroup } from "~/lib/groups";
 import { ViewToggle, useViewPreference } from "~/components/ViewToggle";
@@ -75,22 +76,27 @@ export async function loader({ request }: Route.LoaderArgs) {
     },
   });
 
-  const rows: ProjectRow[] = projects.map((p) => {
-    const startTerm = p.projectTerms
-      .map((pt) => pt.term)
-      .sort((a, b) => a.sortKey - b.sortKey)[0];
-    return {
-      id: p.id,
-      name: p.name,
-      status: p.status,
-      firstTermCode: startTerm?.code ?? null,
-      imageUrl: p.imageUrl,
-      partners: p.partners.map((pp) => ({
-        name: pp.partnerOrg.name,
-        logoUrl: pp.partnerOrg.logoUrl,
-      })),
-    };
-  });
+  const rows: ProjectRow[] = await Promise.all(
+    projects.map(async (p) => {
+      const startTerm = p.projectTerms
+        .map((pt) => pt.term)
+        .sort((a, b) => a.sortKey - b.sortKey)[0];
+      return {
+        id: p.id,
+        name: p.name,
+        status: p.status,
+        firstTermCode: startTerm?.code ?? null,
+        // Uploaded images are stored as S3 keys; presign for display.
+        imageUrl: await resolvePhotoUrl(p.imageUrl),
+        partners: await Promise.all(
+          p.partners.map(async (pp) => ({
+            name: pp.partnerOrg.name,
+            logoUrl: await resolvePhotoUrl(pp.partnerOrg.logoUrl),
+          })),
+        ),
+      };
+    }),
+  );
 
   const [partnerOrgs, canEdit, canStaff] = await Promise.all([
     prisma.partnerOrg.findMany({
@@ -351,7 +357,12 @@ function ProjectsTable({ rows }: { rows: ProjectRow[] }) {
               }}
               className="border-t border-border hover:bg-muted/20 cursor-pointer"
             >
-              <td className="px-4 py-2 text-foreground">{p.name}</td>
+              <td className="px-4 py-2">
+                <div className="flex items-center gap-3 min-w-0">
+                  <ProjectThumb project={p} />
+                  <span className="text-foreground truncate">{p.name}</span>
+                </div>
+              </td>
               <td className="px-4 py-2">
                 <StatusPill status={p.status} />
               </td>
@@ -408,6 +419,30 @@ function ProjectCard({ project }: { project: ProjectRow }) {
       )}
       </div>
     </Link>
+  );
+}
+
+// Row thumbnail for the list view. Falls back to the project's initial so the
+// name column stays aligned whether or not an image is set — same shape as the
+// partners hub's OrgAvatar, but object-cover since these are photos, not logos.
+function ProjectThumb({
+  project,
+}: {
+  project: Pick<ProjectRow, "name" | "imageUrl">;
+}) {
+  if (project.imageUrl) {
+    return (
+      <img
+        src={project.imageUrl}
+        alt=""
+        className="w-8 h-8 rounded object-cover bg-background border border-border flex-shrink-0"
+      />
+    );
+  }
+  return (
+    <div className="w-8 h-8 rounded bg-brand-tint text-dark-blue flex items-center justify-center text-xs font-bold flex-shrink-0">
+      {project.name.slice(0, 1)}
+    </div>
   );
 }
 

--- a/dali-api/app/routes.ts
+++ b/dali-api/app/routes.ts
@@ -51,6 +51,7 @@ export default [
     route("admin-console/members", "admin-console/routes/admin-console.members.tsx"),
     route("admin-console/domains", "admin-console/routes/admin-console.domains.tsx"),
     route("admin-console/announcements", "admin-console/routes/admin-console.announcements.tsx"),
+    route("admin-console/attendance", "admin-console/routes/admin-console.attendance.tsx"),
     route("admin-console/activity", "admin-console/routes/admin-console.activity.tsx"),
     route("admin-console/analytics", "admin-console/routes/admin-console.analytics.tsx"),
     route("admin-console/payroll-export", "admin-console/routes/admin-console.payroll-export.tsx"),

--- a/dali-api/app/routes/portal.education.$offeringId.tsx
+++ b/dali-api/app/routes/portal.education.$offeringId.tsx
@@ -160,7 +160,7 @@ export default function PortalOfferingDetail() {
 
       {descriptionHtml && (
         <section
-          className="bg-card border border-border rounded-lg p-5 prose prose-sm max-w-none"
+          className="bg-card border border-border rounded-lg p-5 prose prose-sm dark:prose-invert max-w-none"
           dangerouslySetInnerHTML={{ __html: descriptionHtml }}
         />
       )}


### PR DESCRIPTION
…-retime (#920)

* Add multi-role timesheets, work-linked calendar blocks, and self-check-in attendance

Members hired for multiple concurrent roles (project, Core, instructor, domain lead, admin) can now attribute calendar blocks and timesheet entries to the specific role the hours belong to, instead of only a single project. Calendar blocks gain a "this is work" toggle that mirrors into the Timesheet tab, the Timesheet week grid overlays all roles by default with a per-role filter, and large all-lab events can use QR/link self-check-in instead of a manually-checked attendance roster.

Also includes other in-progress sp/qol branch work (forms, projects, theme, partner portal) that was already uncommitted locally.



* Remove jobx-extension demo mode; always use configured base URL

Demo mode was dead weight now that the DALI export endpoint is live. The auto-detect fallback also silently guessed a wrong prod hostname (dali.dartmouth.edu instead of os.dali.dartmouth.edu) when the popup's base URL was left blank — now it requires a configured base URL and errors clearly instead of guessing.



* Fix CodeQL alert: decode HTML entities before stripping tags in calendar descriptions

plainTextFromGoogleHtml stripped literal <tag> markup before decoding HTML entities, so an entity-encoded tag (e.g. &lt;script&gt;) decoded into a live <script> after the strip step had already run — CodeQL flagged this as incomplete sanitization / HTML injection. Reorder so all entities decode first, then tags are stripped once, with &amp; decoded last to avoid double-unescaping already-encoded content.



* Sanitize Google Calendar descriptions with DOMPurify, not hand-rolled regex

The regex reorder in the last commit wasn't enough — CodeQL's incomplete-sanitization query doesn't trust hand-rolled tag-strip/ unescape regex at all, and it was right to be suspicious: decoding &lt;/&gt; after DOMPurify would have handed a live <script> straight back out from an inert, safely-escaped &lt;script&gt; in the source.

Now DOMPurify (already used for email bodies in ~/lib/email.ts) does the actual sanitization via a real parser, restricted to the p/br tags we convert to newlines. &lt;/&gt; are deliberately left undecoded — they're the only two entities that can reconstruct an angle bracket — while &amp;/&quot;/&#39;/&nbsp; still decode for readability.



* Replace generic <...> wildcard strip with exact p/br tag matches

CodeQL kept flagging the same line even after switching to DOMPurify: its incomplete-sanitization query distrusts a generic <[^>]+> wildcard regex on externally-sourced data regardless of what ran before it — it doesn't credit DOMPurify's prior pass. Since ALLOWED_TAGS is restricted to p/br with no attributes, DOMPurify's output can only ever contain the exact strings <p>, </p>, <br>, <br/> — so match those literally instead of sweeping with a wildcard.



* Fix e2e: restore share-toggle accessible name, follow Partners heading rename

Two independent partner-portal e2e breakages:

1. Making the Documents actions icon-only changed the share toggle's accessible name to "Stop sharing with partner". With the visible label gone, aria-label IS the name — and partner-portal.spec matches it via getByRole. That broke the toggle test, which then never ran its revert click, leaving "Internal Retro Notes" partnerVisible and cascading into the two partner-portal visibility/404 tests. Restore the exact "Shared with partner" / "Share with partner" names and keep the extra hint in the title attribute.

2. bc908c0 renamed the /partners heading Organizations -> Partners but left the spec asserting the old name. Follow the rename in the spec.



* Fix unreadable prose text in dark mode with dark:prose-invert

Adding @tailwindcss/typography (to make lists/quotes actually render) regressed dark mode: `prose` ships its own colour palette, and --tw-prose-body (a dark grey) wins over an inherited text-foreground. Before the plugin existed `prose` was an inert no-op class, so text just inherited text-foreground and looked fine — installing it turned document body text dark-on-dark.

Add dark:prose-invert everywhere `prose` is used: the collab/rich-text editor + viewer, education course hubs, and the two hiring cycle description blocks. Verified computed colour goes 0.373 -> 0.872 lightness in dark mode while light mode is unchanged.



* Timesheet: per-role hours, required roles, typed time ranges, drag-to-retime

Timesheet tab (this session's asks):

- Filter chips now show each hired role's hours for the visible week, so the calendar doubles as a per-role hours readout. Hours are scoped to what's actually drawn on the grid (the loader sends the last 200 entries, not just this week's), so the totals can't disagree with the blocks.
- "Unassigned" is gone as a choice everywhere time is logged (quick-add, drag popover, edit popover) — it's now a disabled "Select a role…" placeholder, and the schema + action require a real role. Legacy unattributed rows still render in their own bucket; nothing can create or revert to one. Users with no paid role get an explanation instead of an unusable form.
- Manual entries no longer rely on drag-to-pick-a-time: the add form now takes a date + start/end time and derives hours from the range, rather than date + hours pinned to a nominal 9am. Validation runs client-side (button gated, inline message) AND server-side — end must be after start, <= 24h, and submitted hours must match the range, so a hand-rolled POST can't log 8h against a 30-minute window.
- Ordinary calendar events no longer appear on the Timesheet grid. It's a record of paid hours, so linked-calendar events and personal blocks not marked as work are not drawn (blocks that ARE work already surface via their synced TimeEntry). My Availability still shows the full picture.
- Fixed: clicking an entry opened a bogus "New entry" popover on top of it. The day column starts a drag-to-create on any mousedown that reaches it and commits on mouseup even with zero movement; the block only swallowed mousedown when it had an onClick, so Meeting/Block entries fell through. Blocks now always swallow it, and non-editable entries explain where their hours come from.
- A selected entry can be dragged up/down to retime it (duration preserved) and resized by its edge handles — previously only a fresh drag-selection could be resized. Both popovers follow the block live.

Also carries in-progress work from the working tree: attendance admin console, photo/S3 crop handling, epics timeline, partner project hub, member profile view, and project hub banner.



* Epics: create via the detail modal, with sprints addable straight away

"+ New epic" opened a row of inline inputs wedged into the epics list. It now opens a modal like the detail view, and on save hands straight off to the real detail modal for the created epic — scrolled to Sprints with the sprint form already open. So adding a project's first epic and its sprints is one flow instead of save-then-go-find-the-row.

startAddSprint now opens the sprint form rather than only scrolling to it; both of its entry points ("Add one" in the list, and landing here right after creating an epic) mean "add a sprint now".

Adds apiJson so creation can read the new epic's id back; `api` is now a thin void wrapper over it, so error handling stays in one place.

Also fixes a latent crash this flow exposes: EpicsTimeline bailed out early on `epics.length === 0` while calling useRef/useMemo/useEffect below that return. Going 0 -> 1 epics changed the hook count and React threw "Rendered more hooks than during the previous render", taking down the page — precisely what creating a first epic does. The empty-state return now sits after every hook (they all handle bounds === null). Pre-existing on dev; only reachable once you could create a first epic and stay on the page.



---------

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/921"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786851617&installation_id=133523038&pr_number=921&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F921&signature=983026dfedcfb2db2029dd9b56555af30bca0b911c07b5b3f4780ddd9d2dcdb1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->