### PR TITLE
Board: epic filter, Backlog status, cascading epic→sprint, modal redesign, scroll fix

### DIFF
--- a/dali-api/app/projects/components/TaskBoard.tsx
+++ b/dali-api/app/projects/components/TaskBoard.tsx
@@ -42,13 +42,8 @@ const PRIORITY_TONE: Record<Priority, string> = {
   Urgent: "text-accent-coral font-semibold",
 };
 
-// New tasks land in the first column ("To do") unless the modal picked a
-// status-affecting sprint; they can be dragged onward from there. One add
-// affordance for the whole board, not per column.
-const CREATE_STATUS: TaskStatus = TASK_STATUSES[0];
-
-// The `?sprint=` filter value for backlog (tasks with no sprint).
-const BACKLOG = "backlog";
+// The `?epic=` filter value for tasks with no epic.
+const NO_EPIC = "none";
 
 export function TaskBoard({
   projectId,
@@ -85,7 +80,7 @@ export function TaskBoard({
   // filter lives in `?sprint=` for the same reason (shareable board slices).
   const [searchParams, setSearchParams] = useSearchParams();
   const openTaskId = searchParams.get("task");
-  const sprintFilter = searchParams.get("sprint");
+  const epicFilter = searchParams.get("epic");
   const setParam = useCallback(
     (key: string, value: string | null) => {
       setSearchParams(
@@ -106,10 +101,10 @@ export function TaskBoard({
   );
 
   const filteredTasks = useMemo(() => {
-    if (!sprintFilter) return tasks;
-    if (sprintFilter === BACKLOG) return tasks.filter((t) => t.sprintId === null);
-    return tasks.filter((t) => t.sprintId === sprintFilter);
-  }, [tasks, sprintFilter]);
+    if (!epicFilter) return tasks;
+    if (epicFilter === NO_EPIC) return tasks.filter((t) => t.epicId === null);
+    return tasks.filter((t) => t.epicId === epicFilter);
+  }, [tasks, epicFilter]);
 
   const board = useMemo(() => buildTaskBoard(filteredTasks), [filteredTasks]);
   const openTask = openTaskId ? tasks.find((t) => t.id === openTaskId) ?? null : null;
@@ -134,6 +129,7 @@ export function TaskBoard({
           if ("title" in patch) body.title = patch.title;
           if ("description" in patch) body.description = patch.description;
           if ("priority" in patch) body.priority = patch.priority;
+          if ("status" in patch) body.status = patch.status;
           if ("sprintId" in patch) body.sprintId = patch.sprintId ?? null;
           if ("epicId" in patch) body.epicId = patch.epicId ?? null;
           if ("checklist" in patch) body.checklist = patch.checklist ?? null;
@@ -225,7 +221,7 @@ export function TaskBoard({
       body: JSON.stringify({
         title: values.title,
         description: values.description,
-        status: CREATE_STATUS,
+        status: values.status,
         dueAt: values.dueAt,
         sprintId: values.sprintId,
         epicId: values.epicId,
@@ -254,9 +250,9 @@ export function TaskBoard({
         id,
         title: values.title,
         description: values.description,
-        status: CREATE_STATUS,
+        status: values.status,
         priority: values.priority,
-        position: nextPositionInColumn(buildTaskBoard(cur), CREATE_STATUS),
+        position: nextPositionInColumn(buildTaskBoard(cur), values.status),
         dueAt: values.dueAt,
         epicId: values.epicId,
         sprintId: values.sprintId,
@@ -294,9 +290,9 @@ export function TaskBoard({
     listClassName: "flex flex-col gap-2 p-2 min-h-[360px]",
   }));
 
-  // Sprint pills: Active first, then Planned, then Closed (options.sprints
-  // arrive in that order from the loader), plus Backlog for sprint-less tasks.
-  const showSprintFilter = options.sprints.length > 0;
+  // Epic pills slice the board to one epic's tasks, plus "No epic" for tasks
+  // that aren't in any epic.
+  const showEpicFilter = options.epics.length > 0;
 
   return (
     <div className="flex flex-col gap-3">
@@ -313,26 +309,25 @@ export function TaskBoard({
             </Button>
           </>
         )}
-        {showSprintFilter && (
-          <div className="flex flex-wrap items-center gap-1.5" role="group" aria-label="Filter by sprint">
-            <SprintPill
+        {showEpicFilter && (
+          <div className="flex flex-wrap items-center gap-1.5" role="group" aria-label="Filter by epic">
+            <FilterPill
               label="All"
-              active={sprintFilter === null}
-              onClick={() => setParam("sprint", null)}
+              active={epicFilter === null}
+              onClick={() => setParam("epic", null)}
             />
-            {options.sprints.map((s) => (
-              <SprintPill
-                key={s.id}
-                label={s.name}
-                activeSprint={s.status === "Active"}
-                active={sprintFilter === s.id}
-                onClick={() => setParam("sprint", sprintFilter === s.id ? null : s.id)}
+            {options.epics.map((e) => (
+              <FilterPill
+                key={e.id}
+                label={e.title}
+                active={epicFilter === e.id}
+                onClick={() => setParam("epic", epicFilter === e.id ? null : e.id)}
               />
             ))}
-            <SprintPill
-              label="Backlog"
-              active={sprintFilter === BACKLOG}
-              onClick={() => setParam("sprint", sprintFilter === BACKLOG ? null : BACKLOG)}
+            <FilterPill
+              label="No epic"
+              active={epicFilter === NO_EPIC}
+              onClick={() => setParam("epic", epicFilter === NO_EPIC ? null : NO_EPIC)}
             />
           </div>
         )}
@@ -380,8 +375,8 @@ export function TaskBoard({
         <TaskModal
           options={options}
           canManage={canManage}
-          defaultSprintId={
-            sprintFilter && sprintFilter !== BACKLOG ? sprintFilter : null
+          defaultEpicId={
+            epicFilter && epicFilter !== NO_EPIC ? epicFilter : null
           }
           onClose={() => setIsCreating(false)}
           onCreate={handleCreate}
@@ -506,15 +501,13 @@ function ArchivedTasksModal({
   );
 }
 
-function SprintPill({
+function FilterPill({
   label,
   active,
-  activeSprint = false,
   onClick,
 }: {
   label: string;
   active: boolean;
-  activeSprint?: boolean;
   onClick: () => void;
 }) {
   return (
@@ -528,9 +521,6 @@ function SprintPill({
           : "border-border text-muted-foreground hover:bg-muted/30"
       }`}
     >
-      {activeSprint && (
-        <span aria-hidden className="w-1.5 h-1.5 rounded-full bg-accent-teal" />
-      )}
       {label}
     </button>
   );

--- a/dali-api/app/projects/components/TaskModal.tsx
+++ b/dali-api/app/projects/components/TaskModal.tsx
@@ -15,9 +15,15 @@ import {
   CHECKLIST_MAX_TEXT,
   type ChecklistItem,
 } from "../lib/task-checklist";
-import type { TaskBoardOptions, TaskCardModel, Priority } from "../lib/task-board";
+import type { TaskBoardOptions, TaskCardModel, Priority, TaskStatus } from "../lib/task-board";
+import { TASK_STATUSES, TASK_STATUS_LABELS } from "../lib/task-board";
 
 const PRIORITIES: Priority[] = ["Low", "Normal", "High", "Urgent"];
+
+// Borderless control for the Details property panel — the row supplies the
+// structure, so the control itself stays quiet.
+const PROP_CONTROL =
+  "w-full bg-transparent text-sm text-foreground py-1 focus:outline-none disabled:opacity-60";
 
 const COMMENT_MAX = 10_000;
 
@@ -36,6 +42,7 @@ type CommentModel = {
 export type NewTaskValues = {
   title: string;
   description: string | null;
+  status: TaskStatus;
   priority: Priority;
   dueAt: string | null;
   domainId: string | null;
@@ -59,7 +66,7 @@ export function TaskModal({
   onPatch,
   onCreate,
   onDelete,
-  defaultSprintId,
+  defaultEpicId,
 }: {
   // Present in edit mode; omitted (create mode) opens an empty form.
   task?: TaskCardModel;
@@ -72,13 +79,14 @@ export function TaskModal({
   onCreate?: (values: NewTaskValues) => Promise<void> | void;
   // Edit mode: the parent removes the task (and closes the modal).
   onDelete?: () => void;
-  // Create mode: seeds the sprint picker (e.g. from the board's sprint filter).
-  defaultSprintId?: string | null;
+  // Create mode: seeds the epic picker (e.g. from the board's epic filter).
+  defaultEpicId?: string | null;
 }) {
   const isCreate = !task;
   const [title, setTitle] = useState(task?.title ?? "");
   const [description, setDescription] = useState(task?.description ?? "");
   const [priority, setPriority] = useState<Priority>(task?.priority ?? "Normal");
+  const [status, setStatus] = useState<TaskStatus>(task?.status ?? "Todo");
   const [assigneeIds, setAssigneeIds] = useState<string[]>(
     task?.assignees.map((a) => a.id) ?? [],
   );
@@ -86,10 +94,24 @@ export function TaskModal({
     task?.dueAt ? dateInputValue(task.dueAt) : "",
   );
   const [domainId, setDomainId] = useState<string>(task?.domain?.id ?? "");
-  const [sprintId, setSprintId] = useState<string>(
-    task ? task.sprintId ?? "" : defaultSprintId ?? "",
+  const [sprintId, setSprintId] = useState<string>(task?.sprintId ?? "");
+  const [epicId, setEpicId] = useState<string>(
+    task ? task.epicId ?? "" : defaultEpicId ?? "",
   );
-  const [epicId, setEpicId] = useState<string>(task?.epicId ?? "");
+
+  // Cascading Epic → Sprint: only the chosen epic's sprints are selectable
+  // (or, with no epic, the standalone sprints). Changing epic drops a sprint
+  // that no longer belongs.
+  const epicSprints = options.sprints.filter((s) =>
+    epicId ? s.epicId === epicId : s.epicId === null,
+  );
+  function changeEpic(next: string) {
+    setEpicId(next);
+    const stillValid = options.sprints.some(
+      (s) => s.id === sprintId && (next ? s.epicId === next : s.epicId === null),
+    );
+    if (!stillValid) setSprintId("");
+  }
   const [checklist, setChecklist] = useState<ChecklistItem[]>(task?.checklist ?? []);
   const [newItemText, setNewItemText] = useState("");
   const [saving, setSaving] = useState(false);
@@ -143,6 +165,7 @@ export function TaskModal({
     setTitle(task.title);
     setDescription(task.description ?? "");
     setPriority(task.priority);
+    setStatus(task.status);
     setAssigneeIds(task.assignees.map((a) => a.id));
     setDueDate(task.dueAt ? dateInputValue(task.dueAt) : "");
     setDomainId(task.domain?.id ?? "");
@@ -190,6 +213,7 @@ export function TaskModal({
     const nextDescription = description.trim() ? description.trim() : null;
     if (nextDescription !== current.description) patch.description = nextDescription;
     if (priority !== current.priority) patch.priority = priority;
+    if (status !== current.status) patch.status = status;
     const nextDueIso = dueDate ? endOfDayIso(dueDate) : null;
     if (nextDueIso !== current.dueAt) patch.dueAt = nextDueIso;
     const nextDomain =
@@ -230,11 +254,12 @@ export function TaskModal({
       title.trim() !== "" ||
       description.trim() !== "" ||
       priority !== "Normal" ||
+      status !== "Todo" ||
       dueDate !== "" ||
       domainId !== "" ||
       assigneeIds.length > 0 ||
-      sprintId !== (defaultSprintId ?? "") ||
-      epicId !== "" ||
+      sprintId !== "" ||
+      epicId !== (defaultEpicId ?? "") ||
       githubEnabled
     );
   }
@@ -275,6 +300,7 @@ export function TaskModal({
       await onCreate({
         title: trimmed,
         description: description.trim() ? description.trim() : null,
+        status,
         priority,
         dueAt: dueDate ? endOfDayIso(dueDate) : null,
         domainId: domainId === "" ? null : domainId,
@@ -457,13 +483,31 @@ export function TaskModal({
           />
         </Field>
 
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-          <Field label="Priority">
+        {/* Details — one tidy property panel (label · control rows) instead of
+            a grid of boxed inputs, so the metadata reads as scannable
+            properties rather than a wall of fields. */}
+        <div className="rounded-lg border border-border divide-y divide-border">
+          <PropRow label="Status">
+            <select
+              value={status}
+              disabled={!canManage}
+              onChange={(e) => setStatus(e.target.value as TaskStatus)}
+              className={PROP_CONTROL}
+            >
+              {TASK_STATUSES.map((s) => (
+                <option key={s} value={s}>
+                  {TASK_STATUS_LABELS[s]}
+                </option>
+              ))}
+            </select>
+          </PropRow>
+
+          <PropRow label="Priority">
             <select
               value={priority}
               disabled={!canManage}
               onChange={(e) => setPriority(e.target.value as Priority)}
-              className="w-full px-2 py-1.5 text-sm border border-border rounded-md bg-background text-foreground"
+              className={PROP_CONTROL}
             >
               {PRIORITIES.map((p) => (
                 <option key={p} value={p}>
@@ -471,41 +515,14 @@ export function TaskModal({
                 </option>
               ))}
             </select>
-          </Field>
+          </PropRow>
 
-          <Field label="Deadline">
-            <input
-              type="date"
-              value={dueDate}
-              disabled={!canManage}
-              onChange={(e) => setDueDate(e.target.value)}
-              className="w-full px-2 py-1.5 text-sm border border-border rounded-md bg-background text-foreground"
-            />
-          </Field>
-
-          <Field label="Sprint">
-            <select
-              value={sprintId}
-              disabled={!canManage}
-              onChange={(e) => setSprintId(e.target.value)}
-              className="w-full px-2 py-1.5 text-sm border border-border rounded-md bg-background text-foreground"
-            >
-              <option value="">None (backlog)</option>
-              {options.sprints.map((s) => (
-                <option key={s.id} value={s.id}>
-                  {s.name}
-                  {s.status === "Closed" ? " (closed)" : ""}
-                </option>
-              ))}
-            </select>
-          </Field>
-
-          <Field label="Epic">
+          <PropRow label="Epic">
             <select
               value={epicId}
               disabled={!canManage}
-              onChange={(e) => setEpicId(e.target.value)}
-              className="w-full px-2 py-1.5 text-sm border border-border rounded-md bg-background text-foreground"
+              onChange={(e) => changeEpic(e.target.value)}
+              className={PROP_CONTROL}
             >
               <option value="">No epic</option>
               {options.epics.map((e) => (
@@ -514,14 +531,37 @@ export function TaskModal({
                 </option>
               ))}
             </select>
-          </Field>
+          </PropRow>
 
-          <Field label="Domain">
+          <PropRow label="Sprint">
+            <select
+              value={sprintId}
+              disabled={!canManage || epicSprints.length === 0}
+              onChange={(e) => setSprintId(e.target.value)}
+              className={PROP_CONTROL}
+            >
+              <option value="">
+                {epicSprints.length === 0
+                  ? epicId
+                    ? "No sprints in this epic"
+                    : "Pick an epic first"
+                  : "None"}
+              </option>
+              {epicSprints.map((s) => (
+                <option key={s.id} value={s.id}>
+                  {s.name}
+                  {s.status === "Closed" ? " (closed)" : ""}
+                </option>
+              ))}
+            </select>
+          </PropRow>
+
+          <PropRow label="Domain">
             <select
               value={domainId}
               disabled={!canManage}
               onChange={(e) => setDomainId(e.target.value)}
-              className="w-full px-2 py-1.5 text-sm border border-border rounded-md bg-background text-foreground"
+              className={PROP_CONTROL}
             >
               <option value="">—</option>
               {options.domains.map((d) => (
@@ -530,16 +570,26 @@ export function TaskModal({
                 </option>
               ))}
             </select>
-          </Field>
+          </PropRow>
 
-          <Field label="Assignees">
+          <PropRow label="Deadline">
+            <input
+              type="date"
+              value={dueDate}
+              disabled={!canManage}
+              onChange={(e) => setDueDate(e.target.value)}
+              className={PROP_CONTROL}
+            />
+          </PropRow>
+
+          <PropRow label="Assignees" align="start">
             <AssigneePicker
               all={options.members}
               selected={assigneeIds}
               disabled={!canManage}
               onChange={setAssigneeIds}
             />
-          </Field>
+          </PropRow>
         </div>
 
         {!isCreate && (
@@ -851,6 +901,34 @@ function Field({
       </span>
       {children}
     </label>
+  );
+}
+
+// One row in the Details property panel: a fixed-width label and its control.
+function PropRow({
+  label,
+  children,
+  align = "center",
+}: {
+  label: string;
+  children: React.ReactNode;
+  align?: "center" | "start";
+}) {
+  return (
+    <div
+      className={`flex gap-3 px-3 py-2 ${
+        align === "start" ? "items-start" : "items-center"
+      }`}
+    >
+      <span
+        className={`w-24 shrink-0 text-[11px] font-medium uppercase tracking-wide text-muted-foreground ${
+          align === "start" ? "pt-1.5" : ""
+        }`}
+      >
+        {label}
+      </span>
+      <div className="flex-1 min-w-0">{children}</div>
+    </div>
   );
 }
 

--- a/dali-api/app/projects/lib/github-task-sync.ts
+++ b/dali-api/app/projects/lib/github-task-sync.ts
@@ -7,6 +7,7 @@ import type { TaskStatus } from "./task-board";
 // Failures are logged and swallowed so a GH outage never blocks user writes.
 
 const STATUS_LABELS: Record<TaskStatus, string | null> = {
+  Backlog: "status:backlog",
   Todo: "status:todo",
   InProgress: "status:in-progress",
   InReview: "status:in-review",
@@ -15,6 +16,7 @@ const STATUS_LABELS: Record<TaskStatus, string | null> = {
 };
 
 const ALL_STATUS_LABELS = [
+  "status:backlog",
   "status:todo",
   "status:in-progress",
   "status:in-review",

--- a/dali-api/app/projects/lib/task-board.ts
+++ b/dali-api/app/projects/lib/task-board.ts
@@ -3,6 +3,7 @@
 // the board the helper builds, and persistence goes through an /api route.
 
 export const TASK_STATUSES = [
+  "Backlog",
   "Todo",
   "InProgress",
   "InReview",
@@ -13,6 +14,7 @@ export const TASK_STATUSES = [
 export type TaskStatus = (typeof TASK_STATUSES)[number];
 
 export const TASK_STATUS_LABELS: Record<TaskStatus, string> = {
+  Backlog: "Backlog",
   Todo: "To do",
   InProgress: "In progress",
   InReview: "In review",
@@ -59,6 +61,9 @@ export type BoardSprint = {
   id: string;
   name: string;
   status: "Planned" | "Active" | "Closed";
+  // The epic this sprint belongs to (null = standalone). Powers the modal's
+  // cascading Epic → Sprint picker: pick an epic, then only its sprints show.
+  epicId: string | null;
 };
 
 export type BoardEpic = { id: string; title: string };

--- a/dali-api/app/projects/routes/projects.$id.tsx
+++ b/dali-api/app/projects/routes/projects.$id.tsx
@@ -9,6 +9,7 @@ import {
   useRevalidator,
   useSearchParams,
   useSubmit,
+  type ShouldRevalidateFunctionArgs,
 } from "react-router";
 import { CalendarDays, CalendarX, ChartNoAxesGantt, Check, Handshake, History, List, Pencil, Pin, X, Settings, Folder, FolderPlus, ChevronRight, ChevronDown, FileText, Info, Users, Paperclip, Plus, Trash2, Upload, Unlink } from "lucide-react";
 import { Modal, ModalHeader } from "~/components/Modal";
@@ -507,7 +508,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
           sprintFilterOrder[a.status] - sprintFilterOrder[b.status] ||
           a.startsAt.localeCompare(b.startsAt),
       )
-      .map((s) => ({ id: s.id, name: s.name, status: s.status })),
+      .map((s) => ({ id: s.id, name: s.name, status: s.status, epicId: s.epicId })),
     epics: project.epics.map((e) => ({ id: e.id, title: e.title })),
   };
 
@@ -858,6 +859,23 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     presencePhotoUrl: presenceUser?.photoUrl ?? null,
     presenceSubtitle: presenceUser?.subtitle ?? null,
   };
+}
+
+// The loader doesn't depend on search params, so a pure search-param change
+// (opening/closing the task modal via ?task=, switching the ?epic= filter or
+// ?tab=) shouldn't re-run it. Skipping that revalidation avoids a needless
+// DB round-trip and the re-render that otherwise bounces the board's scroll
+// position to the top when you open a task.
+export function shouldRevalidate({
+  currentUrl,
+  nextUrl,
+  formMethod,
+  defaultShouldRevalidate,
+}: ShouldRevalidateFunctionArgs) {
+  if (!formMethod && currentUrl.pathname === nextUrl.pathname) {
+    return false;
+  }
+  return defaultShouldRevalidate;
 }
 
 export async function action({ request, params }: Route.ActionArgs) {

--- a/dali-api/prisma/migrations/20260720170000_add_task_status_backlog/migration.sql
+++ b/dali-api/prisma/migrations/20260720170000_add_task_status_backlog/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "TaskStatus" ADD VALUE IF NOT EXISTS 'Backlog' BEFORE 'Todo';

--- a/dali-api/prisma/schema.prisma
+++ b/dali-api/prisma/schema.prisma
@@ -2520,6 +2520,7 @@ model Task {
 }
 
 enum TaskStatus {
+  Backlog
   Todo
   InProgress
   InReview


### PR DESCRIPTION
Board + task-modal edits, on top of the #941 board rework.

### Fixes & features
- **Opening a task no longer scrolls the board to the top** — re-adds `shouldRevalidate` to the project route (it was dropped when #941 rewrote the route), so a pure `?task=` / filter change doesn't revalidate the live board and bounce its scroll.
- **Epic filter replaces the sprint filter** — the board's top pills now slice by epic (`?epic=`: All / each epic / No epic); new tasks seed the filtered epic.
- **Backlog status** — added to the `TaskStatus` enum (additive enum migration), so the board gains a Backlog column and it's a real, selectable status.
- **Task modal: Status dropdown** — manual status change (Backlog, To do, In progress, In review, Done, Cancelled) in both create and edit.
- **Task modal: cascading Epic → Sprint** — pick an epic first; only that epic's sprints become selectable (standalone sprints show when no epic is chosen). Changing the epic drops a sprint that no longer belongs. Exposes `BoardSprint.epicId` to drive it.
- **Task modal redesign** — the boxed-select grid is now one tidy **Details** property panel (label · control rows, quiet borderless controls), so the metadata reads as scannable properties instead of a wall of input boxes.

### Migration
- `20260720170000_add_task_status_backlog` — `ALTER TYPE "TaskStatus" ADD VALUE 'Backlog'` (additive, safe). Apply with `prisma migrate deploy`.

### Testing
- `task-board` unit tests pass; typecheck clean for all changed files. (Pre-existing typecheck errors in notification files from #937 and `scripts/*` are untouched.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/951"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787172490&installation_model_id=21824&pr_number=951&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F951&signature=e41f89087ff10e0965f6cb3c33334b6e342651a818464f849701bb653fc6d8ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->