### PR TITLE
Task artifacts: versioned work files on tasks + feedback loop (graphi…

### DIFF
--- a/dali-api/app/components/collab/CommentsRail.tsx
+++ b/dali-api/app/components/collab/CommentsRail.tsx
@@ -11,6 +11,9 @@ export type Comment = {
   anchor: { from: string; to: string } | null;
   resolved: boolean;
   createdAt: string;
+  // File comments: the ProjectFileVersion current when the comment was
+  // written. Null on doc/pagedoc comments and pre-pinning file comments.
+  versionId?: string | null;
 };
 
 type Thread = { root: Comment; replies: Comment[] };
@@ -26,6 +29,23 @@ export type ThreadActions = {
 
 export function formatCommentDate(iso: string) {
   return new Date(iso).toLocaleString(undefined, { month: "short", day: "numeric", hour: "numeric", minute: "2-digit" });
+}
+
+// "V2" chip on file comments — which iteration the feedback was written on.
+function VersionChip({
+  comment,
+  versionLabels,
+}: {
+  comment: Comment;
+  versionLabels?: Record<string, string>;
+}) {
+  const label = comment.versionId ? versionLabels?.[comment.versionId] : undefined;
+  if (!label) return null;
+  return (
+    <span className="mr-1.5 px-1 py-0.5 rounded bg-muted text-muted-foreground font-medium">
+      {label}
+    </span>
+  );
 }
 
 // Comment threads for a document or file. Doc-level (anchor === null) and
@@ -46,6 +66,8 @@ export function CommentsRail({
   registerRefresh,
   mentionPath,
   focusCommentId,
+  versionLabels,
+  versionId,
 }: {
   targetType: "doc" | "file" | "pagedoc";
   targetId: string;
@@ -61,6 +83,12 @@ export function CommentsRail({
   // Arriving from a comment-mention notification (?comment=<id>): scroll to and
   // flash this comment once threads load.
   focusCommentId?: string;
+  // File hosts: versionId → display label ("V2"), so feedback reads against
+  // the iteration it was written on.
+  versionLabels?: Record<string, string>;
+  // File hosts: the version currently being previewed — new comments are
+  // stamped with it rather than whatever version happens to be current.
+  versionId?: string | null;
   onClearPendingAnchor?: () => void;
   onFocusAnchor?: (anchor: { from: string; to: string }) => void;
   // Lets the host trigger a refetch (e.g. after creating an inline comment
@@ -140,7 +168,7 @@ export function CommentsRail({
         method: "POST",
         credentials: "include",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ targetType, targetId, body, parentId, anchor, path: mentionPath }),
+        body: JSON.stringify({ targetType, targetId, body, parentId, anchor, path: mentionPath, versionId }),
       });
       if (!res.ok) {
         const b = (await res.json().catch(() => ({}))) as { error?: string };
@@ -298,7 +326,10 @@ export function CommentsRail({
               >
                 <div className="flex items-center justify-between">
                   <span className="text-xs font-medium text-foreground">{t.root.author}</span>
-                  <span className="text-[10px] text-muted-foreground">{formatCommentDate(t.root.createdAt)}</span>
+                  <span className="text-[10px] text-muted-foreground">
+                    <VersionChip comment={t.root} versionLabels={versionLabels} />
+                    {formatCommentDate(t.root.createdAt)}
+                  </span>
                 </div>
                 {t.root.anchor && (
                   <span className="text-[10px] text-accent-coral">inline</span>
@@ -310,7 +341,10 @@ export function CommentsRail({
                 <div key={r.id} data-comment-id={r.id} className="ml-3 mt-1.5 pl-2 border-l border-border">
                   <div className="flex items-center justify-between">
                     <span className="text-xs font-medium text-foreground">{r.author}</span>
-                    <span className="text-[10px] text-muted-foreground">{formatCommentDate(r.createdAt)}</span>
+                    <span className="text-[10px] text-muted-foreground">
+                      <VersionChip comment={r} versionLabels={versionLabels} />
+                      {formatCommentDate(r.createdAt)}
+                    </span>
                   </div>
                   <p className="text-sm text-foreground whitespace-pre-wrap mt-0.5">{r.body}</p>
                 </div>

--- a/dali-api/app/components/collab/PresenceBar.tsx
+++ b/dali-api/app/components/collab/PresenceBar.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { Link } from "react-router";
 import { usePresence, type Peer } from "./PresenceProvider";
 import { initialsFromName } from "./util";
@@ -215,6 +215,28 @@ function HoverCard({
   const meTag = peer.isMe ? " (you)" : "";
   const idleTag = peer.idle ? " · idle" : "";
 
+  // Clamp the centered card inside the viewport: the presence bar usually
+  // sits near the right edge of the page, where a chip-centered card would
+  // run off-screen. Measured on open (the card unmounts when closed) and
+  // applied as an extra translateX on top of the -50% centering.
+  const cardRef = useRef<HTMLDivElement | null>(null);
+  const [shiftX, setShiftX] = useState(0);
+  useLayoutEffect(() => {
+    if (!open) {
+      setShiftX(0);
+      return;
+    }
+    const el = cardRef.current;
+    if (!el) return;
+    const margin = 8;
+    const rect = el.getBoundingClientRect();
+    if (rect.right > window.innerWidth - margin) {
+      setShiftX(window.innerWidth - margin - rect.right);
+    } else if (rect.left < margin) {
+      setShiftX(margin - rect.left);
+    }
+  }, [open]);
+
   // Unmount when closed so the invisible card doesn't intercept clicks on
   // anything below it (the prior implementation kept pointer-events-auto on
   // the inner div even at opacity-0, which could absorb a click meant for
@@ -223,8 +245,10 @@ function HoverCard({
 
   return (
     <div
+      ref={cardRef}
       role="tooltip"
-      className="absolute left-1/2 top-full z-20 mt-2 -translate-x-1/2 transition-opacity"
+      className="absolute left-1/2 top-full z-20 mt-2 transition-opacity"
+      style={{ transform: `translateX(calc(-50% + ${shiftX}px))` }}
       onPointerEnter={onPointerEnter}
       onPointerLeave={onPointerLeave}
     >

--- a/dali-api/app/components/settings/WorkspaceSettingsBlock.tsx
+++ b/dali-api/app/components/settings/WorkspaceSettingsBlock.tsx
@@ -11,16 +11,16 @@ const OPTIONS: {
   icon: typeof PanelTop;
 }[] = [
   {
+    value: "tabless",
+    label: "Single page",
+    description: "One page at a time, using your browser's own tabs and history (default)",
+    icon: Square,
+  },
+  {
     value: "tabs",
     label: "Tabbed workspace",
     description: "Open sections as tabs, with split view and pinning",
     icon: PanelTop,
-  },
-  {
-    value: "tabless",
-    label: "Single page",
-    description: "One page at a time, using your browser's own tabs and history",
-    icon: Square,
   },
 ];
 
@@ -40,7 +40,7 @@ function reloadSettings() {
 export function WorkspaceSettingsBlock() {
   // Matches AppearanceSettingsBlock: render defaults on the server, then correct
   // to the cookie-backed values on mount to avoid a hydration mismatch.
-  const [tabless, setTabless] = useState(false);
+  const [tabless, setTabless] = useState(true);
   const [focus, setFocus] = useState(false);
 
   useEffect(() => {

--- a/dali-api/app/lib/__mocks__/db.ts
+++ b/dali-api/app/lib/__mocks__/db.ts
@@ -193,7 +193,20 @@ export const prisma = {
     create: vi.fn(),
   },
   projectFile: {
+    findUnique: vi.fn(),
     findMany: vi.fn().mockResolvedValue([]),
+  },
+  projectFileVersion: {
+    findFirst: vi.fn(),
+  },
+  docComment: {
+    create: vi.fn(),
+    findUnique: vi.fn(),
+    findMany: vi.fn().mockResolvedValue([]),
+  },
+  taskFileLink: {
+    createMany: vi.fn().mockResolvedValue({ count: 1 }),
+    deleteMany: vi.fn().mockResolvedValue({ count: 1 }),
   },
   scheduledMeeting: {
     findMany: vi.fn().mockResolvedValue([]),

--- a/dali-api/app/lib/__tests__/tabless.test.ts
+++ b/dali-api/app/lib/__tests__/tabless.test.ts
@@ -8,26 +8,26 @@ function req(cookie?: string): Request {
 }
 
 describe("isTablessRequest", () => {
-  it("is false when no Cookie header", () => {
-    expect(isTablessRequest(req())).toBe(false);
+  it("defaults to tabless with no Cookie header", () => {
+    expect(isTablessRequest(req())).toBe(true);
   });
 
-  it("is false when the tabless cookie is absent", () => {
-    expect(isTablessRequest(req("__dali_sid=abc; foo=bar"))).toBe(false);
+  it("defaults to tabless when the cookie is absent", () => {
+    expect(isTablessRequest(req("__dali_sid=abc; foo=bar"))).toBe(true);
   });
 
-  it("is true when the tabless cookie is set to 1", () => {
+  it("is true when the cookie is set to 1", () => {
     expect(isTablessRequest(req(`${TABLESS_COOKIE}=1`))).toBe(true);
   });
 
   it("finds the cookie among others", () => {
     expect(
-      isTablessRequest(req(`__dali_sid=abc; ${TABLESS_COOKIE}=1; theme=dark`)),
-    ).toBe(true);
+      isTablessRequest(req(`__dali_sid=abc; ${TABLESS_COOKIE}=0; theme=dark`)),
+    ).toBe(false);
   });
 
-  it("is false for any value other than 1 (e.g. a cleared cookie)", () => {
-    expect(isTablessRequest(req(`${TABLESS_COOKIE}=`))).toBe(false);
+  it("is false only for the explicit tabbed opt-in (0)", () => {
     expect(isTablessRequest(req(`${TABLESS_COOKIE}=0`))).toBe(false);
+    expect(isTablessRequest(req(`${TABLESS_COOKIE}=`))).toBe(true);
   });
 });

--- a/dali-api/app/lib/notification-events.ts
+++ b/dali-api/app/lib/notification-events.ts
@@ -98,7 +98,7 @@ export const EVENT_TYPES = {
     area: "Tasks",
     label: "Task status changes",
     description: "When someone moves a task you're assigned to a new status.",
-    defaults: { inApp: true, slackDm: false, email: "Off" },
+    defaults: { inApp: true, desktop: false, slackDm: false, email: "Off" },
   },
   "task.github_update": {
     kind: "General",
@@ -112,6 +112,20 @@ export const EVENT_TYPES = {
     area: "Documents",
     label: "Comment replies",
     description: "Replies in document and file comment threads you're part of.",
+    defaults: { inApp: true, desktop: true, slackDm: false, email: "Off" },
+  },
+  "file.comment": {
+    kind: "General",
+    area: "Documents",
+    label: "File feedback",
+    description: "New comments on files you uploaded or are working on via a task.",
+    defaults: { inApp: true, desktop: true, slackDm: false, email: "Off" },
+  },
+  "file.new_version": {
+    kind: "General",
+    area: "Documents",
+    label: "New file versions",
+    description: "When a new version of a file you commented on or are working on is uploaded.",
     defaults: { inApp: true, desktop: true, slackDm: false, email: "Off" },
   },
   "pagedoc.mention": {

--- a/dali-api/app/lib/tabless.ts
+++ b/dali-api/app/lib/tabless.ts
@@ -4,30 +4,34 @@
 // client-only flag would hydrate the wrong one. Self-contained on purpose —
 // lib/cookies.ts is the session-credential module and stays out of the client
 // bundle.
+//
+// Tabless is the default: no cookie (or any value except "0") renders the
+// direct shell; "0" is the explicit opt-in to the tabbed workspace.
 
 export const TABLESS_COOKIE = "dali_tabless";
 
 const MAX_AGE_SECONDS = 60 * 60 * 24 * 365;
 
-function hasTablessCookie(cookieString: string): boolean {
-  return cookieString.split(";").some((part) => {
+function tablessFromCookies(cookieString: string): boolean {
+  for (const part of cookieString.split(";")) {
     const [k, ...rest] = part.split("=");
-    return k?.trim() === TABLESS_COOKIE && rest.join("=").trim() === "1";
-  });
+    if (k?.trim() === TABLESS_COOKIE) return rest.join("=").trim() !== "0";
+  }
+  return true;
 }
 
 export function isTablessRequest(request: Request): boolean {
-  return hasTablessCookie(request.headers.get("Cookie") ?? "");
+  return tablessFromCookies(request.headers.get("Cookie") ?? "");
 }
 
 export function readTablessPreference(): boolean {
-  if (typeof document === "undefined") return false;
-  return hasTablessCookie(document.cookie);
+  if (typeof document === "undefined") return true;
+  return tablessFromCookies(document.cookie);
 }
 
 export function setTablessPreference(on: boolean): void {
   if (typeof document === "undefined") return;
-  document.cookie = on
-    ? `${TABLESS_COOKIE}=1; Max-Age=${MAX_AGE_SECONDS}; Path=/; SameSite=Lax`
-    : `${TABLESS_COOKIE}=; Max-Age=0; Path=/; SameSite=Lax`;
+  // Persist both choices (rather than deleting on the default) so an explicit
+  // pick survives a future default change.
+  document.cookie = `${TABLESS_COOKIE}=${on ? "1" : "0"}; Max-Age=${MAX_AGE_SECONDS}; Path=/; SameSite=Lax`;
 }

--- a/dali-api/app/projects/components/TaskBoard.tsx
+++ b/dali-api/app/projects/components/TaskBoard.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRevalidator, useSearchParams } from "react-router";
 import { Button } from "~/components/ui/Button";
 import type { DragEndEvent } from "@dnd-kit/core";
-import { Archive, Github, X } from "lucide-react";
+import { Archive, Github, Paperclip, X } from "lucide-react";
 import { Confetti } from "~/components/Confetti";
 import { Modal } from "~/components/Modal";
 import { KanbanBoard, type KanbanColumn } from "~/components/board/KanbanBoard";
@@ -267,6 +267,7 @@ export function TaskBoard({
         // next revalidation. Null here means no badge in the meantime.
         githubIssueUrl: null,
         githubIssueNumber: null,
+        files: [],
         createdBy: { id: currentUserId, name: currentUserName },
         createdAt: new Date().toISOString(),
       },
@@ -368,16 +369,19 @@ export function TaskBoard({
       {openTask && (
         <TaskModal
           task={openTask}
+          projectId={projectId}
           options={options}
           canManage={canManage}
           onClose={() => setOpenTaskId(null)}
           onPatch={(patch) => patchTask(openTask.id, patch)}
           onDelete={() => deleteTask(openTask.id)}
+          onArtifactsChanged={refresh}
         />
       )}
 
       {isCreating && (
         <TaskModal
+          projectId={projectId}
           options={options}
           canManage={canManage}
           defaultSprintId={
@@ -618,6 +622,12 @@ function TaskCard({
           {card.githubIssueNumber !== null && (
             <span className="inline-flex items-center gap-0.5 text-[11px] text-muted-foreground">
               <Github aria-hidden className="w-3 h-3" />#{card.githubIssueNumber}
+            </span>
+          )}
+          {card.files.length > 0 && (
+            <span className="inline-flex items-center gap-0.5 text-[11px] text-muted-foreground">
+              <Paperclip aria-hidden className="w-3 h-3" />
+              {card.files.length}
             </span>
           )}
         </div>

--- a/dali-api/app/projects/components/TaskModal.tsx
+++ b/dali-api/app/projects/components/TaskModal.tsx
@@ -6,9 +6,11 @@
 // set of fields and hands them to onCreate on submit.
 
 import { useEffect, useRef, useState } from "react";
+import { Link } from "react-router";
 import { X } from "lucide-react";
 import { Modal } from "~/components/Modal";
 import { Button } from "~/components/ui/Button";
+import { uploadFileToS3 } from "~/lib/upload-client";
 import {
   normalizeChecklist,
   CHECKLIST_MAX_ITEMS,
@@ -51,8 +53,11 @@ export type NewTaskValues = {
   github: { repo: string } | null;
 };
 
+type ArtifactModel = TaskCardModel["files"][number];
+
 export function TaskModal({
   task,
+  projectId,
   options,
   canManage,
   onClose,
@@ -60,9 +65,11 @@ export function TaskModal({
   onCreate,
   onDelete,
   defaultSprintId,
+  onArtifactsChanged,
 }: {
   // Present in edit mode; omitted (create mode) opens an empty form.
   task?: TaskCardModel;
+  projectId: string;
   options: TaskBoardOptions;
   canManage: boolean;
   onClose: () => void;
@@ -74,6 +81,9 @@ export function TaskModal({
   onDelete?: () => void;
   // Create mode: seeds the sprint picker (e.g. from the board's sprint filter).
   defaultSprintId?: string | null;
+  // Edit mode: lets the board revalidate so the card's artifact chip catches
+  // up after a link/unlink/upload (artifacts bypass the onPatch path).
+  onArtifactsChanged?: () => void;
 }) {
   const isCreate = !task;
   const [title, setTitle] = useState(task?.title ?? "");
@@ -129,6 +139,15 @@ export function TaskModal({
   const [linkBusy, setLinkBusy] = useState(false);
   const [linkError, setLinkError] = useState<string | null>(null);
 
+  // Artifacts (edit mode): linked project files. Local so link/unlink/upload
+  // reflect immediately — the parent's task model catches up on revalidation.
+  const [artifacts, setArtifacts] = useState<ArtifactModel[]>(task?.files ?? []);
+  const [artifactBusy, setArtifactBusy] = useState(false);
+  const [artifactError, setArtifactError] = useState<string | null>(null);
+  const [attachOpen, setAttachOpen] = useState(false);
+  const [attachFileId, setAttachFileId] = useState("");
+  const artifactInputRef = useRef<HTMLInputElement | null>(null);
+
   // Comments (edit mode). null = still loading.
   const [comments, setComments] = useState<CommentModel[] | null>(null);
   const [commentsError, setCommentsError] = useState<string | null>(null);
@@ -150,6 +169,7 @@ export function TaskModal({
     setEpicId(task.epicId ?? "");
     setChecklist(task.checklist ?? []);
     setGithub({ issueNumber: task.githubIssueNumber, url: task.githubIssueUrl });
+    setArtifacts(task.files);
     setSaveError(null);
   }, [task?.id]);
 
@@ -353,6 +373,92 @@ export function TaskModal({
       );
     } finally {
       setCommentPosting(false);
+    }
+  }
+
+  async function linkArtifact(fileId: string): Promise<void> {
+    if (!task) return;
+    const res = await fetch(`/api/tasks/${task.id}/files`, {
+      method: "POST",
+      credentials: "include",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ fileId }),
+    });
+    const j = (await res.json().catch(() => ({}))) as Partial<ArtifactModel> & {
+      error?: string;
+    };
+    if (!res.ok) throw new Error(j.error ?? `Request failed: ${res.status}`);
+    setArtifacts((cur) =>
+      cur.some((a) => a.id === j.id)
+        ? cur
+        : [...cur, { id: j.id!, title: j.title!, versionCount: j.versionCount ?? 1 }],
+    );
+    onArtifactsChanged?.();
+  }
+
+  async function handleAttachArtifact() {
+    if (!attachFileId) return;
+    setArtifactBusy(true);
+    setArtifactError(null);
+    try {
+      await linkArtifact(attachFileId);
+      setAttachOpen(false);
+      setAttachFileId("");
+    } catch (err) {
+      setArtifactError(err instanceof Error ? err.message : "Couldn't attach the file.");
+    } finally {
+      setArtifactBusy(false);
+    }
+  }
+
+  async function handleUnlinkArtifact(fileId: string) {
+    if (!task) return;
+    setArtifactBusy(true);
+    setArtifactError(null);
+    try {
+      const res = await fetch(`/api/tasks/${task.id}/files`, {
+        method: "DELETE",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ fileId }),
+      });
+      if (!res.ok) {
+        const j = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(j.error ?? `Request failed: ${res.status}`);
+      }
+      setArtifacts((cur) => cur.filter((a) => a.id !== fileId));
+      onArtifactsChanged?.();
+    } catch (err) {
+      setArtifactError(err instanceof Error ? err.message : "Couldn't unlink the file.");
+    } finally {
+      setArtifactBusy(false);
+    }
+  }
+
+  // Upload a brand-new artifact: S3 direct upload → register as a project
+  // file → link it to this task. The file also appears in the project's
+  // Files section (it's a normal ProjectFile).
+  async function handleUploadArtifact(e: React.ChangeEvent<HTMLInputElement>) {
+    const picked = e.target.files?.[0];
+    e.target.value = "";
+    if (!picked || !task) return;
+    setArtifactBusy(true);
+    setArtifactError(null);
+    try {
+      const meta = await uploadFileToS3(picked, `project-files/${projectId}`);
+      const res = await fetch(`/api/projects/${projectId}/files`, {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title: picked.name, ...meta }),
+      });
+      const j = (await res.json().catch(() => ({}))) as { id?: string; error?: string };
+      if (!res.ok || !j.id) throw new Error(j.error ?? "Failed to save the upload");
+      await linkArtifact(j.id);
+    } catch (err) {
+      setArtifactError(err instanceof Error ? err.message : "Upload failed.");
+    } finally {
+      setArtifactBusy(false);
     }
   }
 
@@ -696,6 +802,105 @@ export function TaskModal({
               </button>
             )}
             {linkError && <p className="text-accent-coral">{linkError}</p>}
+          </div>
+        )}
+
+        {!isCreate && task && (canManage || artifacts.length > 0) && (
+          <div className="flex flex-col gap-2 pt-2 border-t border-border text-xs">
+            <span className="text-muted-foreground font-medium uppercase tracking-wide">
+              Work files
+              {artifacts.length > 0 && ` (${artifacts.length})`}
+            </span>
+            {artifacts.map((a) => (
+              <div key={a.id} className="flex items-center justify-between gap-2">
+                <Link
+                  to={`/documents/file/${a.id}`}
+                  className="min-w-0 truncate text-sm text-accent-coral hover:underline"
+                >
+                  {a.title}
+                </Link>
+                <span className="flex-shrink-0 text-muted-foreground">
+                  {a.versionCount} {a.versionCount === 1 ? "version" : "versions"}
+                  {canManage && (
+                    <button
+                      type="button"
+                      onClick={() => void handleUnlinkArtifact(a.id)}
+                      disabled={artifactBusy}
+                      className="ml-2 text-muted-foreground hover:text-foreground hover:underline disabled:opacity-60"
+                    >
+                      Unlink
+                    </button>
+                  )}
+                </span>
+              </div>
+            ))}
+            {canManage && (
+              <div className="flex items-center gap-3">
+                <input
+                  ref={artifactInputRef}
+                  type="file"
+                  className="hidden"
+                  onChange={(e) => void handleUploadArtifact(e)}
+                />
+                <button
+                  type="button"
+                  onClick={() => artifactInputRef.current?.click()}
+                  disabled={artifactBusy}
+                  className="text-accent-coral hover:underline disabled:opacity-60"
+                >
+                  {artifactBusy ? "Working…" : "Upload file"}
+                </button>
+                {options.projectFiles.some(
+                  (f) => !artifacts.some((a) => a.id === f.id),
+                ) &&
+                  (attachOpen ? (
+                    <span className="flex items-center gap-2">
+                      <select
+                        value={attachFileId}
+                        onChange={(e) => setAttachFileId(e.target.value)}
+                        className="px-2 py-1 text-xs border border-border rounded-md bg-background text-foreground"
+                      >
+                        <option value="">Choose a file…</option>
+                        {options.projectFiles
+                          .filter((f) => !artifacts.some((a) => a.id === f.id))
+                          .map((f) => (
+                            <option key={f.id} value={f.id}>
+                              {f.title}
+                            </option>
+                          ))}
+                      </select>
+                      <button
+                        type="button"
+                        onClick={() => void handleAttachArtifact()}
+                        disabled={artifactBusy || !attachFileId}
+                        className="text-accent-coral hover:underline disabled:opacity-60"
+                      >
+                        Attach
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setAttachOpen(false);
+                          setAttachFileId("");
+                        }}
+                        className="text-muted-foreground hover:underline"
+                      >
+                        Cancel
+                      </button>
+                    </span>
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={() => setAttachOpen(true)}
+                      disabled={artifactBusy}
+                      className="text-accent-coral hover:underline disabled:opacity-60"
+                    >
+                      Attach existing
+                    </button>
+                  ))}
+              </div>
+            )}
+            {artifactError && <p className="text-accent-coral">{artifactError}</p>}
           </div>
         )}
 

--- a/dali-api/app/projects/lib/__tests__/file-groups.test.ts
+++ b/dali-api/app/projects/lib/__tests__/file-groups.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { groupFilesByEpic, type GroupableFile } from "../file-groups";
+
+function file(id: string, taskLinked: boolean, epicIds: string[] = []): GroupableFile {
+  return { id, taskLinked, epicIds };
+}
+
+const EPICS = [
+  { id: "e1", title: "Onboarding redesign" },
+  { id: "e2", title: "Spring campaign" },
+];
+
+describe("groupFilesByEpic", () => {
+  it("splits files into epic groups, epicless work, and general uploads", () => {
+    const { epicGroups, otherWorkFiles, generalFiles } = groupFilesByEpic(
+      [
+        file("hero", true, ["e1"]),
+        file("poster", true, ["e2"]),
+        file("adhoc", true),
+        file("spec", false),
+      ],
+      EPICS,
+    );
+
+    expect(epicGroups.map((g) => ({ id: g.id, files: g.files.map((f) => f.id) }))).toEqual([
+      { id: "e1", files: ["hero"] },
+      { id: "e2", files: ["poster"] },
+    ]);
+    expect(otherWorkFiles.map((f) => f.id)).toEqual(["adhoc"]);
+    expect(generalFiles.map((f) => f.id)).toEqual(["spec"]);
+  });
+
+  it("orders groups by the caller's epic order and skips empty epics", () => {
+    const { epicGroups } = groupFilesByEpic([file("poster", true, ["e2"])], EPICS);
+    expect(epicGroups.map((g) => g.title)).toEqual(["Spring campaign"]);
+  });
+
+  it("shows a multi-epic file under each epic", () => {
+    const { epicGroups } = groupFilesByEpic([file("shared", true, ["e1", "e2"])], EPICS);
+    expect(epicGroups.every((g) => g.files.some((f) => f.id === "shared"))).toBe(true);
+  });
+
+  it("falls back to the epicless bucket for unknown epic ids", () => {
+    const { epicGroups, otherWorkFiles } = groupFilesByEpic(
+      [file("stray", true, ["deleted-epic"])],
+      EPICS,
+    );
+    expect(epicGroups).toEqual([]);
+    expect(otherWorkFiles.map((f) => f.id)).toEqual(["stray"]);
+  });
+
+  it("leaves everything general when nothing is task-linked", () => {
+    const { epicGroups, otherWorkFiles, generalFiles } = groupFilesByEpic(
+      [file("a", false), file("b", false)],
+      EPICS,
+    );
+    expect(epicGroups).toEqual([]);
+    expect(otherWorkFiles).toEqual([]);
+    expect(generalFiles.map((f) => f.id)).toEqual(["a", "b"]);
+  });
+});

--- a/dali-api/app/projects/lib/__tests__/file-notifications.test.ts
+++ b/dali-api/app/projects/lib/__tests__/file-notifications.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("~/lib/db");
+vi.mock("~/lib/notify.server", () => ({ notify: vi.fn() }));
+
+import { prisma } from "~/lib/db";
+import { notify } from "~/lib/notify.server";
+import {
+  notifyFileComment,
+  notifyFileNewVersion,
+} from "~/projects/lib/file-notifications.server";
+
+const mockPrisma = prisma as unknown as {
+  projectFile: { findUnique: ReturnType<typeof vi.fn> };
+};
+const mockNotify = notify as unknown as ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// Audience: version uploaders + comment authors + linked-task assignees,
+// with overlap (uploader is also an assignee here).
+const FILE = {
+  title: "Hero animation",
+  versions: [{ uploadedById: "uploader" }, { uploadedById: "uploader" }],
+  comments: [{ authorId: "mentor" }],
+  taskLinks: [
+    { task: { assignees: [{ userId: "assignee" }, { userId: "uploader" }] } },
+  ],
+};
+
+function recipientIds(): string[] {
+  const call = mockNotify.mock.calls[0][0];
+  return call.recipients.map((r: { userId: string }) => r.userId).sort();
+}
+
+describe("notifyFileComment", () => {
+  it("notifies the file's audience, excluding the comment author", async () => {
+    mockPrisma.projectFile.findUnique.mockResolvedValue(FILE);
+
+    await notifyFileComment({ fileId: "f1", authorId: "mentor", body: "Tighten the easing" });
+
+    expect(mockNotify).toHaveBeenCalledTimes(1);
+    const call = mockNotify.mock.calls[0][0];
+    expect(call.eventType).toBe("file.comment");
+    expect(call.message.title).toBe("New feedback on: Hero animation");
+    expect(call.message.body).toBe("Tighten the easing");
+    expect(call.message.link).toBe("/documents/file/f1");
+    expect(recipientIds()).toEqual(["assignee", "uploader"]);
+  });
+
+  it("truncates long comment bodies to a preview", async () => {
+    mockPrisma.projectFile.findUnique.mockResolvedValue(FILE);
+
+    await notifyFileComment({ fileId: "f1", authorId: "mentor", body: "x".repeat(300) });
+
+    expect(mockNotify.mock.calls[0][0].message.body).toBe(`${"x".repeat(200)}…`);
+  });
+
+  it("is a no-op when the author is the only stakeholder", async () => {
+    mockPrisma.projectFile.findUnique.mockResolvedValue({
+      title: "Solo",
+      versions: [{ uploadedById: "uploader" }],
+      comments: [],
+      taskLinks: [],
+    });
+
+    await notifyFileComment({ fileId: "f1", authorId: "uploader", body: "note to self" });
+
+    expect(mockNotify).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op when the file is gone", async () => {
+    mockPrisma.projectFile.findUnique.mockResolvedValue(null);
+
+    await notifyFileComment({ fileId: "gone", authorId: "mentor", body: "hi" });
+
+    expect(mockNotify).not.toHaveBeenCalled();
+  });
+});
+
+describe("notifyFileNewVersion", () => {
+  it("labels the title with the version count and excludes the uploader", async () => {
+    mockPrisma.projectFile.findUnique.mockResolvedValue(FILE);
+
+    await notifyFileNewVersion({ fileId: "f1", uploadedById: "uploader" });
+
+    expect(mockNotify).toHaveBeenCalledTimes(1);
+    const call = mockNotify.mock.calls[0][0];
+    expect(call.eventType).toBe("file.new_version");
+    expect(call.message.title).toBe("V2 uploaded: Hero animation");
+    expect(recipientIds()).toEqual(["assignee", "mentor"]);
+  });
+
+  it("is a no-op with no audience beyond the uploader", async () => {
+    mockPrisma.projectFile.findUnique.mockResolvedValue({
+      title: "Solo",
+      versions: [{ uploadedById: "uploader" }],
+      comments: [],
+      taskLinks: [],
+    });
+
+    await notifyFileNewVersion({ fileId: "f1", uploadedById: "uploader" });
+
+    expect(mockNotify).not.toHaveBeenCalled();
+  });
+});

--- a/dali-api/app/projects/lib/__tests__/task-board.test.ts
+++ b/dali-api/app/projects/lib/__tests__/task-board.test.ts
@@ -26,6 +26,7 @@ function task(
     domain: null,
     githubIssueUrl: null,
     githubIssueNumber: null,
+    files: [],
     createdBy: { id: "u1", name: "U" },
     createdAt: "2026-07-01T00:00:00.000Z",
   };

--- a/dali-api/app/projects/lib/file-groups.ts
+++ b/dali-api/app/projects/lib/file-groups.ts
@@ -1,0 +1,61 @@
+// Pure grouping for the project Files block: work files cluster under the
+// epic their linked tasks belong to. Organization is derived from
+// TaskFileLink → Task.epicId rather than managed folders, so it can't go
+// stale — re-epic a task and its files follow.
+
+export type GroupableFile = {
+  id: string;
+  taskLinked: boolean;
+  epicIds: string[];
+};
+
+export type FileEpicGroups<F extends GroupableFile> = {
+  // One group per epic that has work files, in the caller's epic order.
+  epicGroups: { id: string; title: string; files: F[] }[];
+  // Task-linked files whose tasks carry no epic.
+  otherWorkFiles: F[];
+  // Files not linked to any task — the plain uploads list.
+  generalFiles: F[];
+};
+
+export function groupFilesByEpic<F extends GroupableFile>(
+  files: F[],
+  epics: { id: string; title: string }[],
+): FileEpicGroups<F> {
+  const byEpic = new Map<string, F[]>();
+  const otherWorkFiles: F[] = [];
+  const generalFiles: F[] = [];
+
+  for (const f of files) {
+    if (!f.taskLinked) {
+      generalFiles.push(f);
+      continue;
+    }
+    if (f.epicIds.length === 0) {
+      otherWorkFiles.push(f);
+      continue;
+    }
+    // A file linked to tasks in several epics appears under each — rare, and
+    // truer than picking one.
+    for (const epicId of f.epicIds) {
+      const list = byEpic.get(epicId);
+      if (list) list.push(f);
+      else byEpic.set(epicId, [f]);
+    }
+  }
+
+  // An epicId missing from the caller's list shouldn't happen (epics are
+  // project-scoped), but fall back to the epicless bucket so nothing vanishes.
+  const known = new Set(epics.map((e) => e.id));
+  for (const [epicId, list] of byEpic) {
+    if (!known.has(epicId)) otherWorkFiles.push(...list);
+  }
+
+  return {
+    epicGroups: epics
+      .filter((e) => byEpic.has(e.id))
+      .map((e) => ({ id: e.id, title: e.title, files: byEpic.get(e.id)! })),
+    otherWorkFiles,
+    generalFiles,
+  };
+}

--- a/dali-api/app/projects/lib/file-notifications.server.ts
+++ b/dali-api/app/projects/lib/file-notifications.server.ts
@@ -1,0 +1,92 @@
+// Emitters for project-file events (file.comment, file.new_version) — the
+// artifact feedback loop on task-linked uploads. Mirrors
+// task-notifications.server.ts: each helper loads what it needs and dispatches
+// via notify(); callers fire-and-forget so a delivery hiccup never fails the
+// underlying write.
+
+import { prisma } from "~/lib/db";
+import { notify } from "~/lib/notify.server";
+
+const PREVIEW_MAX = 200;
+
+function fileLink(fileId: string): string {
+  return `/documents/file/${fileId}`;
+}
+
+// Everyone with a stake in a file: version uploaders, comment authors, and
+// assignees of tasks the file is linked to.
+async function loadFileAudience(fileId: string): Promise<{
+  title: string;
+  versionCount: number;
+  userIds: Set<string>;
+} | null> {
+  const file = await prisma.projectFile.findUnique({
+    where: { id: fileId },
+    select: {
+      title: true,
+      versions: { select: { uploadedById: true } },
+      comments: { select: { authorId: true } },
+      taskLinks: {
+        select: {
+          task: { select: { assignees: { select: { userId: true } } } },
+        },
+      },
+    },
+  });
+  if (!file) return null;
+  const userIds = new Set<string>();
+  for (const v of file.versions) userIds.add(v.uploadedById);
+  for (const c of file.comments) userIds.add(c.authorId);
+  for (const l of file.taskLinks) {
+    for (const a of l.task.assignees) userIds.add(a.userId);
+  }
+  return { title: file.title, versionCount: file.versions.length, userIds };
+}
+
+// A new root comment on a file. Replies stay on collab.comment_reply (thread
+// participants); this covers the previously-silent first touch — the mentor's
+// feedback reaching the uploader.
+export async function notifyFileComment(args: {
+  fileId: string;
+  authorId: string;
+  body: string;
+}): Promise<void> {
+  const audience = await loadFileAudience(args.fileId);
+  if (!audience) return;
+  const recipients = [...audience.userIds].filter((id) => id !== args.authorId);
+  if (recipients.length === 0) return;
+  const preview =
+    args.body.length > PREVIEW_MAX ? `${args.body.slice(0, PREVIEW_MAX)}…` : args.body;
+  await notify({
+    eventType: "file.comment",
+    createdByUserId: args.authorId,
+    message: {
+      title: `New feedback on: ${audience.title}`,
+      body: preview,
+      link: fileLink(args.fileId),
+    },
+    recipients: recipients.map((userId) => ({ userId })),
+  });
+}
+
+// A new version was uploaded. Called after the version row exists, so the
+// version count already includes it ("V3 uploaded"). Closes the loop back to
+// whoever gave feedback on the previous iteration.
+export async function notifyFileNewVersion(args: {
+  fileId: string;
+  uploadedById: string;
+}): Promise<void> {
+  const audience = await loadFileAudience(args.fileId);
+  if (!audience) return;
+  const recipients = [...audience.userIds].filter((id) => id !== args.uploadedById);
+  if (recipients.length === 0) return;
+  await notify({
+    eventType: "file.new_version",
+    createdByUserId: args.uploadedById,
+    message: {
+      title: `V${audience.versionCount} uploaded: ${audience.title}`,
+      link: fileLink(args.fileId),
+    },
+    recipients: recipients.map((userId) => ({ userId })),
+  });
+}

--- a/dali-api/app/projects/lib/task-board.ts
+++ b/dali-api/app/projects/lib/task-board.ts
@@ -50,6 +50,10 @@ export type TaskCardModel = {
   // null means the task is not mirrored.
   githubIssueUrl: string | null;
   githubIssueNumber: number | null;
+  // Linked work artifacts (ProjectFile) — versioned uploads the task's work
+  // lives in (graphics, animation, design exports). Card shows a count chip;
+  // the modal lists them with links to the file page.
+  files: { id: string; title: string; versionCount: number }[];
   createdBy: { id: string; name: string };
   // ISO timestamp (UTC).
   createdAt: string;
@@ -75,6 +79,8 @@ export type TaskBoardOptions = {
   // modal's sprint/epic pickers. Sprints ordered Active → Planned → Closed.
   sprints: BoardSprint[];
   epics: BoardEpic[];
+  // Live project files for the modal's "attach existing artifact" picker.
+  projectFiles: { id: string; title: string }[];
 };
 
 export type TaskBoard = Record<TaskStatus, TaskCardModel[]>;

--- a/dali-api/app/projects/routes/__tests__/api.tasks.$id.files.test.ts
+++ b/dali-api/app/projects/routes/__tests__/api.tasks.$id.files.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("~/lib/auth", () => ({ requireProjectEditAccess: vi.fn() }));
+vi.mock("~/lib/db");
+vi.mock("~/lib/cors", () => ({
+  withCors: (_req: Request, res: Response) => res,
+  handlePreflight: () => null,
+}));
+
+import { requireProjectEditAccess } from "~/lib/auth";
+import { prisma } from "~/lib/db";
+import { action } from "~/projects/routes/api.tasks.$id.files";
+
+const TASK_ID = "task-1";
+const CALLER = "user-1";
+
+const mockPrisma = prisma as unknown as {
+  task: { findUnique: ReturnType<typeof vi.fn> };
+  projectFile: { findUnique: ReturnType<typeof vi.fn> };
+  taskFileLink: {
+    createMany: ReturnType<typeof vi.fn>;
+    deleteMany: ReturnType<typeof vi.fn>;
+  };
+};
+
+function send(method: "POST" | "DELETE" | "PUT", body?: unknown) {
+  const request = new Request(`http://localhost/api/tasks/${TASK_ID}/files`, {
+    method,
+    headers: { "Content-Type": "application/json" },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  return action({ request, params: { id: TASK_ID } } as any);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(requireProjectEditAccess).mockResolvedValue({
+    ok: true,
+    auth: { user: { sub: CALLER } },
+  } as any);
+  mockPrisma.task.findUnique.mockResolvedValue({ id: TASK_ID, projectId: "p1" });
+  mockPrisma.projectFile.findUnique.mockResolvedValue({
+    id: "f1",
+    title: "Poster draft",
+    projectId: "p1",
+    archivedAt: null,
+    _count: { versions: 3 },
+  });
+});
+
+describe("POST /api/tasks/:id/files", () => {
+  it("links a project file and returns the artifact shape", async () => {
+    const res = (await send("POST", { fileId: "f1" })) as Response;
+
+    expect(res.status).toBe(201);
+    expect(await res.json()).toEqual({ id: "f1", title: "Poster draft", versionCount: 3 });
+    expect(mockPrisma.taskFileLink.createMany).toHaveBeenCalledWith({
+      data: [{ taskId: TASK_ID, fileId: "f1" }],
+      skipDuplicates: true,
+    });
+  });
+
+  it("rejects a file from another project", async () => {
+    mockPrisma.projectFile.findUnique.mockResolvedValue({
+      id: "f1",
+      title: "Other",
+      projectId: "p2",
+      archivedAt: null,
+      _count: { versions: 1 },
+    });
+
+    const res = (await send("POST", { fileId: "f1" })) as Response;
+
+    expect(res.status).toBe(404);
+    expect(mockPrisma.taskFileLink.createMany).not.toHaveBeenCalled();
+  });
+
+  it("rejects an archived file", async () => {
+    mockPrisma.projectFile.findUnique.mockResolvedValue({
+      id: "f1",
+      title: "Old",
+      projectId: "p1",
+      archivedAt: new Date(),
+      _count: { versions: 1 },
+    });
+
+    const res = (await send("POST", { fileId: "f1" })) as Response;
+
+    expect(res.status).toBe(404);
+  });
+
+  it("404s on an unknown task", async () => {
+    mockPrisma.task.findUnique.mockResolvedValue(null);
+
+    const res = (await send("POST", { fileId: "f1" })) as Response;
+
+    expect(res.status).toBe(404);
+  });
+
+  it("passes the gate's response through when access is denied", async () => {
+    const denied = Response.json({ error: "Forbidden" }, { status: 403 });
+    vi.mocked(requireProjectEditAccess).mockResolvedValue({
+      ok: false,
+      response: denied,
+    } as any);
+
+    const res = (await send("POST", { fileId: "f1" })) as Response;
+
+    expect(res.status).toBe(403);
+    expect(mockPrisma.taskFileLink.createMany).not.toHaveBeenCalled();
+  });
+});
+
+describe("DELETE /api/tasks/:id/files", () => {
+  it("unlinks without touching the file", async () => {
+    const res = (await send("DELETE", { fileId: "f1" })) as Response;
+
+    expect(res.status).toBe(200);
+    expect(mockPrisma.taskFileLink.deleteMany).toHaveBeenCalledWith({
+      where: { taskId: TASK_ID, fileId: "f1" },
+    });
+  });
+});
+
+it("rejects unsupported methods", async () => {
+  const res = (await send("PUT", { fileId: "f1" })) as Response;
+  expect(res.status).toBe(405);
+});

--- a/dali-api/app/projects/routes/api.files.$id.ts
+++ b/dali-api/app/projects/routes/api.files.$id.ts
@@ -7,6 +7,7 @@ import { withCors, handlePreflight } from "~/lib/cors";
 import { logAuditEvent } from "~/lib/audit";
 import { getDownloadUrl } from "~/lib/s3";
 import { hydrateAuthors } from "~/lib/collabAuth";
+import { notifyFileNewVersion } from "../lib/file-notifications.server";
 
 // GET    /api/files/:id           — version list (newest first) + signed download URLs
 // POST   /api/files/:id           — rename: { intent: "rename", title }
@@ -164,5 +165,10 @@ export async function action({ request, params }: Route.ActionArgs) {
     metadata: { versionId: version.id },
     request,
   });
+  // Close the feedback loop: whoever commented on the previous iteration
+  // hears that a new one landed.
+  void notifyFileNewVersion({ fileId: file.id, uploadedById: auth.user.sub }).catch(
+    (err) => console.error(`file ${file.id}: new version notify failed`, err),
+  );
   return withCors(request, Response.json({ ok: true, versionId: version.id }));
 }

--- a/dali-api/app/projects/routes/api.tasks.$id.files.ts
+++ b/dali-api/app/projects/routes/api.tasks.$id.files.ts
@@ -1,0 +1,73 @@
+import type { Route } from "./+types/api.tasks.$id.files";
+import { z } from "zod";
+import { prisma } from "~/lib/db";
+import { requireProjectEditAccess } from "~/lib/auth";
+import { withCors, handlePreflight } from "~/lib/cors";
+import { parseJson } from "~/lib/validate";
+
+// POST   /api/tasks/:id/files { fileId } — link a project file (work artifact)
+//        to the task. Idempotent: re-linking an already-linked file is a no-op.
+// DELETE /api/tasks/:id/files { fileId } — unlink. The file itself stays.
+//
+// The file must belong to the task's project and be live (not archived).
+// Permission mirrors task edit (isCore === Admin || Core, or a project member).
+
+const BodySchema = z.object({ fileId: z.string().min(1) });
+
+export async function action({ request, params }: Route.ActionArgs) {
+  const preflight = handlePreflight(request);
+  if (preflight) return preflight;
+
+  if (request.method !== "POST" && request.method !== "DELETE") {
+    return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));
+  }
+
+  const task = await prisma.task.findUnique({
+    where: { id: params.id },
+    select: { id: true, projectId: true },
+  });
+  if (!task) {
+    return withCors(request, Response.json({ error: "Task not found" }, { status: 404 }));
+  }
+  const gate = await requireProjectEditAccess(request, task.projectId);
+  if (!gate.ok) return gate.response;
+
+  const body = await parseJson(request, BodySchema);
+  if (body instanceof Response) return withCors(request, body);
+
+  if (request.method === "DELETE") {
+    await prisma.taskFileLink.deleteMany({
+      where: { taskId: task.id, fileId: body.fileId },
+    });
+    return withCors(request, Response.json({ ok: true }));
+  }
+
+  const file = await prisma.projectFile.findUnique({
+    where: { id: body.fileId },
+    select: {
+      id: true,
+      title: true,
+      projectId: true,
+      archivedAt: true,
+      _count: { select: { versions: true } },
+    },
+  });
+  if (!file || file.archivedAt !== null || file.projectId !== task.projectId) {
+    return withCors(request, Response.json({ error: "File not found" }, { status: 404 }));
+  }
+
+  await prisma.taskFileLink.createMany({
+    data: [{ taskId: task.id, fileId: file.id }],
+    skipDuplicates: true,
+  });
+
+  // The linked-artifact shape TaskCardModel carries, so the modal can update
+  // its local list without a refetch.
+  return withCors(
+    request,
+    Response.json(
+      { id: file.id, title: file.title, versionCount: file._count.versions },
+      { status: 201 },
+    ),
+  );
+}

--- a/dali-api/app/projects/routes/projects.$id.tsx
+++ b/dali-api/app/projects/routes/projects.$id.tsx
@@ -54,6 +54,7 @@ import type {
   TaskStatus,
   Priority,
 } from "../lib/task-board";
+import { groupFilesByEpic } from "../lib/file-groups";
 
 export const meta: Route.MetaFunction = ({ data }) => {
   const p = (data as { project?: { name: string } } | undefined)?.project;
@@ -279,6 +280,18 @@ export async function loader({ request, params }: Route.LoaderArgs) {
               user: { select: USER_NAME_SELECT },
             },
           },
+          files: {
+            where: { file: { archivedAt: null } },
+            select: {
+              file: {
+                select: {
+                  id: true,
+                  title: true,
+                  _count: { select: { versions: true } },
+                },
+              },
+            },
+          },
         },
       },
       // Declared domains for this project — editable from the Overview tab.
@@ -361,6 +374,9 @@ export async function loader({ request, params }: Route.LoaderArgs) {
       partnerVisible: true,
       currentVersion: { select: { fileName: true, sizeBytes: true } },
       _count: { select: { versions: true } },
+      // Which epics this file's linked tasks belong to — the Files block
+      // groups work files by epic (derived, not managed; see file-groups.ts).
+      taskLinks: { select: { task: { select: { epicId: true } } } },
     },
   });
   const files = fileRows.map((f) => ({
@@ -370,6 +386,14 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     sizeBytes: f.currentVersion?.sizeBytes ?? null,
     versionCount: f._count.versions,
     partnerVisible: f.partnerVisible,
+    taskLinked: f.taskLinks.length > 0,
+    epicIds: [
+      ...new Set(
+        f.taskLinks
+          .map((l) => l.task.epicId)
+          .filter((id): id is string => id !== null),
+      ),
+    ],
   }));
 
   // Content edits (name/status, description, details, docs/files, epics/
@@ -474,6 +498,11 @@ export async function loader({ request, params }: Route.LoaderArgs) {
       : null,
     githubIssueUrl: t.githubIssueUrl,
     githubIssueNumber: t.githubIssueNumber,
+    files: t.files.map((l) => ({
+      id: l.file.id,
+      title: l.file.title,
+      versionCount: l.file._count.versions,
+    })),
     createdBy: { id: t.createdBy.id, name: fullName(t.createdBy) },
     createdAt: t.createdAt.toISOString(),
   }));
@@ -509,6 +538,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
       )
       .map((s) => ({ id: s.id, name: s.name, status: s.status })),
     epics: project.epics.map((e) => ({ id: e.id, title: e.title })),
+    projectFiles: files.map((f) => ({ id: f.id, title: f.title })),
   };
 
   // Per-epic task progress for the epic list rows + timeline tooltips.
@@ -1239,6 +1269,7 @@ export default function ProjectDetail() {
           documents={documents}
           pinnedDocuments={pinnedDocuments}
           files={files}
+          fileEpics={boardOptions.epics}
           upcomingMeetings={upcomingMeetings}
           recentActivity={recentActivity}
           canEdit={canEdit}
@@ -2282,6 +2313,7 @@ function OverviewTab({
   documents,
   pinnedDocuments,
   files,
+  fileEpics,
   upcomingMeetings,
   recentActivity,
   canEdit,
@@ -2299,6 +2331,7 @@ function OverviewTab({
   documents: LoaderData["documents"];
   pinnedDocuments: LoaderData["pinnedDocuments"];
   files: LoaderData["files"];
+  fileEpics: LoaderData["boardOptions"]["epics"];
   upcomingMeetings: LoaderData["upcomingMeetings"];
   recentActivity: LoaderData["recentActivity"];
   canEdit: boolean;
@@ -2469,10 +2502,12 @@ function OverviewTab({
         hasActivePartner={hasActivePartner}
       />
 
-      {/* Files — standalone uploads with versions. Tags are edited in the file editor. */}
+      {/* Files — standalone uploads with versions, work files grouped under
+          their linked tasks' epics. Tags are edited in the file editor. */}
       <FilesBlock
         projectId={project.id}
         files={files}
+        epics={fileEpics}
         canEdit={canEdit}
         hasActivePartner={hasActivePartner}
       />
@@ -3070,11 +3105,13 @@ function DocumentsBlock({
 function FilesBlock({
   projectId,
   files,
+  epics,
   canEdit,
   hasActivePartner,
 }: {
   projectId: string;
   files: LoaderData["files"];
+  epics: LoaderData["boardOptions"]["epics"];
   canEdit: boolean;
   hasActivePartner: boolean;
 }) {
@@ -3171,6 +3208,11 @@ function FilesBlock({
     }
   }
 
+  // Work files cluster under the epic of their linked task(s); the flat list
+  // survives untouched when nothing is task-linked yet.
+  const { epicGroups, otherWorkFiles, generalFiles } = groupFilesByEpic(files, epics);
+  const grouped = epicGroups.length > 0 || otherWorkFiles.length > 0;
+
   return (
     <section className="bg-card border border-border rounded-lg p-4">
       <input ref={fileInputRef} type="file" className="hidden" onChange={onPick} />
@@ -3204,10 +3246,42 @@ function FilesBlock({
 
       {files.length === 0 ? (
         <p className="text-sm text-muted-foreground italic">No files yet.</p>
-      ) : (
+      ) : !grouped ? (
         <div className="flex flex-col divide-y divide-border">
-          {files.map((f) => (
-            <div key={f.id} className="py-2.5 flex items-center justify-between gap-3 text-sm">
+          {files.map(renderRow)}
+        </div>
+      ) : (
+        <div className="flex flex-col gap-3">
+          {epicGroups.map((g) => fileGroup(g.title, g.files, g.id))}
+          {otherWorkFiles.length > 0 && fileGroup("Other work files", otherWorkFiles)}
+          {generalFiles.length > 0 && fileGroup("Other files", generalFiles)}
+        </div>
+      )}
+    </section>
+  );
+
+  // One group: epic title (or bucket label) over the standard row list.
+  function fileGroup(
+    label: string,
+    groupFiles: LoaderData["files"],
+    key: string = label,
+  ) {
+    return (
+      <div key={key}>
+        <h3 className="text-xs font-medium uppercase tracking-wide text-muted-foreground mb-0.5">
+          {label}
+          <span className="ml-1.5 normal-case tracking-normal">({groupFiles.length})</span>
+        </h3>
+        <div className="flex flex-col divide-y divide-border">
+          {groupFiles.map(renderRow)}
+        </div>
+      </div>
+    );
+  }
+
+  function renderRow(f: LoaderData["files"][number]) {
+    return (
+      <div key={f.id} className="py-2.5 flex items-center justify-between gap-3 text-sm">
               <Link to={`/documents/file/${f.id}`} className="min-w-0 truncate hover:text-accent-coral">
                 <span className="text-foreground font-medium">{f.title}</span>
                 <span className="text-muted-foreground ml-2 text-xs">
@@ -3278,11 +3352,8 @@ function FilesBlock({
                 )}
               </div>
             </div>
-          ))}
-        </div>
-      )}
-    </section>
-  );
+    );
+  }
 }
 
 // Planning holds the epics & sprints manager with the timeline as a display

--- a/dali-api/app/routes.ts
+++ b/dali-api/app/routes.ts
@@ -337,6 +337,7 @@ export default [
   route("api/tasks/:id/move", "projects/routes/api.tasks.$id.move.ts"),
   route("api/tasks/:id/comments", "projects/routes/api.tasks.$id.comments.ts"),
   route("api/tasks/:id/github", "projects/routes/api.tasks.$id.github.ts"),
+  route("api/tasks/:id/files", "projects/routes/api.tasks.$id.files.ts"),
   route("api/tasks/:id", "projects/routes/api.tasks.$id.ts"),
 
   // Project epics & sprints

--- a/dali-api/app/routes/__tests__/api.comments.test.ts
+++ b/dali-api/app/routes/__tests__/api.comments.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("~/lib/auth", () => ({
+  requireAuth: vi.fn(),
+  forbidden: vi.fn(() => Response.json({ error: "Forbidden" }, { status: 403 })),
+}));
+vi.mock("~/lib/db");
+vi.mock("~/lib/roles", () => ({
+  isCore: vi.fn(),
+  isLabMember: vi.fn(),
+  isProjectMember: vi.fn(),
+}));
+vi.mock("~/lib/cors", () => ({
+  withCors: (_req: Request, res: Response) => res,
+  handlePreflight: () => null,
+}));
+vi.mock("~/lib/collabAuth", () => ({ hydrateAuthors: vi.fn().mockResolvedValue([]) }));
+vi.mock("~/lib/notify.server", () => ({ notify: vi.fn() }));
+vi.mock("~/lib/mentions", () => ({
+  extractHandlesFromText: vi.fn(() => []),
+  resolveHandles: vi.fn().mockResolvedValue([]),
+  notifyMentions: vi.fn(),
+  pageDocLink: vi.fn(() => "/"),
+}));
+vi.mock("~/partners/lib/partner-access", () => ({
+  partnerHasProjectAccess: vi.fn().mockResolvedValue(false),
+}));
+vi.mock("~/projects/lib/file-notifications.server", () => ({
+  notifyFileComment: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { requireAuth } from "~/lib/auth";
+import { prisma } from "~/lib/db";
+import { isCore } from "~/lib/roles";
+import { notifyFileComment } from "~/projects/lib/file-notifications.server";
+import { action } from "~/routes/api.comments";
+
+const FILE_ID = "file-1";
+const CALLER = "mentor-1";
+
+const mockPrisma = prisma as unknown as {
+  projectFile: { findUnique: ReturnType<typeof vi.fn> };
+  projectFileVersion: { findFirst: ReturnType<typeof vi.fn> };
+  docComment: {
+    create: ReturnType<typeof vi.fn>;
+    findUnique: ReturnType<typeof vi.fn>;
+    findMany: ReturnType<typeof vi.fn>;
+  };
+};
+
+function post(body: unknown) {
+  const request = new Request("http://localhost/api/comments", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  return action({ request, params: {} } as any);
+}
+
+function fileComment(overrides: Record<string, unknown> = {}) {
+  return {
+    targetType: "file",
+    targetId: FILE_ID,
+    body: "Tighten the easing on the logo reveal",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(requireAuth).mockResolvedValue({
+    ok: true,
+    user: { sub: CALLER, type: "member" },
+  } as any);
+  vi.mocked(isCore).mockResolvedValue(true);
+  // Serves both the targetExists gate (archivedAt) and the currentVersionId
+  // fallback — the route selects each separately.
+  mockPrisma.projectFile.findUnique.mockResolvedValue({
+    archivedAt: null,
+    currentVersionId: "v-current",
+  });
+  mockPrisma.docComment.create.mockResolvedValue({ id: "c1" });
+  mockPrisma.docComment.findMany.mockResolvedValue([]);
+});
+
+describe("POST /api/comments (file version pinning)", () => {
+  it("stamps the version the commenter was viewing", async () => {
+    mockPrisma.projectFileVersion.findFirst.mockResolvedValue({ id: "v-old" });
+
+    const res = (await post(fileComment({ versionId: "v-old" }))) as Response;
+
+    expect(res.status).toBe(201);
+    expect(mockPrisma.projectFileVersion.findFirst).toHaveBeenCalledWith({
+      where: { id: "v-old", fileId: FILE_ID },
+      select: { id: true },
+    });
+    expect(mockPrisma.docComment.create.mock.calls[0][0].data.versionId).toBe("v-old");
+  });
+
+  it("rejects a version that doesn't belong to the file", async () => {
+    mockPrisma.projectFileVersion.findFirst.mockResolvedValue(null);
+
+    const res = (await post(fileComment({ versionId: "other-files-version" }))) as Response;
+
+    expect(res.status).toBe(400);
+    expect(mockPrisma.docComment.create).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the current version when the caller doesn't send one", async () => {
+    const res = (await post(fileComment())) as Response;
+
+    expect(res.status).toBe(201);
+    expect(mockPrisma.projectFileVersion.findFirst).not.toHaveBeenCalled();
+    expect(mockPrisma.docComment.create.mock.calls[0][0].data.versionId).toBe("v-current");
+  });
+
+  it("notifies the file audience on root comments but not replies", async () => {
+    mockPrisma.projectFileVersion.findFirst.mockResolvedValue({ id: "v-old" });
+
+    await post(fileComment({ versionId: "v-old" }));
+    expect(notifyFileComment).toHaveBeenCalledTimes(1);
+
+    vi.mocked(notifyFileComment).mockClear();
+    mockPrisma.docComment.findUnique.mockResolvedValue({
+      targetType: "file",
+      targetId: FILE_ID,
+      parentId: null,
+    });
+    await post(fileComment({ versionId: "v-old", parentId: "root-1" }));
+    expect(notifyFileComment).not.toHaveBeenCalled();
+  });
+});

--- a/dali-api/app/routes/api.comments.ts
+++ b/dali-api/app/routes/api.comments.ts
@@ -2,7 +2,8 @@ import type { Route } from "./+types/api.comments";
 import { z } from "zod";
 import { prisma } from "~/lib/db";
 import { requireAuth, forbidden, type AuthSuccess } from "~/lib/auth";
-import { isCore, isLabMember } from "~/lib/roles";
+import { isCore, isLabMember, isProjectMember } from "~/lib/roles";
+import { notifyFileComment } from "~/projects/lib/file-notifications.server";
 import { partnerHasProjectAccess } from "~/partners/lib/partner-access";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { parseJson } from "~/lib/validate";
@@ -33,6 +34,9 @@ const CreateSchema = z.object({
   // Page-doc FAQ comments only: the page path, so @-mention notifications can
   // deep-link back to the guide (with ?doc=1).
   path: z.string().max(1000).optional(),
+  // File comments only: the version the commenter was viewing, so feedback
+  // is pinned to the iteration it was written against.
+  versionId: z.string().min(1).nullable().optional(),
 });
 
 type CommentTarget = "doc" | "file" | "pagedoc";
@@ -80,7 +84,8 @@ async function partnerCanAccessDoc(userSub: string, pageId: string): Promise<boo
 // Auth split by target: page-doc FAQ threads are open to any lab member (so
 // anyone can ask a question); doc comments stay on the project-edit gate
 // (Core/Admin), plus partners on that page's shared surface; file comments
-// stay Core-only.
+// are open to Core and members of the owning project — the artifact feedback
+// loop (upload → mentor comment → re-upload) runs on project members.
 async function canAccessTarget(
   auth: AuthSuccess,
   targetType: CommentTarget,
@@ -93,7 +98,12 @@ async function canAccessTarget(
       ? partnerCanAccessDoc(auth.user.sub, targetId)
       : false;
   }
-  return isCore(auth.user.sub);
+  if (await isCore(auth.user.sub)) return true;
+  const file = await prisma.projectFile.findUnique({
+    where: { id: targetId },
+    select: { projectId: true },
+  });
+  return file ? isProjectMember(auth.user.sub, file.projectId) : false;
 }
 
 export async function loader({ request }: Route.LoaderArgs) {
@@ -127,6 +137,7 @@ export async function loader({ request }: Route.LoaderArgs) {
       anchor: true,
       resolvedAt: true,
       createdAt: true,
+      versionId: true,
     },
   });
 
@@ -142,6 +153,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     anchor: r.anchor as { from: string; to: string } | null,
     resolved: r.resolvedAt !== null,
     createdAt: r.createdAt.toISOString(),
+    versionId: r.versionId,
   }));
 
   return withCors(request, Response.json({ comments }));
@@ -186,6 +198,31 @@ export async function action({ request }: Route.ActionArgs) {
   // Anchors only make sense on documents.
   const anchor = body.targetType === "doc" ? (body.anchor ?? null) : null;
 
+  // File comments are pinned to a version so feedback reads against the
+  // right iteration: the one the commenter was viewing (sent by the file
+  // page), falling back to the current version for callers that don't say.
+  let versionId: string | null = null;
+  if (body.targetType === "file") {
+    if (body.versionId) {
+      const version = await prisma.projectFileVersion.findFirst({
+        where: { id: body.versionId, fileId: body.targetId },
+        select: { id: true },
+      });
+      if (!version) {
+        return withCors(request, Response.json({ error: "Invalid version" }, { status: 400 }));
+      }
+      versionId = version.id;
+    } else {
+      versionId =
+        (
+          await prisma.projectFile.findUnique({
+            where: { id: body.targetId },
+            select: { currentVersionId: true },
+          })
+        )?.currentVersionId ?? null;
+    }
+  }
+
   const created = await prisma.docComment.create({
     data: {
       targetType: body.targetType,
@@ -196,9 +233,22 @@ export async function action({ request }: Route.ActionArgs) {
       anchor: anchor === null ? undefined : anchor,
       // Real FK only on the file side (see schema note).
       fileId: body.targetType === "file" ? body.targetId : null,
+      versionId,
     },
     select: { id: true },
   });
+
+  // Root comments on a file notify its audience (uploaders + linked-task
+  // assignees). Replies are covered by the thread-reply path below.
+  if (body.targetType === "file" && !body.parentId) {
+    void notifyFileComment({
+      fileId: body.targetId,
+      authorId: auth.user.sub,
+      body: body.body,
+    }).catch((err) =>
+      console.error(`comment ${created.id}: file comment notify failed`, err),
+    );
+  }
 
   if (body.parentId) {
     void notifyThreadReply({

--- a/dali-api/app/routes/documents.file.$fileId.tsx
+++ b/dali-api/app/routes/documents.file.$fileId.tsx
@@ -5,7 +5,7 @@ import { Tooltip } from "~/components/ui/IconButton";
 import type { Route } from "./+types/documents.file.$fileId";
 import { prisma } from "~/lib/db";
 import { requireAuth, redirectPartnerToPortal } from "~/lib/auth";
-import { isCore } from "~/lib/roles";
+import { isCore, isProjectMember } from "~/lib/roles";
 import { getDownloadUrl } from "~/lib/s3";
 import { hydrateAuthors } from "~/lib/collabAuth";
 import { formatBytes, uploadFileToS3 } from "~/lib/upload-client";
@@ -73,14 +73,21 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     throw new Response("Not found", { status: 404 });
   }
 
-  const canEdit = await isCore(auth.user.sub);
+  // Upload + comment are open to Core and members of the owning project (the
+  // artifact feedback loop runs on project members); the curated tag list
+  // stays Core-managed, matching /api/doctags.
+  const core = await isCore(auth.user.sub);
+  const canEdit = core || (await isProjectMember(auth.user.sub, file.projectId));
+  const canManageTags = core;
 
   const uploaderNames = await hydrateAuthors(file.versions.map((v) => v.uploadedById));
   const nameById = new Map(uploaderNames.map((u) => [u.id, u.name]));
 
   const versions = await Promise.all(
-    file.versions.map(async (v) => ({
+    // Newest first, so the oldest upload is V1.
+    file.versions.map(async (v, i) => ({
       id: v.id,
+      label: `V${file.versions.length - i}`,
       fileName: v.fileName,
       sizeBytes: v.sizeBytes,
       uploadedBy: nameById.get(v.uploadedById) ?? "Unknown",
@@ -106,13 +113,23 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     allTags,
     versions,
     canEdit,
+    canManageTags,
     currentUserId: auth.user.sub,
   };
 }
 
 export default function FilePage() {
-  const { fileId, projectId, title, tags, allTags, versions, canEdit, currentUserId } =
-    useLoaderData() as Exclude<Awaited<ReturnType<typeof loader>>, Response>;
+  const {
+    fileId,
+    projectId,
+    title,
+    tags,
+    allTags,
+    versions,
+    canEdit,
+    canManageTags,
+    currentUserId,
+  } = useLoaderData() as Exclude<Awaited<ReturnType<typeof loader>>, Response>;
 
   const revalidator = useRevalidator();
   const [fileSearchParams] = useSearchParams();
@@ -166,8 +183,8 @@ export default function FilePage() {
               targetId={fileId}
               applied={tags}
               allTags={allTags}
-              canEdit={canEdit}
-              canCreate={canEdit}
+              canEdit={canManageTags}
+              canCreate={canManageTags}
             />
           </div>
 
@@ -225,6 +242,9 @@ export default function FilePage() {
                 }`}
               >
                 <div className="min-w-0">
+                  <span className="mr-2 text-[10px] px-1.5 py-0.5 rounded bg-muted text-muted-foreground font-medium">
+                    {v.label}
+                  </span>
                   <span className="text-foreground truncate">{v.fileName}</span>
                   {v.isCurrent && (
                     <span className="ml-2 text-[10px] px-1.5 py-0.5 rounded bg-accent-teal/15 text-accent-teal">
@@ -263,6 +283,8 @@ export default function FilePage() {
             currentUserId={currentUserId}
             canComment={canEdit}
             focusCommentId={focusCommentId}
+            versionLabels={Object.fromEntries(versions.map((v) => [v.id, v.label]))}
+            versionId={selected?.id ?? null}
           />
         </aside>
       </div>
@@ -275,14 +297,34 @@ type FileVersionView = Exclude<
   Response
 >["versions"][number];
 
-// Inline preview of a file version. Images and PDFs render directly from the
-// presigned S3 URL; anything else falls back to a download prompt.
+// Inline preview of a file version. Images, video, audio, and PDFs render
+// directly from the presigned S3 URL; anything else (e.g. .psd/.ae source
+// files) falls back to a download prompt.
 function FilePreview({ version }: { version: FileVersionView }) {
   const ct = version.contentType ?? "";
   const isImage = ct.startsWith("image/");
+  const isVideo = ct.startsWith("video/");
+  const isAudio = ct.startsWith("audio/");
   const isPdf = ct === "application/pdf";
   const isText = ct.startsWith("text/") || ct === "application/json";
 
+  if (isVideo) {
+    return (
+      // `key` forces a reload when the previewed version changes — <video>
+      // doesn't re-fetch on a src prop change alone.
+      <video
+        key={version.id}
+        src={version.downloadUrl}
+        controls
+        className="max-w-full max-h-[70vh] rounded-lg border border-border bg-black"
+      />
+    );
+  }
+  if (isAudio) {
+    return (
+      <audio key={version.id} src={version.downloadUrl} controls className="w-full" />
+    );
+  }
   if (isImage) {
     return (
       <img

--- a/dali-api/e2e/fixtures.ts
+++ b/dali-api/e2e/fixtures.ts
@@ -9,7 +9,7 @@ type LoginOptions = { netId?: string; daliEmail?: string; personalEmail?: string
 const LAUNCH_WELCOME_SEEN_KEY = 'dalios-launch-welcome-seen-v1';
 
 export const test = base.extend<{ loginAs: (opts: LoginOptions) => Promise<void> }>({
-  page: async ({ page }, use) => {
+  page: async ({ page, baseURL }, use) => {
     await page.addInitScript((key) => {
       try {
         window.localStorage.setItem(key, 'e2e');
@@ -17,6 +17,13 @@ export const test = base.extend<{ loginAs: (opts: LoginOptions) => Promise<void>
         // localStorage unavailable (e.g. about:blank) — ignore.
       }
     }, LAUNCH_WELCOME_SEEN_KEY);
+    // The suite was written against the tabbed workspace shell (several specs
+    // locate content via frameLocator on workspace iframes). Tabless is the
+    // app default now, so pin the tabbed opt-in cookie per context. Keep the
+    // name/value in sync with TABLESS_COOKIE in app/lib/tabless.ts.
+    if (baseURL) {
+      await page.context().addCookies([{ name: 'dali_tabless', value: '0', url: baseURL }]);
+    }
     await use(page);
   },
   loginAs: async ({ page }, use) => {

--- a/dali-api/prisma/migrations/20260720190000_task_artifacts/migration.sql
+++ b/dali-api/prisma/migrations/20260720190000_task_artifacts/migration.sql
@@ -1,0 +1,23 @@
+-- AlterTable
+ALTER TABLE "DocComment" ADD COLUMN     "versionId" TEXT;
+
+-- CreateTable
+CREATE TABLE "TaskFileLink" (
+    "taskId" TEXT NOT NULL,
+    "fileId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "TaskFileLink_pkey" PRIMARY KEY ("taskId","fileId")
+);
+
+-- CreateIndex
+CREATE INDEX "TaskFileLink_fileId_idx" ON "TaskFileLink"("fileId");
+
+-- AddForeignKey
+ALTER TABLE "TaskFileLink" ADD CONSTRAINT "TaskFileLink_taskId_fkey" FOREIGN KEY ("taskId") REFERENCES "Task"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TaskFileLink" ADD CONSTRAINT "TaskFileLink_fileId_fkey" FOREIGN KEY ("fileId") REFERENCES "ProjectFile"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DocComment" ADD CONSTRAINT "DocComment_versionId_fkey" FOREIGN KEY ("versionId") REFERENCES "ProjectFileVersion"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/dali-api/prisma/schema.prisma
+++ b/dali-api/prisma/schema.prisma
@@ -1034,10 +1034,26 @@ model ProjectFile {
   versions       ProjectFileVersion[] @relation("FileVersions")
   currentVersion ProjectFileVersion?  @relation("FileCurrentVersion", fields: [currentVersionId], references: [id])
 
-  tags     ProjectFileTag[]
-  comments DocComment[]
+  tags      ProjectFileTag[]
+  comments  DocComment[]
+  taskLinks TaskFileLink[]
 
   @@index([projectId, archivedAt])
+}
+
+// m2m: Task ↔ ProjectFile. Links work artifacts (graphics, animation, design
+// exports) to board tasks so the upload → feedback → re-upload loop is
+// reachable from the card. A file may serve several tasks and vice versa.
+model TaskFileLink {
+  taskId    String
+  fileId    String
+  createdAt DateTime @default(now())
+
+  task Task        @relation(fields: [taskId], references: [id], onDelete: Cascade)
+  file ProjectFile @relation(fields: [fileId], references: [id], onDelete: Cascade)
+
+  @@id([taskId, fileId])
+  @@index([fileId])
 }
 
 model ProjectFileVersion {
@@ -1058,6 +1074,9 @@ model ProjectFileVersion {
   // Back-relation for ProjectFile.currentVersion (a file points at one of its
   // own versions). Optional + named to disambiguate from FileVersions.
   fileAsCurrent ProjectFile? @relation("FileCurrentVersion")
+
+  // File comments pinned to this version (DocComment.versionId).
+  comments DocComment[]
 
   @@index([fileId, createdAt(sort: Desc)])
 }
@@ -1091,6 +1110,12 @@ model DocComment {
   // a second FK on the polymorphic column).
   file   ProjectFile? @relation(fields: [fileId], references: [id], onDelete: Cascade)
   fileId String?
+
+  // File comments only: the version that was current when the comment was
+  // written, so feedback reads against the right iteration ("on V2"). Null for
+  // doc/pagedoc comments and file comments predating version pinning.
+  version   ProjectFileVersion? @relation(fields: [versionId], references: [id], onDelete: SetNull)
+  versionId String?
 
   @@index([targetType, targetId, createdAt])
   @@index([parentId])
@@ -2509,6 +2534,7 @@ model Task {
   assignees TaskAssignee[]
   comments  TaskComment[]
   reminders TaskReminder[]
+  files     TaskFileLink[]
 
   createdById String
   createdBy   User     @relation("TaskCreatedBy", fields: [createdById], references: [id])

--- a/specs/figma-task-linking.md
+++ b/specs/figma-task-linking.md
@@ -1,0 +1,56 @@
+# Figma task linking — spec
+
+_Drafted July 20, 2026. Companion to the task-artifacts work (`TaskFileLink` + versioned feedback on `ProjectFile`), which covers graphics/animation uploads. This spec covers the UI/UX side: linking Figma files to board tasks. Not yet built._
+
+The GitHub issue mirror (`app/projects/lib/github-task-sync.ts`, `Task.githubRepo/githubIssueNumber/githubIssueUrl`) is the precedent: an optional per-task link to an external tool, a chip on the card, link/unlink in the modal, and a webhook route for inbound events. Figma follows the same shape in three tiers — Tier 1+2 ship together; Tier 3 is a fast-follow gated on a plan question.
+
+---
+
+## Tier 1 — link + live embed (no tokens)
+
+**Task fields** (all nullable, populated together like the GitHub triple):
+
+| Field | Example |
+|---|---|
+| `figmaUrl` | `https://www.figma.com/design/AbC123/Homepage?node-id=12-345` |
+| `figmaFileKey` | `AbC123` |
+| `figmaNodeId` | `12-345` (optional — deep-links to a specific frame) |
+
+- Server parses the pasted URL (accept `/design/`, `/proto/`, `/board/` forms) into key + optional `node-id`. Reject anything that isn't a figma.com URL.
+- **Modal**: "Link Figma file" paste field, mirroring the GitHub link/unlink block in `TaskModal.tsx`. **Card**: a Figma chip next to the GitHub chip.
+- **Embed**: Embed Kit 2.0 iframe — `https://embed.figma.com/design/<key>?embed-host=dalios&client-id=$FIGMA_CLIENT_ID&node-id=<id>`. Render behind a "Preview" expander in the modal (embeds are heavy; don't load on every open). `node-id` makes the embed open scrolled to the linked frame — the natural fit for "task = redesign this screen."
+- **Setup**: register one Figma OAuth app to get `FIGMA_CLIENT_ID` and register our origins (prod + staging + preview wildcard if allowed). No token exchange — the client id alone authorizes embedding. Private files show Figma's login screen to viewers without access, which is correct behavior for us.
+- New route: `POST/DELETE /api/tasks/:id/figma` (mirror of `api.tasks.$id.github.ts`).
+
+## Tier 2 — metadata enrichment (one lab-level token)
+
+Make the chip informative: file name, thumbnail, "edited 2h ago" instead of a bare link.
+
+- **Auth**: a single lab-level OAuth grant (a design lead's Figma account) with the `file_metadata:read` scope. Store tokens AES-256-GCM encrypted at rest, same pattern (and same key helper) as `GmailIntegration.oauthTokens`. One row; no per-user OAuth.
+- **Fetch**: `GET /v1/files/:key/meta` → `name`, `thumbnail_url`, `last_touched_at`. This is a Tier-3 rate-limited endpoint — never call it on page load.
+- **Cache**: columns on Task (`figmaFileName`, `figmaThumbnailUrl`, `figmaLastTouchedAt`) refreshed by a jobs-registry entry (`figma-metadata-refresh`, default 15 min, per-tick work bounded: only files linked to non-archived tasks, batched with backoff). Populated once synchronously at link time so the chip isn't blank for its first 15 minutes. If the same fileKey ends up linked from many tasks, promote to a `FigmaFileCache` table keyed by fileKey — start with per-task columns, N will be small.
+- Token missing/expired → chip degrades to the Tier-1 bare link; never block linking on metadata.
+
+## Tier 3 — webhooks (fast-follow, gated)
+
+- **Gate**: confirm webhook availability on DALI's Figma Education team plan before building anything here.
+- `POST /api/webhooks/figma` (mirror `api.webhooks.github.ts`, verify Figma's passcode), one webhook scoped to the team.
+- `FILE_UPDATE` → invalidate/refresh the metadata cache for matching fileKeys. **Never a notification** — it fires on roughly every save batch.
+- `FILE_COMMENT` → new registry event `task.figma_update` (defaults matching `task.github_update`): "New Figma comments on the linked file," notifying task assignees with a link out to Figma.
+
+## Non-goals
+
+- **No comment mirroring in either direction.** REST-posted comments attribute to the token owner, so DALI OS can't post "as" a mentor without per-user OAuth; and canvas-pinned comments in Figma are strictly better in context. Feedback on design work stays in Figma; the webhook (Tier 3) only signals that it exists.
+- **No per-user Figma OAuth.**
+- **No status sync** between Figma and task status.
+
+## Open questions
+
+1. Who owns the lab-level Figma grant (which account, and where the responsibility lands when that person graduates).
+2. Education-plan webhook availability (blocks Tier 3 only).
+
+## References
+
+- Embed Kit 2.0: https://developers.figma.com/docs/embeds/embed-kit-2.0/
+- File metadata endpoint + scopes: https://developers.figma.com/docs/rest-api/file-endpoints/ , https://developers.figma.com/docs/rest-api/scopes/
+- Webhooks: https://developers.figma.com/docs/rest-api/webhooks-endpoints/


### PR DESCRIPTION
…cs/animation/UI) (#950)

* Task artifacts: link versioned project files to tasks + close the feedback loop

Graphics/animation/UI work now has board tracking parity with the GitHub issue mirror: tasks can carry versioned work artifacts (ProjectFile), and the upload → mentor feedback → re-upload loop notifies both directions.

- Schema: TaskFileLink (Task ↔ ProjectFile m2m), DocComment.versionId pins file comments to the version they were written against. Additive migration only.
- Task board: "Work files" section in the task modal (upload new, attach existing, unlink, open file page) and a paperclip count chip on cards.
- File page: version labels (V1…Vn) in the list and on comment chips, inline video/audio preview, and upload/comment access widened from Core-only to Core + owning-project members (tags stay Core-curated, matching /api/doctags).
- Notifications: file.comment (root file comments → uploaders + linked-task assignees) and file.new_version (new upload → prior commenters + audience), both registry-driven; replies remain on collab.comment_reply.
- Fixes a pre-existing type error: task.status_changed defaults were missing the required `desktop` key (behavior unchanged — absent key already resolved falsy), which broke the EVENT_TYPES `satisfies` check.
- specs/figma-task-linking.md: design for the Figma side (embed link, metadata enrichment, webhooks), not built here.



* File comments: pin to the version being viewed, not whatever is current

The file page now sends the previewed version id with each comment; the server validates it belongs to the file and falls back to the current version for callers that don't send one (MCP, older clients). Feedback written while looking at V1 is now labeled V1.



* Files block: group work files by their linked tasks' epics

Derived organization instead of managed folders: files linked to tasks cluster under the epic those tasks belong to (in epic order), epicless task work lands in "Other work files", and unlinked uploads keep the plain list. Re-assigning a task to a different epic moves its files automatically; projects with no task-linked files render exactly as before.



* Clamp presence hover card to the viewport + make tabless the default shell

- PresenceBar hover cards are centered under their chip, which ran off-screen for the avatars at the right edge of the page; measure on open and shift the card to stay 8px inside the viewport.
- Tabless (single-page) is now the default: absent cookie renders the direct shell, dali_tabless=0 is the explicit opt-in to the tabbed workspace. The Settings toggle persists both choices so an explicit pick survives future default changes; users who previously enabled tabless (=1) are unaffected.
- e2e fixtures pin dali_tabless=0 per context: the suite (frameLocator on workspace iframes in 7 specs) keeps testing the tabbed shell.



---------

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/952"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787172987&installation_model_id=21824&pr_number=952&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F952&signature=36b3b7227f6a8a956b0a55214e9cc945049df801fa4f1e5ed1548c40ae494cd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->