### PR TITLE
MCP discovery tools: list_projects + list_terms

### DIFF
--- a/dali-api/app/mcp/tools/__tests__/list-projects.test.ts
+++ b/dali-api/app/mcp/tools/__tests__/list-projects.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("~/lib/db");
+
+import { prisma } from "~/lib/db";
+import { runListProjects, LIST_PROJECTS_TOOL } from "~/mcp/tools/list-projects";
+
+const mockPrisma = prisma as unknown as {
+  project: { findMany: ReturnType<typeof vi.fn> };
+  projectAssignment: { findMany: ReturnType<typeof vi.fn> };
+};
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("list_projects", () => {
+  it("scope is read (mirrors the member-browsable web hub)", () => {
+    expect(LIST_PROJECTS_TOOL.requiredScope).toBe("mcp:read");
+  });
+
+  it("returns the full directory with staffed flags and sorted term codes", async () => {
+    mockPrisma.project.findMany.mockResolvedValue([
+      {
+        id: "p1",
+        name: "DALI OS",
+        status: "Active",
+        projectTerms: [
+          { term: { code: "26X", sortKey: 2 } },
+          { term: { code: "26S", sortKey: 1 } },
+        ],
+        partners: [],
+      },
+      {
+        id: "p2",
+        name: "MakeOS",
+        status: "Active",
+        projectTerms: [{ term: { code: "26X", sortKey: 2 } }],
+        partners: [{ partnerOrg: { id: "org1", name: "Make Co" } }],
+      },
+    ]);
+    mockPrisma.projectAssignment.findMany.mockResolvedValue([{ projectId: "p1" }]);
+
+    const out = await runListProjects("u1", {});
+    expect(out.projects).toEqual([
+      {
+        id: "p1",
+        name: "DALI OS",
+        status: "Active",
+        termCodes: ["26S", "26X"],
+        partnerOrgs: [],
+        staffed: true,
+      },
+      {
+        id: "p2",
+        name: "MakeOS",
+        status: "Active",
+        termCodes: ["26X"],
+        partnerOrgs: [{ id: "org1", name: "Make Co" }],
+        staffed: false,
+      },
+    ]);
+  });
+
+  it("passes a status filter through", async () => {
+    mockPrisma.project.findMany.mockResolvedValue([]);
+    mockPrisma.projectAssignment.findMany.mockResolvedValue([]);
+    await runListProjects("u1", { status: ["Active"] });
+    expect(mockPrisma.project.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { status: { in: ["Active"] } } }),
+    );
+  });
+
+  it("no filter → no where clause (all statuses, matching the hub's archive view)", async () => {
+    mockPrisma.project.findMany.mockResolvedValue([]);
+    mockPrisma.projectAssignment.findMany.mockResolvedValue([]);
+    await runListProjects("u1", {});
+    expect(mockPrisma.project.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: undefined }),
+    );
+  });
+});

