### PR TITLE
Stop project notifications reaching people no longer on the project

### DIFF
--- a/dali-api/app/projects/lib/__tests__/file-notifications.test.ts
+++ b/dali-api/app/projects/lib/__tests__/file-notifications.test.ts
@@ -2,9 +2,13 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 
 vi.mock("~/lib/db");
 vi.mock("~/lib/notify.server", () => ({ notify: vi.fn() }));
+vi.mock("~/projects/lib/project-members.server", () => ({
+  currentProjectParticipantIds: vi.fn(),
+}));
 
 import { prisma } from "~/lib/db";
 import { notify } from "~/lib/notify.server";
+import { currentProjectParticipantIds } from "~/projects/lib/project-members.server";
 import {
   notifyFileComment,
   notifyFileNewVersion,
@@ -14,15 +18,21 @@ const mockPrisma = prisma as unknown as {
   projectFile: { findUnique: ReturnType<typeof vi.fn> };
 };
 const mockNotify = notify as unknown as ReturnType<typeof vi.fn>;
+const mockMembers = currentProjectParticipantIds as unknown as ReturnType<
+  typeof vi.fn
+>;
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // Default: every stakeholder is currently on the project.
+  mockMembers.mockResolvedValue(new Set(["uploader", "mentor", "assignee"]));
 });
 
 // Audience: version uploaders + comment authors + linked-task assignees,
 // with overlap (uploader is also an assignee here).
 const FILE = {
   title: "Hero animation",
+  projectId: "p1",
   versions: [{ uploadedById: "uploader" }, { uploadedById: "uploader" }],
   comments: [{ authorId: "mentor" }],
   taskLinks: [
@@ -56,6 +66,17 @@ describe("notifyFileComment", () => {
     await notifyFileComment({ fileId: "f1", authorId: "mentor", body: "x".repeat(300) });
 
     expect(mockNotify.mock.calls[0][0].message.body).toBe(`${"x".repeat(200)}…`);
+  });
+
+  it("excludes a stakeholder who has rolled off the project", async () => {
+    mockPrisma.projectFile.findUnique.mockResolvedValue(FILE);
+    // "assignee" once worked the file but is no longer on the project.
+    mockMembers.mockResolvedValue(new Set(["uploader", "mentor"]));
+
+    await notifyFileComment({ fileId: "f1", authorId: "mentor", body: "note" });
+
+    expect(currentProjectParticipantIds).toHaveBeenCalledWith("p1");
+    expect(recipientIds()).toEqual(["uploader"]);
   });
 
   it("is a no-op when the author is the only stakeholder", async () => {

--- a/dali-api/app/projects/lib/__tests__/project-members.test.ts
+++ b/dali-api/app/projects/lib/__tests__/project-members.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("~/lib/db", () => ({
+  prisma: {
+    projectAssignment: { findMany: vi.fn() },
+    externalMentor: { findMany: vi.fn() },
+  },
+}));
+vi.mock("~/lib/roles", () => ({ currentTerm: vi.fn() }));
+
+import { prisma } from "~/lib/db";
+import { currentTerm } from "~/lib/roles";
+import { currentProjectParticipantIds } from "~/projects/lib/project-members.server";
+
+const mockPrisma = prisma as unknown as {
+  projectAssignment: { findMany: ReturnType<typeof vi.fn> };
+  externalMentor: { findMany: ReturnType<typeof vi.fn> };
+};
+const mockCurrentTerm = currentTerm as unknown as ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("currentProjectParticipantIds", () => {
+  it("unions current-term roster with current-cycle external mentors", async () => {
+    mockCurrentTerm.mockResolvedValue({ id: "term-1" });
+    mockPrisma.projectAssignment.findMany.mockResolvedValue([
+      { userId: "u1" },
+      { userId: "u2" },
+    ]);
+    mockPrisma.externalMentor.findMany.mockResolvedValue([
+      { userId: "mentor" },
+      { userId: "u2" }, // overlap dedupes
+    ]);
+
+    const ids = await currentProjectParticipantIds("p1");
+
+    expect(ids).toEqual(new Set(["u1", "u2", "mentor"]));
+    // Scoped to the current term / that project.
+    expect(mockPrisma.projectAssignment.findMany).toHaveBeenCalledWith({
+      where: { projectId: "p1", termId: "term-1" },
+      select: { userId: true },
+    });
+    expect(mockPrisma.externalMentor.findMany).toHaveBeenCalledWith({
+      where: { projectId: "p1", staffingCycle: { termId: "term-1" } },
+      select: { userId: true },
+    });
+  });
+
+  it("returns an empty set when there is no current term", async () => {
+    mockCurrentTerm.mockResolvedValue(null);
+
+    const ids = await currentProjectParticipantIds("p1");
+
+    expect(ids.size).toBe(0);
+    expect(mockPrisma.projectAssignment.findMany).not.toHaveBeenCalled();
+    expect(mockPrisma.externalMentor.findMany).not.toHaveBeenCalled();
+  });
+});

--- a/dali-api/app/projects/lib/__tests__/task-notifications.status.test.ts
+++ b/dali-api/app/projects/lib/__tests__/task-notifications.status.test.ts
@@ -2,18 +2,26 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 
 vi.mock("~/lib/db");
 vi.mock("~/lib/notify.server", () => ({ notify: vi.fn() }));
+vi.mock("~/projects/lib/project-members.server", () => ({
+  currentProjectParticipantIds: vi.fn(),
+}));
 
 import { prisma } from "~/lib/db";
 import { notify } from "~/lib/notify.server";
+import { currentProjectParticipantIds } from "~/projects/lib/project-members.server";
 import { notifyTaskStatusChanged } from "~/projects/lib/task-notifications.server";
 
 const mockPrisma = prisma as unknown as {
   task: { findUnique: ReturnType<typeof vi.fn> };
 };
 const mockNotify = notify as unknown as ReturnType<typeof vi.fn>;
+const mockMembers = currentProjectParticipantIds as unknown as ReturnType<
+  typeof vi.fn
+>;
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockMembers.mockResolvedValue(new Set(["u1", "u2"]));
 });
 
 describe("notifyTaskStatusChanged", () => {

--- a/dali-api/app/projects/lib/__tests__/task-notifications.test.ts
+++ b/dali-api/app/projects/lib/__tests__/task-notifications.test.ts
@@ -2,9 +2,13 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 
 vi.mock("~/lib/db");
 vi.mock("~/lib/notify.server", () => ({ notify: vi.fn() }));
+vi.mock("~/projects/lib/project-members.server", () => ({
+  currentProjectParticipantIds: vi.fn(),
+}));
 
 import { prisma } from "~/lib/db";
 import { notify } from "~/lib/notify.server";
+import { currentProjectParticipantIds } from "~/projects/lib/project-members.server";
 import {
   notifyTaskAssigned,
   notifyTaskComment,
@@ -15,9 +19,15 @@ const mockPrisma = prisma as unknown as {
   task: { findUnique: ReturnType<typeof vi.fn> };
 };
 const mockNotify = notify as unknown as ReturnType<typeof vi.fn>;
+const mockMembers = currentProjectParticipantIds as unknown as ReturnType<
+  typeof vi.fn
+>;
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // Default: everyone referenced in these tests is currently on the project.
+  // Individual tests override this to exercise the roll-off gate.
+  mockMembers.mockResolvedValue(new Set(["u1", "u2"]));
 });
 
 describe("notifyTaskAssigned", () => {
@@ -91,6 +101,37 @@ describe("notifyTaskComment", () => {
       projectId: "p1",
       assignees: [{ userId: "u1" }],
     });
+
+    await notifyTaskComment({ taskId: "t1", authorId: "u1", body: "hi" });
+
+    expect(mockNotify).not.toHaveBeenCalled();
+  });
+
+  it("excludes an assignee who has rolled off the project", async () => {
+    mockPrisma.task.findUnique.mockResolvedValue({
+      id: "t1",
+      title: "Ship it",
+      projectId: "p1",
+      assignees: [{ userId: "u1" }, { userId: "u2" }, { userId: "gone" }],
+    });
+    // "gone" is a historical assignee but no longer on the project.
+    mockMembers.mockResolvedValue(new Set(["u1", "u2"]));
+
+    await notifyTaskComment({ taskId: "t1", authorId: "u1", body: "hi" });
+
+    expect(currentProjectParticipantIds).toHaveBeenCalledWith("p1");
+    expect(mockNotify).toHaveBeenCalledTimes(1);
+    expect(mockNotify.mock.calls[0][0].recipients).toEqual([{ userId: "u2" }]);
+  });
+
+  it("no-ops when every remaining assignee has left the project", async () => {
+    mockPrisma.task.findUnique.mockResolvedValue({
+      id: "t1",
+      title: "Ship it",
+      projectId: "p1",
+      assignees: [{ userId: "u2" }],
+    });
+    mockMembers.mockResolvedValue(new Set(["u1"]));
 
     await notifyTaskComment({ taskId: "t1", authorId: "u1", body: "hi" });
 

--- a/dali-api/app/projects/lib/file-notifications.server.ts
+++ b/dali-api/app/projects/lib/file-notifications.server.ts
@@ -6,6 +6,7 @@
 
 import { prisma } from "~/lib/db";
 import { notify } from "~/lib/notify.server";
+import { currentProjectParticipantIds } from "./project-members.server";
 
 const PREVIEW_MAX = 200;
 
@@ -24,6 +25,7 @@ async function loadFileAudience(fileId: string): Promise<{
     where: { id: fileId },
     select: {
       title: true,
+      projectId: true,
       versions: { select: { uploadedById: true } },
       comments: { select: { authorId: true } },
       taskLinks: {
@@ -34,12 +36,19 @@ async function loadFileAudience(fileId: string): Promise<{
     },
   });
   if (!file) return null;
-  const userIds = new Set<string>();
-  for (const v of file.versions) userIds.add(v.uploadedById);
-  for (const c of file.comments) userIds.add(c.authorId);
+  const stakeholders = new Set<string>();
+  for (const v of file.versions) stakeholders.add(v.uploadedById);
+  for (const c of file.comments) stakeholders.add(c.authorId);
   for (const l of file.taskLinks) {
-    for (const a of l.task.assignees) userIds.add(a.userId);
+    for (const a of l.task.assignees) stakeholders.add(a.userId);
   }
+  // Gate to who's currently on the project so people who have rolled off stop
+  // hearing about a file they once touched (uploaded / commented / were an
+  // assignee of a linked task).
+  const members = await currentProjectParticipantIds(file.projectId);
+  const userIds = new Set<string>(
+    [...stakeholders].filter((id) => members.has(id)),
+  );
   return { title: file.title, versionCount: file.versions.length, userIds };
 }
 

--- a/dali-api/app/projects/lib/project-members.server.ts
+++ b/dali-api/app/projects/lib/project-members.server.ts
@@ -1,0 +1,38 @@
+// Who is *currently* on a project — the gate for project-activity notifications.
+//
+// Task/file notification audiences are built from stakeholders (task assignees,
+// file uploaders, past comment authors). Those sets are sticky: a member who
+// rolls off the project stays a historical assignee/author forever, so without
+// a membership gate they keep receiving the project's task and file activity.
+// Intersecting the audience with this set stops that.
+//
+// "Currently on the project" spans both staffing shapes for the current term:
+//   - ProjectAssignment — the staffed roster (term-scoped)
+//   - ExternalMentor    — non-roster mentors placed on the project (cycle-scoped)
+// so a currently-active external mentor still hears replies to their feedback.
+
+import { prisma } from "~/lib/db";
+import { currentTerm } from "~/lib/roles";
+
+export async function currentProjectParticipantIds(
+  projectId: string,
+): Promise<Set<string>> {
+  const term = await currentTerm();
+  if (!term) return new Set();
+
+  const [assignments, externalMentors] = await Promise.all([
+    prisma.projectAssignment.findMany({
+      where: { projectId, termId: term.id },
+      select: { userId: true },
+    }),
+    prisma.externalMentor.findMany({
+      where: { projectId, staffingCycle: { termId: term.id } },
+      select: { userId: true },
+    }),
+  ]);
+
+  const ids = new Set<string>();
+  for (const a of assignments) ids.add(a.userId);
+  for (const m of externalMentors) ids.add(m.userId);
+  return ids;
+}

--- a/dali-api/app/projects/lib/task-notifications.server.ts
+++ b/dali-api/app/projects/lib/task-notifications.server.ts
@@ -6,9 +6,21 @@
 import { prisma } from "~/lib/db";
 import { notify } from "~/lib/notify.server";
 import { TASK_STATUS_LABELS } from "./task-board";
+import { currentProjectParticipantIds } from "./project-members.server";
 
 function taskLink(projectId: string, taskId: string): string {
   return `/projects/${projectId}?tab=board&task=${taskId}`;
+}
+
+// Drop anyone no longer on the project — a historical task assignee who has
+// since rolled off should stop getting the project's task activity.
+async function onProject(
+  projectId: string,
+  userIds: string[],
+): Promise<string[]> {
+  if (userIds.length === 0) return userIds;
+  const members = await currentProjectParticipantIds(projectId);
+  return userIds.filter((id) => members.has(id));
 }
 
 const COMMENT_PREVIEW_MAX = 200;
@@ -20,8 +32,8 @@ export async function notifyTaskAssigned(args: {
   // notifies.
   actorUserId?: string | null;
 }): Promise<void> {
-  const recipients = args.addedUserIds.filter((id) => id !== args.actorUserId);
-  if (recipients.length === 0) return;
+  const added = args.addedUserIds.filter((id) => id !== args.actorUserId);
+  if (added.length === 0) return;
   const task = await prisma.task.findUnique({
     where: { id: args.taskId },
     select: {
@@ -33,6 +45,8 @@ export async function notifyTaskAssigned(args: {
     },
   });
   if (!task) return;
+  const recipients = await onProject(task.projectId, added);
+  if (recipients.length === 0) return;
   await notify({
     eventType: "task.assigned",
     createdByUserId: args.actorUserId ?? null,
@@ -61,9 +75,10 @@ export async function notifyTaskComment(args: {
     },
   });
   if (!task) return;
-  const recipients = task.assignees
-    .map((a) => a.userId)
-    .filter((id) => id !== args.authorId);
+  const recipients = await onProject(
+    task.projectId,
+    task.assignees.map((a) => a.userId).filter((id) => id !== args.authorId),
+  );
   if (recipients.length === 0) return;
   const preview =
     args.body.length > COMMENT_PREVIEW_MAX
@@ -98,9 +113,10 @@ export async function notifyTaskStatusChanged(
     },
   });
   if (!task) return;
-  const recipients = task.assignees
-    .map((a) => a.userId)
-    .filter((id) => id !== actorUserId);
+  const recipients = await onProject(
+    task.projectId,
+    task.assignees.map((a) => a.userId).filter((id) => id !== actorUserId),
+  );
   if (recipients.length === 0) return;
   const label =
     (TASK_STATUS_LABELS as Record<string, string>)[newStatus] ?? newStatus;
@@ -131,6 +147,11 @@ export async function notifyTaskGithubUpdate(args: {
     },
   });
   if (!task || task.assignees.length === 0) return;
+  const recipients = await onProject(
+    task.projectId,
+    task.assignees.map((a) => a.userId),
+  );
+  if (recipients.length === 0) return;
   await notify({
     eventType: "task.github_update",
     message:
@@ -145,6 +166,6 @@ export async function notifyTaskGithubUpdate(args: {
             body: `The linked issue was reopened — status set to ${args.newStatus}.`,
             link: taskLink(task.projectId, task.id),
           },
-    recipients: task.assignees.map((a) => ({ userId: a.userId })),
+    recipients: recipients.map((userId) => ({ userId })),
   });
 }


### PR DESCRIPTION
## The bug
Project notifications — new comments and more — were reaching people **no longer on the project**.

Task and file notification audiences are built from **stakeholders**: task assignees, file uploaders, and past comment authors. Those sets are sticky — once someone rolls off a project they linger as a historical assignee/author, so they kept receiving that project's activity forever.

Affected events: `task.assigned`, `task.comment`, `task.status_changed`, `task.github_update`, `file.comment`, `file.new_version`.

## The fix
New helper `currentProjectParticipantIds(projectId)` returns everyone currently on the project, spanning both staffing shapes for the **current term**:
- **`ProjectAssignment`** — the staffed roster (term-scoped)
- **`ExternalMentor`** — non-roster mentors placed on the project (staffing-cycle-scoped)

Every project task/file notification audience is now intersected with that set. A currently-active external mentor still hears replies to their feedback; anyone who has left the project no longer does.

## Notes / decisions
- **"Currently on the project" = current term.** During a between-terms gap, `currentTerm()` resolves to the upcoming term, so gating follows the upcoming roster once it's staffed. Flag if you'd prefer a different definition — it's a one-line change in the helper.
- **Mentions and threaded comment replies are out of scope** — those target explicitly-mentioned users / thread participants, a deliberate audience, not the sticky-stakeholder bug fixed here.
- 3 files, no schema/migration changes. `npm run typecheck` clean for these files.
- One extra lightweight query per project notification (fire-and-forget path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/962"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787261034&installation_model_id=21824&pr_number=962&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F962&signature=c493ecffe480e20982e41be3afc32cc0cebc2de2a4975f1987fd4dcccba72437"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->