### PR TITLE
Add ⌘K command palette (search + commands)

### DIFF
--- a/dali-api/app/components/CommandPalette.tsx
+++ b/dali-api/app/components/CommandPalette.tsx
@@ -1,0 +1,321 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { LucideIcon } from "lucide-react";
+import {
+  Search,
+  Home,
+  ListTodo,
+  Calendar,
+  ClipboardList,
+  Briefcase,
+  FolderKanban,
+  Users2,
+  UsersRound,
+  Handshake,
+  GraduationCap,
+  Workflow,
+  Settings,
+  HelpCircle,
+  Heart,
+  FileText,
+  PanelTop,
+  Square,
+  Compass,
+  LogOut,
+  CornerDownLeft,
+} from "lucide-react";
+import { Modal } from "~/components/Modal";
+import { setTablessPreference } from "~/lib/tabless";
+import type { SearchResult, SearchResultType } from "~/lib/search";
+
+export interface CommandPaletteRoles {
+  isCore?: boolean;
+  canViewForms?: boolean;
+  canViewStaffing?: boolean;
+  hasHiringAccess?: boolean;
+  isLabMentor?: boolean;
+}
+
+interface CommandPaletteProps {
+  open: boolean;
+  onClose: () => void;
+  /** Current workspace mode — drives the "switch mode" command + how results open. */
+  tabless: boolean;
+  roles: CommandPaletteRoles;
+  /** Open a result. `toSide` = ⌘/Ctrl+Enter (split pane in tab mode, new browser tab in tabless). */
+  onOpen: (url: string, label: string, toSide: boolean) => void;
+}
+
+type PaletteAction =
+  | { kind: "navigate"; url: string; label: string }
+  | { kind: "run"; run: () => void };
+
+interface PaletteItem {
+  id: string;
+  title: string;
+  subtitle?: string;
+  icon: LucideIcon;
+  action: PaletteAction;
+}
+
+const TYPE_ORDER: SearchResultType[] = [
+  "person",
+  "project",
+  "education",
+  "partner",
+  "document",
+  "application",
+];
+
+const TYPE_META: Record<SearchResultType, { label: string; icon: LucideIcon }> = {
+  person: { label: "People", icon: UsersRound },
+  project: { label: "Projects", icon: FolderKanban },
+  education: { label: "Education", icon: GraduationCap },
+  partner: { label: "Partners", icon: Handshake },
+  document: { label: "Documents", icon: FileText },
+  application: { label: "Applications", icon: Briefcase },
+};
+
+export function CommandPalette({ open, onClose, tabless, roles, onOpen }: CommandPaletteProps) {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<SearchResult[]>([]);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  // Fresh palette each open.
+  useEffect(() => {
+    if (open) {
+      setQuery("");
+      setResults([]);
+      setSelectedIndex(0);
+    }
+  }, [open]);
+
+  // Debounced, abortable entity search. Aborting on each keystroke also drops
+  // stale in-flight responses so a slow one can't overwrite a newer query.
+  useEffect(() => {
+    if (!open) return;
+    const q = query.trim();
+    if (q.length < 2) {
+      setResults([]);
+      return;
+    }
+    const ctrl = new AbortController();
+    const t = setTimeout(() => {
+      fetch(`/api/search?q=${encodeURIComponent(q)}`, {
+        credentials: "include",
+        signal: ctrl.signal,
+      })
+        .then((r) => (r.ok ? r.json() : { results: [] }))
+        .then((d) => setResults(d.results ?? []))
+        .catch(() => {
+          /* aborted or network error — leave prior results */
+        });
+    }, 150);
+    return () => {
+      clearTimeout(t);
+      ctrl.abort();
+    };
+  }, [open, query]);
+
+  // Static "Go to" + "Commands" entries, built from role flags (no round-trip)
+  // and filtered client-side by the current query.
+  const staticSections = useMemo(() => {
+    const nav: PaletteItem[] = [
+      navItem("Home", "/", Home),
+      navItem("My Tasks", "/notifications", ListTodo),
+      navItem("Calendar", "/calendar", Calendar),
+      roles.canViewForms ? navItem("Forms", "/forms", ClipboardList) : null,
+      roles.hasHiringAccess ? navItem("Hiring", "/hiring", Briefcase) : null,
+      navItem("Projects", "/projects", FolderKanban),
+      roles.canViewStaffing ? navItem("Staffing", "/projects/staffing", Users2) : null,
+      roles.isLabMentor || roles.isCore ? navItem("Mentorship", "/mentorship", Heart) : null,
+      navItem("People", "/members", UsersRound),
+      navItem("Partners", "/partners", Handshake),
+      navItem("Education", "/education", GraduationCap),
+      navItem("Lab Processes", "/internal-processes", Workflow),
+      roles.isCore ? navItem("Admin", "/admin-console", Settings) : null,
+      navItem("Settings", "/settings", Settings),
+      navItem("Help", "/help", HelpCircle),
+    ].filter((x): x is PaletteItem => x !== null);
+
+    const commands: PaletteItem[] = [
+      {
+        id: "cmd-workspace",
+        title: tabless ? "Switch to tabbed workspace" : "Switch to single-page mode",
+        subtitle: "Command",
+        icon: tabless ? PanelTop : Square,
+        action: {
+          kind: "run",
+          run: () => {
+            setTablessPreference(!tabless);
+            window.location.reload();
+          },
+        },
+      },
+      {
+        id: "cmd-tour",
+        title: "Start the tour",
+        subtitle: "Command",
+        icon: Compass,
+        action: { kind: "run", run: () => window.dispatchEvent(new Event("dali:start-tour")) },
+      },
+      {
+        id: "cmd-logout",
+        title: "Log out",
+        subtitle: "Command",
+        icon: LogOut,
+        action: { kind: "run", run: () => window.location.assign("/logout") },
+      },
+    ];
+
+    const q = query.trim().toLowerCase();
+    const match = (i: PaletteItem) => !q || i.title.toLowerCase().includes(q);
+    return { nav: nav.filter(match), commands: commands.filter(match) };
+  }, [roles, tabless, query]);
+
+  const sections = useMemo(() => {
+    const out: { key: string; label: string; items: PaletteItem[] }[] = [];
+    if (staticSections.nav.length) out.push({ key: "nav", label: "Go to", items: staticSections.nav });
+    if (staticSections.commands.length)
+      out.push({ key: "cmd", label: "Commands", items: staticSections.commands });
+    for (const type of TYPE_ORDER) {
+      const items = results
+        .filter((r) => r.type === type)
+        .map((r) => resultItem(r));
+      if (items.length) out.push({ key: type, label: TYPE_META[type].label, items });
+    }
+    return out;
+  }, [staticSections, results]);
+
+  const flatItems = useMemo(() => sections.flatMap((s) => s.items), [sections]);
+
+  // Reset highlight to the top item as the visible set changes.
+  useEffect(() => {
+    setSelectedIndex(0);
+  }, [query, results]);
+
+  // Keep the highlighted row in view during arrow navigation.
+  useEffect(() => {
+    listRef.current
+      ?.querySelector(`[data-idx="${selectedIndex}"]`)
+      ?.scrollIntoView({ block: "nearest" });
+  }, [selectedIndex]);
+
+  function select(item: PaletteItem, toSide: boolean) {
+    if (item.action.kind === "navigate") onOpen(item.action.url, item.action.label, toSide);
+    else item.action.run();
+    onClose();
+  }
+
+  function onKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setSelectedIndex((i) => Math.min(i + 1, flatItems.length - 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setSelectedIndex((i) => Math.max(i - 1, 0));
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      const item = flatItems[selectedIndex];
+      if (item) select(item, e.metaKey || e.ctrlKey);
+    }
+  }
+
+  let runningIdx = -1;
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      labelledBy="command-palette-title"
+      initialFocusRef={inputRef}
+      className="fixed inset-0 z-50 flex items-start justify-center bg-black/40 p-4 pt-[12vh] overflow-y-auto"
+      containerClassName="bg-card rounded-2xl shadow-brand-2 max-w-xl w-full overflow-hidden"
+    >
+      <h2 id="command-palette-title" className="sr-only">
+        Search and commands
+      </h2>
+
+      <div className="flex items-center gap-2.5 border-b border-border px-4">
+        <Search className="w-4 h-4 text-muted-foreground shrink-0" aria-hidden />
+        <input
+          ref={inputRef}
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          onKeyDown={onKeyDown}
+          placeholder="Search people, projects, docs… or run a command"
+          className="flex-1 bg-transparent py-3.5 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none"
+          aria-label="Search and commands"
+          autoComplete="off"
+          spellCheck={false}
+        />
+      </div>
+
+      <div ref={listRef} className="max-h-[60vh] overflow-y-auto py-2">
+        {flatItems.length === 0 ? (
+          <p className="px-4 py-6 text-center text-sm text-muted-foreground">
+            {query.trim().length >= 2 ? "No matches" : "Type to search"}
+          </p>
+        ) : (
+          sections.map((section) => (
+            <div key={section.key} className="mb-1 last:mb-0">
+              <p className="px-4 pt-2 pb-1 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                {section.label}
+              </p>
+              {section.items.map((item) => {
+                runningIdx += 1;
+                const idx = runningIdx;
+                const active = idx === selectedIndex;
+                const Icon = item.icon;
+                return (
+                  <button
+                    key={item.id}
+                    type="button"
+                    data-idx={idx}
+                    // onMouseDown (not onClick) so the input doesn't blur first,
+                    // and onMouseMove to sync the highlight to the pointer.
+                    onMouseMove={() => setSelectedIndex(idx)}
+                    onClick={(e) => select(item, e.metaKey || e.ctrlKey)}
+                    className={`flex w-full items-center gap-3 px-4 py-2 text-left text-sm transition-colors ${
+                      active ? "bg-accent-coral/10 text-foreground" : "text-foreground/80 hover:bg-muted/50"
+                    }`}
+                  >
+                    <Icon
+                      className={`w-4 h-4 shrink-0 ${active ? "text-accent-coral" : "text-muted-foreground"}`}
+                      aria-hidden
+                    />
+                    <span className="truncate flex-1">{item.title}</span>
+                    {item.subtitle && (
+                      <span className="truncate text-xs text-muted-foreground max-w-[40%]">
+                        {item.subtitle}
+                      </span>
+                    )}
+                    {active && (
+                      <CornerDownLeft className="w-3.5 h-3.5 shrink-0 text-muted-foreground" aria-hidden />
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+          ))
+        )}
+      </div>
+    </Modal>
+  );
+}
+
+function navItem(title: string, url: string, icon: LucideIcon): PaletteItem {
+  return { id: `nav-${url}`, title, subtitle: "Go to", icon, action: { kind: "navigate", url, label: title } };
+}
+
+function resultItem(r: SearchResult): PaletteItem {
+  return {
+    id: `${r.type}-${r.id}`,
+    title: r.title,
+    subtitle: r.subtitle,
+    icon: TYPE_META[r.type].icon,
+    action: { kind: "navigate", url: r.url, label: r.title },
+  };
+}

--- a/dali-api/app/components/Layout.tsx
+++ b/dali-api/app/components/Layout.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react'
+import React, { useState, useEffect, useRef, useCallback } from 'react'
 import { Link, useLocation, useNavigate, useRevalidator } from 'react-router'
 import {
   LogOut,
@@ -24,6 +24,7 @@ import { userInitials } from '~/lib/display'
 import { TabWorkspace, type TabWorkspaceHandle, type OpenTabRequest } from '~/components/TabWorkspace'
 import { useOpenTasks, TASKS_CHANGED_EVENT } from '~/components/NotificationBell'
 import { DesktopBanner } from '~/components/DesktopBanner'
+import { CommandPalette } from '~/components/CommandPalette'
 
 interface LayoutProps {
   user: { email: string; firstName?: string; lastName?: string }
@@ -76,12 +77,44 @@ export function Layout({ user, photoUrl, isCore = false, isAdmin = false, isDoma
   const [mobileNavOpen, setMobileNavOpen] = useState(false)
   const workspaceRef = useRef<TabWorkspaceHandle | null>(null)
 
+  const [paletteOpen, setPaletteOpen] = useState(false)
+  const togglePalette = useCallback(() => setPaletteOpen((v) => !v), [])
+  // ⌘/Ctrl+K opens the command palette. In tab mode TabWorkspace owns the
+  // listener (its handler is attached to the shell window AND every iframe's
+  // document, so it fires wherever focus is) and calls togglePalette via
+  // onOpenPalette. In tabless mode there's no TabWorkspace, so listen here.
+  // Gating on `tabless` avoids both handlers firing for one keypress.
+  useEffect(() => {
+    if (!tabless) return
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && !e.altKey && !e.shiftKey && (e.key === 'k' || e.key === 'K')) {
+        e.preventDefault()
+        togglePalette()
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [tabless, togglePalette])
+
   const openInWorkspace = (req: OpenTabRequest) => {
     if (tabless) {
       navigate(req.url)
       return
     }
     workspaceRef.current?.openTab(req)
+  }
+
+  // Open a palette result. Mirrors sidebar navigation: tabless → navigate the
+  // top window (⌘Enter → real browser tab); tab mode → a kept workspace tab
+  // (⌘Enter → split-pane). The user picked this explicitly, so no ephemeral tab.
+  const openFromPalette = (url: string, label: string, toSide: boolean) => {
+    if (tabless) {
+      if (toSide) window.open(url, '_blank', 'noopener')
+      else navigate(url)
+      return
+    }
+    if (toSide) workspaceRef.current?.openTabToSide({ url, label })
+    else workspaceRef.current?.openTab({ url, label })
   }
 
   // Props bundle for any sidebar button that opens a surface. In tab mode it
@@ -583,6 +616,7 @@ export function Layout({ user, photoUrl, isCore = false, isAdmin = false, isDoma
         ) : (
           <TabWorkspace
             apiRef={workspaceRef}
+            onOpenPalette={togglePalette}
             initialTabs={[
               { url: '/', label: 'Home' },
               ...(initialTabLabel && location.pathname !== '/'
@@ -593,6 +627,14 @@ export function Layout({ user, photoUrl, isCore = false, isAdmin = false, isDoma
           />
         )}
       </main>
+
+      <CommandPalette
+        open={paletteOpen}
+        onClose={() => setPaletteOpen(false)}
+        tabless={tabless}
+        roles={{ isCore, canViewForms, canViewStaffing, hasHiringAccess, isLabMentor }}
+        onOpen={openFromPalette}
+      />
     </div>
   )
 }

--- a/dali-api/app/components/TabWorkspace.tsx
+++ b/dali-api/app/components/TabWorkspace.tsx
@@ -264,6 +264,10 @@ export interface TabWorkspaceProps {
   apiRef?: React.MutableRefObject<TabWorkspaceHandle | null>
   /** Notified when the focused pane's active tab URL changes (null when no tab). */
   onActiveUrlChange?: (url: string | null) => void
+  /** ⌘/Ctrl+K — open the command palette. Called for keypresses in the shell
+   *  window and inside any workspace iframe (the shortcut handler is attached
+   *  to both), so the palette opens wherever focus is. */
+  onOpenPalette?: () => void
 }
 
 interface DragSource {
@@ -287,7 +291,7 @@ interface PaneDrop {
   zone: PaneDropZone
 }
 
-export function TabWorkspace({ initialTabs, apiRef, onActiveUrlChange }: TabWorkspaceProps) {
+export function TabWorkspace({ initialTabs, apiRef, onActiveUrlChange, onOpenPalette }: TabWorkspaceProps) {
   const [state, setState] = useState<WorkspaceState>(emptyState)
   const [contextMenu, setContextMenu] = useState<
     | { paneId: string; tabId: string; x: number; y: number }
@@ -820,6 +824,11 @@ export function TabWorkspace({ initialTabs, apiRef, onActiveUrlChange }: TabWork
     stateRef.current = state
   }, [state])
 
+  // onShortcut is created once (below) and never re-created, so read the latest
+  // palette callback through a ref rather than closing over the prop.
+  const onOpenPaletteRef = useRef(onOpenPalette)
+  onOpenPaletteRef.current = onOpenPalette
+
   if (!handlersRef.current) {
     handlersRef.current = {
       onShortcut: (e: KeyboardEvent) => {
@@ -847,6 +856,13 @@ export function TabWorkspace({ initialTabs, apiRef, onActiveUrlChange }: TabWork
         }
 
         if (!mod) return
+
+        // mod + k — open the command palette. (mod+shift+k closes a tab, below.)
+        if (!e.altKey && !e.shiftKey && (e.key === 'k' || e.key === 'K')) {
+          e.preventDefault()
+          onOpenPaletteRef.current?.()
+          return
+        }
 
         // mod + [ / mod + ] — in-tab back/forward.
         if (!e.altKey && !e.shiftKey && (e.key === '[' || e.key === ']')) {

--- a/dali-api/app/lib/__tests__/search.test.ts
+++ b/dali-api/app/lib/__tests__/search.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import {
+  matchScore,
+  bestScore,
+  rankResults,
+  buildUrl,
+  computeHiringVisibility,
+  PER_CATEGORY_CAP,
+  type Rankable,
+} from "~/lib/search";
+
+describe("matchScore", () => {
+  it("ranks exact > prefix > word-start > substring", () => {
+    expect(matchScore("Alex", "alex")).toBe(0);
+    expect(matchScore("Alexander", "alex")).toBe(1);
+    expect(matchScore("Jordan Alexander", "alex")).toBe(2);
+    expect(matchScore("Malex", "alex")).toBe(3);
+  });
+
+  it("is case- and whitespace-insensitive", () => {
+    expect(matchScore("  PROJECT Zero ", "project")).toBe(1);
+  });
+
+  it("returns null for no match or empty query", () => {
+    expect(matchScore("Alex", "bob")).toBeNull();
+    expect(matchScore("Alex", "")).toBeNull();
+    expect(matchScore("", "alex")).toBeNull();
+  });
+});
+
+describe("bestScore", () => {
+  it("takes the best score across fields (e.g. name vs email)", () => {
+    // name is a substring match (3), email is a prefix match (1) → best is 1.
+    expect(bestScore(["Sam Malex", "alex@dali.dev"], "alex")).toBe(1);
+  });
+
+  it("returns null when no field matches", () => {
+    expect(bestScore(["Sam", "sam@dali.dev"], "zzz")).toBeNull();
+  });
+});
+
+describe("rankResults", () => {
+  const mk = (title: string): Rankable => ({
+    result: { type: "project", id: title, title, url: buildUrl.project(title) },
+    text: [title],
+  });
+
+  it("orders by score then alphabetically, dropping non-matches", () => {
+    const out = rankResults([mk("Zeta Query"), mk("Query"), mk("Query Tools"), mk("Nope")], "query");
+    expect(out.map((r) => r.title)).toEqual(["Query", "Query Tools", "Zeta Query"]);
+  });
+
+  it("caps each category at PER_CATEGORY_CAP", () => {
+    const many = Array.from({ length: PER_CATEGORY_CAP + 3 }, (_, i) => mk(`Query ${i}`));
+    expect(rankResults(many, "query")).toHaveLength(PER_CATEGORY_CAP);
+  });
+});
+
+describe("buildUrl (route-param gotchas)", () => {
+  it("maps each type to its canonical detail URL", () => {
+    expect(buildUrl.person("u1")).toBe("/members/u1");
+    expect(buildUrl.project("p1")).toBe("/projects/p1");
+    expect(buildUrl.education("o1")).toBe("/education/o1");
+    expect(buildUrl.partner("g1")).toBe("/partners/g1");
+    expect(buildUrl.document("d1")).toBe("/documents/d1");
+    expect(buildUrl.application("da1")).toBe("/hiring/applications/da1");
+  });
+});
+
+describe("computeHiringVisibility (leak-proofing)", () => {
+  const rows = [
+    { applicationCycleId: "c1", domainId: "d1" },
+    { applicationCycleId: "c1", domainId: "d2" },
+  ];
+
+  it("Core sees everything", () => {
+    expect(computeHiringVisibility(true, [])).toEqual({ all: true });
+  });
+
+  it("a reviewer sees only their assigned (cycle, domain) pairs", () => {
+    expect(computeHiringVisibility(false, rows)).toEqual({ all: false, pairs: rows });
+  });
+
+  it("a non-Core user with no reviewer rows sees nothing", () => {
+    expect(computeHiringVisibility(false, [])).toEqual({ all: false, pairs: [] });
+  });
+});

--- a/dali-api/app/lib/search.server.ts
+++ b/dali-api/app/lib/search.server.ts
@@ -1,0 +1,213 @@
+import type { Prisma } from "~/generated/prisma/client";
+import { prisma } from "~/lib/db";
+import { LAB_MEMBER_WHERE } from "~/lib/prisma-shapes";
+import type { UserRoles } from "~/lib/roles";
+import { getCycleConfidentialityState } from "~/hiring/lib/confidentiality";
+import {
+  buildUrl,
+  computeHiringVisibility,
+  MIN_QUERY_LENGTH,
+  rankResults,
+  type SearchResult,
+} from "~/lib/search";
+
+// Server side of the command-palette search: permission-scoped Prisma queries
+// that feed the pure ranking in lib/search.ts. Each category is scoped to what
+// the caller may already reach — see the per-category notes below.
+
+export async function runSearch(opts: {
+  userId: string;
+  roles: UserRoles;
+  q: string;
+}): Promise<SearchResult[]> {
+  const q = opts.q.trim();
+  if (q.length < MIN_QUERY_LENGTH) return [];
+  // Not a lab member (e.g. an applicant who reached the endpoint directly) —
+  // nothing to surface. The palette itself only mounts in the member shell.
+  if (!opts.roles.isLabMember) return [];
+
+  const like = { contains: q, mode: "insensitive" as const };
+  // Over-fetch a bounded set per category, then rank+cap in JS. At lab scale a
+  // 2+ char substring query returns few rows; the cap bounds payload + render.
+  const RAW_TAKE = 40;
+
+  const [people, projects, offerings, partners, documents] = await Promise.all([
+    prisma.user.findMany({
+      where: {
+        ...LAB_MEMBER_WHERE,
+        OR: [{ firstName: like }, { lastName: like }, { daliEmail: like }, { dartmouthEmail: like }],
+      },
+      select: { id: true, firstName: true, lastName: true, daliEmail: true, dartmouthEmail: true },
+      take: RAW_TAKE,
+    }),
+    // Archived projects are effectively retired — keep them out of quick-jump.
+    prisma.project.findMany({
+      where: { status: { not: "Archived" }, name: like },
+      select: { id: true, name: true },
+      take: RAW_TAKE,
+    }),
+    // Only Published offerings are member-visible; Draft/Archived stay hidden.
+    prisma.educationOffering.findMany({
+      where: { status: "Published", title: like },
+      select: { id: true, title: true },
+      take: RAW_TAKE,
+    }),
+    prisma.partnerOrg.findMany({
+      where: { name: like },
+      select: { id: true, name: true },
+      take: RAW_TAKE,
+    }),
+    // Any authenticated member may already open any live page by URL (only
+    // editing is gated), so title search matches that existing view surface.
+    prisma.page.findMany({
+      where: { archivedAt: null, title: like },
+      select: { id: true, title: true },
+      take: RAW_TAKE,
+    }),
+  ]);
+
+  const results: SearchResult[] = [];
+
+  results.push(
+    ...rankResults(
+      people.map((u) => {
+        const name = `${u.firstName ?? ""} ${u.lastName ?? ""}`.trim() || "Member";
+        const email = u.daliEmail ?? u.dartmouthEmail ?? undefined;
+        return {
+          result: { type: "person", id: u.id, title: name, subtitle: email, url: buildUrl.person(u.id) },
+          text: [name, email ?? ""],
+        };
+      }),
+      q,
+    ),
+  );
+
+  results.push(
+    ...rankResults(
+      projects.map((p) => ({
+        result: { type: "project", id: p.id, title: p.name, subtitle: "Project", url: buildUrl.project(p.id) },
+        text: [p.name],
+      })),
+      q,
+    ),
+  );
+
+  results.push(
+    ...rankResults(
+      offerings.map((o) => ({
+        result: { type: "education", id: o.id, title: o.title, subtitle: "Education", url: buildUrl.education(o.id) },
+        text: [o.title],
+      })),
+      q,
+    ),
+  );
+
+  results.push(
+    ...rankResults(
+      partners.map((o) => ({
+        result: { type: "partner", id: o.id, title: o.name, subtitle: "Partner", url: buildUrl.partner(o.id) },
+        text: [o.name],
+      })),
+      q,
+    ),
+  );
+
+  results.push(
+    ...rankResults(
+      documents.map((d) => ({
+        result: { type: "document", id: d.id, title: d.title || "Untitled", subtitle: "Document", url: buildUrl.document(d.id) },
+        text: [d.title || ""],
+      })),
+      q,
+    ),
+  );
+
+  results.push(...(await searchApplications(opts.userId, opts.roles, q, like)));
+
+  return results;
+}
+
+// Role-gated applicant search — kept separate because its visibility rules are
+// the security-critical part. Mirrors app/hiring/routes/applications.tsx and
+// additionally requires the cycle's confidentiality agreement to be signed
+// before any applicant name is disclosed (stricter than the list view).
+async function searchApplications(
+  userId: string,
+  roles: UserRoles,
+  q: string,
+  like: { contains: string; mode: "insensitive" },
+): Promise<SearchResult[]> {
+  const reviewerRows = await prisma.cycleReviewer.findMany({
+    where: { userId },
+    select: { applicationCycleId: true, domainId: true },
+  });
+  if (!roles.isCore && reviewerRows.length === 0) return [];
+
+  const visibility = computeHiringVisibility(roles.isCore, reviewerRows);
+
+  const candidateCycleIds = visibility.all
+    ? (await prisma.applicationCycle.findMany({ select: { id: true } })).map((c) => c.id)
+    : [...new Set(reviewerRows.map((r) => r.applicationCycleId))];
+
+  // Leak-proofing: only cycles whose currently-bound confidentiality agreement
+  // this user has signed. Applies to Core too (no-agreement → nobody sees).
+  const signedCycleIds = (
+    await Promise.all(
+      candidateCycleIds.map(async (id) =>
+        (await getCycleConfidentialityState(userId, id)).status === "signed" ? id : null,
+      ),
+    )
+  ).filter((id): id is string => id !== null);
+  if (signedCycleIds.length === 0) return [];
+
+  const nameMatch = { user: { OR: [{ firstName: like }, { lastName: like }] } };
+  let where: Prisma.DomainApplicationWhereInput;
+  if (visibility.all) {
+    where = {
+      selected: true,
+      application: { applicationCycleId: { in: signedCycleIds }, ...nameMatch },
+    };
+  } else {
+    const pairs = visibility.pairs.filter((r) => signedCycleIds.includes(r.applicationCycleId));
+    if (pairs.length === 0) return [];
+    where = {
+      selected: true,
+      // Standard cycles link Domain via challengeVersion; InternToFull links it
+      // directly — match whichever path is set (mirrors the reviewer route).
+      OR: pairs.map((r) => ({
+        application: { applicationCycleId: r.applicationCycleId, ...nameMatch },
+        OR: [{ challengeVersion: { domainId: r.domainId } }, { domainId: r.domainId }],
+      })),
+    };
+  }
+
+  const apps = await prisma.domainApplication.findMany({
+    where,
+    select: {
+      id: true,
+      domain: { select: { displayName: true } },
+      challengeVersion: { select: { domain: { select: { displayName: true } } } },
+      application: { select: { user: { select: { firstName: true, lastName: true } } } },
+    },
+    take: 40,
+  });
+
+  return rankResults(
+    apps.map((da) => {
+      const u = da.application.user;
+      const name = `${u.firstName ?? ""} ${u.lastName ?? ""}`.trim() || "Applicant";
+      const domain = da.domain?.displayName ?? da.challengeVersion?.domain?.displayName;
+      return {
+        result: {
+          type: "application" as const,
+          id: da.id,
+          title: name,
+          subtitle: domain ? `Applicant · ${domain}` : "Applicant",
+          url: buildUrl.application(da.id),
+        },
+        text: [name],
+      };
+    }),
+    q,
+  );
+}

--- a/dali-api/app/lib/search.ts
+++ b/dali-api/app/lib/search.ts
@@ -1,0 +1,89 @@
+// Pure, client-safe core for the command-palette search: types, ranking, URL
+// building, and the hiring-visibility rule. No prisma/db imports so it loads in
+// the browser bundle and in unit tests without a generated client. The DB
+// queries live in search.server.ts.
+
+export type SearchResultType =
+  | "person"
+  | "project"
+  | "education"
+  | "partner"
+  | "document"
+  | "application";
+
+export interface SearchResult {
+  type: SearchResultType;
+  id: string;
+  title: string;
+  subtitle?: string;
+  url: string;
+}
+
+export const MIN_QUERY_LENGTH = 2;
+export const PER_CATEGORY_CAP = 5;
+
+// Canonical detail URLs. Centralized so the route-param gotchas live in one
+// place: members key on User.id, education on :offeringId, partners on :orgId,
+// applications on the DomainApplication id.
+export const buildUrl: Record<SearchResultType, (id: string) => string> = {
+  person: (id) => `/members/${id}`,
+  project: (id) => `/projects/${id}`,
+  education: (id) => `/education/${id}`,
+  partner: (id) => `/partners/${id}`,
+  document: (id) => `/documents/${id}`,
+  application: (id) => `/hiring/applications/${id}`,
+};
+
+// Lower is better; null means no match. exact(0) > prefix(1) > word-start(2) >
+// substring(3). Whitespace-trimmed, case-insensitive.
+export function matchScore(text: string, query: string): number | null {
+  const t = text.trim().toLowerCase();
+  const q = query.trim().toLowerCase();
+  if (!q || !t) return null;
+  if (t === q) return 0;
+  if (t.startsWith(q)) return 1;
+  if (t.split(/\s+/).some((word) => word.startsWith(q))) return 2;
+  if (t.includes(q)) return 3;
+  return null;
+}
+
+// Best (lowest) score across candidate fields (e.g. name + email).
+export function bestScore(fields: string[], query: string): number | null {
+  let best: number | null = null;
+  for (const f of fields) {
+    const s = matchScore(f, query);
+    if (s !== null && (best === null || s < best)) best = s;
+  }
+  return best;
+}
+
+export interface Rankable {
+  result: SearchResult;
+  /** Fields to score/rank against (title, and e.g. email for people). */
+  text: string[];
+}
+
+// Rank matches, tie-break alphabetically by title, cap to PER_CATEGORY_CAP.
+export function rankResults(entries: Rankable[], query: string): SearchResult[] {
+  return entries
+    .map((e) => ({ e, score: bestScore(e.text, query) }))
+    .filter((x): x is { e: Rankable; score: number } => x.score !== null)
+    .sort((a, b) => a.score - b.score || a.e.result.title.localeCompare(b.e.result.title))
+    .slice(0, PER_CATEGORY_CAP)
+    .map((x) => x.e.result);
+}
+
+export type ReviewerRow = { applicationCycleId: string; domainId: string };
+
+// Which hiring applications a user may see, mirroring the LIST route
+// (app/hiring/routes/applications.tsx): Core sees every cycle/domain; everyone
+// else sees only their assigned (cycle, domain) reviewer pairs. Deliberately
+// does NOT grant domain leads blanket access — the list view doesn't either, so
+// search never discloses more than that view already would.
+export function computeHiringVisibility(
+  isCore: boolean,
+  reviewerRows: ReviewerRow[],
+): { all: true } | { all: false; pairs: ReviewerRow[] } {
+  if (isCore) return { all: true };
+  return { all: false, pairs: reviewerRows };
+}

--- a/dali-api/app/routes.ts
+++ b/dali-api/app/routes.ts
@@ -266,6 +266,9 @@ export default [
   // Authenticated API endpoints (no layout)
   route("users/:id", "members/routes/users.$id.ts"),
 
+  // Global command-palette search (⌘K) — permission-scoped in the loader.
+  route("api/search", "routes/api.search.ts"),
+
   // Domain & member management API
   route("api/domains", "admin-console/routes/api.domains.ts"),
   route("api/domains/:domainId", "admin-console/routes/api.domains.$domainId.ts"),

--- a/dali-api/app/routes/api.search.ts
+++ b/dali-api/app/routes/api.search.ts
@@ -1,0 +1,23 @@
+import type { Route } from "./+types/api.search";
+import { requireAuth } from "~/lib/auth";
+import { getUserRoles } from "~/lib/roles";
+import { withCors, handlePreflight } from "~/lib/cors";
+import { runSearch } from "~/lib/search.server";
+
+// Global command-palette search.
+//   GET /api/search?q=...  → { results: SearchResult[] }
+// Results are permission-scoped server-side (see lib/search.server.ts). Empty
+// for a <2-char query or a non-member session.
+export async function loader({ request }: Route.LoaderArgs) {
+  const preflight = handlePreflight(request);
+  if (preflight) return preflight;
+
+  const auth = await requireAuth(request);
+  if (!auth.ok) return withCors(request, auth.response);
+
+  const q = new URL(request.url).searchParams.get("q") ?? "";
+  const roles = await getUserRoles(auth.user.sub);
+  const results = await runSearch({ userId: auth.user.sub, roles, q });
+
+  return withCors(request, Response.json({ results }));
+}

--- a/dali-api/app/routes/help.shortcuts.tsx
+++ b/dali-api/app/routes/help.shortcuts.tsx
@@ -6,6 +6,10 @@ export const meta: Route.MetaFunction = () => [
 
 // Source of truth for these bindings is the keydown handler in
 // components/TabWorkspace.tsx. Keep this page in sync if those change.
+const GENERAL: Array<[string, string]> = [
+  ["⌘ K", "Open the command palette — search people, projects, docs, and run commands"],
+];
+
 const TABS: Array<[string, string]> = [
   ["⌘ ⌥ →", "Next tab in the focused pane"],
   ["⌘ ⌥ ←", "Previous tab in the focused pane"],
@@ -34,6 +38,7 @@ export default function HelpShortcutsPage() {
         browser claims (like ⌘W and ⌘1–9).
       </p>
 
+      <Section title="General" rows={GENERAL} />
       <Section title="Tabs and panes" rows={TABS} />
       <Section title="In-tab navigation" rows={NAV} />
     </main>


### PR DESCRIPTION
## ⚠️ Stacked on #923 (tabless mode)

This branches off `claude/tabless-mode`, not `dev`, because it reuses that work (the `setTablessPreference` command, the tabless-aware navigation in `Layout`, and both features edit `Layout.tsx`). **Base is `claude/tabless-mode` to keep this diff focused.** Once #923 merges to `dev`, retarget this PR's base to `dev` (one click) — the diff will then show only the palette.

## What

A global **⌘/Ctrl+K command palette** — quick-switcher + command runner. Type to jump to any area, person, project, education offering, partner, document, or (role-permitting) hiring application, and run a few commands. Works in **both** the tabbed workspace and tabless mode.

## How

- **`app/lib/search.ts`** — pure, client-safe core: types, ranking (exact > prefix > word-start > substring, capped 5/category), URL building, and the hiring-visibility rule. No prisma import, so it loads in the browser bundle and in unit tests with no mocks.
- **`app/lib/search.server.ts`** — permission-scoped Prisma queries feeding the ranker.
- **`app/routes/api.search.ts`** — thin `requireAuth` + `getUserRoles` + `withCors` loader.
- **`app/components/CommandPalette.tsx`** — `Modal`-based palette (top-aligned via props), debounced + `AbortController`ed fetch, from-scratch arrow-key nav, static nav/command entries built from role flags (no round-trip). Commands: switch workspace mode, start tour, log out.
- **Global shortcut** (`mod+K` is unbound): in tab mode, TabWorkspace's existing per-iframe shortcut handler gains a `mod+K` case — via an `onOpenPalette` **ref**, since that handler is created once and would otherwise capture a stale closure — so ⌘K fires whether focus is in the shell or inside an iframe. In tabless mode there's no TabWorkspace, so `Layout` owns a `window` listener. Gated so exactly one fires per keypress.
- **Result activation** reuses the sidebar's dual-mode navigation: tabless → `navigate` (⌘Enter → real browser tab); tab mode → a kept tab (⌘Enter → split pane).

## Permissions (the security-critical part)

- **Hiring applications** mirror `app/hiring/routes/applications.tsx` exactly — Core sees all cycles/domains; everyone else sees only their assigned reviewer `(cycle, domain)` pairs (domain leads are **not** granted blanket access, matching the list view). **Additionally**, a result is only included if the user has **signed that cycle's confidentiality agreement** — stricter than the list route, leak-proof by construction.
- **Document titles**: any authenticated member can already open any live page by URL (only *editing* is gated), so title search matches that existing surface. Flag if you want this tightened to workspace membership.
- People/projects/education/partners are member-wide (already the case in their list views). Draft/archived offerings and archived projects are excluded.

## Testing

- **Unit** (`app/lib/__tests__/search.test.ts`): ranking order + caps, URL mapping (guards the `:orgId`/`:offeringId`/`User.id`/`DomainApplication.id` gotchas), and the hiring-visibility resolver (Core → all, reviewer → assigned pairs, no-role → nothing).
- `npm test` → 1755 pass. `npm run typecheck` → no new errors vs baseline. `npm run build` → clean.
- **Manual**: ⌘K with focus in the sidebar, inside an iframe page (tab mode), and in tabless mode; type a member name → Enter jumps, ⌘Enter opens to the side / a browser tab; run "switch workspace mode"; Esc closes. As a hiring reviewer on one domain, confirm applicants from other domains do **not** appear.

No migrations. `/auth`/desktop routes untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/924"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786908461&installation_id=133523038&pr_number=924&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F924&signature=11ce448d94169e77c351e923dadb66c88afb1fa2bb695d4203f882838700f4f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->