--- a/dali-api/app/mcp/tools/list-projects.ts
+++ b/dali-api/app/mcp/tools/list-projects.ts
@@ -1,0 +1,68 @@
+// MCP `list_projects` — the whole project directory, mirroring the web
+// projects hub (requireAuth only: any member browses all projects, all
+// statuses). Complements list_my_projects (staffing-scoped): this is how an
+// agent discovers a project it isn't staffed on — e.g. Core targeting another
+// team's hub for a Notion-export sync. `staffed` marks the caller's own
+// projects so agents can tell the two sets apart.
+
+import { prisma } from "~/lib/db";
+
+export const LIST_PROJECTS_TOOL = {
+  name: "list_projects",
+  description:
+    "List every project in the lab (id, name, status, terms, partner orgs) — the full directory, not just the caller's assignments. Use list_my_projects for staffed-on detail; get_project_overview to drill into one.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      status: {
+        description: "Restrict to these statuses. Default: all (Active, Paused, Archived).",
+        type: "array",
+        items: { enum: ["Active", "Paused", "Archived"], type: "string" },
+        maxItems: 3,
+      },
+    },
+    additionalProperties: false,
+  },
+  requiredScope: "mcp:read" as const,
+};
+
+type Input = { status?: ("Active" | "Paused" | "Archived")[] };
+
+export async function runListProjects(callerId: string, input: Input) {
+  const [projects, assignments] = await Promise.all([
+    prisma.project.findMany({
+      where: input.status?.length ? { status: { in: input.status } } : undefined,
+      orderBy: [{ status: "asc" }, { name: "asc" }],
+      select: {
+        id: true,
+        name: true,
+        status: true,
+        projectTerms: {
+          select: { term: { select: { code: true, sortKey: true } } },
+        },
+        partners: {
+          select: { partnerOrg: { select: { id: true, name: true } } },
+        },
+      },
+    }),
+    prisma.projectAssignment.findMany({
+      where: { userId: callerId },
+      select: { projectId: true },
+    }),
+  ]);
+  const staffedIds = new Set(assignments.map((a) => a.projectId));
+
+  return {
+    projects: projects.map((p) => ({
+      id: p.id,
+      name: p.name,
+      status: p.status,
+      termCodes: p.projectTerms
+        .map((pt) => pt.term)
+        .sort((a, b) => a.sortKey - b.sortKey)
+        .map((t) => t.code),
+      partnerOrgs: p.partners.map((x) => x.partnerOrg),
+      staffed: staffedIds.has(p.id),
+    })),
+  };
+}

--- a/dali-api/app/routes/mcp.ts
+++ b/dali-api/app/routes/mcp.ts
@@ -68,6 +68,7 @@ import {
   LIST_MY_PROJECTS_TOOL,
   runListMyProjects,
 } from "~/mcp/tools/list-my-projects";
+import { LIST_PROJECTS_TOOL, runListProjects } from "~/mcp/tools/list-projects";
 import {
   GET_PROJECT_OVERVIEW_TOOL,
   runGetProjectOverview,
@@ -289,6 +290,7 @@ const TOOLS = [
   CANCEL_MEETING_TOOL,
   LIST_GROUPS_TOOL,
   LIST_MY_PROJECTS_TOOL,
+  LIST_PROJECTS_TOOL,
   GET_PROJECT_OVERVIEW_TOOL,
   LIST_MY_TASKS_TOOL,
   GET_TASK_TOOL,
@@ -561,6 +563,12 @@ export async function action({ request }: Route.ActionArgs) {
             payload = await runListMyProjects(
               auth.user.id,
               args as Parameters<typeof runListMyProjects>[1],
+            );
+            break;
+          case "list_projects":
+            payload = await runListProjects(
+              auth.user.id,
+              args as Parameters<typeof runListProjects>[1],
             );
             break;
           case "get_project_overview":


### PR DESCRIPTION
Follow-up to #953 (this commit landed on that branch just after it merged, so re-raising it cleanly off current staging).

`list_my_projects` is staffing-scoped and `get_project_overview` needs an id you already have — so there was no MCP path to discover a project you aren't on, which is exactly what a Core-run Notion-export sync of another team's hub needs first.

**`list_projects`** (`mcp:read`) returns the full project directory: id, name, status, sorted term codes, partner orgs, and a `staffed` flag distinguishing the caller's own projects. Optional `status` filter (`Active`/`Paused`/`Archived`); no filter = the full archive view. Access mirrors the web projects hub, which is `requireAuth`-only — any member browses all projects there, so the tool is member-wide, not Core-gated.

Discovery flow for syncs is now: `list_projects` → `get_project_overview` / `list_project_pages` → the #953 write tools.

No schema changes, no migrations. Full suite passes (248 files / 2075 tests); typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/959"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787190086&installation_model_id=21824&pr_number=959&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F959&signature=4fb4c9534ee079748f6b7c1a39e9ec4d10115bf65d322505d22823dae5f185d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->