### PR TITLE
Fix task reminder dismissal and broken PDF previews

### DIFF
--- a/dali-api/app/lib/s3.ts
+++ b/dali-api/app/lib/s3.ts
@@ -69,10 +69,44 @@ export async function putObject(
 }
 
 // Generate a presigned URL for reading a private file.
-export async function getDownloadUrl(key: string, expiresIn = 3600) {
+//
+// `options` may be a number (legacy `expiresIn`) or an options object. Setting
+// `contentType` / `inline` overrides the response headers on the presigned URL
+// (`response-content-type` / `response-content-disposition`). This matters for
+// inline previews: the browser renders a file by these headers, so an object
+// stored with a wrong or missing Content-Type (common for server-generated
+// PDFs) would otherwise fail to load in an <iframe> even though we know its
+// real type. Forcing the type we have on record — and `inline` disposition —
+// makes the preview render regardless of how the bytes were stored.
+type DownloadUrlOptions = {
+  expiresIn?: number
+  contentType?: string
+  fileName?: string
+  inline?: boolean
+}
+
+export async function getDownloadUrl(
+  key: string,
+  options: number | DownloadUrlOptions = {},
+) {
   if (!isS3Configured()) {
     throw new Error("AWS S3 is not configured")
   }
-  const command = new GetObjectCommand({ Bucket: BUCKET, Key: key })
+  const { expiresIn = 3600, contentType, fileName, inline } =
+    typeof options === "number" ? { expiresIn: options } : options
+
+  const disposition = inline
+    ? "inline"
+    : fileName
+      ? // Strip quotes/control chars so the filename can't break out of the header.
+        `attachment; filename="${fileName.replace(/["\r\n]/g, "")}"`
+      : undefined
+
+  const command = new GetObjectCommand({
+    Bucket: BUCKET,
+    Key: key,
+    ...(contentType ? { ResponseContentType: contentType } : {}),
+    ...(disposition ? { ResponseContentDisposition: disposition } : {}),
+  })
   return getSignedUrl(s3, command, { expiresIn })
 }

--- a/dali-api/app/routes/documents.file.$fileId.tsx
+++ b/dali-api/app/routes/documents.file.$fileId.tsx
@@ -95,6 +95,13 @@ export async function loader({ request, params }: Route.LoaderArgs) {
       isCurrent: v.id === file.currentVersionId,
       contentType: v.contentType,
       downloadUrl: await getDownloadUrl(v.s3Key),
+      // Inline-preview URL: forces the known content type + inline disposition
+      // so the browser renders it even when the S3 object's stored Content-Type
+      // is wrong or missing (e.g. generated PDFs served as octet-stream).
+      previewUrl: await getDownloadUrl(v.s3Key, {
+        contentType: v.contentType ?? undefined,
+        inline: true,
+      }),
     })),
   );
 
