### PR TITLE
Taskboard fixes + auto-archive, file preview, invite-link cleanup (#940)

### DIFF
--- a/dali-api/app/components/Modal.tsx
+++ b/dali-api/app/components/Modal.tsx
@@ -69,7 +69,10 @@ export function Modal({
     const dialog = dialogRef.current;
     if (dialog) {
       const target = initialFocusRef?.current ?? getFocusable(dialog)[0] ?? dialog;
-      target.focus();
+      // preventScroll: focusing the dialog must not scroll the page/board
+      // behind the overlay into view (the trigger — e.g. a task card — can be
+      // far down a long board, which otherwise jumps it to the top on open).
+      target.focus({ preventScroll: true });
     }
 
     const previousOverflow = document.body.style.overflow;

--- a/dali-api/app/jobs/__tests__/task-auto-archive.test.ts
+++ b/dali-api/app/jobs/__tests__/task-auto-archive.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("~/lib/db");
+
+import { prisma } from "~/lib/db";
+import { runTaskAutoArchive } from "~/jobs/task-auto-archive.server";
+
+const mockPrisma = prisma as unknown as Record<
+  string,
+  Record<string, ReturnType<typeof vi.fn>>
+>;
+
+const NOW = new Date("2026-07-20T12:00:00Z");
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe("runTaskAutoArchive", () => {
+  it("archives Done/Cancelled tasks idle past the configured threshold", async () => {
+    mockPrisma.task.updateMany.mockResolvedValue({ count: 3 });
+
+    const result = await runTaskAutoArchive({
+      now: NOW,
+      lastSuccessAt: null,
+      settings: { archiveAfterDays: 30 },
+    });
+
+    expect(result.items).toBe(3);
+    expect(mockPrisma.task.updateMany).toHaveBeenCalledTimes(1);
+    const arg = mockPrisma.task.updateMany.mock.calls[0][0];
+    // Only unarchived, terminal-status, stale rows are touched...
+    expect(arg.where.archivedAt).toBeNull();
+    expect(arg.where.status).toEqual({ in: ["Done", "Cancelled"] });
+    // ...where "stale" is now minus the threshold (30 days here).
+    const cutoff = arg.where.updatedAt.lt as Date;
+    expect(NOW.getTime() - cutoff.getTime()).toBe(30 * 24 * 60 * 60 * 1000);
+    // ...and it stamps archivedAt with the run's `now`.
+    expect(arg.data).toEqual({ archivedAt: NOW });
+  });
+
+  it("honors a custom threshold", async () => {
+    mockPrisma.task.updateMany.mockResolvedValue({ count: 0 });
+
+    await runTaskAutoArchive({
+      now: NOW,
+      lastSuccessAt: null,
+      settings: { archiveAfterDays: 7 },
+    });
+
+    const arg = mockPrisma.task.updateMany.mock.calls[0][0];
+    const cutoff = arg.where.updatedAt.lt as Date;
+    expect(NOW.getTime() - cutoff.getTime()).toBe(7 * 24 * 60 * 60 * 1000);
+  });
+
+  it("reports nothing archived without a note", async () => {
+    mockPrisma.task.updateMany.mockResolvedValue({ count: 0 });
+
+    const result = await runTaskAutoArchive({
+      now: NOW,
+      lastSuccessAt: null,
+      settings: { archiveAfterDays: 30 },
+    });
+
+    expect(result.items).toBe(0);
+    expect(result.note).toBeUndefined();
+  });
+});

--- a/dali-api/app/jobs/registry.ts
+++ b/dali-api/app/jobs/registry.ts
@@ -76,6 +76,7 @@ import { runSprintLifecycle } from "~/jobs/sprint-lifecycle.server";
 import { runFormWindows } from "~/jobs/form-windows.server";
 import { runInterviewReminders } from "~/jobs/interview-reminders.server";
 import { runStandupPrompts } from "~/jobs/standup-prompts.server";
+import { runTaskAutoArchive } from "~/jobs/task-auto-archive.server";
 
 export const JOBS: JobDefinition[] = [
   {
@@ -230,6 +231,23 @@ export const JOBS: JobDefinition[] = [
       },
     ],
     handler: runRetentionJanitor,
+  },
+  {
+    name: "task-auto-archive",
+    description:
+      "Archives Done/Cancelled tasks left untouched past the threshold so they drop off the project board.",
+    intervalMinutes: 1440,
+    settings: [
+      {
+        key: "archiveAfterDays",
+        label: "Archive after (idle)",
+        unit: "days",
+        min: 1,
+        max: 365,
+        default: 30,
+      },
+    ],
+    handler: runTaskAutoArchive,
   },
 ];
 

--- a/dali-api/app/jobs/task-auto-archive.server.ts
+++ b/dali-api/app/jobs/task-auto-archive.server.ts
@@ -1,0 +1,39 @@
+// Auto-archive job: sweeps tasks that have sat in a terminal status
+// (Done / Cancelled) untouched past the configured threshold and stamps
+// Task.archivedAt so they drop off the project board (the loader filters
+// archivedAt: null). Rows are preserved, not deleted.
+//
+// Idempotent by construction: the `archivedAt: null` guard means a re-run
+// (e.g. after a crashed lease) never re-archives an already-archived task,
+// and a single bounded updateMany keeps per-tick work well under the lease.
+
+import { prisma } from "~/lib/db";
+import type { JobContext, JobResult } from "~/jobs/registry";
+
+const ARCHIVABLE_STATUSES = ["Done", "Cancelled"] as const;
+
+export async function runTaskAutoArchive({
+  now,
+  settings,
+}: JobContext): Promise<JobResult> {
+  const days = settings.archiveAfterDays ?? 30;
+  const cutoff = new Date(now.getTime() - days * 24 * 60 * 60 * 1000);
+
+  const { count } = await prisma.task.updateMany({
+    where: {
+      archivedAt: null,
+      status: { in: [...ARCHIVABLE_STATUSES] },
+      // updatedAt is bumped on any field edit, so this is "no activity since".
+      updatedAt: { lt: cutoff },
+    },
+    data: { archivedAt: now },
+  });
+
+  return {
+    items: count,
+    note:
+      count > 0
+        ? `Archived ${count} Done/Cancelled task(s) idle >${days}d`
+        : undefined,
+  };
+}

--- a/dali-api/app/lib/scheduled-meeting.ts
+++ b/dali-api/app/lib/scheduled-meeting.ts
@@ -109,12 +109,6 @@ export type CreateScheduledMeetingResult =
     }
   | { ok: false; error: string };
 
-const MEETING_TYPE_LABELS: Record<MeetingType, string> = {
-  Team: "Team",
-  Partner: "Partner",
-  Other: "", // overridden by meetingTypeLabel
-};
-
 export async function createScheduledMeeting(
   input: CreateScheduledMeetingInput,
 ): Promise<CreateScheduledMeetingResult> {
@@ -223,12 +217,12 @@ export async function createScheduledMeeting(
   // instead, so there's still somewhere to host the QR / AttendanceChecklist.
   let notePageId: string | null = null;
   if (input.meetingType) {
-    const label =
-      input.meetingType === "Other"
-        ? (input.meetingTypeLabel ?? "").trim() || "Other"
-        : MEETING_TYPE_LABELS[input.meetingType];
+    // Auto-generated note pages are titled with just the meeting date — the
+    // note already lives under its Team/Partner folder (or carries its custom
+    // "Other" label via the meeting itself), so repeating "… meeting note" in
+    // the title is redundant.
     const noteDate = startDate ?? new Date();
-    const title = `${label} meeting note (${formatDateShort(noteDate)})`;
+    const title = formatDateShort(noteDate);
 
     if (input.projectId) {
       // Team/Partner notes nest under their default, undeletable folder;

--- a/dali-api/app/projects/components/TaskBoard.tsx
+++ b/dali-api/app/projects/components/TaskBoard.tsx
@@ -1,8 +1,9 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "react-router";
 import { Button } from "~/components/ui/Button";
 import type { DragEndEvent } from "@dnd-kit/core";
-import { GripVertical } from "lucide-react";
+import { Archive, GripVertical, X } from "lucide-react";
+import { Modal } from "~/components/Modal";
 import { KanbanBoard, type KanbanColumn } from "~/components/board/KanbanBoard";
 import { useOptimisticBoardMove } from "~/components/board/useOptimisticBoardMove";
 import {
@@ -57,6 +58,7 @@ export function TaskBoard({
   const { items: tasks, move, error, setError, setItems } =
     useOptimisticBoardMove<TaskCardModel>(initialTasks, { adoptServerItems: false });
   const [isCreating, setIsCreating] = useState(false);
+  const [showArchived, setShowArchived] = useState(false);
 
   // The open task is tracked in the URL (`?task=<id>`) so GitHub issue mirrors
   // and other external links can deep-link straight to a task.
@@ -106,6 +108,17 @@ export function TaskBoard({
           throw new Error(j.error ?? `Request failed: ${res.status}`);
         }
       },
+    );
+  }
+
+  // Optimistically drop the card, then DELETE the row. The hook restores it
+  // on failure and surfaces the error. Close the modal first so the deleted
+  // task doesn't briefly render behind a rollback.
+  function deleteTask(taskId: string) {
+    setOpenTaskId(null);
+    move(
+      (cur) => cur.filter((t) => t.id !== taskId),
+      () => persistDelete(taskId),
     );
   }
 
@@ -209,9 +222,17 @@ export function TaskBoard({
   return (
     <div className="flex flex-col gap-3">
       {canManage && (
-        <div>
+        <div className="flex items-center gap-2">
           <Button variant="primary" size="sm" onClick={() => setIsCreating(true)}>
             + Add task
+          </Button>
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={() => setShowArchived(true)}
+          >
+            <Archive className="w-3.5 h-3.5" />
+            Archived
           </Button>
         </div>
       )}
@@ -242,6 +263,7 @@ export function TaskBoard({
           canManage={canManage}
           onClose={() => setOpenTaskId(null)}
           onPatch={(patch) => patchTask(openTask.id, patch)}
+          onDelete={() => deleteTask(openTask.id)}
         />
       )}
 
@@ -253,15 +275,132 @@ export function TaskBoard({
           onCreate={handleCreate}
         />
       )}
+
+      {showArchived && (
+        <ArchivedTasksModal
+          projectId={projectId}
+          onClose={() => setShowArchived(false)}
+        />
+      )}
     </div>
+  );
+}
+
+type ArchivedTask = {
+  id: string;
+  title: string;
+  status: TaskStatus;
+  priority: Priority;
+  dueAt: string | null;
+  archivedAt: string;
+  domain: { id: string; name: string } | null;
+  assignees: { id: string; name: string }[];
+};
+
+// Lazily fetches and lists a project's archived tasks. Read-only — archived
+// tasks aren't editable/restorable from here (they live off the board by
+// design); this is a record of what was auto-archived.
+function ArchivedTasksModal({
+  projectId,
+  onClose,
+}: {
+  projectId: string;
+  onClose: () => void;
+}) {
+  const [tasks, setTasks] = useState<ArchivedTask[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(`/api/projects/${projectId}/tasks`, {
+          credentials: "include",
+        });
+        if (!res.ok) throw new Error(`Request failed: ${res.status}`);
+        const body = (await res.json()) as { tasks: ArchivedTask[] };
+        if (!cancelled) setTasks(body.tasks);
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : "Failed to load");
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [projectId]);
+
+  return (
+    <Modal
+      open
+      onClose={onClose}
+      labelledBy="archived-tasks-title"
+      containerClassName="bg-card rounded-2xl shadow-brand-2 max-w-xl w-full p-5 sm:p-6 my-auto max-h-[80vh] flex flex-col"
+    >
+      <div className="flex items-start justify-between gap-3 mb-3">
+        <h2 id="archived-tasks-title" className="text-lg font-semibold text-foreground">
+          Archived tasks
+        </h2>
+        <button
+          type="button"
+          onClick={onClose}
+          className="text-muted-foreground/70 hover:text-foreground rounded p-1 hover:bg-muted"
+          aria-label="Close"
+        >
+          <X className="w-5 h-5" aria-hidden />
+        </button>
+      </div>
+
+      {error && <p className="text-sm text-destructive">{error}</p>}
+      {!error && tasks === null && (
+        <p className="text-sm text-muted-foreground">Loading…</p>
+      )}
+      {tasks !== null && tasks.length === 0 && (
+        <p className="text-sm text-muted-foreground">
+          No archived tasks yet. Done/Cancelled tasks are archived automatically
+          once they've been idle past the threshold.
+        </p>
+      )}
+
+      {tasks !== null && tasks.length > 0 && (
+        <ul className="flex flex-col gap-2 overflow-y-auto -mx-1 px-1">
+          {tasks.map((t) => (
+            <li
+              key={t.id}
+              className="border border-border rounded-md bg-background p-2.5 text-sm"
+            >
+              <div className="flex items-center justify-between gap-2">
+                <span className="text-foreground min-w-0 truncate">{t.title}</span>
+                <span className="text-[11px] text-muted-foreground flex-shrink-0">
+                  {TASK_STATUS_LABELS[t.status]}
+                </span>
+              </div>
+              <div className="mt-1.5 flex flex-wrap items-center gap-x-2 gap-y-1 text-[11px] text-muted-foreground">
+                <span className={PRIORITY_TONE[t.priority]}>{t.priority}</span>
+                {t.domain && <span>· {t.domain.name}</span>}
+                {t.assignees.length > 0 && (
+                  <span className="truncate">
+                    · {t.assignees.map((a) => a.name).join(", ")}
+                  </span>
+                )}
+                <span className="ml-auto">
+                  Archived {new Date(t.archivedAt).toLocaleDateString()}
+                </span>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </Modal>
   );
 }
 
 // The drag handle and the card body are split so the body's click can open
 // the modal without dnd-kit's pointer listeners swallowing it. Listeners go
-// only on the GripVertical handle; the rest of the card has a regular
-// onClick. Keyboard activation (Enter/Space) also opens the modal so the
-// card stays operable without a pointer.
+// only on the GripVertical handle; the rest of the card is a role="button"
+// div (not a real <button>, whose contents browsers refuse to let you
+// select) so the title text can be drag-selected/copied. A drag that leaves
+// a text selection inside the card is treated as a select, not an open.
+// Keyboard activation (Enter/Space) still opens the modal.
 function TaskCard({
   card,
   draggable,
@@ -275,11 +414,28 @@ function TaskCard({
   isDragging: boolean;
   onOpen: () => void;
 }) {
+  const bodyRef = useRef<HTMLDivElement>(null);
   const overdue =
     card.dueAt != null &&
     card.status !== "Done" &&
     card.status !== "Cancelled" &&
     new Date(card.dueAt).getTime() < Date.now();
+
+  // Don't open the task if the click ended a text selection inside this card
+  // (e.g. the user drag-selected the title to copy it).
+  function handleActivate() {
+    const sel = typeof window !== "undefined" ? window.getSelection() : null;
+    if (
+      sel &&
+      !sel.isCollapsed &&
+      sel.toString().trim() !== "" &&
+      sel.anchorNode &&
+      bodyRef.current?.contains(sel.anchorNode)
+    ) {
+      return;
+    }
+    onOpen();
+  }
 
   return (
     <div
@@ -296,10 +452,18 @@ function TaskCard({
           <GripVertical className="w-4 h-4" />
         </div>
       )}
-      <button
-        type="button"
-        onClick={onOpen}
-        className="flex-1 min-w-0 text-left p-2.5 pl-1.5 focus:outline-none"
+      <div
+        ref={bodyRef}
+        role="button"
+        tabIndex={0}
+        onClick={handleActivate}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            onOpen();
+          }
+        }}
+        className="flex-1 min-w-0 text-left p-2.5 pl-1.5 cursor-pointer select-text focus:outline-none"
       >
         <div className="text-foreground">{card.title}</div>
         <div className="mt-1.5 flex items-center justify-between gap-2">
@@ -330,7 +494,7 @@ function TaskCard({
             </span>
           )}
         </div>
-      </button>
+      </div>
     </div>
   );
 }
@@ -356,6 +520,17 @@ async function persistMove(
     credentials: "include",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ status, position }),
+  });
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as { error?: string };
+    throw new Error(body.error ?? `Request failed: ${res.status}`);
+  }
+}
+
+async function persistDelete(taskId: string): Promise<void> {
+  const res = await fetch(`/api/tasks/${taskId}`, {
+    method: "DELETE",
+    credentials: "include",
   });
   if (!res.ok) {
     const body = (await res.json().catch(() => ({}))) as { error?: string };

--- a/dali-api/app/projects/components/TaskModal.tsx
+++ b/dali-api/app/projects/components/TaskModal.tsx
@@ -35,6 +35,7 @@ export function TaskModal({
   onClose,
   onPatch,
   onCreate,
+  onDelete,
 }: {
   // Present in edit mode; omitted (create mode) opens an empty form.
   task?: TaskCardModel;
@@ -43,6 +44,9 @@ export function TaskModal({
   onClose: () => void;
   onPatch?: (patch: Patch) => Promise<void> | void;
   onCreate?: (values: NewTaskValues) => Promise<void> | void;
+  // Edit mode only. Removes the task (parent handles optimistic removal +
+  // closing the modal).
+  onDelete?: () => Promise<void> | void;
 }) {
   const isCreate = !task;
   const [title, setTitle] = useState(task?.title ?? "");
@@ -56,6 +60,8 @@ export function TaskModal({
   );
   const [domainId, setDomainId] = useState<string>(task?.domain?.id ?? "");
   const [saving, setSaving] = useState(false);
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+  const [deleting, setDeleting] = useState(false);
 
   // Auto-grow the title textarea so long titles wrap into view instead of
   // scrolling horizontally inside a single-line input.
@@ -288,7 +294,45 @@ export function TaskModal({
           </div>
         )}
 
-        <div className="flex justify-end gap-2 pt-2 border-t border-border">
+        <div className="flex items-center justify-end gap-2 pt-2 border-t border-border">
+          {!isCreate && canManage && onDelete && (
+            confirmingDelete ? (
+              <div className="mr-auto flex items-center gap-2 text-sm">
+                <span className="text-muted-foreground">Delete this task?</span>
+                <button
+                  type="button"
+                  disabled={deleting}
+                  onClick={async () => {
+                    setDeleting(true);
+                    try {
+                      await onDelete();
+                    } finally {
+                      setDeleting(false);
+                    }
+                  }}
+                  className="font-medium text-destructive hover:underline disabled:opacity-60"
+                >
+                  {deleting ? "Deleting…" : "Delete"}
+                </button>
+                <button
+                  type="button"
+                  disabled={deleting}
+                  onClick={() => setConfirmingDelete(false)}
+                  className="text-muted-foreground hover:text-foreground"
+                >
+                  Keep
+                </button>
+              </div>
+            ) : (
+              <button
+                type="button"
+                onClick={() => setConfirmingDelete(true)}
+                className="mr-auto text-sm font-medium text-destructive hover:underline"
+              >
+                Delete
+              </button>
+            )
+          )}
           <button
             type="button"
             onClick={onClose}

--- a/dali-api/app/projects/routes/api.projects.$id.tasks.ts
+++ b/dali-api/app/projects/routes/api.projects.$id.tasks.ts
@@ -4,6 +4,8 @@ import { requireProjectEditAccess } from "~/lib/auth";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { isTaskStatus } from "../lib/task-board";
 import { createIssueForTask, normalizeRepo } from "../lib/github-task-sync";
+import { USER_NAME_SELECT } from "~/lib/prisma-shapes";
+import { fullName } from "~/lib/display";
 
 // POST /api/projects/:id/tasks
 //
@@ -47,6 +49,46 @@ function parseDueAt(raw: string | null | undefined): Date | null | "invalid" {
   const d = new Date(raw);
   if (Number.isNaN(d.getTime())) return "invalid";
   return d;
+}
+
+// GET /api/projects/:id/tasks — list a project's archived tasks
+// (auto-archived Done/Cancelled), newest-archived first. Backs the board's
+// "Archived" modal, so it stays a lazy fetch rather than bloating the project
+// loader (which only ever loads the live, non-archived board).
+export async function loader({ request, params }: Route.LoaderArgs) {
+  const preflight = handlePreflight(request);
+  if (preflight) return preflight;
+
+  const gate = await requireProjectEditAccess(request, params.id!);
+  if (!gate.ok) return gate.response;
+
+  const rows = await prisma.task.findMany({
+    where: { projectId: params.id, archivedAt: { not: null } },
+    orderBy: { archivedAt: "desc" },
+    select: {
+      id: true,
+      title: true,
+      status: true,
+      priority: true,
+      dueAt: true,
+      archivedAt: true,
+      domain: { select: { id: true, displayName: true } },
+      assignees: { select: { user: { select: USER_NAME_SELECT } } },
+    },
+  });
+
+  const tasks = rows.map((t) => ({
+    id: t.id,
+    title: t.title,
+    status: t.status,
+    priority: t.priority,
+    dueAt: t.dueAt ? t.dueAt.toISOString() : null,
+    archivedAt: t.archivedAt!.toISOString(),
+    domain: t.domain ? { id: t.domain.id, name: t.domain.displayName } : null,
+    assignees: t.assignees.map((a) => ({ id: a.user.id, name: fullName(a.user) })),
+  }));
+
+  return withCors(request, Response.json({ tasks }));
 }
 
 export async function action({ request, params }: Route.ActionArgs) {

--- a/dali-api/app/projects/routes/api.tasks.$id.ts
+++ b/dali-api/app/projects/routes/api.tasks.$id.ts
@@ -70,7 +70,7 @@ export async function action({ request, params }: Route.ActionArgs) {
   const preflight = handlePreflight(request);
   if (preflight) return preflight;
 
-  if (request.method !== "PATCH") {
+  if (request.method !== "PATCH" && request.method !== "DELETE") {
     return withCors(
       request,
       Response.json({ error: "Method not allowed" }, { status: 405 }),
@@ -85,6 +85,19 @@ export async function action({ request, params }: Route.ActionArgs) {
   }
   const gate = await requireProjectEditAccess(request, task.projectId);
   if (!gate.ok) return gate.response;
+
+  // DELETE /api/tasks/:id — remove the task and its owned rows. TaskAssignee
+  // and TaskComment have no onDelete: Cascade, so drop them first; TaskReminder
+  // cascades at the DB. Mirrors the MCP delete_task tool. The mirrored GitHub
+  // issue (if any) is intentionally left in place.
+  if (request.method === "DELETE") {
+    await prisma.$transaction([
+      prisma.taskAssignee.deleteMany({ where: { taskId: params.id } }),
+      prisma.taskComment.deleteMany({ where: { taskId: params.id } }),
+      prisma.task.delete({ where: { id: params.id } }),
+    ]);
+    return withCors(request, Response.json({ ok: true }));
+  }
 
   let body: unknown;
   try {

--- a/dali-api/app/projects/routes/projects.$id.tsx
+++ b/dali-api/app/projects/routes/projects.$id.tsx
@@ -208,6 +208,8 @@ export async function loader({ request, params }: Route.LoaderArgs) {
         },
       },
       tasks: {
+        // Archived tasks (auto-archived Done/Cancelled) drop off the board.
+        where: { archivedAt: null },
         orderBy: { createdAt: "asc" },
         select: {
           id: true,

--- a/dali-api/app/routes/documents.file.$fileId.tsx
+++ b/dali-api/app/routes/documents.file.$fileId.tsx
@@ -64,6 +64,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
           uploadedById: true,
           createdAt: true,
           s3Key: true,
+          contentType: true,
         },
       },
     },
@@ -85,6 +86,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
       uploadedBy: nameById.get(v.uploadedById) ?? "Unknown",
       createdAt: v.createdAt.toISOString(),
       isCurrent: v.id === file.currentVersionId,
+      contentType: v.contentType,
       downloadUrl: await getDownloadUrl(v.s3Key),
     })),
   );
@@ -118,6 +120,14 @@ export default function FilePage() {
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const [uploading, setUploading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // Which version the preview panel shows. Defaults to the current version
+  // (versions are newest-first, and the current one is usually newest).
+  const [selectedVersionId, setSelectedVersionId] = useState<string | null>(
+    versions.find((v) => v.isCurrent)?.id ?? versions[0]?.id ?? null,
+  );
+  const selected =
+    versions.find((v) => v.id === selectedVersionId) ?? versions[0] ?? null;
 
   async function onPick(e: React.ChangeEvent<HTMLInputElement>) {
     const picked = e.target.files?.[0];
@@ -161,6 +171,12 @@ export default function FilePage() {
             />
           </div>
 
+          {selected && (
+            <div className="mt-6">
+              <FilePreview version={selected} />
+            </div>
+          )}
+
           <div className="flex items-center justify-between mt-6 mb-2">
             <h2 className="text-sm font-semibold text-foreground">Versions</h2>
             {canEdit && (
@@ -192,7 +208,22 @@ export default function FilePage() {
 
           <ul className="flex flex-col divide-y divide-border border border-border rounded-lg">
             {versions.map((v) => (
-              <li key={v.id} className="flex items-center justify-between gap-3 px-3 py-2.5 text-sm">
+              <li
+                key={v.id}
+                role="button"
+                tabIndex={0}
+                aria-pressed={v.id === selected?.id}
+                onClick={() => setSelectedVersionId(v.id)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    setSelectedVersionId(v.id);
+                  }
+                }}
+                className={`flex items-center justify-between gap-3 px-3 py-2.5 text-sm cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-coral/40 ${
+                  v.id === selected?.id ? "bg-accent-teal/10" : "hover:bg-muted/40"
+                }`}
+              >
                 <div className="min-w-0">
                   <span className="text-foreground truncate">{v.fileName}</span>
                   {v.isCurrent && (
@@ -214,6 +245,7 @@ export default function FilePage() {
                   <a
                     href={v.downloadUrl}
                     aria-label="Download"
+                    onClick={(e) => e.stopPropagation()}
                     className="inline-flex items-center justify-center p-1.5 rounded border border-border hover:bg-muted text-muted-foreground hover:text-foreground flex-shrink-0"
                   >
                     <Download className="w-3.5 h-3.5" />
@@ -234,6 +266,54 @@ export default function FilePage() {
           />
         </aside>
       </div>
+    </div>
+  );
+}
+
+type FileVersionView = Exclude<
+  Awaited<ReturnType<typeof loader>>,
+  Response
+>["versions"][number];
+
+// Inline preview of a file version. Images and PDFs render directly from the
+// presigned S3 URL; anything else falls back to a download prompt.
+function FilePreview({ version }: { version: FileVersionView }) {
+  const ct = version.contentType ?? "";
+  const isImage = ct.startsWith("image/");
+  const isPdf = ct === "application/pdf";
+  const isText = ct.startsWith("text/") || ct === "application/json";
+
+  if (isImage) {
+    return (
+      <img
+        src={version.downloadUrl}
+        alt={version.fileName}
+        className="max-w-full max-h-[70vh] rounded-lg border border-border object-contain bg-muted/20"
+      />
+    );
+  }
+  if (isPdf || isText) {
+    return (
+      <iframe
+        src={version.downloadUrl}
+        title={version.fileName}
+        className="w-full h-[70vh] rounded-lg border border-border bg-white"
+      />
+    );
+  }
+  return (
+    <div className="rounded-lg border border-border bg-muted/20 px-4 py-10 text-center text-sm text-muted-foreground">
+      <p>
+        No inline preview for this file type
+        {version.contentType ? ` (${version.contentType})` : ""}.
+      </p>
+      <a
+        href={version.downloadUrl}
+        className="mt-3 inline-flex items-center gap-1 text-accent-coral hover:underline"
+      >
+        <Download className="w-3.5 h-3.5" />
+        Download to view
+      </a>
     </div>
   );
 }

--- a/dali-api/app/routes/notifications.tsx
+++ b/dali-api/app/routes/notifications.tsx
@@ -335,17 +335,17 @@ function HistoryTab({
                       {n.canRsvp ? <RsvpButtons notificationId={n.id} /> : null}
                     </div>
                     <div className="flex flex-col items-end gap-1.5 flex-shrink-0">
-                      {n.link && (
+                      {/* RSVP-able notifications (meeting invites) already
+                          have inline RSVP buttons, so the extra "Open calendar"
+                          link is redundant — it just dumps you on the calendar.
+                          Keep the link only for non-RSVP notifications. */}
+                      {n.link && !n.canRsvp && (
                         <button
                           type="button"
                           onClick={() => openLink(n.link!, n.title)}
                           className="flex items-center gap-1 text-xs font-medium text-accent-coral hover:underline"
                         >
-                          {n.canRsvp
-                            ? "Open calendar"
-                            : n.state === "Submitted"
-                              ? "View"
-                              : "Open"}{" "}
+                          {n.state === "Submitted" ? "View" : "Open"}{" "}
                           <ExternalLink className="w-3 h-3" />
                         </button>
                       )}

--- a/dali-api/prisma/migrations/20260720160000_add_task_archived_at/migration.sql
+++ b/dali-api/prisma/migrations/20260720160000_add_task_archived_at/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Task" ADD COLUMN     "archivedAt" TIMESTAMP(3);

--- a/dali-api/prisma/schema.prisma
+++ b/dali-api/prisma/schema.prisma
@@ -2488,6 +2488,12 @@ model Task {
   // JSON shape: [{ "text": "...", "done": false }]
   checklist Json?
 
+  // Soft archive. Done/Cancelled tasks left untouched past the
+  // task-auto-archive job's threshold get stamped here and drop off the
+  // board (the loader filters archivedAt: null). The row is preserved, not
+  // deleted, so it stays reportable/restorable.
+  archivedAt DateTime?
+
   // Optional mirror to a GitHub issue. All three populated together when the
   // task was created with the "Create GitHub issue" toggle on; null when not
   // mirrored. The (githubRepo, githubIssueNumber) pair is the lookup key for


### PR DESCRIPTION
* Taskboard fixes + auto-archive; meeting-note title = date

Bug fixes and one feature on the project taskboard, plus a meeting-note title tweak.

- Modal: focus with { preventScroll: true } so opening a task no longer jumps a long board to the top.
- TaskBoard: card body is a role="button" div (not a real <button>, whose contents can't be selected) with a selection guard — the task title can be drag-selected/copied without opening the task.
- Tasks: add DELETE /api/tasks/:id (mirrors the delete_task MCP cascade) and a Delete affordance (inline confirm) in the task modal; the board removes the card optimistically with rollback.
- Auto-archive: new Task.archivedAt soft-archive column + migration, a task-auto-archive job (operator-tunable "archive after N idle days", default 30) that stamps Done/Cancelled tasks idle past the threshold, and a loader filter so archived tasks drop off the board. Unit-tested.
- Meeting notes: auto-generated note pages are now titled with just the date (drop the redundant "<type> meeting note" prefix).



* Archived-tasks view, file preview, drop redundant invite link

- Taskboard: "Archived" button opens a modal listing the project's archived tasks (lazy GET on /api/projects/:id/tasks), read-only.
- File detail page: clicking a version (now cursor-pointer + selectable highlight, keyboard-operable) previews it inline — images via <img>, PDFs/ text via <iframe>, other types fall back to a download prompt. Added contentType to the loader.
- Notifications: meeting-invite notifications already carry inline RSVP buttons, so drop the redundant "Open calendar" link that just dumped you on the calendar. The link is kept for non-RSVP notifications (and still travels in email/Slack, which have no inline RSVP).



---------

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/942"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787162766&installation_model_id=21824&pr_number=942&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F942&signature=d4466c2951c9859da18c58a35ca2e821d7d9de182aa1dea278d8f556ed7ba5de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->