### PR TITLE
MCP: add list_terms

### DIFF
--- a/dali-api/app/mcp/tools/__tests__/list-terms.test.ts
+++ b/dali-api/app/mcp/tools/__tests__/list-terms.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("~/lib/db");
+vi.mock("~/lib/roles", async (orig) => {
+  const real = await orig<typeof import("~/lib/roles")>();
+  return { ...real, currentTerm: vi.fn() };
+});
+
+import { prisma } from "~/lib/db";
+import { currentTerm } from "~/lib/roles";
+import { runListTerms, LIST_TERMS_TOOL } from "~/mcp/tools/list-terms";
+
+const mockPrisma = prisma as unknown as {
+  term: { findMany: ReturnType<typeof vi.fn> };
+};
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("list_terms", () => {
+  it("scope is read", () => {
+    expect(LIST_TERMS_TOOL.requiredScope).toBe("mcp:read");
+  });
+
+  it("returns chronological terms with the current one flagged", async () => {
+    mockPrisma.term.findMany.mockResolvedValue([
+      {
+        id: "t-26s",
+        code: "26S",
+        year: 2026,
+        season: "Spring",
+        startDate: new Date("2026-03-30T00:00:00Z"),
+        endDate: new Date("2026-06-10T00:00:00Z"),
+      },
+      {
+        id: "t-26x",
+        code: "26X",
+        year: 2026,
+        season: "Summer",
+        startDate: new Date("2026-06-25T00:00:00Z"),
+        endDate: new Date("2026-08-30T00:00:00Z"),
+      },
+    ]);
+    vi.mocked(currentTerm).mockResolvedValue({ id: "t-26x" } as never);
+
+    const out = await runListTerms();
+    expect(out.terms.map((t) => [t.code, t.isCurrent])).toEqual([
+      ["26S", false],
+      ["26X", true],
+    ]);
+    expect(out.terms[1]).toMatchObject({
+      id: "t-26x",
+      year: 2026,
+      season: "Summer",
+      startsAt: "2026-06-25T00:00:00.000Z",
+    });
+    expect(mockPrisma.term.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ orderBy: { sortKey: "asc" } }),
+    );
+  });
+
+  it("no current term (empty table) → nothing flagged", async () => {
+    mockPrisma.term.findMany.mockResolvedValue([]);
+    vi.mocked(currentTerm).mockResolvedValue(null as never);
+    const out = await runListTerms();
+    expect(out.terms).toEqual([]);
+  });
+});

--- a/dali-api/app/mcp/tools/list-terms.ts
+++ b/dali-api/app/mcp/tools/list-terms.ts
@@ -1,0 +1,50 @@
+// MCP `list_terms` — the lab's term vocabulary (code "26S"/"26X"/…, dates),
+// chronological. Terms key nearly everything (staffing, project terms,
+// assignments, CE credits), and agents previously had no way to resolve a
+// code like "26X" to an id or find the current term. `isCurrent` uses the
+// same roll-forward currentTerm() the app's role checks use: between terms
+// it advances to the next upcoming term rather than reporting none.
+
+import { prisma } from "~/lib/db";
+import { currentTerm } from "~/lib/roles";
+
+export const LIST_TERMS_TOOL = {
+  name: "list_terms",
+  description:
+    "List all lab terms chronologically (id, code like '26X', year, season, start/end dates). isCurrent marks the active term (rolls forward to the next term during inter-term gaps). Read-only.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {},
+    additionalProperties: false,
+  },
+  requiredScope: "mcp:read" as const,
+};
+
+export async function runListTerms() {
+  const [terms, current] = await Promise.all([
+    prisma.term.findMany({
+      orderBy: { sortKey: "asc" },
+      select: {
+        id: true,
+        code: true,
+        year: true,
+        season: true,
+        startDate: true,
+        endDate: true,
+      },
+    }),
+    currentTerm(),
+  ]);
+
+  return {
+    terms: terms.map((t) => ({
+      id: t.id,
+      code: t.code,
+      year: t.year,
+      season: t.season,
+      startsAt: t.startDate.toISOString(),
+      endsAt: t.endDate.toISOString(),
+      isCurrent: t.id === current?.id,
+    })),
+  };
+}

--- a/dali-api/app/routes/mcp.ts
+++ b/dali-api/app/routes/mcp.ts
@@ -69,6 +69,7 @@ import {
   runListMyProjects,
 } from "~/mcp/tools/list-my-projects";
 import { LIST_PROJECTS_TOOL, runListProjects } from "~/mcp/tools/list-projects";
+import { LIST_TERMS_TOOL, runListTerms } from "~/mcp/tools/list-terms";
 import {
   GET_PROJECT_OVERVIEW_TOOL,
   runGetProjectOverview,
@@ -291,6 +292,7 @@ const TOOLS = [
   LIST_GROUPS_TOOL,
   LIST_MY_PROJECTS_TOOL,
   LIST_PROJECTS_TOOL,
+  LIST_TERMS_TOOL,
   GET_PROJECT_OVERVIEW_TOOL,
   LIST_MY_TASKS_TOOL,
   GET_TASK_TOOL,
@@ -570,6 +572,9 @@ export async function action({ request }: Route.ActionArgs) {
               auth.user.id,
               args as Parameters<typeof runListProjects>[1],
             );
+            break;
+          case "list_terms":
+            payload = await runListTerms();
             break;
           case "get_project_overview":
             payload = await runGetProjectOverview(


### PR DESCRIPTION
Re-raise of the `list_terms` commit that landed on the #959 branch just after it merged (same race as #953 → #959). Clean cherry-pick onto current staging; no other changes.

**`list_terms`** (`mcp:read`, any member, no inputs): all lab terms chronologically — id, code (`26S`/`26X`), year, season, start/end dates — with `isCurrent` flagged via the app's roll-forward `currentTerm()` (advances to the next upcoming term during inter-term gaps, matching role-check semantics). Closes the last discovery gap for sync agents: resolving a term code to an id / finding the active term.

No schema changes, no migrations. 249 files / 2078 tests pass; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/960"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787191614&installation_model_id=21824&pr_number=960&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F960&signature=c672f84cb2c67052d67b63f7d797f0d33d3d54af940680ed9b42e105b79f28ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->