@@ -314,7 +321,7 @@ function FilePreview({ version }: { version: FileVersionView }) {
       // doesn't re-fetch on a src prop change alone.
       <video
         key={version.id}
-        src={version.downloadUrl}
+        src={version.previewUrl}
         controls
         className="max-w-full max-h-[70vh] rounded-lg border border-border bg-black"
       />
@@ -322,13 +329,13 @@ function FilePreview({ version }: { version: FileVersionView }) {
   }
   if (isAudio) {
     return (
-      <audio key={version.id} src={version.downloadUrl} controls className="w-full" />
+      <audio key={version.id} src={version.previewUrl} controls className="w-full" />
     );
   }
   if (isImage) {
     return (
       <img
-        src={version.downloadUrl}
+        src={version.previewUrl}
         alt={version.fileName}
         className="max-w-full max-h-[70vh] rounded-lg border border-border object-contain bg-muted/20"
       />
@@ -337,7 +344,8 @@ function FilePreview({ version }: { version: FileVersionView }) {
   if (isPdf || isText) {
     return (
       <iframe
-        src={version.downloadUrl}
+        key={version.id}
+        src={version.previewUrl}
         title={version.fileName}
         className="w-full h-[70vh] rounded-lg border border-border bg-white"
       />

--- a/dali-api/app/routes/notifications.tsx
+++ b/dali-api/app/routes/notifications.tsx
@@ -6,6 +6,7 @@ import {
   Search,
   ExternalLink,
   RotateCcw,
+  Check,
 } from "lucide-react";
 import { requireAuth, redirectPartnerToPortal } from "~/lib/auth";
 import {
@@ -18,6 +19,7 @@ import {
 } from "~/lib/tasks";
 import { requestOpenTabIfEmbedded } from "~/components/workspace-link";
 import { RsvpButtons } from "~/components/RsvpButtons";
+import { TASKS_CHANGED_EVENT } from "~/components/NotificationBell";
 import type { Route } from "./+types/notifications";
 
 export const meta: Route.MetaFunction = () => [
@@ -107,7 +109,27 @@ function openLink(link: string, label: string) {
 }
 
 function OpenTab({ tasks }: { tasks: Task[] }) {
-  if (tasks.length === 0) {
+  const [items, setItems] = useState(tasks);
+  // Re-sync when the loader hands down a fresh list (revalidation, tab switch).
+  useEffect(() => setItems(tasks), [tasks]);
+
+  // Meeting invites clear only by RSVPing, so they carry no manual dismiss.
+  // Everything else — reminders, announcements, general to-dos — can be marked
+  // read here: POST /read clears the notification and drops the sidebar count.
+  async function markRead(id: string) {
+    setItems((prev) => prev.filter((t) => t.id !== id));
+    try {
+      await fetch(`/api/notifications/${id}/read`, {
+        method: "POST",
+        credentials: "include",
+        keepalive: true,
+      });
+    } finally {
+      window.dispatchEvent(new Event(TASKS_CHANGED_EVENT));
+    }
+  }
+
+  if (items.length === 0) {
     return (
       <p className="text-sm text-muted-foreground py-8 text-center">
         You're all caught up — no open tasks.
@@ -116,7 +138,7 @@ function OpenTab({ tasks }: { tasks: Task[] }) {
   }
   return (
     <ul className="flex flex-col gap-2">
-      {tasks.map((t) => (
+      {items.map((t) => (
         <li
           key={t.id}
           className="flex items-start gap-3 rounded-lg border border-border bg-card px-4 py-3"
@@ -146,14 +168,25 @@ function OpenTab({ tasks }: { tasks: Task[] }) {
               </div>
             ) : null}
           </div>
-          {t.source !== "meeting" && t.link && (
-            <button
-              type="button"
-              onClick={() => openLink(t.link!, t.title)}
-              className="flex items-center gap-1 text-xs font-medium text-accent-coral hover:underline flex-shrink-0"
-            >
-              Open <ExternalLink className="w-3 h-3" />
-            </button>
+          {t.source !== "meeting" && (
+            <div className="flex flex-shrink-0 items-center gap-3">
+              {t.link && (
+                <button
+                  type="button"
+                  onClick={() => openLink(t.link!, t.title)}
+                  className="flex items-center gap-1 text-xs font-medium text-accent-coral hover:underline"
+                >
+                  Open <ExternalLink className="w-3 h-3" />
+                </button>
+              )}
+              <button
+                type="button"
+                onClick={() => void markRead(t.id)}
+                className="flex items-center gap-1 text-xs font-medium text-muted-foreground hover:text-foreground"
+              >
+                <Check className="w-3 h-3" /> Mark as read
+              </button>
+            </div>
           )}
         </li>
       ))}


### PR DESCRIPTION
Two small, independent bug fixes.

## 1. Meeting reminders can't be dismissed from My Tasks
A "Starting soon: …" reminder (`MeetingReminder` → task `source: "reminder"`) showed up in **My Tasks → Open** with only an **Open** action, and that link never marked the notification read — so there was no way to clear it. Only meeting *invites* (`source: "meeting"`) were special-cased with RSVP buttons.

**Fix:** reminders and other non-invite tasks (announcements, general to-dos) now get a **Mark as read** action that `POST`s `/api/notifications/{id}/read`, removes the tile optimistically, and fires `TASKS_CHANGED` so the sidebar count updates. Meeting invites are unchanged (still clear via RSVP).

## 2. Some PDFs fail to render in the file viewer
The inline preview `<iframe>` pointed at a presigned S3 URL with **no response-header overrides**, so the browser rendered strictly by the object's *stored* Content-Type. Files stored with a wrong/missing type (e.g. generated PDFs served as `application/octet-stream`) failed with "Failed to load PDF document," even though the DB correctly recorded `application/pdf`.

**Fix:** `getDownloadUrl` now optionally stamps `response-content-type` + `response-content-disposition` onto the presigned URL (backwards-compatible with the numeric `expiresIn` callers). The file viewer builds a dedicated `previewUrl` that forces the known content type and `inline` disposition for inline previews (PDF/text/image/video/audio). Download links still use the plain `downloadUrl`, so download behavior is unchanged.

## Scope / notes
- 3 files: `app/lib/s3.ts`, `app/routes/documents.file.$fileId.tsx`, `app/routes/notifications.tsx`. Presentation/serving only — no schema, migration, or business-logic changes.
- `npm run typecheck` clean for these files.
- Follow-up (not included): the partner project hub and the project-files API render PDFs the same way and have the identical latent Content-Type bug — worth the same `previewUrl` treatment in a later change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/961"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787248223&installation_model_id=21824&pr_number=961&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F961&signature=269c10f1916206642b41a2f063dea31f704c832dd97bb242ed74c4c798b3c9f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->