### PR TITLE
Partner hub: inline file preview + always-visible Shared files section

### DIFF
--- a/dali-api/app/partners/components/PartnerProjectHubView.tsx
+++ b/dali-api/app/partners/components/PartnerProjectHubView.tsx
@@ -349,9 +349,7 @@ export function PartnerProjectHubView({
       ? [{ id: "recently-completed", label: "Recently completed" }]
       : []),
     { id: "shared-documents", label: "Shared documents" },
-    ...(sharedFiles.length > 0
-      ? [{ id: "shared-files", label: "Shared files" }]
-      : []),
+    { id: "shared-files", label: "Shared files" },
     ...(team.length > 0 ? [{ id: "team", label: "Team" }] : []),
   ];
   const activeSection = useActiveSection(sections.map((s) => s.id));
@@ -525,11 +523,15 @@ export function PartnerProjectHubView({
 
       {/* Shared files — uploads the team has shared, downloaded via a
           short-lived signed URL resolved in the loader. */}
-      {sharedFiles.length > 0 && (
-        <section id="shared-files" className="scroll-mt-24">
-          <h2 className="font-heading text-lg font-semibold text-dark-blue mb-3">
-            Shared files
-          </h2>
+      <section id="shared-files" className="scroll-mt-24">
+        <h2 className="font-heading text-lg font-semibold text-dark-blue mb-3">
+          Shared files
+        </h2>
+        {sharedFiles.length === 0 ? (
+          <div className="bg-card border border-border rounded-2xl p-6 text-sm text-muted-foreground">
+            The team hasn't shared any files yet.
+          </div>
+        ) : (
           <ul className="bg-card border border-border rounded-2xl divide-y divide-border">
             {sharedFiles.map((f) => (
               <li key={f.id}>
@@ -563,8 +565,8 @@ export function PartnerProjectHubView({
               </li>
             ))}
           </ul>
-        </section>
-      )}
+        )}
+      </section>
 
       {/* Team */}
       {team.length > 0 && (

--- a/dali-api/app/partners/components/PartnerProjectHubView.tsx
+++ b/dali-api/app/partners/components/PartnerProjectHubView.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useState } from "react";
 import { Link } from "react-router";
-import { Download } from "lucide-react";
+import { Download, Eye, X } from "lucide-react";
 import { termCodeLabel } from "~/lib/display";
 import { formatBytes } from "~/lib/upload-client";
 import { Avatar } from "~/components/ui/Avatar";
 import { Markdown } from "~/components/Markdown";
+import { Modal } from "~/components/Modal";
 import { PartnerBackLink } from "~/partners/components/PartnerBackLink";
 import type {
   PartnerProjectEpic,
@@ -13,6 +14,8 @@ import type {
   PartnerProjectViewData,
   PartnerWorkState,
 } from "~/partners/lib/partner-project-view.server";
+
+type SharedFile = PartnerProjectViewData["sharedFiles"][number];
 
 const fmtDate = (iso: string) =>
   new Date(iso).toLocaleDateString(undefined, { month: "short", day: "numeric" });
@@ -325,6 +328,10 @@ export function PartnerProjectHubView({
 
   const hasWork = epics.length > 0 || ungroupedSprints.length > 0;
 
+  // Shared-file inline preview (mirrors the internal file view): clicking a
+  // file opens it in a modal — image/PDF inline, everything else a download.
+  const [previewFile, setPreviewFile] = useState<SharedFile | null>(null);
+
   // The roadmap opens on live work — epics that are Open or In progress. The
   // rest (Backlog, Done) sit behind a toggle so a partner isn't wading through
   // finished or not-yet-started epics to see what's happening now.
@@ -526,17 +533,17 @@ export function PartnerProjectHubView({
           <ul className="bg-card border border-border rounded-2xl divide-y divide-border">
             {sharedFiles.map((f) => (
               <li key={f.id}>
-                <a
-                  href={f.downloadUrl ?? undefined}
-                  download={f.fileName ?? undefined}
-                  aria-disabled={!f.downloadUrl}
-                  className={`px-4 py-3 flex items-center gap-3 text-sm transition ${
+                <button
+                  type="button"
+                  onClick={() => setPreviewFile(f)}
+                  disabled={!f.downloadUrl}
+                  className={`w-full text-left px-4 py-3 flex items-center gap-3 text-sm transition ${
                     f.downloadUrl
-                      ? "hover:bg-muted/20"
-                      : "pointer-events-none opacity-60"
+                      ? "hover:bg-muted/20 cursor-pointer"
+                      : "opacity-60 cursor-not-allowed"
                   }`}
                 >
-                  <Download className="w-4 h-4 text-accent-teal flex-shrink-0" />
+                  <Eye className="w-4 h-4 text-accent-teal flex-shrink-0" />
                   <span className="flex-1 min-w-0">
                     <span className="block truncate font-medium text-foreground">
                       {f.title}
@@ -550,9 +557,9 @@ export function PartnerProjectHubView({
                     )}
                   </span>
                   <span className="text-xs text-muted-foreground flex-shrink-0">
-                    {f.downloadUrl ? "Download" : "Unavailable"}
+                    {f.downloadUrl ? "Preview" : "Unavailable"}
                   </span>
-                </a>
+                </button>
               </li>
             ))}
           </ul>
@@ -582,8 +589,103 @@ export function PartnerProjectHubView({
           </div>
         </section>
       )}
+
+      {previewFile && (
+        <SharedFilePreviewModal
+          file={previewFile}
+          onClose={() => setPreviewFile(null)}
+        />
+      )}
         </div>
       </div>
     </div>
+  );
+}
+
+// Inline preview of a shared file (parity with the internal file view).
+// Images and PDFs render from the short-lived signed URL; anything else falls
+// back to a download prompt. Download stays one click away in the header.
+function SharedFilePreviewModal({
+  file,
+  onClose,
+}: {
+  file: SharedFile;
+  onClose: () => void;
+}) {
+  const ct = file.contentType ?? "";
+  const url = file.downloadUrl ?? undefined;
+  const isImage = ct.startsWith("image/");
+  const isPdf = ct === "application/pdf";
+  const isText = ct.startsWith("text/") || ct === "application/json";
+
+  return (
+    <Modal
+      open
+      onClose={onClose}
+      labelledBy="shared-file-preview-title"
+      containerClassName="bg-card rounded-2xl shadow-brand-2 max-w-3xl w-full p-5 sm:p-6 my-auto max-h-[85vh] flex flex-col"
+    >
+      <div className="flex items-start justify-between gap-3 mb-3">
+        <h2
+          id="shared-file-preview-title"
+          className="text-lg font-semibold text-foreground min-w-0 truncate"
+        >
+          {file.title}
+        </h2>
+        <div className="flex items-center gap-3 flex-shrink-0">
+          {url && (
+            <a
+              href={url}
+              download={file.fileName ?? undefined}
+              className="inline-flex items-center gap-1 text-sm font-medium text-accent-teal hover:underline"
+            >
+              <Download className="w-4 h-4" />
+              Download
+            </a>
+          )}
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="text-muted-foreground/70 hover:text-foreground rounded p-1 hover:bg-muted"
+          >
+            <X className="w-5 h-5" aria-hidden />
+          </button>
+        </div>
+      </div>
+
+      <div className="min-h-0 overflow-auto">
+        {isImage ? (
+          <img
+            src={url}
+            alt={file.title}
+            className="max-w-full max-h-[70vh] mx-auto rounded-lg border border-border object-contain bg-muted/20"
+          />
+        ) : isPdf || isText ? (
+          <iframe
+            src={url}
+            title={file.title}
+            className="w-full h-[70vh] rounded-lg border border-border bg-white"
+          />
+        ) : (
+          <div className="rounded-lg border border-border bg-muted/20 px-4 py-10 text-center text-sm text-muted-foreground">
+            <p>
+              No inline preview for this file type
+              {file.contentType ? ` (${file.contentType})` : ""}.
+            </p>
+            {url && (
+              <a
+                href={url}
+                download={file.fileName ?? undefined}
+                className="mt-3 inline-flex items-center gap-1 text-accent-teal hover:underline"
+              >
+                <Download className="w-3.5 h-3.5" />
+                Download to view
+              </a>
+            )}
+          </div>
+        )}
+      </div>
+    </Modal>
   );
 }

--- a/dali-api/app/partners/lib/partner-project-view.server.ts
+++ b/dali-api/app/partners/lib/partner-project-view.server.ts
@@ -82,6 +82,7 @@ export type PartnerProjectViewData = {
     title: string;
     fileName: string | null;
     sizeBytes: number | null;
+    contentType: string | null;
     downloadUrl: string | null;
   }[];
 };
@@ -210,7 +211,7 @@ export async function loadPartnerProjectView(
           id: true,
           title: true,
           currentVersion: {
-            select: { fileName: true, sizeBytes: true, s3Key: true },
+            select: { fileName: true, sizeBytes: true, s3Key: true, contentType: true },
           },
         },
       }),
@@ -362,6 +363,7 @@ export async function loadPartnerProjectView(
         title: f.title,
         fileName: f.currentVersion?.fileName ?? null,
         sizeBytes: f.currentVersion?.sizeBytes ?? null,
+        contentType: f.currentVersion?.contentType ?? null,
         downloadUrl: f.currentVersion?.s3Key
           ? await getDownloadUrl(f.currentVersion.s3Key)
           : null,


### PR DESCRIPTION
Small partner-portal enhancement, cleanly on top of current `staging`.

The internal file view already lets staff preview files inline. This brings the same to the **partner project hub**:

- **Shared files are click-to-preview** — image via `<img>`, PDF/text via `<iframe>`, other types fall back to a download prompt. Download stays one click away in the preview header. Adds `contentType` to the partner loader's `sharedFiles`.
- **"Shared files" section always renders** (with a "The team hasn't shared any files yet." empty state), matching the "Shared documents" section, instead of disappearing when nothing is shared.

Scoped to two files: `PartnerProjectHubView.tsx` + `partner-project-view.server.ts`.

> Replaces #945, which had drifted behind staging (its taskboard/partner-hub work already landed via #940 and #938, causing large conflicts). This carries only the genuinely-new partner-view changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/948"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787169193&installation_model_id=21824&pr_number=948&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F948&signature=4ab4e710023d94cc044280433d643353dce6ddb13ecd058ae59aef88642d2d3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->