### PR TITLE
Board drag: whole card drags (title included), reorder works under filters

### DIFF
--- a/dali-api/app/projects/components/TaskBoard.tsx
+++ b/dali-api/app/projects/components/TaskBoard.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRevalidator, useSearchParams } from "react-router";
 import { Button } from "~/components/ui/Button";
 import type { DragEndEvent } from "@dnd-kit/core";
@@ -189,28 +189,21 @@ export function TaskBoard({
     let targetIndex: number;
     if (isTaskStatus(overId)) {
       toStatus = overId;
-      targetIndex = -1; // dropped on the column shell: append
-      if (toStatus === fromStatus && !sprintFilter) {
-        // Same column, no card target — nothing to reorder.
-        return;
-      }
+      // Dropped on the column shell: append. On the card's own column that's
+      // no reorder intent at all — bail.
+      if (toStatus === fromStatus) return;
+      targetIndex = -1;
     } else {
       const overTask = tasks.find((t) => t.id === overId);
       if (!overTask || overTask.id === taskId) return;
       toStatus = overTask.status;
-      if (sprintFilter) {
-        // With a sprint slice active the visible order isn't the full column
-        // order, so card-relative indexes would scramble hidden tasks. Allow
-        // status moves (append) but not reordering.
-        if (toStatus === fromStatus) return;
-        targetIndex = -1;
-      } else {
-        targetIndex = buildTaskBoard(tasks)[toStatus].findIndex(
-          (t) => t.id === overId,
-        );
-      }
+      // The over card's index in the FULL column, even when a sprint filter
+      // is active: inserting at the target's global position preserves hidden
+      // tasks' relative order while landing where the user sees.
+      targetIndex = buildTaskBoard(tasks)[toStatus].findIndex(
+        (t) => t.id === overId,
+      );
     }
-    if (toStatus === fromStatus && targetIndex === -1 && sprintFilter) return;
 
     const orderedIds = moveTaskInBoard(tasks, taskId, toStatus, targetIndex).orderedIds;
     move(
@@ -543,14 +536,13 @@ function SprintPill({
   );
 }
 
-// The whole card is the drag source: the KanbanBoard pointer sensor's
-// activation distance disambiguates click from drag, so a press-and-release
-// still opens the modal while a press-and-move starts a drag. The one
-// exception is the title, which swallows pointerdown so its text can be
-// drag-selected/copied (a real <button> body would refuse selection
-// entirely); a click that ended a selection inside the card is treated as a
-// select, not an open. Keyboard activation (Enter/Space) also opens the
-// modal so the card stays operable without a pointer.
+// The whole card — title included — is the drag source: the KanbanBoard
+// pointer sensor's activation distance disambiguates click from drag, so a
+// press-and-release still opens the modal while a press-and-move starts a
+// drag. Card text is deliberately not selectable (Trello/Linear behavior);
+// copy the title from the modal, where it's an input. Keyboard activation
+// (Enter/Space) also opens the modal so the card stays operable without a
+// pointer.
 function TaskCard({
   card,
   dragHandleProps = {},
@@ -562,7 +554,6 @@ function TaskCard({
   isDragging: boolean;
   onOpen: () => void;
 }) {
-  const bodyRef = useRef<HTMLDivElement>(null);
   const overdue =
     card.dueAt != null &&
     card.status !== "Done" &&
@@ -572,22 +563,6 @@ function TaskCard({
   const checklist = Array.isArray(card.checklist) ? card.checklist : null;
   const checklistDone = checklist?.filter((i) => i.done).length ?? 0;
 
-  // Don't open the task if the click ended a text selection inside this card
-  // (e.g. the user drag-selected the title to copy it).
-  function handleActivate() {
-    const sel = typeof window !== "undefined" ? window.getSelection() : null;
-    if (
-      sel &&
-      !sel.isCollapsed &&
-      sel.toString().trim() !== "" &&
-      sel.anchorNode &&
-      bodyRef.current?.contains(sel.anchorNode)
-    ) {
-      return;
-    }
-    onOpen();
-  }
-
   return (
     <div
       {...dragHandleProps}
@@ -596,10 +571,9 @@ function TaskCard({
       }`}
     >
       <div
-        ref={bodyRef}
         role="button"
         tabIndex={0}
-        onClick={handleActivate}
+        onClick={onOpen}
         onKeyDown={(e) => {
           if (e.key === "Enter" || e.key === " ") {
             e.preventDefault();
@@ -608,12 +582,7 @@ function TaskCard({
         }}
         className="flex-1 min-w-0 text-left p-2.5 cursor-pointer focus:outline-none"
       >
-        <div
-          className="text-foreground select-text"
-          onPointerDown={(e) => e.stopPropagation()}
-        >
-          {card.title}
-        </div>
+        <div className="text-foreground">{card.title}</div>
         <div className="mt-1.5 flex items-center justify-between gap-2">
           <span className={`text-[11px] ${PRIORITY_TONE[card.priority]}`}>
             {card.priority}

--- a/dali-api/e2e/kanban-drag.spec.ts
+++ b/dali-api/e2e/kanban-drag.spec.ts
@@ -20,8 +20,9 @@ import type { Locator, Page } from '@playwright/test';
 //
 // dnd-kit's PointerSensor has an activation distance of 6px, so the drag must
 // move past that threshold before it engages; we step the mouse to be safe.
-// The whole card is the drag source (no separate grip handle); a sub-threshold
-// press still counts as the click that opens the task modal.
+// The whole card — title included — is the drag source (no grip handle, no
+// selectable text); a sub-threshold press still counts as the click that
+// opens the task modal.
 
 // The task-board column shell: `flex-shrink-0 w-64 border rounded-lg ...`.
 const COLUMN = 'div.w-64.rounded-lg';
@@ -47,9 +48,7 @@ async function dragHandleTo(page: Page, handle: Locator, target: Locator) {
   }
 
   const startX = handleBox.x + handleBox.width / 2;
-  // Grab the lower portion of the card: the title line swallows pointerdown
-  // so its text stays drag-selectable, so a drag must start below it.
-  const startY = handleBox.y + handleBox.height * 0.75;
+  const startY = handleBox.y + handleBox.height / 2;
   // Drop at the destination column's horizontal centre, on the same row band as
   // the (now visible) handle. The columns share a row, so the handle's y is
   // inside the destination column's visible area too — no risk of aiming


### PR DESCRIPTION
Follow-up to #941, fixing the "tasks without a sprint aren't draggable" report. The cause wasn't sprint membership — two invisible drag restrictions:

1. **The card title was a drag dead-zone.** It swallowed pointer-down to keep its text drag-selectable (from #940), so on minimal cards (title + priority only) most of the surface couldn't start a drag. On-card text selection is now dropped entirely — Trello/Linear behavior; the title is copyable from the task modal, where it's an input — and the whole card drags.
2. **Filtered views silently refused within-column reordering.** Reordering now inserts at the over-card's index in the *full* column, which preserves hidden tasks' relative order while landing where the user sees — so it simply works under sprint/Backlog filters.

The e2e drag spec grabs the card center again. Suite green: 2,005 tests, no new type errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/947"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787168695&installation_model_id=21824&pr_number=947&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F947&signature=839f48f3a018e4c80d658747aac1e61d0b38b433a9948455f63bdf7d980172d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->