### PR TITLE
Add lab-wide Documents tab with folders, tag filter, search, pins, an…

### DIFF
--- a/dali-api/app/components/Layout.tsx
+++ b/dali-api/app/components/Layout.tsx
@@ -16,6 +16,7 @@ import {
   Home,
   Workflow,
   ClipboardList,
+  FileText,
   GraduationCap,
   ListTodo,
   HelpCircle,
@@ -243,6 +244,7 @@ export function Layout({ user, photoUrl, isCore = false, isAdmin = false, isDoma
     { key: 'forms', label: 'Forms', to: '/forms', icon: ClipboardList, show: canViewForms },
     { key: 'hiring', label: 'Hiring', to: '/hiring', icon: Briefcase, show: hasHiringAccess },
     { key: 'projects', label: 'Projects', to: '/projects', icon: FolderKanban, show: true },
+    { key: 'documents', label: 'Documents', to: '/documents', icon: FileText, show: true },
     // Hidden from mentees entirely; the routes are gated server-side by
     // canViewMentorship. Mentors only see own-domain notes; Core/Admin see all.
     { key: 'mentorship', label: 'Mentorship', to: '/mentorship', icon: Heart, show: isLabMentor || isCore },

--- a/dali-api/app/lib/__tests__/collabAuth.test.ts
+++ b/dali-api/app/lib/__tests__/collabAuth.test.ts
@@ -17,6 +17,7 @@ vi.mock("~/lib/roles", () => ({
   isDomainLead: vi.fn().mockResolvedValue(false),
   isCore: vi.fn().mockResolvedValue(false),
   isProjectMember: vi.fn().mockResolvedValue(false),
+  isLabMember: vi.fn().mockResolvedValue(false),
 }));
 
 vi.mock("~/partners/lib/partner-access", () => ({
@@ -28,7 +29,7 @@ vi.mock("~/hiring/lib/confidentiality", () => ({
 }));
 
 import { prisma } from "~/lib/db";
-import { isDomainLead, isCore, isProjectMember } from "~/lib/roles";
+import { isDomainLead, isCore, isProjectMember, isLabMember } from "~/lib/roles";
 import { partnerHasProjectAccess } from "~/partners/lib/partner-access";
 import { getCycleConfidentialityState } from "~/hiring/lib/confidentiality";
 import { authorizeCollabDoc } from "../collabAuth";
@@ -40,6 +41,7 @@ beforeEach(() => {
   (isDomainLead as any).mockResolvedValue(false);
   (isCore as any).mockResolvedValue(false);
   (isProjectMember as any).mockResolvedValue(false);
+  (isLabMember as any).mockResolvedValue(false);
   (partnerHasProjectAccess as any).mockResolvedValue(false);
   (getCycleConfidentialityState as any).mockResolvedValue({ status: "signed", activeVersionId: "v1" });
   (prisma as any).interview.findUnique.mockResolvedValue({ applicationCycleId: "cycle1" });
@@ -195,7 +197,16 @@ describe("authorizeCollabDoc", () => {
       expect(await authorizeCollabDoc("user1", "doc:p1:body")).toBe(true);
     });
 
-    it("rejects non-Core on Lab pages", async () => {
+    it("allows a lab member on Lab pages", async () => {
+      (isLabMember as any).mockResolvedValue(true);
+      mockPrisma.page.findUnique.mockResolvedValue(
+        projectPage({ workspaceType: "Lab", workspaceId: null }),
+      );
+      expect(await authorizeCollabDoc("user1", "doc:p1:body")).toBe(true);
+      expect(isLabMember).toHaveBeenCalledWith("user1");
+    });
+
+    it("rejects a non-member on Lab pages", async () => {
       mockPrisma.page.findUnique.mockResolvedValue(
         projectPage({ workspaceType: "Lab", workspaceId: null }),
       );

--- a/dali-api/app/lib/collabAuth.ts
+++ b/dali-api/app/lib/collabAuth.ts
@@ -1,5 +1,5 @@
 import { prisma } from "~/lib/db";
-import { isCore, isDomainLead, isProjectMember } from "~/lib/roles";
+import { isCore, isDomainLead, isProjectMember, isLabMember } from "~/lib/roles";
 import { getCycleConfidentialityState } from "~/hiring/lib/confidentiality";
 import { partnerHasProjectAccess } from "~/partners/lib/partner-access";
 
@@ -129,6 +129,13 @@ export async function authorizeCollabDoc(
       return false;
     }
     if (await isCore(userSub)) return true;
+    // Lab-workspace pages (the lab-wide Documents area) open to any lab member
+    // — the lab's members are the Lab workspace's members, mirroring the
+    // project-member gate below. There's no read-only collab connection, so
+    // "can open" == "can edit the body" here (same as project pages).
+    if (page.workspaceType === "Lab") {
+      return isLabMember(userSub);
+    }
     if (page.workspaceType === "Project" && page.workspaceId) {
       if (await isProjectMember(userSub, page.workspaceId)) return true;
       if (page.partnerVisible) {

--- a/dali-api/app/lib/pages.ts
+++ b/dali-api/app/lib/pages.ts
@@ -68,6 +68,39 @@ export async function createLabMeetingPage(input: {
   });
 }
 
+// Creates a Page in the Lab workspace (workspaceType=Lab, workspaceId=null —
+// see Page.workspaceType comment in schema.prisma). Same shape as
+// createProjectPage but for the lab-wide Documents area: supports Folder-kind
+// containers and one level of nesting under a top-level folder. Appends after
+// the current max position among siblings under the same parent.
+export async function createLabPage(input: {
+  title: string;
+  createdById: string;
+  parentPageId?: string | null;
+  kind?: PageKind;
+}): Promise<{ id: string }> {
+  const parentPageId = input.parentPageId ?? null;
+  const last = await prisma.page.findFirst({
+    where: { workspaceType: "Lab", workspaceId: null, parentPageId },
+    orderBy: { position: "desc" },
+    select: { position: true },
+  });
+  const position = last ? last.position + 1 : 0;
+
+  return prisma.page.create({
+    data: {
+      workspaceType: "Lab",
+      workspaceId: null,
+      title: input.title,
+      kind: input.kind ?? "FreeForm",
+      position,
+      parentPageId,
+      createdById: input.createdById,
+    },
+    select: { id: true },
+  });
+}
+
 export type MeetingNotesFolderKind = "Team" | "Partner";
 
 const MEETING_NOTES_FOLDER_TITLE: Record<MeetingNotesFolderKind, string> = {

--- a/dali-api/app/projects/routes/api.documents.$id.ts
+++ b/dali-api/app/projects/routes/api.documents.$id.ts
@@ -1,16 +1,19 @@
 import type { Route } from "./+types/api.documents.$id";
+import type { AuthSuccess } from "~/lib/auth";
 import { prisma } from "~/lib/db";
-import { requireProjectEditAccess } from "~/lib/auth";
+import { requireProjectEditAccess, requireMemberSession } from "~/lib/auth";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { logAuditEvent } from "~/lib/audit";
 
 // POST   /api/documents/:id — rename. Body: { title }
 // DELETE /api/documents/:id — soft delete (sets archivedAt, matching the
 //                             Page model's documented soft-delete pattern;
-//                             archived pages drop out of the project list).
+//                             archived pages drop out of the workspace list).
 //
-// Documents are project-scoped FreeForm Pages. Same permission model as
-// project edit (isCore === Admin || Core).
+// Documents are FreeForm Pages. Project-scoped pages use the project-edit gate
+// (isCore === Admin || Core, or a project assignee); Lab-scoped pages (the
+// lab-wide Documents area) use the lab-member gate — the lab's members are the
+// Lab workspace's members, mirroring project membership.
 
 type Body = { title: string };
 
@@ -30,12 +33,23 @@ export async function action({ request, params }: Route.ActionArgs) {
     where: { id: pageId },
     select: { id: true, workspaceType: true, workspaceId: true, systemKey: true, kind: true },
   });
-  if (!page || page.workspaceType !== "Project" || !page.workspaceId) {
+  if (
+    !page ||
+    (page.workspaceType !== "Project" && page.workspaceType !== "Lab") ||
+    (page.workspaceType === "Project" && !page.workspaceId)
+  ) {
     return withCors(request, Response.json({ error: "Document not found" }, { status: 404 }));
   }
-  const gate = await requireProjectEditAccess(request, page.workspaceId);
-  if (!gate.ok) return gate.response;
-  const auth = gate.auth;
+  let auth: AuthSuccess;
+  if (page.workspaceType === "Lab") {
+    const gate = await requireMemberSession(request);
+    if (!gate.ok) return withCors(request, gate.response);
+    auth = gate.auth;
+  } else {
+    const gate = await requireProjectEditAccess(request, page.workspaceId!);
+    if (!gate.ok) return gate.response;
+    auth = gate.auth;
+  }
 
   if (request.method === "DELETE") {
     if (page.systemKey) {

--- a/dali-api/app/projects/routes/api.pages.$id.move.ts
+++ b/dali-api/app/projects/routes/api.pages.$id.move.ts
@@ -1,0 +1,113 @@
+import type { Route } from "./+types/api.pages.$id.move";
+import type { AuthSuccess } from "~/lib/auth";
+import { z } from "zod";
+import { prisma } from "~/lib/db";
+import { requireMemberSession, requireProjectEditAccess } from "~/lib/auth";
+import { withCors, handlePreflight } from "~/lib/cors";
+import { parseJson } from "~/lib/validate";
+
+// POST /api/pages/:id/move — move and/or reorder a document within its
+// Documents view. Body: { parentPageId: string | null, beforeId?: string | null }.
+//   - parentPageId: the folder to nest under, or null for the top level.
+//   - beforeId: the sibling to drop directly before; omitted/null appends last.
+// Works for both Lab pages (the lab-wide Documents hub — any lab member) and
+// Project pages (the project hub — project editors). Folders stay top-level
+// (they may be reordered but never nested). Enforces the 2-level cap: a
+// document only nests directly under a top-level Folder in the same workspace.
+
+const BodySchema = z.object({
+  parentPageId: z.string().min(1).nullable(),
+  beforeId: z.string().min(1).nullable().optional(),
+});
+
+export async function action({ request, params }: Route.ActionArgs) {
+  const preflight = handlePreflight(request);
+  if (preflight) return preflight;
+
+  if (request.method !== "POST") {
+    return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));
+  }
+
+  const pageId = params.id!;
+  const page = await prisma.page.findUnique({
+    where: { id: pageId },
+    select: { id: true, workspaceType: true, workspaceId: true, kind: true, archivedAt: true },
+  });
+  if (
+    !page ||
+    (page.workspaceType !== "Lab" && page.workspaceType !== "Project") ||
+    (page.workspaceType === "Lab" ? page.workspaceId !== null : !page.workspaceId) ||
+    page.archivedAt !== null
+  ) {
+    return withCors(request, Response.json({ error: "Document not found" }, { status: 404 }));
+  }
+
+  let auth: AuthSuccess;
+  if (page.workspaceType === "Lab") {
+    const gate = await requireMemberSession(request);
+    if (!gate.ok) return withCors(request, gate.response);
+    auth = gate.auth;
+  } else {
+    const gate = await requireProjectEditAccess(request, page.workspaceId!);
+    if (!gate.ok) return gate.response;
+    auth = gate.auth;
+  }
+  void auth;
+
+  const body = await parseJson(request, BodySchema);
+  if (body instanceof Response) return withCors(request, body);
+
+  if (body.parentPageId === pageId) {
+    return withCors(request, Response.json({ error: "A document can't be moved into itself" }, { status: 400 }));
+  }
+  if (page.kind === "Folder" && body.parentPageId !== null) {
+    return withCors(request, Response.json({ error: "Folders can't be nested inside another folder" }, { status: 400 }));
+  }
+
+  let parentPageId: string | null = null;
+  if (body.parentPageId) {
+    const parent = await prisma.page.findUnique({
+      where: { id: body.parentPageId },
+      select: { workspaceType: true, workspaceId: true, parentPageId: true, kind: true, archivedAt: true },
+    });
+    if (
+      !parent ||
+      parent.archivedAt !== null ||
+      parent.workspaceType !== page.workspaceType ||
+      parent.workspaceId !== page.workspaceId
+    ) {
+      return withCors(request, Response.json({ error: "Folder not found" }, { status: 404 }));
+    }
+    if (parent.kind !== "Folder" || parent.parentPageId !== null) {
+      return withCors(request, Response.json({ error: "Documents can only nest inside a top-level folder" }, { status: 400 }));
+    }
+    parentPageId = body.parentPageId;
+  }
+
+  // Rebuild the destination sibling order with the moved page inserted before
+  // `beforeId` (or appended), then rewrite positions 0..n so the order is
+  // stable. Done in a transaction so a concurrent move can't interleave.
+  const siblings = await prisma.page.findMany({
+    where: {
+      workspaceType: page.workspaceType,
+      workspaceId: page.workspaceId,
+      parentPageId,
+      archivedAt: null,
+    },
+    orderBy: { position: "asc" },
+    select: { id: true },
+  });
+  const order = siblings.map((s) => s.id).filter((id) => id !== pageId);
+  const beforeIndex = body.beforeId ? order.indexOf(body.beforeId) : -1;
+  if (beforeIndex >= 0) order.splice(beforeIndex, 0, pageId);
+  else order.push(pageId);
+
+  await prisma.$transaction([
+    prisma.page.update({ where: { id: pageId }, data: { parentPageId } }),
+    ...order.map((id, index) =>
+      prisma.page.update({ where: { id }, data: { position: index } }),
+    ),
+  ]);
+
+  return withCors(request, Response.json({ ok: true }));
+}

--- a/dali-api/app/projects/routes/api.pages.$id.pin.ts
+++ b/dali-api/app/projects/routes/api.pages.$id.pin.ts
@@ -1,12 +1,15 @@
 import type { Route } from "./+types/api.pages.$id.pin";
+import type { AuthSuccess } from "~/lib/auth";
 import { prisma } from "~/lib/db";
-import { requireProjectEditAccess } from "~/lib/auth";
+import { requireProjectEditAccess, requireMemberSession } from "~/lib/auth";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { logAuditEvent } from "~/lib/audit";
 
-// POST /api/pages/:id/pin — pin/unpin a project page to the top of the
-// Documents block. Body: { pinned: boolean }. Team-editable (same gate as the
-// other document APIs).
+// POST /api/pages/:id/pin — pin/unpin a page (document or folder) to the top
+// of its Documents view. Body: { pinned: boolean }. Project pages use the
+// project-edit gate; Lab pages (the lab-wide Documents area) use the
+// lab-member gate. pinnedAt is a single flag on the Page, so pinning a project
+// doc here and in the project hub are the same pin.
 
 type Body = { pinned: boolean };
 
@@ -32,14 +35,22 @@ export async function action({ request, params }: Route.ActionArgs) {
   });
   if (
     !page ||
-    page.workspaceType !== "Project" ||
-    !page.workspaceId ||
+    (page.workspaceType !== "Project" && page.workspaceType !== "Lab") ||
+    (page.workspaceType === "Project" && !page.workspaceId) ||
     page.archivedAt !== null
   ) {
     return withCors(request, Response.json({ error: "Document not found" }, { status: 404 }));
   }
-  const gate = await requireProjectEditAccess(request, page.workspaceId);
-  if (!gate.ok) return gate.response;
+  let auth: AuthSuccess;
+  if (page.workspaceType === "Lab") {
+    const gate = await requireMemberSession(request);
+    if (!gate.ok) return withCors(request, gate.response);
+    auth = gate.auth;
+  } else {
+    const gate = await requireProjectEditAccess(request, page.workspaceId!);
+    if (!gate.ok) return gate.response;
+    auth = gate.auth;
+  }
 
   let body: unknown;
   try {
@@ -57,9 +68,9 @@ export async function action({ request, params }: Route.ActionArgs) {
   });
   await logAuditEvent({
     action: "page.pin",
-    userId: gate.auth.user.sub,
+    userId: auth.user.sub,
     targetId: pageId,
-    metadata: { projectId: page.workspaceId, pinned: body.pinned },
+    metadata: { workspaceType: page.workspaceType, projectId: page.workspaceId, pinned: body.pinned },
     request,
   });
   return withCors(request, Response.json({ ok: true }));

--- a/dali-api/app/projects/routes/projects.$id.tsx
+++ b/dali-api/app/projects/routes/projects.$id.tsx
@@ -2959,7 +2959,88 @@ function DocumentsBlock({
     }
   }
 
-  function DocRow({ doc, indent }: { doc: LoaderData["documents"][number]["children"][number]; indent: boolean }) {
+  // Drag-and-drop: reorder documents and move them into/out of folders.
+  // `drag` tracks the item being dragged; `dropTarget` highlights the current
+  // drop zone (a page id, or "root" for the top-level list).
+  const [drag, setDrag] = useState<{ id: string; isFolder: boolean } | null>(null);
+  const [dropTarget, setDropTarget] = useState<string | "root" | null>(null);
+  async function moveDocument(id: string, parentPageId: string | null, beforeId: string | null) {
+    setDrag(null);
+    setDropTarget(null);
+    if (id === beforeId) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/pages/${id}/move`, {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ parentPageId, beforeId }),
+      });
+      if (!res.ok) {
+        const b = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(b.error ?? "Failed to move document");
+      }
+      if (parentPageId) setExpanded((prev) => new Set(prev).add(parentPageId));
+      revalidator.revalidate();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Something went wrong");
+    } finally {
+      setBusy(false);
+    }
+  }
+  // Drop onto a document row → reorder before it, into that row's parent.
+  function onDropBefore(targetId: string, targetParentId: string | null) {
+    if (drag) void moveDocument(drag.id, targetParentId, targetId);
+  }
+  // Drop onto a folder header → a doc moves into the folder; a folder reorders
+  // before that folder at the top level (folders never nest).
+  function onDropOnFolder(folderId: string) {
+    if (!drag) return;
+    if (drag.isFolder) void moveDocument(drag.id, null, folderId);
+    else void moveDocument(drag.id, folderId, null);
+  }
+
+  function DocRow({
+    doc,
+    indent,
+    parentId,
+  }: {
+    doc: LoaderData["documents"][number]["children"][number];
+    indent: boolean;
+    parentId: string | null;
+  }) {
+    const dragProps = canEdit
+      ? {
+          draggable: true,
+          onDragStart: (e: React.DragEvent) => {
+            setDrag({ id: doc.id, isFolder: false });
+            e.dataTransfer.effectAllowed = "move";
+            e.dataTransfer.setData("text/plain", doc.id);
+          },
+          onDragEnd: () => setDrag(null),
+          onDragOver: (e: React.DragEvent) => {
+            if (!drag) return;
+            e.preventDefault();
+            e.dataTransfer.dropEffect = "move";
+            if (dropTarget !== doc.id) setDropTarget(doc.id);
+          },
+          onDragLeave: () => setDropTarget((t) => (t === doc.id ? null : t)),
+          onDrop: (e: React.DragEvent) => {
+            e.preventDefault();
+            e.stopPropagation();
+            onDropBefore(doc.id, parentId);
+          },
+        }
+      : {};
+    return (
+      <div {...dragProps} className={drag && dropTarget === doc.id ? "border-t-2 border-accent-coral" : ""}>
+        <DocRowInner doc={doc} indent={indent} />
+      </div>
+    );
+  }
+
+  function DocRowInner({ doc, indent }: { doc: LoaderData["documents"][number]["children"][number]; indent: boolean }) {
     return (
       <div className={`py-2.5 flex items-center justify-between gap-3 text-sm ${indent ? "pl-6" : ""}`}>
         <button
@@ -3085,16 +3166,79 @@ function DocumentsBlock({
       {documents.length === 0 ? (
         <p className="text-sm text-muted-foreground italic">No documents yet.</p>
       ) : (
-        <div className="flex flex-col divide-y divide-border">
+        <div
+          onDragOver={
+            canEdit && drag
+              ? (e) => {
+                  e.preventDefault();
+                  e.dataTransfer.dropEffect = "move";
+                  if (dropTarget !== "root") setDropTarget("root");
+                }
+              : undefined
+          }
+          onDragLeave={
+            canEdit ? () => setDropTarget((t) => (t === "root" ? null : t)) : undefined
+          }
+          onDrop={
+            canEdit && drag
+              ? (e) => {
+                  e.preventDefault();
+                  void moveDocument(drag.id, null, null);
+                }
+              : undefined
+          }
+          className={`flex flex-col divide-y divide-border rounded-md ${
+            dropTarget === "root" ? "ring-2 ring-accent-coral/40" : ""
+          }`}
+        >
           {/* Pinned docs on top — full document rows (share/pin/delete), just
               lifted above the rest. The filled coral pin marks them pinned. */}
           {pinnedDocuments.map((d) => (
-            <DocRow key={d.id} doc={d} indent={false} />
+            <DocRow key={d.id} doc={d} indent={false} parentId={null} />
           ))}
           {documents.map((doc) =>
             doc.kind === "Folder" ? (
-              <div key={doc.id} className="py-2.5 flex flex-col gap-1">
-                <div className="flex items-center justify-between gap-3 text-sm">
+              <div
+                key={doc.id}
+                draggable={canEdit}
+                onDragStart={
+                  canEdit
+                    ? (e) => {
+                        setDrag({ id: doc.id, isFolder: true });
+                        e.dataTransfer.effectAllowed = "move";
+                        e.dataTransfer.setData("text/plain", doc.id);
+                      }
+                    : undefined
+                }
+                onDragEnd={canEdit ? () => setDrag(null) : undefined}
+                className={`py-2.5 flex flex-col gap-1 ${canEdit ? "cursor-grab active:cursor-grabbing" : ""}`}
+              >
+                <div
+                  onDragOver={
+                    canEdit && drag
+                      ? (e) => {
+                          e.preventDefault();
+                          e.dataTransfer.dropEffect = "move";
+                          if (dropTarget !== doc.id) setDropTarget(doc.id);
+                        }
+                      : undefined
+                  }
+                  onDragLeave={
+                    canEdit ? () => setDropTarget((t) => (t === doc.id ? null : t)) : undefined
+                  }
+                  onDrop={
+                    canEdit && drag
+                      ? (e) => {
+                          e.preventDefault();
+                          e.stopPropagation();
+                          onDropOnFolder(doc.id);
+                        }
+                      : undefined
+                  }
+                  className={`flex items-center justify-between gap-3 text-sm rounded-md ${
+                    dropTarget === doc.id ? "ring-2 ring-accent-coral/60 bg-accent-coral/5" : ""
+                  }`}
+                >
                   <button
                     type="button"
                     onClick={() => toggleExpanded(doc.id)}
@@ -3151,13 +3295,13 @@ function DocumentsBlock({
                   ) : (
                     <div className="flex flex-col divide-y divide-border">
                       {doc.children.map((child) => (
-                        <DocRow key={child.id} doc={child} indent />
+                        <DocRow key={child.id} doc={child} indent parentId={doc.id} />
                       ))}
                     </div>
                   ))}
               </div>
             ) : (
-              <DocRow key={doc.id} doc={doc} indent={false} />
+              <DocRow key={doc.id} doc={doc} indent={false} parentId={null} />
             ),
           )}
         </div>

--- a/dali-api/app/routes.ts
+++ b/dali-api/app/routes.ts
@@ -95,6 +95,9 @@ export default [
 
     // Documents & files — full-page reusable editor + file viewer. Literal
     // "file" segment precedes the :pageId param so it isn't captured.
+    // The bare /documents route is the lab-wide Documents hub (aggregates
+    // lab-wide docs + the viewer's project-hub docs).
+    route("documents", "routes/documents.hub.tsx"),
     route("documents/file/:fileId", "routes/documents.file.$fileId.tsx"),
     route("documents/:pageId", "routes/documents.$pageId.tsx"),
 
@@ -357,9 +360,12 @@ export default [
 
   // Project documents (collab Pages scoped to the project)
   route("api/projects/:id/documents", "projects/routes/api.projects.$id.documents.ts"),
+  // Lab-wide documents (collab Pages scoped to the Lab workspace)
+  route("api/lab-documents", "routes/api.lab-documents.ts"),
   route("api/documents/:id", "projects/routes/api.documents.$id.ts"),
   route("api/pages/:id/partner-visible", "projects/routes/api.pages.$id.partner-visible.ts"),
   route("api/pages/:id/pin", "projects/routes/api.pages.$id.pin.ts"),
+  route("api/pages/:id/move", "projects/routes/api.pages.$id.move.ts"),
 
   // Project files (standalone uploads with versions)
   route("api/projects/:id/files", "projects/routes/api.projects.$id.files.ts"),

--- a/dali-api/app/routes/api.doctags.apply.ts
+++ b/dali-api/app/routes/api.doctags.apply.ts
@@ -46,7 +46,11 @@ export async function action({ request }: Route.ActionArgs) {
       where: { id: targetId },
       select: { workspaceType: true, archivedAt: true },
     });
-    if (!page || page.workspaceType !== "Project" || page.archivedAt !== null) {
+    if (
+      !page ||
+      (page.workspaceType !== "Project" && page.workspaceType !== "Lab") ||
+      page.archivedAt !== null
+    ) {
       return withCors(request, Response.json({ error: "Document not found" }, { status: 404 }));
     }
     if (op === "add") {

--- a/dali-api/app/routes/api.lab-documents.ts
+++ b/dali-api/app/routes/api.lab-documents.ts
@@ -1,0 +1,78 @@
+import type { Route } from "./+types/api.lab-documents";
+import { z } from "zod";
+import { prisma } from "~/lib/db";
+import { requireMemberSession } from "~/lib/auth";
+import { withCors, handlePreflight } from "~/lib/cors";
+import { parseJson } from "~/lib/validate";
+import { createLabPage } from "~/lib/pages";
+
+// POST /api/lab-documents
+//
+// Add a lab-wide document or folder — Pages scoped to the Lab workspace
+// (workspaceType=Lab, workspaceId=null), the same Page model the project
+// Documents block uses, just lab-scoped. Body: { title, kind?, parentPageId? }.
+// kind defaults to "FreeForm"; "Folder" creates a container. parentPageId
+// nests a document under an existing top-level Folder (the 2-level cap means
+// folders never nest). Any lab member may create — the lab's members are the
+// Lab workspace's members (mirrors the project-member gate on project docs).
+
+const BodySchema = z.object({
+  title: z.string().trim().min(1).max(200),
+  kind: z.enum(["FreeForm", "Folder"]).optional().default("FreeForm"),
+  parentPageId: z.string().min(1).optional(),
+});
+
+export async function action({ request }: Route.ActionArgs) {
+  const preflight = handlePreflight(request);
+  if (preflight) return preflight;
+
+  if (request.method !== "POST") {
+    return withCors(request, Response.json({ error: "Method not allowed" }, { status: 405 }));
+  }
+  const gate = await requireMemberSession(request);
+  if (!gate.ok) return withCors(request, gate.response);
+  const auth = gate.auth;
+
+  const body = await parseJson(request, BodySchema);
+  if (body instanceof Response) return withCors(request, body);
+
+  if (body.kind === "Folder" && body.parentPageId) {
+    return withCors(
+      request,
+      Response.json({ error: "Folders can't be nested inside another folder" }, { status: 400 }),
+    );
+  }
+
+  if (body.parentPageId) {
+    const parent = await prisma.page.findUnique({
+      where: { id: body.parentPageId },
+      select: { workspaceType: true, workspaceId: true, parentPageId: true, kind: true, archivedAt: true },
+    });
+    if (
+      !parent ||
+      parent.archivedAt !== null ||
+      parent.workspaceType !== "Lab" ||
+      parent.workspaceId !== null
+    ) {
+      return withCors(request, Response.json({ error: "Parent folder not found" }, { status: 404 }));
+    }
+    if (parent.kind !== "Folder") {
+      return withCors(
+        request,
+        Response.json({ error: "Documents can only nest inside a folder" }, { status: 400 }),
+      );
+    }
+    if (parent.parentPageId !== null) {
+      return withCors(request, Response.json({ error: "Pages only nest one level deep" }, { status: 400 }));
+    }
+  }
+
+  const page = await createLabPage({
+    title: body.title,
+    createdById: auth.user.sub,
+    kind: body.kind,
+    parentPageId: body.parentPageId ?? null,
+  });
+
+  return withCors(request, Response.json({ id: page.id }));
+}

--- a/dali-api/app/routes/documents.$pageId.tsx
+++ b/dali-api/app/routes/documents.$pageId.tsx
@@ -4,7 +4,7 @@ import type { Route } from "./+types/documents.$pageId";
 import { prisma } from "~/lib/db";
 import { requireAuth, redirectPartnerToPortal } from "~/lib/auth";
 import { parseSessionCookie } from "~/lib/cookies";
-import { isCore, isProjectMember } from "~/lib/roles";
+import { isCore, isProjectMember, isLabMember } from "~/lib/roles";
 import { fullName } from "~/lib/display";
 import { getPresenceUser } from "~/lib/presence-user";
 import { DocumentEditor } from "~/components/DocumentEditor";
@@ -79,6 +79,9 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   // the collab handshake rejected members), plus the offering's instructors
   // for EducationOffering-workspace pages.
   let canEdit = await isCore(auth.user.sub);
+  if (!canEdit && page.workspaceType === "Lab") {
+    canEdit = await isLabMember(auth.user.sub);
+  }
   if (!canEdit && page.workspaceType === "Project" && page.workspaceId) {
     canEdit = await isProjectMember(auth.user.sub, page.workspaceId);
   }

--- a/dali-api/app/routes/documents.hub.tsx
+++ b/dali-api/app/routes/documents.hub.tsx
@@ -1,0 +1,794 @@
+import { useEffect, useMemo, useState } from "react";
+import { redirect, useLoaderData, useRevalidator } from "react-router";
+import type { Route } from "./+types/documents.hub";
+import {
+  ChevronDown,
+  ChevronRight,
+  FileText,
+  Folder,
+  FolderPlus,
+  Pin,
+  Plus,
+  Search,
+  Tag as TagIcon,
+  Trash2,
+  X,
+} from "lucide-react";
+import { prisma } from "~/lib/db";
+import { requireAuth, redirectPartnerToPortal } from "~/lib/auth";
+import { isCore, isLabMember } from "~/lib/roles";
+import { Tooltip } from "~/components/ui/IconButton";
+
+export const meta: Route.MetaFunction = () => [{ title: "Documents · DALI OS" }];
+
+// The lab-wide Documents hub. Aggregates the Lab-workspace document tree (the
+// dedicated home for lab-wide docs) plus the viewer's project-hub documents,
+// so everything is filterable/searchable in one place. Lab docs are fully
+// managed here (create/delete/pin — any lab member); project docs are read +
+// pin only (their create/delete stays in the project hub). Tags are applied in
+// each document's editor; here they only drive the filter bar.
+
+type DocTagOut = { id: string; label: string; slug: string; color: string | null };
+
+type DocOut = {
+  id: string;
+  title: string;
+  kind: "FreeForm" | "Structured" | "Folder";
+  parentPageId: string | null;
+  isSystem: boolean;
+  pinned: boolean;
+  pinnedAt: number | null;
+  tags: DocTagOut[];
+  workspaceKey: string;
+  workspaceLabel: string;
+  workspaceKind: "lab" | "project";
+};
+
+type WorkspaceOut = {
+  key: string;
+  label: string;
+  kind: "lab" | "project";
+  canManage: boolean;
+};
+
+const pageSelect = {
+  id: true,
+  title: true,
+  kind: true,
+  parentPageId: true,
+  systemKey: true,
+  pinnedAt: true,
+  tags: {
+    select: { tag: { select: { id: true, label: true, slug: true, color: true } } },
+  },
+} as const;
+
+export async function loader({ request }: Route.LoaderArgs) {
+  const auth = await requireAuth(request);
+  if (!auth.ok) return redirect("/login");
+  if (auth.user.type === "applicant") return redirect("/portal");
+  const partnerRedirect = await redirectPartnerToPortal(auth);
+  if (partnerRedirect) return partnerRedirect;
+
+  const [member, core] = await Promise.all([
+    isLabMember(auth.user.sub),
+    isCore(auth.user.sub),
+  ]);
+
+  // Lab-wide pages + the projects whose docs the viewer may see (Core sees all
+  // non-archived projects; everyone else sees the projects they're staffed on).
+  const [labPages, projects] = await Promise.all([
+    prisma.page.findMany({
+      where: { workspaceType: "Lab", workspaceId: null, archivedAt: null },
+      orderBy: { position: "asc" },
+      select: pageSelect,
+    }),
+    prisma.project.findMany({
+      where: {
+        status: { not: "Archived" },
+        ...(core ? {} : { assignments: { some: { userId: auth.user.sub } } }),
+      },
+      orderBy: { name: "asc" },
+      select: { id: true, name: true },
+    }),
+  ]);
+
+  const projectIds = projects.map((p) => p.id);
+  const projectPages = projectIds.length
+    ? await prisma.page.findMany({
+        where: { workspaceType: "Project", workspaceId: { in: projectIds }, archivedAt: null },
+        orderBy: { position: "asc" },
+        select: { ...pageSelect, workspaceId: true },
+      })
+    : [];
+
+  const allTags = await prisma.docTag.findMany({
+    where: { archivedAt: null },
+    orderBy: { label: "asc" },
+    select: { id: true, label: true, slug: true, color: true },
+  });
+
+  const projectNameById = new Map(projects.map((p) => [p.id, p.name]));
+  const toDto = (
+    p: (typeof labPages)[number] & { workspaceId?: string | null },
+    workspaceKey: string,
+    workspaceLabel: string,
+    workspaceKind: "lab" | "project",
+  ): DocOut => ({
+    id: p.id,
+    title: p.title,
+    kind: p.kind as DocOut["kind"],
+    parentPageId: p.parentPageId,
+    isSystem: p.systemKey !== null,
+    pinned: p.pinnedAt !== null,
+    pinnedAt: p.pinnedAt?.getTime() ?? null,
+    tags: p.tags
+      .map((t) => t.tag)
+      .sort((a, b) => a.label.localeCompare(b.label)),
+    workspaceKey,
+    workspaceLabel,
+    workspaceKind,
+  });
+
+  const docs: DocOut[] = [
+    ...labPages.map((p) => toDto(p, "lab", "Lab-wide", "lab")),
+    ...projectPages.map((p) =>
+      toDto(p, p.workspaceId!, projectNameById.get(p.workspaceId!) ?? "Project", "project"),
+    ),
+  ];
+
+  const workspaces: WorkspaceOut[] = [
+    { key: "lab", label: "Lab-wide", kind: "lab", canManage: member },
+    ...projects.map((p): WorkspaceOut => ({ key: p.id, label: p.name, kind: "project", canManage: true })),
+  ];
+
+  return { docs, workspaces, allTags };
+}
+
+// Open a document as a split-screen tab beside the hub. This page renders
+// inside the TabWorkspace iframe, so ask the parent shell to open
+// /documents/:id in a second pane (dali:openTabToSide → Layout). Falls back to
+// a same-tab navigation when rendered standalone.
+function openDocumentTab(pageId: string, label: string) {
+  const url = `/documents/${pageId}`;
+  if (typeof window !== "undefined" && window.self !== window.top) {
+    window.parent.postMessage({ type: "dali:openTabToSide", url, label }, window.location.origin);
+  } else if (typeof window !== "undefined") {
+    window.location.assign(url);
+  }
+}
+
+function TagChip({ tag }: { tag: DocTagOut }) {
+  return (
+    <span
+      className="inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium"
+      style={
+        tag.color
+          ? { backgroundColor: `${tag.color}22`, color: tag.color }
+          : undefined
+      }
+    >
+      <span className={tag.color ? "" : "text-muted-foreground bg-muted rounded-full px-2 py-0.5"}>
+        {tag.label}
+      </span>
+    </span>
+  );
+}
+
+export default function DocumentsHub() {
+  const { docs, workspaces, allTags } = useLoaderData() as Exclude<
+    Awaited<ReturnType<typeof loader>>,
+    Response
+  >;
+  const revalidator = useRevalidator();
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [query, setQuery] = useState("");
+  const [scope, setScope] = useState<"all" | "lab" | "project">("all");
+  const [selectedTagIds, setSelectedTagIds] = useState<Set<string>>(() => new Set());
+  const [expandedFolders, setExpandedFolders] = useState<Set<string>>(
+    () => new Set(docs.filter((d) => d.kind === "Folder").map((d) => d.id)),
+  );
+  const [collapsedWorkspaces, setCollapsedWorkspaces] = useState<Set<string>>(() => new Set());
+
+  // A rename happens in the doc's own split-screen tab (separate loader). The
+  // shell relays `dali:documentTitleChanged` to open tabs — revalidate so the
+  // row label here updates without a reload (same pattern as the project hub).
+  useEffect(() => {
+    const knownIds = new Set(docs.map((d) => d.id));
+    function onMessage(e: MessageEvent) {
+      if (e.origin !== window.location.origin) return;
+      const data = e.data as { type?: string; pageId?: string } | undefined;
+      if (data?.type !== "dali:documentTitleChanged") return;
+      if (!data.pageId || !knownIds.has(data.pageId)) return;
+      revalidator.revalidate();
+    }
+    window.addEventListener("message", onMessage);
+    return () => window.removeEventListener("message", onMessage);
+  }, [docs, revalidator]);
+
+  const q = query.trim().toLowerCase();
+  const filtering = q.length > 0 || selectedTagIds.size > 0;
+
+  function toggleTag(id: string) {
+    setSelectedTagIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+  function toggleFolder(id: string) {
+    setExpandedFolders((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+  function toggleWorkspace(key: string) {
+    setCollapsedWorkspaces((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }
+
+  async function post(url: string, body?: unknown, method: "POST" | "DELETE" = "POST") {
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch(url, {
+        method,
+        credentials: "include",
+        ...(body ? { headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) } : {}),
+      });
+      const b = (await res.json().catch(() => ({}))) as { id?: string; error?: string };
+      if (!res.ok) throw new Error(b.error ?? "Something went wrong");
+      return b;
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Something went wrong");
+      return null;
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function createLabDocument(parentPageId?: string) {
+    const title = "Untitled";
+    const b = await post("/api/lab-documents", parentPageId ? { title, parentPageId } : { title });
+    if (b?.id) {
+      openDocumentTab(b.id, title);
+      revalidator.revalidate();
+    }
+  }
+  async function createLabFolder() {
+    const title = window.prompt("Folder name");
+    if (!title || !title.trim()) return;
+    const b = await post("/api/lab-documents", { title: title.trim(), kind: "Folder" });
+    if (b?.id) {
+      setExpandedFolders((prev) => new Set(prev).add(b.id!));
+      revalidator.revalidate();
+    }
+  }
+  async function deleteDocument(id: string, title: string, isFolder: boolean) {
+    if (!window.confirm(`Delete ${isFolder ? "folder" : "document"} "${title}"?`)) return;
+    const b = await post(`/api/documents/${id}`, undefined, "DELETE");
+    if (b) revalidator.revalidate();
+  }
+  async function togglePin(id: string, next: boolean) {
+    const b = await post(`/api/pages/${id}/pin`, { pinned: next });
+    if (b) revalidator.revalidate();
+  }
+  // Drag a lab document into a folder (parentPageId = folder id) or back to the
+  // top level (null). Folders themselves aren't draggable.
+  const [dragDocId, setDragDocId] = useState<string | null>(null);
+  const [dropTarget, setDropTarget] = useState<string | "root" | null>(null);
+  async function moveDocument(
+    id: string,
+    parentPageId: string | null,
+    beforeId: string | null = null,
+  ) {
+    setDragDocId(null);
+    setDropTarget(null);
+    if (id === beforeId) return;
+    const b = await post(`/api/pages/${id}/move`, { parentPageId, beforeId });
+    if (b) {
+      if (parentPageId) setExpandedFolders((prev) => new Set(prev).add(parentPageId));
+      revalidator.revalidate();
+    }
+  }
+
+  const inScope = (kind: "lab" | "project") => scope === "all" || scope === kind;
+
+  const filteredDocs = useMemo(() => {
+    if (!filtering) return [];
+    return docs
+      .filter((d) => d.kind !== "Folder")
+      .filter((d) => inScope(d.workspaceKind))
+      .filter((d) => (q ? d.title.toLowerCase().includes(q) : true))
+      .filter((d) =>
+        selectedTagIds.size === 0 ? true : d.tags.some((t) => selectedTagIds.has(t.id)),
+      )
+      .sort((a, b) => a.title.localeCompare(b.title));
+  }, [docs, filtering, q, selectedTagIds, scope]);
+
+  const pinned = useMemo(
+    () =>
+      docs
+        .filter((d) => d.pinned && d.parentPageId === null && inScope(d.workspaceKind))
+        .sort((a, b) => (b.pinnedAt ?? 0) - (a.pinnedAt ?? 0)),
+    [docs, scope],
+  );
+
+  const visibleWorkspaces = useMemo(
+    () => workspaces.filter((w) => inScope(w.kind)),
+    [workspaces, scope],
+  );
+
+  const childrenByParent = useMemo(() => {
+    const map = new Map<string, DocOut[]>();
+    for (const d of docs) {
+      if (!d.parentPageId) continue;
+      const list = map.get(d.parentPageId);
+      if (list) list.push(d);
+      else map.set(d.parentPageId, [d]);
+    }
+    return map;
+  }, [docs]);
+
+  const canManageByWorkspace = useMemo(
+    () => new Map(workspaces.map((w) => [w.key, w.canManage])),
+    [workspaces],
+  );
+  const canManageLab = canManageByWorkspace.get("lab") ?? false;
+
+  function DocRow({
+    doc,
+    indent,
+    parentId = null,
+  }: {
+    doc: DocOut;
+    indent: boolean;
+    parentId?: string | null;
+  }) {
+    const canManage = canManageByWorkspace.get(doc.workspaceKey) ?? false;
+    const canDelete = canManage && doc.workspaceKind === "lab" && !doc.isSystem;
+    const draggable = canManage && doc.workspaceKind === "lab";
+    return (
+      <div
+        draggable={draggable}
+        onDragStart={
+          draggable
+            ? (e) => {
+                setDragDocId(doc.id);
+                e.dataTransfer.effectAllowed = "move";
+                e.dataTransfer.setData("text/plain", doc.id);
+              }
+            : undefined
+        }
+        onDragEnd={draggable ? () => setDragDocId(null) : undefined}
+        onDragOver={
+          draggable && dragDocId
+            ? (e) => {
+                e.preventDefault();
+                e.dataTransfer.dropEffect = "move";
+                if (dropTarget !== doc.id) setDropTarget(doc.id);
+              }
+            : undefined
+        }
+        onDragLeave={
+          draggable ? () => setDropTarget((t) => (t === doc.id ? null : t)) : undefined
+        }
+        onDrop={
+          draggable && dragDocId
+            ? (e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                void moveDocument(dragDocId, parentId, doc.id);
+              }
+            : undefined
+        }
+        className={`py-2.5 flex items-center justify-between gap-3 text-sm ${indent ? "pl-6" : ""} ${
+          draggable ? "cursor-grab active:cursor-grabbing" : ""
+        } ${dragDocId === doc.id ? "opacity-50" : ""} ${
+          dragDocId && dropTarget === doc.id ? "border-t-2 border-accent-coral" : ""
+        }`}
+      >
+        <button
+          type="button"
+          onClick={() => openDocumentTab(doc.id, doc.title)}
+          className="flex items-center gap-2 min-w-0 text-left font-medium text-foreground hover:text-accent-coral"
+        >
+          <FileText className="w-3.5 h-3.5 flex-shrink-0 text-muted-foreground" />
+          <span className="truncate">{doc.title}</span>
+        </button>
+        <div className="flex items-center gap-2 flex-shrink-0">
+          {doc.tags.map((t) => (
+            <TagChip key={t.id} tag={t} />
+          ))}
+          {canManage && !indent && (
+            <Tooltip label={doc.pinned ? "Pinned — click to unpin" : "Pin to top"}>
+              <button
+                type="button"
+                disabled={busy}
+                onClick={() => void togglePin(doc.id, !doc.pinned)}
+                aria-label={doc.pinned ? "Unpin document" : "Pin document"}
+                aria-pressed={doc.pinned}
+                className={`flex items-center disabled:opacity-60 ${
+                  doc.pinned ? "text-accent-coral" : "text-muted-foreground hover:text-foreground"
+                }`}
+              >
+                <Pin className={`w-3.5 h-3.5 ${doc.pinned ? "fill-current" : ""}`} />
+              </button>
+            </Tooltip>
+          )}
+          {canDelete && (
+            <Tooltip label="Delete document">
+              <button
+                type="button"
+                disabled={busy}
+                onClick={() => void deleteDocument(doc.id, doc.title, false)}
+                aria-label="Delete document"
+                className="text-destructive hover:text-destructive/80 disabled:opacity-60"
+              >
+                <Trash2 className="w-3.5 h-3.5" />
+              </button>
+            </Tooltip>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  function FolderRow({ doc, canManage }: { doc: DocOut; canManage: boolean }) {
+    const children = childrenByParent.get(doc.id) ?? [];
+    const canDelete = canManage && doc.workspaceKind === "lab" && !doc.isSystem;
+    const isDropZone = canManage && doc.workspaceKind === "lab";
+    const dropActive = dropTarget === doc.id;
+    return (
+      <div className="py-2.5 flex flex-col gap-1">
+        <div
+          onDragOver={
+            isDropZone && dragDocId
+              ? (e) => {
+                  e.preventDefault();
+                  e.dataTransfer.dropEffect = "move";
+                  if (dropTarget !== doc.id) setDropTarget(doc.id);
+                }
+              : undefined
+          }
+          onDragLeave={
+            isDropZone ? () => setDropTarget((t) => (t === doc.id ? null : t)) : undefined
+          }
+          onDrop={
+            isDropZone && dragDocId
+              ? (e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  if (dragDocId !== doc.id) void moveDocument(dragDocId, doc.id);
+                }
+              : undefined
+          }
+          className={`flex items-center justify-between gap-3 text-sm rounded-md ${
+            dropActive ? "ring-2 ring-accent-coral/60 bg-accent-coral/5" : ""
+          }`}
+        >
+          <button
+            type="button"
+            onClick={() => toggleFolder(doc.id)}
+            className="flex items-center gap-1.5 text-left font-medium text-foreground min-w-0"
+          >
+            {expandedFolders.has(doc.id) ? (
+              <ChevronDown className="w-3.5 h-3.5 flex-shrink-0 text-muted-foreground" />
+            ) : (
+              <ChevronRight className="w-3.5 h-3.5 flex-shrink-0 text-muted-foreground" />
+            )}
+            <Folder className="w-3.5 h-3.5 flex-shrink-0 text-muted-foreground" />
+            <span className="truncate">{doc.title}</span>
+            {doc.isSystem && (
+              <span className="text-[10px] uppercase tracking-wide text-muted-foreground/70 flex-shrink-0">
+                Default
+              </span>
+            )}
+          </button>
+          {canManage && (
+            <div className="flex items-center gap-2 flex-shrink-0">
+              <Tooltip label={doc.pinned ? "Pinned — click to unpin" : "Pin to top"}>
+                <button
+                  type="button"
+                  disabled={busy}
+                  onClick={() => void togglePin(doc.id, !doc.pinned)}
+                  aria-label={doc.pinned ? "Unpin folder" : "Pin folder"}
+                  aria-pressed={doc.pinned}
+                  className={`flex items-center disabled:opacity-60 ${
+                    doc.pinned ? "text-accent-coral" : "text-muted-foreground hover:text-foreground"
+                  }`}
+                >
+                  <Pin className={`w-3.5 h-3.5 ${doc.pinned ? "fill-current" : ""}`} />
+                </button>
+              </Tooltip>
+              {doc.workspaceKind === "lab" && (
+                <Tooltip label="Add document to folder">
+                  <button
+                    type="button"
+                    disabled={busy}
+                    onClick={() => void createLabDocument(doc.id)}
+                    aria-label="Add document to folder"
+                    className="flex items-center text-accent-coral hover:text-accent-coral/80 disabled:opacity-60"
+                  >
+                    <Plus className="w-3.5 h-3.5" />
+                  </button>
+                </Tooltip>
+              )}
+              {canDelete && (
+                <button
+                  type="button"
+                  disabled={busy || children.length > 0}
+                  title={
+                    children.length > 0
+                      ? "Move or delete the documents inside this folder first"
+                      : "Delete folder"
+                  }
+                  aria-label="Delete folder"
+                  onClick={() => void deleteDocument(doc.id, doc.title, true)}
+                  className="p-1 rounded text-destructive hover:text-destructive/80 disabled:opacity-60"
+                >
+                  <Trash2 className="w-3.5 h-3.5" />
+                </button>
+              )}
+            </div>
+          )}
+        </div>
+        {expandedFolders.has(doc.id) &&
+          (children.length === 0 ? (
+            <p className="pl-6 text-xs text-muted-foreground italic">Empty</p>
+          ) : (
+            <div className="flex flex-col divide-y divide-border">
+              {children.map((child) => (
+                <DocRow key={child.id} doc={child} indent parentId={doc.id} />
+              ))}
+            </div>
+          ))}
+      </div>
+    );
+  }
+
+  function WorkspaceGroup({ workspace }: { workspace: WorkspaceOut }) {
+    const topLevel = docs.filter(
+      (d) => d.workspaceKey === workspace.key && d.parentPageId === null && !d.pinned,
+    );
+    const isLab = workspace.kind === "lab";
+    // Lab-wide is a flat list with no header of its own — its "Add document"
+    // action lives in the page header. Project groups keep the collapsible
+    // folder styling since their docs nest.
+    const collapsed = !isLab && collapsedWorkspaces.has(workspace.key);
+    return (
+      <section
+        className={`bg-card border border-border rounded-lg px-4 ${
+          isLab ? "py-1.5" : collapsed ? "py-2.5" : "py-4"
+        }`}
+      >
+        {!isLab && (
+          <div className={`flex items-center justify-between ${collapsed ? "" : "mb-3"}`}>
+            <button
+              type="button"
+              onClick={() => toggleWorkspace(workspace.key)}
+              className="flex items-center gap-2 text-sm font-semibold text-foreground min-w-0"
+            >
+              {collapsed ? (
+                <ChevronRight className="w-4 h-4 flex-shrink-0 text-muted-foreground" />
+              ) : (
+                <ChevronDown className="w-4 h-4 flex-shrink-0 text-muted-foreground" />
+              )}
+              <Folder className="w-4 h-4 flex-shrink-0" />
+              <span className="truncate">{workspace.label}</span>
+              <span className="text-[10px] uppercase tracking-wide text-muted-foreground/70 flex-shrink-0">
+                Project
+              </span>
+            </button>
+          </div>
+        )}
+        {!collapsed &&
+          (topLevel.length === 0 ? (
+            <p className="text-sm text-muted-foreground italic">No documents yet.</p>
+          ) : (
+            <div
+              onDragOver={
+                isLab && workspace.canManage && dragDocId
+                  ? (e) => {
+                      e.preventDefault();
+                      e.dataTransfer.dropEffect = "move";
+                      if (dropTarget !== "root") setDropTarget("root");
+                    }
+                  : undefined
+              }
+              onDragLeave={
+                isLab && workspace.canManage
+                  ? () => setDropTarget((t) => (t === "root" ? null : t))
+                  : undefined
+              }
+              onDrop={
+                isLab && workspace.canManage && dragDocId
+                  ? (e) => {
+                      e.preventDefault();
+                      void moveDocument(dragDocId, null);
+                    }
+                  : undefined
+              }
+              className={`flex flex-col divide-y divide-border rounded-md ${
+                dropTarget === "root" ? "ring-2 ring-accent-coral/40" : ""
+              }`}
+            >
+              {topLevel.map((doc) =>
+                doc.kind === "Folder" ? (
+                  <FolderRow key={doc.id} doc={doc} canManage={workspace.canManage} />
+                ) : (
+                  <DocRow key={doc.id} doc={doc} indent={false} />
+                ),
+              )}
+            </div>
+          ))}
+      </section>
+    );
+  }
+
+  return (
+    <div className="w-full flex flex-col gap-4 p-4">
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2 min-w-0">
+          <FileText className="w-5 h-5 text-accent-coral" />
+          <h1 className="text-lg font-semibold text-foreground">Documents</h1>
+        </div>
+        {canManageLab && (
+          <div className="flex items-center gap-2 flex-shrink-0">
+            <button
+              type="button"
+              disabled={busy}
+              onClick={() => void createLabFolder()}
+              className="inline-flex items-center gap-1.5 rounded-md border border-border px-3 py-1.5 text-sm font-medium text-foreground hover:bg-muted disabled:opacity-60"
+            >
+              <FolderPlus className="w-4 h-4" /> New folder
+            </button>
+            <button
+              type="button"
+              disabled={busy}
+              onClick={() => void createLabDocument()}
+              className="inline-flex items-center gap-1.5 rounded-md bg-accent-coral px-3 py-1.5 text-sm font-medium text-white hover:bg-accent-coral/90 disabled:opacity-60"
+            >
+              <Plus className="w-4 h-4" /> New document
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* Filter bar: search + scope toggle on one row, tag chips below */}
+      <div className="flex flex-col gap-3">
+        <div className="flex items-center gap-3 flex-wrap">
+          <div className="relative flex-1 min-w-[16rem]">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+            <input
+              type="search"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search documents…"
+              className="w-full rounded-md border border-border bg-background pl-9 pr-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent-coral/40"
+            />
+          </div>
+          <div className="inline-flex rounded-md border border-border bg-card p-0.5 text-sm">
+            {([
+              ["all", "All"],
+              ["lab", "Lab-wide"],
+              ["project", "Projects"],
+            ] as const).map(([value, label]) => (
+              <button
+                key={value}
+                type="button"
+                onClick={() => setScope(value)}
+                aria-pressed={scope === value}
+                className={`px-3 py-1 rounded font-medium transition-colors ${
+                  scope === value
+                    ? "bg-accent-coral/10 text-accent-coral"
+                    : "text-muted-foreground hover:text-foreground"
+                }`}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+        </div>
+        {allTags.length > 0 && (
+          <div className="flex items-center gap-2 flex-wrap">
+            <TagIcon className="w-3.5 h-3.5 text-muted-foreground" />
+            {allTags.map((tag) => {
+              const active = selectedTagIds.has(tag.id);
+              return (
+                <button
+                  key={tag.id}
+                  type="button"
+                  onClick={() => toggleTag(tag.id)}
+                  aria-pressed={active}
+                  className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium border transition-colors ${
+                    active
+                      ? "border-accent-coral bg-accent-coral/10 text-accent-coral"
+                      : "border-border text-muted-foreground hover:text-foreground hover:border-foreground/30"
+                  }`}
+                >
+                  {tag.label}
+                </button>
+              );
+            })}
+            {selectedTagIds.size > 0 && (
+              <button
+                type="button"
+                onClick={() => setSelectedTagIds(new Set())}
+                className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+              >
+                <X className="w-3 h-3" /> Clear
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+
+      {error && (
+        <div className="bg-destructive/10 border border-destructive/30 text-destructive text-xs rounded-md px-3 py-2">
+          {error}
+        </div>
+      )}
+
+      {filtering ? (
+        <section className="bg-card border border-border rounded-lg p-4">
+          <h2 className="text-sm font-semibold text-foreground mb-3">
+            {filteredDocs.length} {filteredDocs.length === 1 ? "result" : "results"}
+          </h2>
+          {filteredDocs.length === 0 ? (
+            <p className="text-sm text-muted-foreground italic">No documents match your filters.</p>
+          ) : (
+            <div className="flex flex-col divide-y divide-border">
+              {filteredDocs.map((doc) => (
+                <div key={doc.id} className="flex flex-col">
+                  <DocRow doc={doc} indent={false} />
+                  <span className="pl-6 -mt-1.5 mb-1 text-[11px] text-muted-foreground">
+                    {doc.workspaceLabel}
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
+      ) : (
+        <>
+          {pinned.length > 0 && (
+            <section className="bg-card border border-border rounded-lg p-4">
+              <h2 className="text-sm font-semibold text-foreground flex items-center gap-2 mb-3">
+                <Pin className="w-4 h-4 fill-current text-accent-coral" /> Pinned
+              </h2>
+              <div className="flex flex-col divide-y divide-border">
+                {pinned.map((doc) => (
+                  <div key={doc.id} className="flex flex-col">
+                    {doc.kind === "Folder" ? (
+                      <FolderRow
+                        doc={doc}
+                        canManage={canManageByWorkspace.get(doc.workspaceKey) ?? false}
+                      />
+                    ) : (
+                      <DocRow doc={doc} indent={false} />
+                    )}
+                    <span className="pl-6 -mt-1.5 mb-1 text-[11px] text-muted-foreground">
+                      {doc.workspaceLabel}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </section>
+          )}
+          {visibleWorkspaces.map((workspace) => (
+            <WorkspaceGroup key={workspace.key} workspace={workspace} />
+          ))}
+        </>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
…d drag-and-drop (#957)

Adds a Documents tab to the sidebar backed by a lab-wide Documents hub at /documents. It aggregates lab-wide docs (Lab-workspace Pages) plus the viewer's project-hub docs, with a scope toggle (All/Lab-wide/Projects), tag-based filter, search, and a pinned section for both folders and documents.

Lab docs reuse the existing Page model (workspaceType=Lab); any lab member can view/create/edit/delete/pin them (project docs keep their own gates). Backend extends the pin, rename/delete, doctag-apply, and collab-auth paths to accept Lab-workspace pages, plus a new create route.

Adds drag-and-drop in both the Documents hub and the project-hub Documents block: drop onto a folder to move a doc in, onto a row to reorder, onto the background to move to top level. A shared move/reorder endpoint (parentPageId + beforeId) rewrites sibling positions in a transaction and enforces the 2-level cap.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/958"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787188186&installation_model_id=21824&pr_number=958&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F958&signature=c58666c9db32489b3963549e75e237582dcc45b9c5932f145873096941d9fc76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->