### PR TITLE
Finalize staffing: honor deselected automations

### DIFF
--- a/dali-api/app/projects/components/FinalizeModal.tsx
+++ b/dali-api/app/projects/components/FinalizeModal.tsx
@@ -372,21 +372,17 @@ export function FinalizeModal({
         </div>
 
         <div className="flex gap-2">
-          <button
-            type="button"
-            disabled={running || savingFields}
-            onClick={() => run([...selected])}
-            className="px-3 py-1.5 text-sm font-medium rounded-md border border-border hover:bg-muted disabled:opacity-60 transition-colors"
-          >
-            {running ? "Running…" : "Run selected"}
-          </button>
           <Button
             variant="primary"
             size="sm"
-            disabled={running || savingFields}
-            onClick={() => run(AUTOMATIONS.filter((a) => a.configured).map((a) => a.id))}
+            disabled={running || savingFields || selected.size === 0}
+            onClick={() => run([...selected])}
           >
-            {running ? "Running…" : "Run all"}
+            {running
+              ? "Running…"
+              : selected.size === AUTOMATIONS.filter((a) => a.configured).length
+                ? "Finalize"
+                : `Finalize (${selected.size})`}
           </Button>
         </div>
       </div>


### PR DESCRIPTION
## The bug
The **Finalize staffing** modal ran **all** automations even when a lead had deselected some.

It had two buttons: a secondary **"Run selected"** (which respected the checkboxes) and a prominent primary **"Run all"** that hardcoded every configured automation, ignoring the selection. Deselecting an automation and clicking the primary button still ran everything — and the modal's own subtitle says *"Run the selected automations."*

## The fix (UI only)
Collapse to a single primary **Finalize** button that runs exactly the selected automations. Everything starts checked, so the default is still "run all"; unchecking one now actually skips it. The button is disabled when nothing is selected and reads **"Finalize (N)"** on a partial run so it's clear how many will fire.

The backend (`api.staffing.finalize.ts`) already gated every step on the selected set — it was correct. No server change.

- 1 file: `app/projects/components/FinalizeModal.tsx`. Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/963"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787262586&installation_model_id=21824&pr_number=963&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F963&signature=1bc5d92b39813a9eafec31fa60f319849dfe1d26f23f5987b52205c716b31362"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->