### PR TITLE
Create-meeting UI/UX, board+planning rework, doc pinning, mentorship filters+avatars

### DIFF
--- a/dali-api/app/calendar/routes/api.scheduled-meetings.ts
+++ b/dali-api/app/calendar/routes/api.scheduled-meetings.ts
@@ -21,8 +21,8 @@ const Base = {
   // a project one — see createScheduledMeeting in ~/lib/scheduled-meeting.
   // Invites still come only from the meeting's participant scope.
   projectId: z.string().min(1).optional(),
-  // SelfCheckIn only makes sense alongside meetingType (that's what creates
-  // MeetingAttendance rows at all) — enforced by the refine below.
+  // SelfCheckIn is independent of meeting notes — attendance rows fan out
+  // whenever SelfCheckIn (or meetingType) is set; see createScheduledMeeting.
   attendanceMode: z.enum(["Roster", "SelfCheckIn"]).optional(),
 } as const;
 
@@ -39,10 +39,6 @@ const CreateSchema = z
   .refine((v) => v.meetingType !== "Other" || !!v.meetingTypeLabel, {
     message: "meetingTypeLabel is required when meetingType is Other",
     path: ["meetingTypeLabel"],
-  })
-  .refine((v) => v.attendanceMode !== "SelfCheckIn" || !!v.meetingType, {
-    message: "meetingType is required when attendanceMode is SelfCheckIn",
-    path: ["attendanceMode"],
   });
 
 export async function action({ request }: Route.ActionArgs) {

--- a/dali-api/app/calendar/routes/calendar.check-in.$id.tsx
+++ b/dali-api/app/calendar/routes/calendar.check-in.$id.tsx
@@ -1,0 +1,83 @@
+import { redirect, useLoaderData } from "react-router";
+import QRCode from "qrcode";
+import { requireAuth, redirectApplicantToPortal } from "~/lib/auth";
+import { prisma } from "~/lib/db";
+import { isCore } from "~/lib/roles";
+import { CheckInPanel } from "~/components/CheckInPanel";
+import type { Route } from "./+types/calendar.check-in.$id";
+
+export const meta: Route.MetaFunction = () => [{ title: "Check in · DALI OS" }];
+
+export const handle = {
+  breadcrumb: () => "Check in",
+};
+
+// Standalone self-check-in surface for meetings that don't have a meeting
+// note (the note page hosts the same CheckInPanel when one exists). QR codes
+// and share links point here when attendanceMode is SelfCheckIn and there's
+// no document to open.
+export async function loader({ request, params }: Route.LoaderArgs) {
+  const auth = await requireAuth(request);
+  if (!auth.ok) return redirect("/login");
+  const portalRedirect = redirectApplicantToPortal(auth);
+  if (portalRedirect) return portalRedirect;
+
+  const meeting = await prisma.scheduledMeeting.findUnique({
+    where: { id: params.id },
+    select: {
+      id: true,
+      title: true,
+      organizerId: true,
+      attendanceMode: true,
+      status: true,
+      attendance: {
+        where: { userId: auth.user.sub },
+        select: { present: true },
+      },
+    },
+  });
+  if (!meeting || meeting.attendanceMode !== "SelfCheckIn" || meeting.status === "Cancelled") {
+    throw new Response("Not found", { status: 404 });
+  }
+
+  const viewerRow = meeting.attendance[0];
+  const canShare = (await isCore(auth.user.sub)) || auth.user.sub === meeting.organizerId;
+
+  let checkInUrl: string | null = null;
+  let checkInQrSvg: string | null = null;
+  if (canShare) {
+    const origin = new URL(request.url).origin;
+    checkInUrl = `${origin}/calendar/check-in/${meeting.id}`;
+    checkInQrSvg = await QRCode.toString(checkInUrl, { type: "svg", margin: 1, width: 180 });
+  }
+
+  return {
+    meetingId: meeting.id,
+    meetingLabel: meeting.title,
+    viewerInvited: viewerRow !== undefined,
+    viewerPresent: viewerRow?.present ?? false,
+    checkInUrl,
+    checkInQrSvg,
+  };
+}
+
+export default function CalendarCheckInPage() {
+  const data = useLoaderData<typeof loader>();
+  return (
+    <div className="max-w-lg mx-auto py-8 px-4">
+      <CheckInPanel
+        meetingId={data.meetingId}
+        meetingLabel={data.meetingLabel}
+        viewerInvited={data.viewerInvited}
+        initialPresent={data.viewerPresent}
+        checkInUrl={data.checkInUrl}
+        checkInQrSvg={data.checkInQrSvg}
+      />
+      {!data.viewerInvited && !data.checkInUrl && (
+        <p className="text-sm text-muted-foreground mt-4 text-center">
+          You weren't invited to this meeting, so there's nothing to check in for.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/dali-api/app/calendar/routes/calendar.tsx
+++ b/dali-api/app/calendar/routes/calendar.tsx
@@ -3568,13 +3568,24 @@ function CreateScheduledMeetingForm({
   const [organizerCalendarLinkId, setOrganizerCalendarLinkId] = useState<string>(
     googleLinks[0]?.id ?? "",
   );
+  // Meeting notes are opt-in — type/label/project only appear when this is on.
+  const [createNote, setCreateNote] = useState(false);
   const [meetingType, setMeetingType] = useState<"Team" | "Partner" | "Other">("Other");
   const [meetingTypeLabel, setMeetingTypeLabel] = useState("");
   const [projectId, setProjectId] = useState("");
+  // Self check-in is independent of the meeting note (QR lives on the note when
+  // one exists, otherwise on /calendar/check-in/:id).
   const [selfCheckIn, setSelfCheckIn] = useState(false);
   const [status, setStatus] = useState<
     | null
-    | { ok: true; count: number; gcalError?: string | null; notePageId?: string | null }
+    | {
+        ok: true;
+        count: number;
+        gcalError?: string | null;
+        notePageId?: string | null;
+        meetingId?: string | null;
+        selfCheckIn?: boolean;
+      }
     | { ok: false; error: string }
   >(null);
   const [submitting, setSubmitting] = useState(false);
@@ -3586,11 +3597,11 @@ function CreateScheduledMeetingForm({
   // system-managed project group (see GroupOption.projectId) — still fully
   // overridable by the sender.
   useEffect(() => {
-    if (selectedGroupIds.length !== 1) return;
+    if (!createNote || selectedGroupIds.length !== 1) return;
     const g = groupsById.get(selectedGroupIds[0]!);
     if (g?.projectId && !projectId) setProjectId(g.projectId);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedGroupIds]);
+  }, [selectedGroupIds, createNote]);
 
   // Both pickers filled → derive duration; otherwise fall back to 30 min so
   // "schedule later" (no start/end yet) still produces a valid payload.
@@ -3598,7 +3609,7 @@ function CreateScheduledMeetingForm({
   const startEndValid =
     !startLocal || !endLocal || new Date(endLocal).getTime() > new Date(startLocal).getTime();
   const meetingTypeValid =
-    meetingType !== "Other" || meetingTypeLabel.trim().length > 0;
+    !createNote || meetingType !== "Other" || meetingTypeLabel.trim().length > 0;
 
   async function submit(e: React.FormEvent) {
     e.preventDefault();
@@ -3622,9 +3633,11 @@ function CreateScheduledMeetingForm({
       if (organizerCalendarLinkId) {
         payload.organizerCalendarLinkId = organizerCalendarLinkId;
       }
-      payload.meetingType = meetingType;
-      if (meetingType === "Other") payload.meetingTypeLabel = meetingTypeLabel.trim();
-      if (projectId) payload.projectId = projectId;
+      if (createNote) {
+        payload.meetingType = meetingType;
+        if (meetingType === "Other") payload.meetingTypeLabel = meetingTypeLabel.trim();
+        if (projectId) payload.projectId = projectId;
+      }
       if (canSetSelfCheckIn) {
         payload.attendanceMode = selfCheckIn ? "SelfCheckIn" : "Roster";
       }
@@ -3656,6 +3669,8 @@ function CreateScheduledMeetingForm({
           count: json.notifiedCount ?? 0,
           gcalError: json.gcalError ?? null,
           notePageId: json.notePageId ?? null,
+          meetingId: json.meeting?.id ?? null,
+          selfCheckIn,
         });
         setTitle("");
         setRepeats("none");
@@ -3663,6 +3678,7 @@ function CreateScheduledMeetingForm({
         onEndLocalChange("");
         onChangeSelectedUserIds([]);
         onChangeSelectedGroupIds([]);
+        setCreateNote(false);
         setMeetingType("Other");
         setMeetingTypeLabel("");
         setProjectId("");
@@ -3678,201 +3694,239 @@ function CreateScheduledMeetingForm({
   const canSubmit =
     title.trim().length > 0 && duration > 0 && startEndValid && meetingTypeValid && !submitting;
 
+  const fieldClass =
+    "w-full px-3 py-2 text-sm border border-border rounded-md bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-accent-coral/40";
+  const labelClass = "block text-sm font-medium text-foreground mb-1";
+
   return (
     <section className="bg-card border border-border shadow-brand-1 rounded-lg p-4">
-      <h2 className="font-heading font-semibold text-foreground mb-3">Create Meeting</h2>
-      <form onSubmit={submit} className="space-y-3">
-        <div>
-          <label htmlFor="meeting-title" className="block text-sm font-medium text-foreground mb-1">
-            Title
-          </label>
-          <input
-            id="meeting-title"
-            type="text"
-            value={title}
-            onChange={(e) => setTitle(e.target.value)}
-            required
-            className="w-full px-3 py-2 text-sm border border-border rounded-md bg-background text-foreground"
-          />
-        </div>
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+      <h2 className="font-heading font-semibold text-foreground mb-4">Create Meeting</h2>
+      <form onSubmit={submit} className="space-y-5">
+        {/* Essentials */}
+        <div className="space-y-3">
           <div>
-            <label htmlFor="meeting-start" className="block text-sm font-medium text-foreground mb-1">
-              Starts <span className="text-muted-foreground font-normal">(optional)</span>
+            <label htmlFor="meeting-title" className={labelClass}>
+              Title
             </label>
             <input
-              id="meeting-start"
-              type="datetime-local"
-              value={startLocal}
-              onChange={(e) => {
-                const next = e.target.value;
-                onStartLocalChange(next);
-                // If end is missing or now precedes start, push it to start + current duration.
-                if (next && (!endLocal || new Date(endLocal).getTime() <= new Date(next).getTime())) {
-                  const d = new Date(next);
-                  d.setMinutes(d.getMinutes() + (duration > 0 ? duration : 30));
-                  onEndLocalChange(toDatetimeLocal(d));
-                }
-              }}
-              className="w-full px-3 py-2 text-sm border border-border rounded-md bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-accent-coral/40"
+              id="meeting-title"
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              required
+              className={fieldClass}
             />
           </div>
-          <div>
-            <label htmlFor="meeting-end" className="block text-sm font-medium text-foreground mb-1">
-              Ends
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div>
+              <label htmlFor="meeting-start" className={labelClass}>
+                Starts <span className="text-muted-foreground font-normal">(optional)</span>
+              </label>
+              <input
+                id="meeting-start"
+                type="datetime-local"
+                value={startLocal}
+                onChange={(e) => {
+                  const next = e.target.value;
+                  onStartLocalChange(next);
+                  if (next && (!endLocal || new Date(endLocal).getTime() <= new Date(next).getTime())) {
+                    const d = new Date(next);
+                    d.setMinutes(d.getMinutes() + (duration > 0 ? duration : 30));
+                    onEndLocalChange(toDatetimeLocal(d));
+                  }
+                }}
+                className={fieldClass}
+              />
+            </div>
+            <div>
+              <label htmlFor="meeting-end" className={labelClass}>
+                Ends
+              </label>
+              <input
+                id="meeting-end"
+                type="datetime-local"
+                value={endLocal}
+                min={startLocal || undefined}
+                onChange={(e) => onEndLocalChange(e.target.value)}
+                className={`${fieldClass} ${startEndValid ? "" : "border-red-500"}`}
+              />
+              {!startEndValid && (
+                <p className="mt-1 text-xs text-red-600">End must be after start.</p>
+              )}
+            </div>
+          </div>
+          <ParticipantPicker
+            users={users}
+            groups={groups}
+            selectedUserIds={selectedUserIds}
+            selectedGroupIds={selectedGroupIds}
+            onChangeUsers={onChangeSelectedUserIds}
+            onChangeGroups={onChangeSelectedGroupIds}
+            usersById={usersById}
+            groupsById={groupsById}
+            resolvedCount={resolvedParticipantIds.length}
+          />
+        </div>
+
+        {/* Secondary scheduling details — quieter, less visual weight */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 pt-1 border-t border-border">
+          <div className="pt-3">
+            <label htmlFor="meeting-recurrence" className={labelClass}>
+              Repeats
             </label>
-            <input
-              id="meeting-end"
-              type="datetime-local"
-              value={endLocal}
-              min={startLocal || undefined}
-              onChange={(e) => onEndLocalChange(e.target.value)}
-              className={`w-full px-3 py-2 text-sm border rounded-md bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-accent-coral/40 ${
-                startEndValid ? "border-border" : "border-red-500"
-              }`}
-            />
-            {!startEndValid && (
-              <p className="mt-1 text-xs text-red-600">End must be after start.</p>
+            <select
+              id="meeting-recurrence"
+              value={repeats}
+              onChange={(e) => setRepeats(e.target.value as Repeats)}
+              className={fieldClass}
+            >
+              {REPEATS_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="pt-3">
+            <label htmlFor="organizer-calendar" className={labelClass}>
+              Send invite from
+            </label>
+            {googleLinks.length === 0 ? (
+              <p className="text-xs text-muted-foreground pt-2">
+                No Google calendar linked. Link one in My Availability to send Gmail invites.
+              </p>
+            ) : (
+              <select
+                id="organizer-calendar"
+                value={organizerCalendarLinkId}
+                onChange={(e) => setOrganizerCalendarLinkId(e.target.value)}
+                className={fieldClass}
+              >
+                <option value="">No invite (in-app notification only)</option>
+                {googleLinks.map((l) => (
+                  <option key={l.id} value={l.id}>
+                    {l.displayName ? `${l.displayName} — ${l.externalEmail}` : l.externalEmail}
+                  </option>
+                ))}
+              </select>
             )}
           </div>
         </div>
-        <div>
-          <label htmlFor="meeting-recurrence" className="block text-sm font-medium text-foreground mb-1">
-            Repeats
-          </label>
-          <select
-            id="meeting-recurrence"
-            value={repeats}
-            onChange={(e) => setRepeats(e.target.value as Repeats)}
-            className="w-full px-3 py-2 text-sm border border-border rounded-md bg-background text-foreground"
-          >
-            {REPEATS_OPTIONS.map((opt) => (
-              <option key={opt.value} value={opt.value}>
-                {opt.label}
-              </option>
-            ))}
-          </select>
-        </div>
 
-        <div>
-          <label htmlFor="organizer-calendar" className="block text-sm font-medium text-foreground mb-1">
-            Send invite from
-          </label>
-          {googleLinks.length === 0 ? (
-            <p className="text-xs text-muted-foreground">
-              No Google calendar linked. Link one in the My Availability tab to send Gmail invites.
-            </p>
-          ) : (
-            <select
-              id="organizer-calendar"
-              value={organizerCalendarLinkId}
-              onChange={(e) => setOrganizerCalendarLinkId(e.target.value)}
-              className="w-full px-3 py-2 text-sm border border-border rounded-md bg-background text-foreground"
-            >
-              <option value="">No invite (in-app notification only)</option>
-              {googleLinks.map((l) => (
-                <option key={l.id} value={l.id}>
-                  {l.displayName ? `${l.displayName} — ${l.externalEmail}` : l.externalEmail}
-                </option>
-              ))}
-            </select>
-          )}
-        </div>
+        {/* Optional add-ons */}
+        <div className="space-y-3 pt-1 border-t border-border">
+          <p className="pt-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Optional
+          </p>
 
-        <ParticipantPicker
-          users={users}
-          groups={groups}
-          selectedUserIds={selectedUserIds}
-          selectedGroupIds={selectedGroupIds}
-          onChangeUsers={onChangeSelectedUserIds}
-          onChangeGroups={onChangeSelectedGroupIds}
-          usersById={usersById}
-          groupsById={groupsById}
-          resolvedCount={resolvedParticipantIds.length}
-        />
-
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-          <div>
-            <label htmlFor="meeting-type" className="block text-sm font-medium text-foreground mb-1">
-              Meeting type
-            </label>
-            <select
-              id="meeting-type"
-              value={meetingType}
-              onChange={(e) => setMeetingType(e.target.value as typeof meetingType)}
-              className="w-full px-3 py-2 text-sm border border-border rounded-md bg-background text-foreground"
-            >
-              <option value="Team">Team meeting</option>
-              <option value="Partner">Partner meeting</option>
-              <option value="Other">Other</option>
-            </select>
-            <p className="mt-1 text-xs text-muted-foreground">
-              Creates a meeting note with an attendance checklist
-              {canSetSelfCheckIn && selfCheckIn
-                ? " and a self check-in QR code."
-                : projectId
-                  ? " under the project's documents."
-                  : " in Lab documents."}{" "}
-              Invites go only to people and groups in Participants.
-            </p>
-          </div>
-          {meetingType === "Other" && (
-            <div>
-              <label
-                htmlFor="meeting-type-label"
-                className="block text-sm font-medium text-foreground mb-1"
-              >
-                Meeting type name
-              </label>
+          <div className="rounded-md border border-border bg-muted/20 p-3 space-y-3">
+            <label className="flex items-start gap-2.5 cursor-pointer">
               <input
-                id="meeting-type-label"
-                type="text"
-                value={meetingTypeLabel}
-                onChange={(e) => setMeetingTypeLabel(e.target.value)}
-                placeholder="e.g. Kickoff"
-                required
-                className="w-full px-3 py-2 text-sm border border-border rounded-md bg-background text-foreground"
+                type="checkbox"
+                checked={createNote}
+                onChange={(e) => setCreateNote(e.target.checked)}
+                className="mt-0.5 h-3.5 w-3.5 rounded border-border"
               />
+              <span>
+                <span className="block text-sm font-medium text-foreground">
+                  Create meeting note
+                </span>
+                <span className="block text-xs text-muted-foreground mt-0.5">
+                  Adds a note with an attendance checklist
+                  {projectId ? " under the project's documents" : " in Lab documents"}. Invites
+                  still go only to people and groups in Participants.
+                </span>
+              </span>
+            </label>
+
+            {createNote && (
+              <div className="pl-6 space-y-3">
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                  <div>
+                    <label htmlFor="meeting-type" className={labelClass}>
+                      Meeting type
+                    </label>
+                    <select
+                      id="meeting-type"
+                      value={meetingType}
+                      onChange={(e) => setMeetingType(e.target.value as typeof meetingType)}
+                      className={fieldClass}
+                    >
+                      <option value="Team">Team meeting</option>
+                      <option value="Partner">Partner meeting</option>
+                      <option value="Other">Other</option>
+                    </select>
+                  </div>
+                  {meetingType === "Other" && (
+                    <div>
+                      <label htmlFor="meeting-type-label" className={labelClass}>
+                        Meeting type name
+                      </label>
+                      <input
+                        id="meeting-type-label"
+                        type="text"
+                        value={meetingTypeLabel}
+                        onChange={(e) => setMeetingTypeLabel(e.target.value)}
+                        placeholder="e.g. Partner hub meeting"
+                        required
+                        className={fieldClass}
+                      />
+                    </div>
+                  )}
+                  <div className={meetingType === "Other" ? "sm:col-span-2" : ""}>
+                    <label htmlFor="meeting-project" className={labelClass}>
+                      Project <span className="text-muted-foreground font-normal">(optional)</span>
+                    </label>
+                    <select
+                      id="meeting-project"
+                      value={projectId}
+                      onChange={(e) => setProjectId(e.target.value)}
+                      className={fieldClass}
+                    >
+                      <option value="">No project — Lab documents</option>
+                      {myProjects.map((p) => (
+                        <option key={p.id} value={p.id}>
+                          {p.name}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
+
+          {canSetSelfCheckIn && (
+            <div className="rounded-md border border-border bg-muted/20 p-3">
+              <label className="flex items-start gap-2.5 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={selfCheckIn}
+                  onChange={(e) => setSelfCheckIn(e.target.checked)}
+                  className="mt-0.5 h-3.5 w-3.5 rounded border-border"
+                />
+                <span>
+                  <span className="block text-sm font-medium text-foreground">
+                    Self check-in (QR)
+                  </span>
+                  <span className="block text-xs text-muted-foreground mt-0.5">
+                    Attendees mark themselves present. Works with or without a meeting note —
+                    {createNote
+                      ? " the QR appears on the note."
+                      : " you'll get a shareable check-in link after creating."}
+                  </span>
+                </span>
+              </label>
             </div>
           )}
-          <div>
-            <label htmlFor="meeting-project" className="block text-sm font-medium text-foreground mb-1">
-              Project{" "}
-              <span className="text-muted-foreground font-normal">(optional)</span>
-            </label>
-            <select
-              id="meeting-project"
-              value={projectId}
-              onChange={(e) => setProjectId(e.target.value)}
-              className="w-full px-3 py-2 text-sm border border-border rounded-md bg-background text-foreground"
-            >
-              <option value="">No project</option>
-              {myProjects.map((p) => (
-                <option key={p.id} value={p.id}>
-                  {p.name}
-                </option>
-              ))}
-            </select>
-          </div>
         </div>
 
-        {canSetSelfCheckIn && (
-          <label className="inline-flex items-center gap-2 text-sm text-foreground cursor-pointer">
-            <input
-              type="checkbox"
-              checked={selfCheckIn}
-              onChange={(e) => setSelfCheckIn(e.target.checked)}
-              className="h-3.5 w-3.5 rounded border-border"
-            />
-            Self check-in (QR)
-          </label>
-        )}
-
-        <div className="flex items-center justify-between pt-1">
-          <div className="text-sm">
+        <div className="flex items-center justify-between gap-3 pt-1">
+          <div className="text-sm min-w-0">
             {status?.ok === true && !status.gcalError && (
               <span className="text-green-700">
-                Meeting created. Notified {status.count} participant{status.count === 1 ? "" : "s"}.
+                Meeting created. Notified {status.count} participant
+                {status.count === 1 ? "" : "s"}.
                 {status.notePageId && (
                   <>
                     {" "}
@@ -3883,6 +3937,19 @@ function CreateScheduledMeetingForm({
                       className="underline font-medium"
                     >
                       View meeting note
+                    </a>
+                  </>
+                )}
+                {status.selfCheckIn && !status.notePageId && status.meetingId && (
+                  <>
+                    {" "}
+                    <a
+                      href={`/calendar/check-in/${status.meetingId}`}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="underline font-medium"
+                    >
+                      Open check-in / QR
                     </a>
                   </>
                 )}

--- a/dali-api/app/lib/audit-actions.ts
+++ b/dali-api/app/lib/audit-actions.ts
@@ -78,6 +78,7 @@ export const AUDIT_ACTIONS = [
   "partner.application.submitted",
   "partner.magic_link.requested",
   "page.partner-visibility",
+  "page.pin",
   "education.offering.create",
   "education.offering.update",
   "education.offering.status",

--- a/dali-api/app/lib/scheduled-meeting.ts
+++ b/dali-api/app/lib/scheduled-meeting.ts
@@ -91,10 +91,11 @@ export type CreateScheduledMeetingInput = {
   meetingType?: MeetingType | null;
   meetingTypeLabel?: string | null;
   projectId?: string | null;
-  // Roster (default): organizer/Core check attendees off by hand. SelfCheckIn:
-  // a checkInToken is generated and attendees mark themselves present via the
-  // check-in route — meant for events too large to check off manually (e.g.
-  // an all-lab Group meeting). Only meaningful alongside meetingType.
+  // Roster (default): organizer/Core check attendees off by hand (needs a
+  // meeting note for the checklist UI). SelfCheckIn: a checkInToken is
+  // generated and attendees mark themselves present via the check-in route —
+  // works with or without a meeting note (QR lives on the note when present,
+  // otherwise on /calendar/check-in/:id).
   attendanceMode?: AttendanceMode;
 };
 
@@ -207,14 +208,10 @@ export async function createScheduledMeeting(
     }
   }
 
-  // MeetingAttendance fan-out follows the meeting's participant scope only
-  // (plus the organizer) — never the whole lab. A project-less meeting still
-  // only invites whoever was listed; pick a Term group in Participants if you
-  // actually want every current-term member. Note-page creation branches on
-  // whether there's a project: project-scoped meetings get a Page under the
-  // project's shared documents (optionally nested in the Team/Partner
-  // meeting-notes folder); project-less meetings get a Lab-workspace page
-  // instead, so there's still somewhere to host the QR / AttendanceChecklist.
+  // Note-page creation is optional (driven by meetingType). Attendance rows
+  // fan out for notes (roster checklist) and for SelfCheckIn (QR / self-serve
+  // present) — either alone or together. Scope is always the meeting's
+  // participants (+ organizer), never the whole lab.
   let notePageId: string | null = null;
   if (input.meetingType) {
     // Auto-generated note pages are titled with just the meeting date — the
@@ -252,7 +249,9 @@ export async function createScheduledMeeting(
       });
       notePageId = page.id;
     }
+  }
 
+  if (input.meetingType || attendanceMode === "SelfCheckIn") {
     const attendeeIds = Array.from(new Set([...participantUserIds, input.organizerId]));
     await prisma.meetingAttendance.createMany({
       data: attendeeIds.map((userId) => ({

--- a/dali-api/app/mentorship/components/MentorGrid.tsx
+++ b/dali-api/app/mentorship/components/MentorGrid.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { Link, useNavigate } from "react-router";
 import { Plus } from "lucide-react";
+import { Avatar } from "~/components/ui/Avatar";
 import { VIBE_META } from "../lib/vibe";
 import type {
   GridCell,
@@ -35,8 +36,17 @@ export function MentorGrid({
 }) {
   return (
     <section className="bg-card border border-border rounded-lg p-4 flex flex-col gap-3">
-      <h2 className="font-heading font-semibold text-foreground">
-        {heading ?? fullName(group.mentor)}
+      <h2 className="font-heading font-semibold text-foreground flex items-center gap-2">
+        {heading ?? (
+          <>
+            <Avatar
+              photoUrl={group.mentor.photoUrl}
+              name={fullName(group.mentor)}
+              size="sm"
+            />
+            {fullName(group.mentor)}
+          </>
+        )}
       </h2>
       <div className="overflow-x-auto">
         <table className="border-separate border-spacing-1 text-sm">
@@ -62,8 +72,15 @@ export function MentorGrid({
             {group.rows.map((row) => (
               <tr key={row.key}>
                 <td className="pr-3 whitespace-nowrap">
-                  <span className="font-medium text-foreground">
-                    {fullName(row.mentee)}
+                  <span className="inline-flex items-center gap-2 align-middle">
+                    <Avatar
+                      photoUrl={row.mentee.photoUrl}
+                      name={fullName(row.mentee)}
+                      size="xs"
+                    />
+                    <span className="font-medium text-foreground">
+                      {fullName(row.mentee)}
+                    </span>
                   </span>{" "}
                   <span className="text-xs text-muted-foreground">
                     {row.projectName} · {row.domainCode}

--- a/dali-api/app/mentorship/lib/mentor-grid.server.ts
+++ b/dali-api/app/mentorship/lib/mentor-grid.server.ts
@@ -1,4 +1,5 @@
 import { prisma } from "~/lib/db";
+import { resolvePhotoUrl } from "~/lib/photo";
 import { weekNumberInTerm, weekStartForNumber, weeksInTerm } from "./week";
 import type { Vibe } from "./vibe";
 
@@ -7,7 +8,13 @@ import type { Vibe } from "./vibe";
 // is one cell — a submitted note (with its vibe), a missing note (a due week
 // with no note), or a future week (not yet due).
 
-export type GridPerson = { id: string; firstName: string; lastName: string };
+export type GridPerson = {
+  id: string;
+  firstName: string;
+  lastName: string;
+  // Resolved (browser-usable) profile photo URL, or null.
+  photoUrl: string | null;
+};
 
 export type GridCell = {
   week: number;
@@ -111,8 +118,8 @@ export async function buildGrid({
         menteeUserId: true,
         projectId: true,
         domainId: true,
-        mentor: { select: { id: true, firstName: true, lastName: true } },
-        mentee: { select: { id: true, firstName: true, lastName: true } },
+        mentor: { select: { id: true, firstName: true, lastName: true, photoUrl: true } },
+        mentee: { select: { id: true, firstName: true, lastName: true, photoUrl: true } },
       },
     }),
     prisma.mentorNote.findMany({
@@ -155,12 +162,38 @@ export async function buildGrid({
     );
   }
 
+  // Resolve each unique person's stored photo once (S3 presign / passthrough),
+  // then stamp the resolved URL onto every GridPerson.
+  const rawPhotoById = new Map<string, string | null>();
+  for (const p of pairs) {
+    rawPhotoById.set(p.mentor.id, p.mentor.photoUrl);
+    rawPhotoById.set(p.mentee.id, p.mentee.photoUrl);
+  }
+  const photoById = new Map(
+    await Promise.all(
+      [...rawPhotoById].map(
+        async ([id, raw]) =>
+          [id, await resolvePhotoUrl(raw)] as [string, string | null],
+      ),
+    ),
+  );
+  const toPerson = (u: {
+    id: string;
+    firstName: string;
+    lastName: string;
+  }): GridPerson => ({
+    id: u.id,
+    firstName: u.firstName,
+    lastName: u.lastName,
+    photoUrl: photoById.get(u.id) ?? null,
+  });
+
   // Group pairs by mentor.
   const byMentor = new Map<string, GridMentorGroup>();
   for (const p of pairs) {
     let group = byMentor.get(p.mentorUserId);
     if (!group) {
-      group = { mentor: p.mentor, rows: [] };
+      group = { mentor: toPerson(p.mentor), rows: [] };
       byMentor.set(p.mentorUserId, group);
     }
     const cells: GridCell[] = weeks.map((week) => {
@@ -186,7 +219,7 @@ export async function buildGrid({
     });
     group.rows.push({
       key: `${p.mentorUserId}|${p.menteeUserId}|${p.projectId}|${p.domainId}`,
-      mentee: p.mentee,
+      mentee: toPerson(p.mentee),
       menteeId: p.menteeUserId,
       projectId: p.projectId,
       domainId: p.domainId,

--- a/dali-api/app/mentorship/routes/mentorship.browse.tsx
+++ b/dali-api/app/mentorship/routes/mentorship.browse.tsx
@@ -23,9 +23,9 @@ import { TemplatesModal } from "../components/TemplatesModal";
 import { MentorGrid } from "../components/MentorGrid";
 import {
   buildGrid,
-  termWeekCount,
   type MentorGridResult,
 } from "../lib/mentor-grid.server";
+import { VIBES, VIBE_META } from "../lib/vibe";
 
 export const meta: Route.MetaFunction = () => [
   { title: "Notes · DALI OS" },
@@ -43,9 +43,9 @@ type LoaderData = {
     projectId: string;
     domainId: string;
     termId: string;
-    // Week number within the selected term ("" = any week). When set, the grid
-    // shows only that week's column.
-    week: string;
+    // Vibe ("" = any). When set, only mentee rows with at least one weekly
+    // note of this vibe are shown.
+    status: string;
   };
   options: {
     mentors: FilterOption[];
@@ -53,8 +53,8 @@ type LoaderData = {
     projects: FilterOption[];
     domains: FilterOption[];
     terms: FilterOption[];
-    // Week 1..N for the selected term (empty when no term is selected).
-    weeks: FilterOption[];
+    // Vibe filter options (Good / Ok / Bad with user-facing labels).
+    statuses: FilterOption[];
   };
   grid: MentorGridResult;
   isCore: boolean;
@@ -84,7 +84,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     projectId: pickFilter(url.searchParams.get("projectId")),
     domainId: pickFilter(url.searchParams.get("domainId")),
     termId: termParam !== null ? termParam : defaultTerm?.id ?? "",
-    week: pickFilter(url.searchParams.get("week")),
+    status: pickFilter(url.searchParams.get("status")),
   };
 
   // Scope non-Core viewers to their own notes/pairs + own-domain mentee data.
@@ -130,7 +130,6 @@ export async function loader({ request }: Route.LoaderArgs) {
 
   // The selected term (defaulted to current) drives the grid's week axis.
   const selectedTerm = terms.find((t) => t.id === filters.termId) ?? null;
-  const selectedWeek = filters.week ? Number(filters.week) : null;
 
   function uniquePeople(
     ...lists: { id: string; firstName: string; lastName: string }[][]
@@ -166,28 +165,37 @@ export async function loader({ request }: Route.LoaderArgs) {
       label: `${d.displayName} (${d.code})`,
     })),
     terms: terms.map((t) => ({ id: t.id, label: t.code })),
-    // Week 1..N of the selected term. Empty when no term is selected (week
-    // numbering has no origin then).
-    weeks: selectedTerm
-      ? Array.from({ length: termWeekCount(selectedTerm.startDate, selectedTerm.endDate) }, (_, i) => ({
-          id: String(i + 1),
-          label: `Week ${i + 1}`,
-        }))
-      : [],
+    // Vibe filter options — the note's at-a-glance status.
+    statuses: VIBES.map((v) => ({ id: v, label: VIBE_META[v].label })),
   };
 
   // The grid is a mentor → mentees → weeks matrix, scoped to one term. Without
   // a selected term there's no week axis, so we render an empty-state prompt.
-  const grid: LoaderData["grid"] = selectedTerm
+  let grid: LoaderData["grid"] = selectedTerm
     ? await buildGrid({
         term: selectedTerm,
         filters,
-        weekFilter: selectedWeek,
         viewerId: auth.user.sub,
         pairScope,
         noteScope,
       })
     : { weeks: [], currentWeek: null, mentors: [], termSelected: false };
+
+  // Status (vibe) filter: keep only mentee rows with at least one weekly note
+  // of the selected vibe, and drop mentors left with no matching rows.
+  if (filters.status) {
+    grid = {
+      ...grid,
+      mentors: grid.mentors
+        .map((m) => ({
+          ...m,
+          rows: m.rows.filter((r) =>
+            r.cells.some((c) => c.vibe === filters.status),
+          ),
+        }))
+        .filter((m) => m.rows.length > 0),
+    };
+  }
 
   const data: LoaderData = {
     filters,
@@ -308,10 +316,10 @@ export default function MentorshipBrowse() {
           value={data.filters.domainId}
         />
         <FilterSelect
-          name="week"
-          label="Week"
-          options={data.options.weeks}
-          value={data.filters.week}
+          name="status"
+          label="Status"
+          options={data.options.statuses}
+          value={data.filters.status}
         />
         <div className="ml-auto flex items-center gap-2">
           <button

--- a/dali-api/app/projects/components/EpicSprintManager.tsx
+++ b/dali-api/app/projects/components/EpicSprintManager.tsx
@@ -1356,7 +1356,9 @@ function EpicForm({
           size="sm"
           disabled={busy}
         >
-          Save
+          {/* Creating a new epic hands off to the detail modal to add
+              sprints/stories, so "Next" signals there's more after this. */}
+          {initial ? "Save" : "Next"}
         </Button>
         <button
           type="button"

--- a/dali-api/app/projects/components/EpicSprintManager.tsx
+++ b/dali-api/app/projects/components/EpicSprintManager.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState, type CSSProperties, type ReactNode } from "react";
 import { useRevalidator } from "react-router";
-import { X, GripVertical, Check, Trash2 } from "lucide-react";
+import { X, GripVertical, Check, Trash2, Pencil, Maximize2 } from "lucide-react";
+import { Tooltip } from "~/components/ui/IconButton";
 import {
   DndContext,
   PointerSensor,
@@ -74,6 +75,9 @@ type Props = {
   view?: "list" | "timeline";
   // TimelineEpic shape for the timeline body (only read when view=timeline).
   timelineEpics?: TimelineEpic[];
+  // The list/timeline view switch, rendered on the toolbar row (right side),
+  // with the "Add epic" button on the left of the same line.
+  viewToggle?: ReactNode;
 };
 
 function dateInputValue(iso: string): string {
@@ -111,6 +115,7 @@ export function EpicSprintManager({
   userName,
   view = "list",
   timelineEpics = [],
+  viewToggle,
 }: Props) {
   const revalidator = useRevalidator();
   const [error, setError] = useState<string | null>(null);
@@ -231,6 +236,25 @@ export function EpicSprintManager({
     <div className="flex flex-col gap-4">
       {errorBanner}
 
+      {/* Toolbar: "Add epic" (timeline view) on the left, the list/timeline
+          toggle on the right — same line. */}
+      {viewToggle && (
+        <div className="flex items-center justify-between gap-2">
+          {view === "timeline" && canManage ? (
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => setNewEpicOpen(true)}
+            >
+              + Add epic
+            </Button>
+          ) : (
+            <span />
+          )}
+          {viewToggle}
+        </div>
+      )}
+
       {/* New epic — a modal like the detail view, not inline inputs in the
           list. On save we immediately reopen as the real detail modal for the
           created epic (see onSubmit), so sprints/stories can be added right
@@ -308,17 +332,6 @@ export function EpicSprintManager({
 
       {view === "timeline" ? (
         <div className="flex flex-col gap-3">
-          {canManage && (
-            <div className="flex justify-end">
-              <Button
-                variant="secondary"
-                size="sm"
-                onClick={() => setNewEpicOpen(true)}
-              >
-                + Add epic
-              </Button>
-            </div>
-          )}
           {/* Clicking an epic or sprint bar opens the same detail/edit modal
               the list view uses (openEpic). */}
           <EpicsTimeline
@@ -505,14 +518,16 @@ export function EpicSprintManager({
                         </span>
                       )}
                     </div>
-                    <button
-                      type="button"
-                      onClick={() => openEpic(epic.id)}
-                      aria-label={`Open ${epic.title}`}
-                      className="flex-shrink-0 text-xs font-medium text-accent-coral hover:underline"
-                    >
-                      Open
-                    </button>
+                    <Tooltip label="Open">
+                      <button
+                        type="button"
+                        onClick={() => openEpic(epic.id)}
+                        aria-label={`Open ${epic.title}`}
+                        className="flex-shrink-0 text-muted-foreground hover:text-accent-coral"
+                      >
+                        <Maximize2 className="w-3.5 h-3.5" />
+                      </button>
+                    </Tooltip>
                   </div>
 
                   {expanded && (
@@ -672,13 +687,16 @@ export function EpicSprintManager({
                     </span>
                   </div>
                   {canManage && (
-                    <button
-                      type="button"
-                      onClick={() => setEditSprintId(sprint.id)}
-                      className="text-xs text-muted-foreground hover:text-foreground flex-shrink-0"
-                    >
-                      Edit
-                    </button>
+                    <Tooltip label="Edit sprint">
+                      <button
+                        type="button"
+                        onClick={() => setEditSprintId(sprint.id)}
+                        aria-label="Edit sprint"
+                        className="text-muted-foreground hover:text-foreground flex-shrink-0"
+                      >
+                        <Pencil className="w-3.5 h-3.5" />
+                      </button>
+                    </Tooltip>
                   )}
                 </div>
               ),
@@ -878,37 +896,43 @@ function EpicDetail({
         </div>
         <div className="flex items-center gap-3 flex-shrink-0">
           {canManage && !editing && (
-            <button
-              type="button"
-              onClick={() => {
-                setEditing(true);
-                setEditEpicOpen(true);
-              }}
-              className="text-xs font-medium text-accent-coral hover:underline"
-            >
-              Edit
-            </button>
+            <Tooltip label="Edit epic">
+              <button
+                type="button"
+                onClick={() => {
+                  setEditing(true);
+                  setEditEpicOpen(true);
+                }}
+                aria-label="Edit epic"
+                className="text-muted-foreground hover:text-accent-coral"
+              >
+                <Pencil className="w-4 h-4" />
+              </button>
+            </Tooltip>
           )}
           {canManage && (
-            <button
-              type="button"
-              disabled={busy}
-              onClick={() => {
-                if (
-                  !window.confirm(
-                    `Delete epic "${epic.title}"? Its sprints and tasks will be unlinked; its user stories will be deleted.`,
+            <Tooltip label="Delete epic">
+              <button
+                type="button"
+                disabled={busy}
+                onClick={() => {
+                  if (
+                    !window.confirm(
+                      `Delete epic "${epic.title}"? Its sprints and tasks will be unlinked; its user stories will be deleted.`,
+                    )
                   )
-                )
-                  return;
-                run(async () => {
-                  await api(`/api/epics/${epic.id}`, "DELETE");
-                  onDeleted();
-                });
-              }}
-              className="text-xs text-destructive hover:underline disabled:opacity-60"
-            >
-              Delete epic
-            </button>
+                    return;
+                  run(async () => {
+                    await api(`/api/epics/${epic.id}`, "DELETE");
+                    onDeleted();
+                  });
+                }}
+                aria-label="Delete epic"
+                className="text-destructive hover:text-destructive/80 disabled:opacity-60"
+              >
+                <Trash2 className="w-4 h-4" />
+              </button>
+            </Tooltip>
           )}
           <button
             type="button"
@@ -1076,24 +1100,30 @@ function EpicDetail({
                     <span className="text-[11px] text-muted-foreground">{story.status}</span>
                     {canEditContent && (
                       <>
-                        <button
-                          type="button"
-                          onClick={() => setEditStoryId(story.id)}
-                          className="text-xs text-muted-foreground hover:text-foreground"
-                        >
-                          Edit
-                        </button>
-                        <button
-                          type="button"
-                          disabled={busy}
-                          onClick={() => {
-                            if (!window.confirm(`Delete story "${story.title}"?`)) return;
-                            run(() => api(`/api/stories/${story.id}`, "DELETE"));
-                          }}
-                          className="text-xs text-destructive hover:underline disabled:opacity-60"
-                        >
-                          Delete
-                        </button>
+                        <Tooltip label="Edit story">
+                          <button
+                            type="button"
+                            onClick={() => setEditStoryId(story.id)}
+                            aria-label="Edit story"
+                            className="text-muted-foreground hover:text-foreground"
+                          >
+                            <Pencil className="w-3.5 h-3.5" />
+                          </button>
+                        </Tooltip>
+                        <Tooltip label="Delete story">
+                          <button
+                            type="button"
+                            disabled={busy}
+                            onClick={() => {
+                              if (!window.confirm(`Delete story "${story.title}"?`)) return;
+                              run(() => api(`/api/stories/${story.id}`, "DELETE"));
+                            }}
+                            aria-label="Delete story"
+                            className="text-destructive hover:text-destructive/80 disabled:opacity-60"
+                          >
+                            <Trash2 className="w-3.5 h-3.5" />
+                          </button>
+                        </Tooltip>
                       </>
                     )}
                   </div>
@@ -1201,13 +1231,16 @@ function EpicDetail({
                   <div className="flex items-center gap-2 flex-shrink-0">
                     <span className="text-[11px] text-muted-foreground">{sprint.status}</span>
                     {canEditContent && (
-                      <button
-                        type="button"
-                        onClick={() => setEditSprintId(sprint.id)}
-                        className="text-xs text-muted-foreground hover:text-foreground"
-                      >
-                        Edit
-                      </button>
+                      <Tooltip label="Edit sprint">
+                        <button
+                          type="button"
+                          onClick={() => setEditSprintId(sprint.id)}
+                          aria-label="Edit sprint"
+                          className="text-muted-foreground hover:text-foreground"
+                        >
+                          <Pencil className="w-3.5 h-3.5" />
+                        </button>
+                      </Tooltip>
                     )}
                   </div>
                 </div>

--- a/dali-api/app/projects/components/EpicSprintManager.tsx
+++ b/dali-api/app/projects/components/EpicSprintManager.tsx
@@ -15,6 +15,7 @@ import { Modal } from "~/components/Modal";
 import { Button } from "~/components/ui/Button";
 import { CollaborativeEditor } from "~/components/CollaborativeEditor";
 import { PresenceProvider } from "~/components/collab/PresenceProvider";
+import { EpicsTimeline, type TimelineEpic } from "./EpicsTimeline";
 
 export type EditableStory = {
   id: string;
@@ -67,6 +68,12 @@ type Props = {
   // the editor's read-only fallback handles it.
   collabToken: string | null;
   userName: string;
+  // Which body to render. "timeline" (the default planning view) swaps the
+  // epic/sprint list for the clickable timeline; the New-epic + detail modals
+  // stay shared across both. "list" keeps the original manager.
+  view?: "list" | "timeline";
+  // TimelineEpic shape for the timeline body (only read when view=timeline).
+  timelineEpics?: TimelineEpic[];
 };
 
 function dateInputValue(iso: string): string {
@@ -102,6 +109,8 @@ export function EpicSprintManager({
   canManage,
   collabToken,
   userName,
+  view = "list",
+  timelineEpics = [],
 }: Props) {
   const revalidator = useRevalidator();
   const [error, setError] = useState<string | null>(null);
@@ -297,6 +306,34 @@ export function EpicSprintManager({
         )}
       </Modal>
 
+      {view === "timeline" ? (
+        <div className="flex flex-col gap-3">
+          {canManage && (
+            <div className="flex justify-end">
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={() => setNewEpicOpen(true)}
+              >
+                + Add epic
+              </Button>
+            </div>
+          )}
+          {/* Clicking an epic or sprint bar opens the same detail/edit modal
+              the list view uses (openEpic). */}
+          <EpicsTimeline
+            epics={timelineEpics}
+            taskCounts={taskCounts}
+            onEpicClick={canManage ? (id) => openEpic(id) : undefined}
+            onSprintClick={
+              canManage
+                ? (epicId, sprintId) => openEpic(epicId, { sprintId })
+                : undefined
+            }
+          />
+        </div>
+      ) : (
+        <>
       {/* Epics */}
       <section className="bg-card border border-border rounded-lg p-4">
         <div className={`flex items-center justify-between gap-2 ${epicsOpen ? "mb-3" : ""}`}>
@@ -651,6 +688,8 @@ export function EpicSprintManager({
           </>
         )}
       </section>
+        </>
+      )}
     </div>
   );
 }

--- a/dali-api/app/projects/components/EpicSprintManager.tsx
+++ b/dali-api/app/projects/components/EpicSprintManager.tsx
@@ -1419,8 +1419,9 @@ function SprintForm({
           ...(epics ? { epicId: epicId || null } : {}),
         });
       }}
-      className="flex flex-wrap items-end gap-2 mb-3"
+      className="flex items-end gap-2 mb-3"
     >
+      <div className="flex flex-wrap items-end gap-2 flex-1 min-w-0">
       <label className="flex flex-col gap-1 text-xs flex-1 min-w-[160px]">
         <span className="text-muted-foreground">Name</span>
         <input
@@ -1481,7 +1482,8 @@ function SprintForm({
           </select>
         </label>
       )}
-      <div className="flex items-center gap-1">
+      </div>
+      <div className="flex items-center gap-1 flex-shrink-0">
         <button
           type="submit"
           disabled={busy}

--- a/dali-api/app/projects/components/EpicsTimeline.tsx
+++ b/dali-api/app/projects/components/EpicsTimeline.tsx
@@ -206,12 +206,15 @@ function HoverBar({
   title,
   rows,
   children,
+  onClick,
 }: {
   className: string;
   style: CSSProperties;
   title: string;
   rows: { label: string; value: string }[];
   children?: ReactNode;
+  // When set, the bar becomes a button that opens the epic/sprint detail.
+  onClick?: () => void;
 }) {
   const [open, setOpen] = useState(false);
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
@@ -219,10 +222,23 @@ function HoverBar({
     <>
       <div
         ref={setAnchorEl}
-        className={className}
+        className={`${className}${onClick ? " cursor-pointer" : ""}`}
         style={style}
         onMouseEnter={() => setOpen(true)}
         onMouseLeave={() => setOpen(false)}
+        {...(onClick
+          ? {
+              role: "button" as const,
+              tabIndex: 0,
+              onClick,
+              onKeyDown: (e: { key: string; preventDefault: () => void }) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  onClick();
+                }
+              },
+            }
+          : {})}
       >
         {children}
       </div>
@@ -234,11 +250,16 @@ function HoverBar({
 export function EpicsTimeline({
   epics,
   taskCounts,
+  onEpicClick,
+  onSprintClick,
 }: {
   epics: TimelineEpic[];
   // Optional per-epic task progress keyed by epic id (Cancelled tasks
   // excluded), shown in the epic hover card.
   taskCounts?: Record<string, { done: number; total: number }>;
+  // When set, epic/sprint bars become clickable (open the detail modal).
+  onEpicClick?: (epicId: string) => void;
+  onSprintClick?: (epicId: string, sprintId: string) => void;
 }) {
   const bounds = useMemo(() => {
     // All day math is in UTC days (see ../lib/timeline-days): dates arrive
@@ -466,13 +487,14 @@ export function EpicsTimeline({
                         {/* Parent epic bar — solid coral so it stays visible
                             above the thinner sprint stack. */}
                         <HoverBar
-                          className={`absolute rounded-md shadow-sm ${EPIC_BAR[e.status]} flex items-center gap-1.5 px-1.5 cursor-default min-w-[22px]`}
+                          className={`absolute rounded-md shadow-sm ${EPIC_BAR[e.status]} flex items-center gap-1.5 px-1.5 min-w-[22px]`}
                           style={{
                             left: x(e.startsAt!),
                             width: w(e.startsAt!, e.endsAt!),
                             top: ROW_PAD_Y,
                             height: EPIC_BAR_H,
                           }}
+                          onClick={onEpicClick ? () => onEpicClick(e.id) : undefined}
                           title={e.title}
                           rows={[
                             { label: "Status", value: EPIC_LABEL[e.status] },
@@ -505,13 +527,18 @@ export function EpicsTimeline({
                           return (
                             <HoverBar
                               key={s.id}
-                              className={`absolute rounded-sm shadow-sm ${SPRINT_BAR[s.status]} cursor-default`}
+                              className={`absolute rounded-sm shadow-sm ${SPRINT_BAR[s.status]}`}
                               style={{
                                 left: x(s.startsAt),
                                 width: w(s.startsAt, s.endsAt),
                                 top,
                                 height: SPRINT_BAR_H,
                               }}
+                              onClick={
+                                onSprintClick
+                                  ? () => onSprintClick(e.id, s.id)
+                                  : undefined
+                              }
                               title={s.name}
                               rows={[
                                 { label: "Status", value: SPRINT_LABEL[s.status] },

--- a/dali-api/app/projects/components/TaskBoard.tsx
+++ b/dali-api/app/projects/components/TaskBoard.tsx
@@ -81,6 +81,7 @@ export function TaskBoard({
   const [searchParams, setSearchParams] = useSearchParams();
   const openTaskId = searchParams.get("task");
   const epicFilter = searchParams.get("epic");
+  const sprintFilter = searchParams.get("sprint");
   const setParam = useCallback(
     (key: string, value: string | null) => {
       setSearchParams(
@@ -95,16 +96,44 @@ export function TaskBoard({
     },
     [setSearchParams],
   );
+  // Picking an epic resets the sprint sub-filter (its sprints are epic-scoped).
+  const setEpicFilter = useCallback(
+    (value: string | null) => {
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          if (value) next.set("epic", value);
+          else next.delete("epic");
+          next.delete("sprint");
+          return next;
+        },
+        { replace: true, preventScrollReset: true },
+      );
+    },
+    [setSearchParams],
+  );
   const setOpenTaskId = useCallback(
     (id: string | null) => setParam("task", id),
     [setParam],
   );
 
+  // Sprint sub-filter only applies within a concrete epic; its options are that
+  // epic's sprints.
+  const epicSprints = useMemo(
+    () =>
+      epicFilter && epicFilter !== NO_EPIC
+        ? options.sprints.filter((s) => s.epicId === epicFilter)
+        : [],
+    [options.sprints, epicFilter],
+  );
+
   const filteredTasks = useMemo(() => {
-    if (!epicFilter) return tasks;
-    if (epicFilter === NO_EPIC) return tasks.filter((t) => t.epicId === null);
-    return tasks.filter((t) => t.epicId === epicFilter);
-  }, [tasks, epicFilter]);
+    let ts = tasks;
+    if (epicFilter === NO_EPIC) ts = ts.filter((t) => t.epicId === null);
+    else if (epicFilter) ts = ts.filter((t) => t.epicId === epicFilter);
+    if (sprintFilter) ts = ts.filter((t) => t.sprintId === sprintFilter);
+    return ts;
+  }, [tasks, epicFilter, sprintFilter]);
 
   const board = useMemo(() => buildTaskBoard(filteredTasks), [filteredTasks]);
   const openTask = openTaskId ? tasks.find((t) => t.id === openTaskId) ?? null : null;
@@ -298,8 +327,51 @@ export function TaskBoard({
     <div className="flex flex-col gap-3">
       <Confetti trigger={celebrate} onFire={() => setCelebrate(false)} />
       <div className="flex flex-wrap items-center gap-2">
+        {showEpicFilter && (
+          <div className="flex flex-wrap items-center gap-1.5" role="group" aria-label="Filter by epic">
+            <FilterPill
+              label="All"
+              active={epicFilter === null}
+              onClick={() => setEpicFilter(null)}
+            />
+            {options.epics.map((e) => (
+              <FilterPill
+                key={e.id}
+                label={e.title}
+                active={epicFilter === e.id}
+                onClick={() => setEpicFilter(epicFilter === e.id ? null : e.id)}
+              />
+            ))}
+            <FilterPill
+              label="No epic"
+              active={epicFilter === NO_EPIC}
+              onClick={() => setEpicFilter(epicFilter === NO_EPIC ? null : NO_EPIC)}
+            />
+          </div>
+        )}
+        {epicSprints.length > 0 && (
+          <div
+            className="flex flex-wrap items-center gap-1.5 pl-2 border-l border-border"
+            role="group"
+            aria-label="Filter by sprint"
+          >
+            <FilterPill
+              label="All sprints"
+              active={sprintFilter === null}
+              onClick={() => setParam("sprint", null)}
+            />
+            {epicSprints.map((s) => (
+              <FilterPill
+                key={s.id}
+                label={s.name}
+                active={sprintFilter === s.id}
+                onClick={() => setParam("sprint", sprintFilter === s.id ? null : s.id)}
+              />
+            ))}
+          </div>
+        )}
         {canManage && (
-          <>
+          <div className="flex items-center gap-2 ml-auto">
             <Button variant="primary" size="sm" onClick={() => setIsCreating(true)}>
               + Add task
             </Button>
@@ -307,28 +379,6 @@ export function TaskBoard({
               <Archive className="w-3.5 h-3.5" />
               Archived
             </Button>
-          </>
-        )}
-        {showEpicFilter && (
-          <div className="flex flex-wrap items-center gap-1.5" role="group" aria-label="Filter by epic">
-            <FilterPill
-              label="All"
-              active={epicFilter === null}
-              onClick={() => setParam("epic", null)}
-            />
-            {options.epics.map((e) => (
-              <FilterPill
-                key={e.id}
-                label={e.title}
-                active={epicFilter === e.id}
-                onClick={() => setParam("epic", epicFilter === e.id ? null : e.id)}
-              />
-            ))}
-            <FilterPill
-              label="No epic"
-              active={epicFilter === NO_EPIC}
-              onClick={() => setParam("epic", epicFilter === NO_EPIC ? null : NO_EPIC)}
-            />
           </div>
         )}
       </div>

--- a/dali-api/app/projects/components/TaskBoard.tsx
+++ b/dali-api/app/projects/components/TaskBoard.tsx
@@ -42,13 +42,8 @@ const PRIORITY_TONE: Record<Priority, string> = {
   Urgent: "text-accent-coral font-semibold",
 };
 
-// New tasks land in the first column ("To do") unless the modal picked a
-// status-affecting sprint; they can be dragged onward from there. One add
-// affordance for the whole board, not per column.
-const CREATE_STATUS: TaskStatus = TASK_STATUSES[0];
-
-// The `?sprint=` filter value for backlog (tasks with no sprint).
-const BACKLOG = "backlog";
+// The `?epic=` filter value for tasks with no epic.
+const NO_EPIC = "none";
 
 export function TaskBoard({
   projectId,
@@ -85,7 +80,7 @@ export function TaskBoard({
   // filter lives in `?sprint=` for the same reason (shareable board slices).
   const [searchParams, setSearchParams] = useSearchParams();
   const openTaskId = searchParams.get("task");
-  const sprintFilter = searchParams.get("sprint");
+  const epicFilter = searchParams.get("epic");
   const setParam = useCallback(
     (key: string, value: string | null) => {
       setSearchParams(
@@ -106,10 +101,10 @@ export function TaskBoard({
   );
 
   const filteredTasks = useMemo(() => {
-    if (!sprintFilter) return tasks;
-    if (sprintFilter === BACKLOG) return tasks.filter((t) => t.sprintId === null);
-    return tasks.filter((t) => t.sprintId === sprintFilter);
-  }, [tasks, sprintFilter]);
+    if (!epicFilter) return tasks;
+    if (epicFilter === NO_EPIC) return tasks.filter((t) => t.epicId === null);
+    return tasks.filter((t) => t.epicId === epicFilter);
+  }, [tasks, epicFilter]);
 
   const board = useMemo(() => buildTaskBoard(filteredTasks), [filteredTasks]);
   const openTask = openTaskId ? tasks.find((t) => t.id === openTaskId) ?? null : null;
@@ -134,6 +129,7 @@ export function TaskBoard({
           if ("title" in patch) body.title = patch.title;
           if ("description" in patch) body.description = patch.description;
           if ("priority" in patch) body.priority = patch.priority;
+          if ("status" in patch) body.status = patch.status;
           if ("sprintId" in patch) body.sprintId = patch.sprintId ?? null;
           if ("epicId" in patch) body.epicId = patch.epicId ?? null;
           if ("checklist" in patch) body.checklist = patch.checklist ?? null;
@@ -225,7 +221,7 @@ export function TaskBoard({
       body: JSON.stringify({
         title: values.title,
         description: values.description,
-        status: CREATE_STATUS,
+        status: values.status,
         dueAt: values.dueAt,
         sprintId: values.sprintId,
         epicId: values.epicId,
@@ -254,9 +250,9 @@ export function TaskBoard({
         id,
         title: values.title,
         description: values.description,
-        status: CREATE_STATUS,
+        status: values.status,
         priority: values.priority,
-        position: nextPositionInColumn(buildTaskBoard(cur), CREATE_STATUS),
+        position: nextPositionInColumn(buildTaskBoard(cur), values.status),
         dueAt: values.dueAt,
         epicId: values.epicId,
         sprintId: values.sprintId,
@@ -294,9 +290,9 @@ export function TaskBoard({
     listClassName: "flex flex-col gap-2 p-2 min-h-[360px]",
   }));
 
-  // Sprint pills: Active first, then Planned, then Closed (options.sprints
-  // arrive in that order from the loader), plus Backlog for sprint-less tasks.
-  const showSprintFilter = options.sprints.length > 0;
+  // Epic pills slice the board to one epic's tasks, plus "No epic" for tasks
+  // that aren't in any epic.
+  const showEpicFilter = options.epics.length > 0;
 
   return (
     <div className="flex flex-col gap-3">
@@ -313,26 +309,25 @@ export function TaskBoard({
             </Button>
           </>
         )}
-        {showSprintFilter && (
-          <div className="flex flex-wrap items-center gap-1.5" role="group" aria-label="Filter by sprint">
-            <SprintPill
+        {showEpicFilter && (
+          <div className="flex flex-wrap items-center gap-1.5" role="group" aria-label="Filter by epic">
+            <FilterPill
               label="All"
-              active={sprintFilter === null}
-              onClick={() => setParam("sprint", null)}
+              active={epicFilter === null}
+              onClick={() => setParam("epic", null)}
             />
-            {options.sprints.map((s) => (
-              <SprintPill
-                key={s.id}
-                label={s.name}
-                activeSprint={s.status === "Active"}
-                active={sprintFilter === s.id}
-                onClick={() => setParam("sprint", sprintFilter === s.id ? null : s.id)}
+            {options.epics.map((e) => (
+              <FilterPill
+                key={e.id}
+                label={e.title}
+                active={epicFilter === e.id}
+                onClick={() => setParam("epic", epicFilter === e.id ? null : e.id)}
               />
             ))}
-            <SprintPill
-              label="Backlog"
-              active={sprintFilter === BACKLOG}
-              onClick={() => setParam("sprint", sprintFilter === BACKLOG ? null : BACKLOG)}
+            <FilterPill
+              label="No epic"
+              active={epicFilter === NO_EPIC}
+              onClick={() => setParam("epic", epicFilter === NO_EPIC ? null : NO_EPIC)}
             />
           </div>
         )}
@@ -380,8 +375,8 @@ export function TaskBoard({
         <TaskModal
           options={options}
           canManage={canManage}
-          defaultSprintId={
-            sprintFilter && sprintFilter !== BACKLOG ? sprintFilter : null
+          defaultEpicId={
+            epicFilter && epicFilter !== NO_EPIC ? epicFilter : null
           }
           onClose={() => setIsCreating(false)}
           onCreate={handleCreate}
@@ -506,15 +501,13 @@ function ArchivedTasksModal({
   );
 }
 
-function SprintPill({
+function FilterPill({
   label,
   active,
-  activeSprint = false,
   onClick,
 }: {
   label: string;
   active: boolean;
-  activeSprint?: boolean;
   onClick: () => void;
 }) {
   return (
@@ -528,9 +521,6 @@ function SprintPill({
           : "border-border text-muted-foreground hover:bg-muted/30"
       }`}
     >
-      {activeSprint && (
-        <span aria-hidden className="w-1.5 h-1.5 rounded-full bg-accent-teal" />
-      )}
       {label}
     </button>
   );

--- a/dali-api/app/projects/components/TaskModal.tsx
+++ b/dali-api/app/projects/components/TaskModal.tsx
@@ -15,9 +15,15 @@ import {
   CHECKLIST_MAX_TEXT,
   type ChecklistItem,
 } from "../lib/task-checklist";
-import type { TaskBoardOptions, TaskCardModel, Priority } from "../lib/task-board";
+import type { TaskBoardOptions, TaskCardModel, Priority, TaskStatus } from "../lib/task-board";
+import { TASK_STATUSES, TASK_STATUS_LABELS } from "../lib/task-board";
 
 const PRIORITIES: Priority[] = ["Low", "Normal", "High", "Urgent"];
+
+// Borderless control for the Details property panel — the row supplies the
+// structure, so the control itself stays quiet.
+const PROP_CONTROL =
+  "w-full bg-transparent text-sm text-foreground py-1 focus:outline-none disabled:opacity-60";
 
 const COMMENT_MAX = 10_000;
 
@@ -36,6 +42,7 @@ type CommentModel = {
 export type NewTaskValues = {
   title: string;
   description: string | null;
+  status: TaskStatus;
   priority: Priority;
   dueAt: string | null;
   domainId: string | null;
@@ -59,7 +66,7 @@ export function TaskModal({
   onPatch,
   onCreate,
   onDelete,
-  defaultSprintId,
+  defaultEpicId,
 }: {
   // Present in edit mode; omitted (create mode) opens an empty form.
   task?: TaskCardModel;
@@ -72,13 +79,14 @@ export function TaskModal({
   onCreate?: (values: NewTaskValues) => Promise<void> | void;
   // Edit mode: the parent removes the task (and closes the modal).
   onDelete?: () => void;
-  // Create mode: seeds the sprint picker (e.g. from the board's sprint filter).
-  defaultSprintId?: string | null;
+  // Create mode: seeds the epic picker (e.g. from the board's epic filter).
+  defaultEpicId?: string | null;
 }) {
   const isCreate = !task;
   const [title, setTitle] = useState(task?.title ?? "");
   const [description, setDescription] = useState(task?.description ?? "");
   const [priority, setPriority] = useState<Priority>(task?.priority ?? "Normal");
+  const [status, setStatus] = useState<TaskStatus>(task?.status ?? "Todo");
   const [assigneeIds, setAssigneeIds] = useState<string[]>(
     task?.assignees.map((a) => a.id) ?? [],
   );
@@ -86,10 +94,24 @@ export function TaskModal({
     task?.dueAt ? dateInputValue(task.dueAt) : "",
   );
   const [domainId, setDomainId] = useState<string>(task?.domain?.id ?? "");
-  const [sprintId, setSprintId] = useState<string>(
-    task ? task.sprintId ?? "" : defaultSprintId ?? "",
+  const [sprintId, setSprintId] = useState<string>(task?.sprintId ?? "");
+  const [epicId, setEpicId] = useState<string>(
+    task ? task.epicId ?? "" : defaultEpicId ?? "",
   );
-  const [epicId, setEpicId] = useState<string>(task?.epicId ?? "");
+
+  // Cascading Epic → Sprint: only the chosen epic's sprints are selectable
+  // (or, with no epic, the standalone sprints). Changing epic drops a sprint
+  // that no longer belongs.
+  const epicSprints = options.sprints.filter((s) =>
+    epicId ? s.epicId === epicId : s.epicId === null,
+  );
+  function changeEpic(next: string) {
+    setEpicId(next);
+    const stillValid = options.sprints.some(
+      (s) => s.id === sprintId && (next ? s.epicId === next : s.epicId === null),
+    );
+    if (!stillValid) setSprintId("");
+  }
   const [checklist, setChecklist] = useState<ChecklistItem[]>(task?.checklist ?? []);
   const [newItemText, setNewItemText] = useState("");
   const [saving, setSaving] = useState(false);
@@ -143,6 +165,7 @@ export function TaskModal({
     setTitle(task.title);
     setDescription(task.description ?? "");
     setPriority(task.priority);
+    setStatus(task.status);
     setAssigneeIds(task.assignees.map((a) => a.id));
     setDueDate(task.dueAt ? dateInputValue(task.dueAt) : "");
     setDomainId(task.domain?.id ?? "");
@@ -190,6 +213,7 @@ export function TaskModal({
     const nextDescription = description.trim() ? description.trim() : null;
     if (nextDescription !== current.description) patch.description = nextDescription;
     if (priority !== current.priority) patch.priority = priority;
+    if (status !== current.status) patch.status = status;
     const nextDueIso = dueDate ? endOfDayIso(dueDate) : null;
     if (nextDueIso !== current.dueAt) patch.dueAt = nextDueIso;
     const nextDomain =
@@ -230,11 +254,12 @@ export function TaskModal({
       title.trim() !== "" ||
       description.trim() !== "" ||
       priority !== "Normal" ||
+      status !== "Todo" ||
       dueDate !== "" ||
       domainId !== "" ||
       assigneeIds.length > 0 ||
-      sprintId !== (defaultSprintId ?? "") ||
-      epicId !== "" ||
+      sprintId !== "" ||
+      epicId !== (defaultEpicId ?? "") ||
       githubEnabled
     );
   }
@@ -275,6 +300,7 @@ export function TaskModal({
       await onCreate({
         title: trimmed,
         description: description.trim() ? description.trim() : null,
+        status,
         priority,
         dueAt: dueDate ? endOfDayIso(dueDate) : null,
         domainId: domainId === "" ? null : domainId,
@@ -457,13 +483,31 @@ export function TaskModal({
           />
         </Field>
 
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-          <Field label="Priority">
+        {/* Details — one tidy property panel (label · control rows) instead of
+            a grid of boxed inputs, so the metadata reads as scannable
+            properties rather than a wall of fields. */}
+        <div className="rounded-lg border border-border divide-y divide-border">
+          <PropRow label="Status">
+            <select
+              value={status}
+              disabled={!canManage}
+              onChange={(e) => setStatus(e.target.value as TaskStatus)}
+              className={PROP_CONTROL}
+            >
+              {TASK_STATUSES.map((s) => (
+                <option key={s} value={s}>
+                  {TASK_STATUS_LABELS[s]}
+                </option>
+              ))}
+            </select>
+          </PropRow>
+
+          <PropRow label="Priority">
             <select
               value={priority}
               disabled={!canManage}
               onChange={(e) => setPriority(e.target.value as Priority)}
-              className="w-full px-2 py-1.5 text-sm border border-border rounded-md bg-background text-foreground"
+              className={PROP_CONTROL}
             >
               {PRIORITIES.map((p) => (
                 <option key={p} value={p}>
@@ -471,41 +515,14 @@ export function TaskModal({
                 </option>
               ))}
             </select>
-          </Field>
+          </PropRow>
 
-          <Field label="Deadline">
-            <input
-              type="date"
-              value={dueDate}
-              disabled={!canManage}
-              onChange={(e) => setDueDate(e.target.value)}
-              className="w-full px-2 py-1.5 text-sm border border-border rounded-md bg-background text-foreground"
-            />
-          </Field>
-
-          <Field label="Sprint">
-            <select
-              value={sprintId}
-              disabled={!canManage}
-              onChange={(e) => setSprintId(e.target.value)}
-              className="w-full px-2 py-1.5 text-sm border border-border rounded-md bg-background text-foreground"
-            >
-              <option value="">None (backlog)</option>
-              {options.sprints.map((s) => (
-                <option key={s.id} value={s.id}>
-                  {s.name}
-                  {s.status === "Closed" ? " (closed)" : ""}
-                </option>
-              ))}
-            </select>
-          </Field>
-
-          <Field label="Epic">
+          <PropRow label="Epic">
             <select
               value={epicId}
               disabled={!canManage}
-              onChange={(e) => setEpicId(e.target.value)}
-              className="w-full px-2 py-1.5 text-sm border border-border rounded-md bg-background text-foreground"
+              onChange={(e) => changeEpic(e.target.value)}
+              className={PROP_CONTROL}
             >
               <option value="">No epic</option>
               {options.epics.map((e) => (
@@ -514,14 +531,37 @@ export function TaskModal({
                 </option>
               ))}
             </select>
-          </Field>
+          </PropRow>
 
-          <Field label="Domain">
+          <PropRow label="Sprint">
+            <select
+              value={sprintId}
+              disabled={!canManage || epicSprints.length === 0}
+              onChange={(e) => setSprintId(e.target.value)}
+              className={PROP_CONTROL}
+            >
+              <option value="">
+                {epicSprints.length === 0
+                  ? epicId
+                    ? "No sprints in this epic"
+                    : "Pick an epic first"
+                  : "None"}
+              </option>
+              {epicSprints.map((s) => (
+                <option key={s.id} value={s.id}>
+                  {s.name}
+                  {s.status === "Closed" ? " (closed)" : ""}
+                </option>
+              ))}
+            </select>
+          </PropRow>
+
+          <PropRow label="Domain">
             <select
               value={domainId}
               disabled={!canManage}
               onChange={(e) => setDomainId(e.target.value)}
-              className="w-full px-2 py-1.5 text-sm border border-border rounded-md bg-background text-foreground"
+              className={PROP_CONTROL}
             >
               <option value="">—</option>
               {options.domains.map((d) => (
@@ -530,16 +570,26 @@ export function TaskModal({
                 </option>
               ))}
             </select>
-          </Field>
+          </PropRow>
 
-          <Field label="Assignees">
+          <PropRow label="Deadline">
+            <input
+              type="date"
+              value={dueDate}
+              disabled={!canManage}
+              onChange={(e) => setDueDate(e.target.value)}
+              className={PROP_CONTROL}
+            />
+          </PropRow>
+
+          <PropRow label="Assignees" align="start">
             <AssigneePicker
               all={options.members}
               selected={assigneeIds}
               disabled={!canManage}
               onChange={setAssigneeIds}
             />
-          </Field>
+          </PropRow>
         </div>
 
         {!isCreate && (
@@ -851,6 +901,34 @@ function Field({
       </span>
       {children}
     </label>
+  );
+}
+
+// One row in the Details property panel: a fixed-width label and its control.
+function PropRow({
+  label,
+  children,
+  align = "center",
+}: {
+  label: string;
+  children: React.ReactNode;
+  align?: "center" | "start";
+}) {
+  return (
+    <div
+      className={`flex gap-3 px-3 py-2 ${
+        align === "start" ? "items-start" : "items-center"
+      }`}
+    >
+      <span
+        className={`w-24 shrink-0 text-[11px] font-medium uppercase tracking-wide text-muted-foreground ${
+          align === "start" ? "pt-1.5" : ""
+        }`}
+      >
+        {label}
+      </span>
+      <div className="flex-1 min-w-0">{children}</div>
+    </div>
   );
 }
 

--- a/dali-api/app/projects/components/TaskModal.tsx
+++ b/dali-api/app/projects/components/TaskModal.tsx
@@ -442,7 +442,7 @@ export function TaskModal({
       open
       onClose={guardedClose}
       labelledBy="task-modal-title"
-      containerClassName="bg-card rounded-2xl shadow-brand-2 max-w-lg w-full p-5 sm:p-6 my-auto"
+      containerClassName="bg-card rounded-2xl shadow-brand-2 max-w-2xl w-full p-5 sm:p-6 my-auto"
     >
       <div className="flex flex-col gap-4">
         <div className="flex items-start justify-between gap-3">
@@ -812,12 +812,6 @@ export function TaskModal({
           </div>
         )}
 
-        {!isCreate && task && (
-          <div className="pt-2 border-t border-border text-[11px] text-muted-foreground">
-            Created by {task.createdBy.name} on {formatCreatedAt(task.createdAt)}
-          </div>
-        )}
-
         {saveError && <p className="text-xs text-accent-coral">{saveError}</p>}
 
         <div className="flex items-center gap-2 pt-2 border-t border-border">
@@ -882,6 +876,12 @@ export function TaskModal({
               ))}
           </div>
         </div>
+
+        {!isCreate && task && (
+          <div className="text-[11px] text-muted-foreground text-right">
+            Created by {task.createdBy.name} on {formatCreatedAt(task.createdAt)}
+          </div>
+        )}
       </div>
     </Modal>
   );

--- a/dali-api/app/projects/lib/github-task-sync.ts
+++ b/dali-api/app/projects/lib/github-task-sync.ts
@@ -7,6 +7,7 @@ import type { TaskStatus } from "./task-board";
 // Failures are logged and swallowed so a GH outage never blocks user writes.
 
 const STATUS_LABELS: Record<TaskStatus, string | null> = {
+  Backlog: "status:backlog",
   Todo: "status:todo",
   InProgress: "status:in-progress",
   InReview: "status:in-review",
@@ -15,6 +16,7 @@ const STATUS_LABELS: Record<TaskStatus, string | null> = {
 };
 
 const ALL_STATUS_LABELS = [
+  "status:backlog",
   "status:todo",
   "status:in-progress",
   "status:in-review",

--- a/dali-api/app/projects/lib/task-board.ts
+++ b/dali-api/app/projects/lib/task-board.ts
@@ -3,6 +3,7 @@
 // the board the helper builds, and persistence goes through an /api route.
 
 export const TASK_STATUSES = [
+  "Backlog",
   "Todo",
   "InProgress",
   "InReview",
@@ -13,6 +14,7 @@ export const TASK_STATUSES = [
 export type TaskStatus = (typeof TASK_STATUSES)[number];
 
 export const TASK_STATUS_LABELS: Record<TaskStatus, string> = {
+  Backlog: "Backlog",
   Todo: "To do",
   InProgress: "In progress",
   InReview: "In review",
@@ -59,6 +61,9 @@ export type BoardSprint = {
   id: string;
   name: string;
   status: "Planned" | "Active" | "Closed";
+  // The epic this sprint belongs to (null = standalone). Powers the modal's
+  // cascading Epic → Sprint picker: pick an epic, then only its sprints show.
+  epicId: string | null;
 };
 
 export type BoardEpic = { id: string; title: string };

--- a/dali-api/app/projects/routes/api.pages.$id.pin.ts
+++ b/dali-api/app/projects/routes/api.pages.$id.pin.ts
@@ -1,0 +1,66 @@
+import type { Route } from "./+types/api.pages.$id.pin";
+import { prisma } from "~/lib/db";
+import { requireProjectEditAccess } from "~/lib/auth";
+import { withCors, handlePreflight } from "~/lib/cors";
+import { logAuditEvent } from "~/lib/audit";
+
+// POST /api/pages/:id/pin — pin/unpin a project page to the top of the
+// Documents block. Body: { pinned: boolean }. Team-editable (same gate as the
+// other document APIs).
+
+type Body = { pinned: boolean };
+
+function isBody(x: unknown): x is Body {
+  return (
+    !!x &&
+    typeof x === "object" &&
+    typeof (x as Record<string, unknown>).pinned === "boolean"
+  );
+}
+
+export async function action({ request, params }: Route.ActionArgs) {
+  const preflight = handlePreflight(request);
+  if (preflight) return preflight;
+
+  if (request.method !== "POST") {
+    return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));
+  }
+  const pageId = params.id!;
+  const page = await prisma.page.findUnique({
+    where: { id: pageId },
+    select: { id: true, workspaceType: true, workspaceId: true, archivedAt: true },
+  });
+  if (
+    !page ||
+    page.workspaceType !== "Project" ||
+    !page.workspaceId ||
+    page.archivedAt !== null
+  ) {
+    return withCors(request, Response.json({ error: "Document not found" }, { status: 404 }));
+  }
+  const gate = await requireProjectEditAccess(request, page.workspaceId);
+  if (!gate.ok) return gate.response;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return withCors(request, Response.json({ error: "Invalid JSON" }, { status: 400 }));
+  }
+  if (!isBody(body)) {
+    return withCors(request, Response.json({ error: "Invalid body" }, { status: 400 }));
+  }
+
+  await prisma.page.update({
+    where: { id: pageId },
+    data: { pinnedAt: body.pinned ? new Date() : null },
+  });
+  await logAuditEvent({
+    action: "page.pin",
+    userId: gate.auth.user.sub,
+    targetId: pageId,
+    metadata: { projectId: page.workspaceId, pinned: body.pinned },
+    request,
+  });
+  return withCors(request, Response.json({ ok: true }));
+}

--- a/dali-api/app/projects/routes/projects.$id.tsx
+++ b/dali-api/app/projects/routes/projects.$id.tsx
@@ -334,17 +334,19 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     partnerVisible: d.partnerVisible,
     pinned: d.pinnedAt !== null,
   });
+  // Top-level docs for the main list. Pinned ones are lifted into
+  // `pinnedDocuments` (rendered above), so they don't appear twice.
   const documents = pageRows
-    .filter((p) => p.parentPageId === null)
+    .filter((p) => p.parentPageId === null && p.pinnedAt === null)
     .map((p) => ({
       ...toDocumentDto(p),
       children: (childrenByParent.get(p.id) ?? []).map(toDocumentDto),
     }));
 
   // Pinned docs — any page a teammate pinned, most-recent pin first, rendered
-  // at the top of the Documents block.
+  // at the top of the Documents block (and lifted out of the list above).
   const pinnedDocuments = pageRows
-    .filter((p) => p.pinnedAt !== null)
+    .filter((p) => p.pinnedAt !== null && p.parentPageId === null)
     .sort((a, b) => (b.pinnedAt?.getTime() ?? 0) - (a.pinnedAt?.getTime() ?? 0))
     .map((p) => ({ id: p.id, label: p.title }));
 

--- a/dali-api/app/projects/routes/projects.$id.tsx
+++ b/dali-api/app/projects/routes/projects.$id.tsx
@@ -3391,29 +3391,6 @@ function PlanningTab({
 
   return (
     <div className="flex flex-col gap-3">
-      <div className="flex justify-end">
-        <div
-          className="inline-flex items-center border border-border rounded-md overflow-hidden"
-          role="group"
-          aria-label="Planning view"
-        >
-          <PlanningToggleButton
-            active={!timeline}
-            onClick={() => setTimeline(false)}
-            label="List view"
-          >
-            <List className="w-3.5 h-3.5" />
-          </PlanningToggleButton>
-          <PlanningToggleButton
-            active={timeline}
-            onClick={() => setTimeline(true)}
-            label="Timeline view"
-          >
-            <ChartNoAxesGantt className="w-3.5 h-3.5" />
-          </PlanningToggleButton>
-        </div>
-      </div>
-
       <EpicSprintManager
         projectId={projectId}
         epics={editableEpics}
@@ -3424,6 +3401,28 @@ function PlanningTab({
         userName={userName}
         view={timeline ? "timeline" : "list"}
         timelineEpics={epics}
+        viewToggle={
+          <div
+            className="inline-flex items-center border border-border rounded-md overflow-hidden"
+            role="group"
+            aria-label="Planning view"
+          >
+            <PlanningToggleButton
+              active={!timeline}
+              onClick={() => setTimeline(false)}
+              label="List view"
+            >
+              <List className="w-3.5 h-3.5" />
+            </PlanningToggleButton>
+            <PlanningToggleButton
+              active={timeline}
+              onClick={() => setTimeline(true)}
+              label="Timeline view"
+            >
+              <ChartNoAxesGantt className="w-3.5 h-3.5" />
+            </PlanningToggleButton>
+          </div>
+        }
       />
     </div>
   );

--- a/dali-api/app/projects/routes/projects.$id.tsx
+++ b/dali-api/app/projects/routes/projects.$id.tsx
@@ -316,6 +316,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
       parentPageId: true,
       systemKey: true,
       partnerVisible: true,
+      pinnedAt: true,
     },
   });
   const childrenByParent = new Map<string, typeof pageRows>();
@@ -331,6 +332,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     kind: d.kind,
     isSystem: d.systemKey !== null,
     partnerVisible: d.partnerVisible,
+    pinned: d.pinnedAt !== null,
   });
   const documents = pageRows
     .filter((p) => p.parentPageId === null)
@@ -339,16 +341,12 @@ export async function loader({ request, params }: Route.LoaderArgs) {
       children: (childrenByParent.get(p.id) ?? []).map(toDocumentDto),
     }));
 
-  // Pinned Overview/PRD docs — rendered at the top of the Documents block.
-  // Only shown while the referenced page still exists non-archived in this
-  // project's workspace (pageRows is exactly that set).
-  const workspacePageIds = new Set(pageRows.map((p) => p.id));
-  const pinnedDocuments = [
-    { id: project.overviewPageId, label: "Overview" },
-    { id: project.prdPageId, label: "PRD" },
-  ].flatMap((d) =>
-    d.id && workspacePageIds.has(d.id) ? [{ id: d.id, label: d.label }] : [],
-  );
+  // Pinned docs — any page a teammate pinned, most-recent pin first, rendered
+  // at the top of the Documents block.
+  const pinnedDocuments = pageRows
+    .filter((p) => p.pinnedAt !== null)
+    .sort((a, b) => (b.pinnedAt?.getTime() ?? 0) - (a.pinnedAt?.getTime() ?? 0))
+    .map((p) => ({ id: p.id, label: p.title }));
 
   // Project files — standalone uploads with their current version.
   // Tags are edited in the file/document editor, not on this list.
@@ -2801,6 +2799,30 @@ function DocumentsBlock({
     }
   }
 
+  // Pin/unpin a doc to the top of the Documents block. Same persist-then-
+  // revalidate shape as sharing.
+  async function togglePin(id: string, next: boolean) {
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/pages/${id}/pin`, {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ pinned: next }),
+      });
+      if (!res.ok) {
+        const b = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(b.error ?? "Failed to update pin");
+      }
+      revalidator.revalidate();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Something went wrong");
+    } finally {
+      setBusy(false);
+    }
+  }
+
   // Add document: create an "Untitled" page immediately, then open it as a
   // split-screen tab beside the project. The title is renamed inline in the
   // editor (auto-saves), so there's no separate title prompt first. When
@@ -2914,6 +2936,24 @@ function DocumentsBlock({
             </Tooltip>
           )}
           {canEdit && (
+            <Tooltip label={doc.pinned ? "Pinned — click to unpin" : "Pin to top"}>
+              <button
+                type="button"
+                disabled={busy}
+                onClick={() => void togglePin(doc.id, !doc.pinned)}
+                aria-label={doc.pinned ? "Unpin document" : "Pin document"}
+                aria-pressed={doc.pinned}
+                className={`flex items-center disabled:opacity-60 ${
+                  doc.pinned
+                    ? "text-accent-coral"
+                    : "text-muted-foreground hover:text-foreground"
+                }`}
+              >
+                <Pin className={`w-3.5 h-3.5 ${doc.pinned ? "fill-current" : ""}`} />
+              </button>
+            </Tooltip>
+          )}
+          {canEdit && (
             <Tooltip label="Delete document">
               <button
                 type="button"
@@ -2975,21 +3015,30 @@ function DocumentsBlock({
         <p className="text-sm text-muted-foreground italic">No documents yet.</p>
       ) : (
         <div className="flex flex-col divide-y divide-border">
-          {/* Pinned Overview/PRD pages on top — same open-as-tab flow as the
-              rows below, marked like the DEFAULT-folder chip. */}
+          {/* Pinned docs on top — same open-as-tab flow as the rows below. */}
           {pinnedDocuments.map((d) => (
             <div key={d.id} className="py-2.5 flex items-center gap-1.5 text-sm">
-              <Pin className="w-3.5 h-3.5 flex-shrink-0 text-muted-foreground" />
+              <Pin className="w-3.5 h-3.5 flex-shrink-0 text-accent-coral fill-current" />
               <button
                 type="button"
                 onClick={() => openDocumentTab(d.id, d.label)}
-                className="truncate text-left font-medium text-foreground hover:text-accent-coral"
+                className="flex-1 min-w-0 truncate text-left font-medium text-foreground hover:text-accent-coral"
               >
                 {d.label}
               </button>
-              <span className="text-[10px] uppercase tracking-wide text-muted-foreground/70 flex-shrink-0">
-                Pinned
-              </span>
+              {canEdit && (
+                <Tooltip label="Unpin">
+                  <button
+                    type="button"
+                    disabled={busy}
+                    onClick={() => void togglePin(d.id, false)}
+                    aria-label="Unpin document"
+                    className="text-muted-foreground hover:text-foreground disabled:opacity-60 flex-shrink-0"
+                  >
+                    <X className="w-3.5 h-3.5" />
+                  </button>
+                </Tooltip>
+              )}
             </div>
           ))}
           {documents.map((doc) =>

--- a/dali-api/app/projects/routes/projects.$id.tsx
+++ b/dali-api/app/projects/routes/projects.$id.tsx
@@ -869,7 +869,19 @@ export function shouldRevalidate({
   formMethod,
   defaultShouldRevalidate,
 }: ShouldRevalidateFunctionArgs) {
-  if (!formMethod && currentUrl.pathname === nextUrl.pathname) {
+  // Skip revalidation only for a pure search-param *navigation* — opening/
+  // closing the task modal (?task=), switching the board filter (?epic=/
+  // ?sprint=) or the planning view (?view=). Those don't change loader data,
+  // and re-running the loader would bounce the board's scroll to the top.
+  //
+  // Crucially, this must NOT swallow an explicit revalidator.revalidate()
+  // (same URL, search unchanged), which the page relies on to refresh after a
+  // mutation — pinning a doc, partner-sharing, file uploads, epic/task edits.
+  if (
+    !formMethod &&
+    currentUrl.pathname === nextUrl.pathname &&
+    currentUrl.search !== nextUrl.search
+  ) {
     return false;
   }
   return defaultShouldRevalidate;
@@ -2952,7 +2964,9 @@ function DocumentsBlock({
               </button>
             </Tooltip>
           )}
-          {canEdit && (
+          {/* Pin is top-level only — nested docs (e.g. under Partner/Team
+              meeting-notes folders) can't be pinned to the top. */}
+          {canEdit && !indent && (
             <Tooltip label={doc.pinned ? "Pinned — click to unpin" : "Pin to top"}>
               <button
                 type="button"

--- a/dali-api/app/projects/routes/projects.$id.tsx
+++ b/dali-api/app/projects/routes/projects.$id.tsx
@@ -40,7 +40,6 @@ import { getPresenceUser } from "~/lib/presence-user";
 import { TaskBoard } from "../components/TaskBoard";
 import { ProjectMentorshipTab } from "~/mentorship/components/ProjectMentorshipTab";
 import {
-  EpicsTimeline,
   type TimelineEpic,
   type EpicStatus,
 } from "../components/EpicsTimeline";
@@ -3377,12 +3376,13 @@ function PlanningTab({
   userName: string;
 }) {
   const [searchParams, setSearchParams] = useSearchParams();
-  const timeline = searchParams.get("view") === "timeline";
+  // Timeline is the default view; the list view is opt-in via ?view=list.
+  const timeline = searchParams.get("view") !== "list";
   const setTimeline = (next: boolean) => {
     setSearchParams(
       (prev) => {
-        if (next) prev.set("view", "timeline");
-        else prev.delete("view");
+        if (next) prev.delete("view");
+        else prev.set("view", "list");
         return prev;
       },
       { replace: true, preventScrollReset: true },
@@ -3414,19 +3414,17 @@ function PlanningTab({
         </div>
       </div>
 
-      {timeline ? (
-        <EpicsTimeline epics={epics} taskCounts={taskCountsByEpic} />
-      ) : (
-        <EpicSprintManager
-          projectId={projectId}
-          epics={editableEpics}
-          sprints={sprints}
-          taskCounts={taskCountsByEpic}
-          canManage={canEdit}
-          collabToken={collabToken}
-          userName={userName}
-        />
-      )}
+      <EpicSprintManager
+        projectId={projectId}
+        epics={editableEpics}
+        sprints={sprints}
+        taskCounts={taskCountsByEpic}
+        canManage={canEdit}
+        collabToken={collabToken}
+        userName={userName}
+        view={timeline ? "timeline" : "list"}
+        timelineEpics={epics}
+      />
     </div>
   );
 }

--- a/dali-api/app/projects/routes/projects.$id.tsx
+++ b/dali-api/app/projects/routes/projects.$id.tsx
@@ -348,7 +348,10 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   const pinnedDocuments = pageRows
     .filter((p) => p.pinnedAt !== null && p.parentPageId === null)
     .sort((a, b) => (b.pinnedAt?.getTime() ?? 0) - (a.pinnedAt?.getTime() ?? 0))
-    .map((p) => ({ id: p.id, label: p.title }));
+    .map((p) => ({
+      ...toDocumentDto(p),
+      children: (childrenByParent.get(p.id) ?? []).map(toDocumentDto),
+    }));
 
   // Project files — standalone uploads with their current version.
   // Tags are edited in the file/document editor, not on this list.
@@ -3048,31 +3051,10 @@ function DocumentsBlock({
         <p className="text-sm text-muted-foreground italic">No documents yet.</p>
       ) : (
         <div className="flex flex-col divide-y divide-border">
-          {/* Pinned docs on top — same open-as-tab flow as the rows below. */}
+          {/* Pinned docs on top — full document rows (share/pin/delete), just
+              lifted above the rest. The filled coral pin marks them pinned. */}
           {pinnedDocuments.map((d) => (
-            <div key={d.id} className="py-2.5 flex items-center gap-1.5 text-sm">
-              <Pin className="w-3.5 h-3.5 flex-shrink-0 text-accent-coral fill-current" />
-              <button
-                type="button"
-                onClick={() => openDocumentTab(d.id, d.label)}
-                className="flex-1 min-w-0 truncate text-left font-medium text-foreground hover:text-accent-coral"
-              >
-                {d.label}
-              </button>
-              {canEdit && (
-                <Tooltip label="Unpin">
-                  <button
-                    type="button"
-                    disabled={busy}
-                    onClick={() => void togglePin(d.id, false)}
-                    aria-label="Unpin document"
-                    className="text-muted-foreground hover:text-foreground disabled:opacity-60 flex-shrink-0"
-                  >
-                    <X className="w-3.5 h-3.5" />
-                  </button>
-                </Tooltip>
-              )}
-            </div>
+            <DocRow key={d.id} doc={d} indent={false} />
           ))}
           {documents.map((doc) =>
             doc.kind === "Folder" ? (

--- a/dali-api/app/projects/routes/projects.$id.tsx
+++ b/dali-api/app/projects/routes/projects.$id.tsx
@@ -9,6 +9,7 @@ import {
   useRevalidator,
   useSearchParams,
   useSubmit,
+  type ShouldRevalidateFunctionArgs,
 } from "react-router";
 import { CalendarDays, CalendarX, ChartNoAxesGantt, Check, Handshake, History, List, Pencil, Pin, X, Settings, Folder, FolderPlus, ChevronRight, ChevronDown, FileText, Info, Users, Paperclip, Plus, Trash2, Upload, Unlink } from "lucide-react";
 import { Modal, ModalHeader } from "~/components/Modal";
@@ -505,7 +506,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
           sprintFilterOrder[a.status] - sprintFilterOrder[b.status] ||
           a.startsAt.localeCompare(b.startsAt),
       )
-      .map((s) => ({ id: s.id, name: s.name, status: s.status })),
+      .map((s) => ({ id: s.id, name: s.name, status: s.status, epicId: s.epicId })),
     epics: project.epics.map((e) => ({ id: e.id, title: e.title })),
   };
 
@@ -856,6 +857,23 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     presencePhotoUrl: presenceUser?.photoUrl ?? null,
     presenceSubtitle: presenceUser?.subtitle ?? null,
   };
+}
+
+// The loader doesn't depend on search params, so a pure search-param change
+// (opening/closing the task modal via ?task=, switching the ?epic= filter or
+// ?tab=) shouldn't re-run it. Skipping that revalidation avoids a needless
+// DB round-trip and the re-render that otherwise bounces the board's scroll
+// position to the top when you open a task.
+export function shouldRevalidate({
+  currentUrl,
+  nextUrl,
+  formMethod,
+  defaultShouldRevalidate,
+}: ShouldRevalidateFunctionArgs) {
+  if (!formMethod && currentUrl.pathname === nextUrl.pathname) {
+    return false;
+  }
+  return defaultShouldRevalidate;
 }
 
 export async function action({ request, params }: Route.ActionArgs) {

--- a/dali-api/app/routes.ts
+++ b/dali-api/app/routes.ts
@@ -358,6 +358,7 @@ export default [
   route("api/projects/:id/documents", "projects/routes/api.projects.$id.documents.ts"),
   route("api/documents/:id", "projects/routes/api.documents.$id.ts"),
   route("api/pages/:id/partner-visible", "projects/routes/api.pages.$id.partner-visible.ts"),
+  route("api/pages/:id/pin", "projects/routes/api.pages.$id.pin.ts"),
 
   // Project files (standalone uploads with versions)
   route("api/projects/:id/files", "projects/routes/api.projects.$id.files.ts"),

--- a/dali-api/app/routes.ts
+++ b/dali-api/app/routes.ts
@@ -7,6 +7,8 @@ export default [
     route("profile", "routes/profile.tsx"),
     route("onboarding", "routes/onboarding.tsx"),
     route("calendar", "calendar/routes/calendar.tsx"),
+    // Standalone self-check-in surface for meetings without a meeting note.
+    route("calendar/check-in/:id", "calendar/routes/calendar.check-in.$id.tsx"),
     // My Tasks surface: Open tasks + browsable notification history.
     route("notifications", "routes/notifications.tsx"),
 

--- a/dali-api/prisma/migrations/20260720170000_add_task_status_backlog/migration.sql
+++ b/dali-api/prisma/migrations/20260720170000_add_task_status_backlog/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "TaskStatus" ADD VALUE IF NOT EXISTS 'Backlog' BEFORE 'Todo';

--- a/dali-api/prisma/migrations/20260720180000_add_page_pinned_at/migration.sql
+++ b/dali-api/prisma/migrations/20260720180000_add_page_pinned_at/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Page" ADD COLUMN     "pinnedAt" TIMESTAMP(3);

--- a/dali-api/prisma/schema.prisma
+++ b/dali-api/prisma/schema.prisma
@@ -3397,6 +3397,11 @@ model Page {
   // future public flag — the audiences are orthogonal.
   partnerVisible Boolean @default(false)
 
+  // Pinned to the top of the project's Documents block. Timestamp so pins can
+  // be ordered most-recent-first. Null = not pinned. (Distinct from the
+  // system Overview/PRD docs, which are always shown pinned.)
+  pinnedAt DateTime?
+
   // Set when this page was auto-created as a meeting's attendance-tracking
   // note (see ScheduledMeeting.notePage / meetingType). Lets the document
   // route know to render the AttendanceChecklist above the editor.

--- a/dali-api/prisma/schema.prisma
+++ b/dali-api/prisma/schema.prisma
@@ -2520,6 +2520,7 @@ model Task {
 }
 
 enum TaskStatus {
+  Backlog
   Todo
   InProgress
   InReview


### PR DESCRIPTION
A batch of project-hub, planning, mentorship, and calendar work off current `staging`. Migrations: `add_task_status_backlog`, `add_page_pinned_at` (both additive).

### Create-meeting UI/UX (restored)
- Restores the create-meeting form rework + self-check-in handling and the `/calendar/check-in/:id` page (shelved local WIP, re-applied onto staging; was never merged).

### Board
- **Add task / Archived** buttons pushed to the far right; filter pills on the left.
- **Epic-first filter** with an **optional sprint sub-filter** (sprints in the selected epic; changing epic resets it).
- **Backlog** added to the `TaskStatus` enum → Backlog column + selectable status.
- Task modal: **Status dropdown** (incl. Backlog), **cascading Epic → Sprint**, redesigned into a scannable Details panel, **wider** (max-w-2xl), and "Created by …" moved below Save.
- Opening a task no longer scrolls the board to the top (re-added `shouldRevalidate`, now scoped so it doesn't swallow post-mutation refreshes).

### Planning
- **Timeline is the default** view (list view stays); `EpicSprintManager` owns both so the New-epic + detail/edit modals are shared.
- Timeline: **clickable epic/sprint bars** open the epic detail modal; **"Add epic"** sits on the toolbar line left of the view toggle; New-epic button reads **"Next"**.
- Epic/sprint/story **Open/Edit/Delete are tooltip icon buttons**; sprint-edit keeps its buttons on the input row.

### Project-hub documents
- **Pin any document** (Page.pinnedAt + `/api/pages/:id/pin`): pinned docs lift to the top as full document rows (share/pin/delete), shown once, top-level only.

### Mentorship notes
- Replace the **Week filter with a Status (vibe) filter** — a mentee's whole row surfaces if any weekly note matches the vibe.
- Show **mentor + mentee avatars** in the grid.

> Note: supersedes #951 (board-edits) — its board work is included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/954"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787181787&installation_model_id=21824&pr_number=954&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F954&signature=599c65917053184ab7d6886ccf22234598dd8bc8411884b995685eda6a5e28cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->