### PR TITLE
Redesign the hiring UI/UX (in-brand consistency pass)

### DIFF
--- a/dali-api/app/hiring/components/ApplicantDetailHeader.tsx
+++ b/dali-api/app/hiring/components/ApplicantDetailHeader.tsx
@@ -1,7 +1,10 @@
 import type React from "react";
+import { PageHeader } from "~/hiring/components/PageHeader";
 
 // Applicant name + "domain · cycle" subtitle for the hiring detail routes,
-// with an optional status pill rendered top-right.
+// with an optional status pill rendered inline beside the name. Delegates to
+// the shared PageHeader so every detail view opens with the same Dosis title,
+// spacing, and chip placement as the rest of the hiring area.
 export function ApplicantDetailHeader({
   name,
   domainName,
@@ -14,14 +17,10 @@ export function ApplicantDetailHeader({
   statusSlot?: React.ReactNode;
 }): React.ReactElement {
   return (
-    <div className="flex items-start justify-between gap-4">
-      <div>
-        <h1 className="text-2xl font-bold text-foreground">{name}</h1>
-        <p className="mt-1 text-muted-foreground">
-          {domainName} · {cycleName}
-        </p>
-      </div>
-      {statusSlot != null && <div className="flex-shrink-0">{statusSlot}</div>}
-    </div>
+    <PageHeader
+      title={name}
+      subtitle={`${domainName} · ${cycleName}`}
+      chip={statusSlot}
+    />
   );
 }

--- a/dali-api/app/hiring/components/ApplicationViewer.tsx
+++ b/dali-api/app/hiring/components/ApplicationViewer.tsx
@@ -138,11 +138,11 @@ function AnnotationMark({
           className="fixed z-50 pointer-events-none -translate-x-1/2"
           style={{ left: tooltip.left, top: tooltip.top, bottom: tooltip.bottom, maxWidth: TOOLTIP_MAX_WIDTH }}
         >
-          {tooltip.below && <span className="block w-2 h-2 bg-gray-900 rotate-45 mx-auto -mb-1" />}
-          <span className="block bg-gray-900 text-white text-xs rounded-lg px-3 py-2 whitespace-pre-wrap shadow-lg">
+          {tooltip.below && <span className="block w-2 h-2 bg-foreground rotate-45 mx-auto -mb-1" />}
+          <span className="block bg-foreground text-background text-xs rounded-lg px-3 py-2 whitespace-pre-wrap shadow-lg">
             {ann.comment}
           </span>
-          {!tooltip.below && <span className="block w-2 h-2 bg-gray-900 rotate-45 mx-auto -mt-1" />}
+          {!tooltip.below && <span className="block w-2 h-2 bg-foreground rotate-45 mx-auto -mt-1" />}
         </span>
       )}
     </span>
@@ -317,13 +317,13 @@ function AnnotatableField({
                 <div className="flex gap-1.5 mb-2">
                   {COLOR_OPTIONS.map((c) => (
                     <button key={c} onClick={() => setPendingColor(c)}
-                      className={`w-6 h-6 rounded-full border-2 transition-transform ${c === 'yellow' ? 'bg-yellow-300' : c === 'green' ? 'bg-green-300' : c === 'red' ? 'bg-red-300' : 'bg-blue-300'} ${pendingColor === c ? 'border-gray-700 scale-110' : 'border-transparent'}`} />
+                      className={`w-6 h-6 rounded-full border-2 transition-transform ${c === 'yellow' ? 'bg-yellow-300' : c === 'green' ? 'bg-green-300' : c === 'red' ? 'bg-red-300' : 'bg-blue-300'} ${pendingColor === c ? 'border-foreground scale-110' : 'border-transparent'}`} />
                   ))}
                 </div>
                 <textarea autoFocus rows={3} value={pendingComment}
                   onChange={(e) => setPendingComment(e.target.value)}
                   placeholder="Add a comment... (optional)"
-                  className="w-full text-sm text-foreground border border-border rounded-lg p-2 resize-none focus:outline-none focus:ring-1 focus:ring-blue-400"
+                  className="w-full text-sm text-foreground border border-border rounded-lg p-2 resize-none focus:outline-none focus:ring-1 focus:ring-accent-coral"
                   onKeyDown={(e) => { if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) handleSave(); if (e.key === 'Escape') setPopover(null) }}
                 />
                 <div className="flex gap-2 mt-2">

--- a/dali-api/app/hiring/components/CalendarGrid.tsx
+++ b/dali-api/app/hiring/components/CalendarGrid.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useCallback, useEffect } from 'react'
 import { ChevronLeft, ChevronRight, Calendar } from 'lucide-react'
 import { APPLICATION_TZ, zonedWallTimeUtc, getZonedParts } from '~/lib/timezone'
+import { Button, buttonClasses } from '~/components/ui/Button'
 
 // ─── Types ─���─────────────────────────────────────────────────────────────────
 
@@ -318,10 +319,10 @@ export default function CalendarGrid({
           <button
             onClick={onImportFromGoogle}
             disabled={importing}
-            className="inline-flex items-center gap-2 px-3 py-1.5 rounded-lg border border-gray-300 text-xs font-medium text-foreground/80 hover:bg-muted/50 disabled:opacity-50 transition"
+            className={buttonClasses('secondary', 'sm')}
           >
             <Calendar className="w-4 h-4" />
-            <span className="hidden sm:inline">{importing ? 'Importing...' : 'Import from Google Calendar'}</span>
+            <span className="hidden sm:inline">{importing ? 'Importing…' : 'Import from Google Calendar'}</span>
             <span className="sm:hidden">{importing ? 'Importing…' : 'Import'}</span>
           </button>
         )}
@@ -386,13 +387,12 @@ export default function CalendarGrid({
                   const isOutOfRange = cellDate < rangeStartDay || cellDate >= dayAfterRangeEnd
                   const isLocked = isInterview || isPast || isOutOfRange
 
-                  let bg = 'bg-card hover:bg-green-50'
-                  
+                  let bg = 'bg-card hover:bg-green-100 cursor-pointer'
+
                   if (isInterview) bg = 'bg-blue-100 cursor-not-allowed'
                   else if (isOutOfRange) bg = 'bg-muted/30 cursor-not-allowed'
-
                   else if (isPast) bg = 'bg-muted/50 cursor-not-allowed'
-                  else if (isSelected) bg = 'bg-green-400 hover:bg-green-500'
+                  else if (isSelected) bg = 'bg-green-400 hover:bg-green-500 cursor-pointer'
 
                   return (
                     <div
@@ -401,7 +401,7 @@ export default function CalendarGrid({
                       data-block-past={isPast ? '1' : '0'}
                       onMouseDown={() => !isLocked && handleMouseDown(key, isPast)}
                       onMouseEnter={() => !isLocked && handleMouseEnter(key, isPast)}
-                      className={`border-r last:border-r-0 border-border transition-colors ${isHourBoundary ? 'border-t border-border' : 'border-t border-gray-50'} ${bg}`}
+                      className={`border-r last:border-r-0 border-border transition-colors ${isHourBoundary ? 'border-t border-border' : 'border-t border-border/40'} ${bg}`}
                       style={{ height: BLOCK_HEIGHT_PX }}
                     />
                   )
@@ -416,7 +416,7 @@ export default function CalendarGrid({
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 px-4 sm:px-6 py-3 sm:py-4 border-t border-border">
         <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5 text-xs text-muted-foreground">
           <div className="flex items-center gap-1.5">
-            <div className="w-3 h-3 bg-card border border-gray-300 rounded" /> Unavailable
+            <div className="w-3 h-3 bg-card border border-border rounded" /> Unavailable
           </div>
           <div className="flex items-center gap-1.5">
             <div className="w-3 h-3 bg-green-400 rounded" /> Available
@@ -427,15 +427,15 @@ export default function CalendarGrid({
         </div>
         <div className="flex items-center gap-3 sm:justify-end">
           {dirty && (
-            <span className="text-xs text-amber-600 font-medium">Unsaved changes</span>
+            <span className="text-xs text-accent-coral font-medium">Unsaved changes</span>
           )}
-          <button
+          <Button
             onClick={handleSave}
             disabled={!dirty || saving}
-            className="px-5 py-2 text-sm font-medium rounded-lg bg-accent-coral hover:bg-accent-coral/90 text-white transition disabled:opacity-50 disabled:cursor-not-allowed"
+            variant="primary"
           >
-            {saving ? 'Saving...' : 'Save Availability'}
-          </button>
+            {saving ? 'Saving…' : 'Save availability'}
+          </Button>
         </div>
       </div>
     </div>

--- a/dali-api/app/hiring/components/ChallengeDetail.tsx
+++ b/dali-api/app/hiring/components/ChallengeDetail.tsx
@@ -5,9 +5,12 @@ import { FormBuilderTab } from '~/components/form-builder/FormBuilder'
 import { RichTextViewer, isEmptyDoc } from '~/components/RichTextViewer'
 import { ChallengePreviewModal } from '~/hiring/components/ChallengePreviewModal'
 import { Tooltip } from '~/components/ui/IconButton'
+import { Button } from '~/components/ui/Button'
+import { PageHeader } from '~/hiring/components/PageHeader'
 import type { Question } from '~/types'
 import type { loader } from '~/hiring/routes/challenges.$id'
 import { formatDateTime } from '~/lib/display'
+import { cn } from '~/lib/cn'
 
 export function resolveDuplicateDomainId(version: { domainId: string | null }): string {
   // A general version's domainId is null; coerce to '' so the form's selected
@@ -103,28 +106,24 @@ export function ChallengeDetail() {
 
   return (
     <div className="space-y-6">
-      <div>
-        <div className="flex justify-between items-start">
-          <div>
-            <h1 className="text-2xl font-bold text-foreground">{challenge.name}</h1>
-            <p className="mt-1 text-muted-foreground">
-              Created {new Date(challenge.createdAt).toLocaleDateString()}
-            </p>
-          </div>
-          {!isCreatingVersion && (
-            <button
+      <PageHeader
+        title={challenge.name}
+        subtitle={`Created ${new Date(challenge.createdAt).toLocaleDateString()}`}
+        actions={
+          !isCreatingVersion && (
+            <Button
+              variant="primary"
               onClick={() => {
                 if (selectedVersion && selectedVersion.domainId) setSelectedDomainId(selectedVersion.domainId)
                 setIsCreatingVersion(true)
               }}
-              className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-lg text-white bg-accent-coral hover:bg-accent-coral/90 shadow-sm"
             >
-              <Plus className="w-4 h-4 mr-2" />
-              New Version
-            </button>
-          )}
-        </div>
-      </div>
+              <Plus className="h-4 w-4" />
+              New version
+            </Button>
+          )
+        }
+      />
 
       <div className="flex flex-col lg:flex-row gap-8">
         {/* Left Sidebar: Versions List */}
@@ -143,11 +142,12 @@ export function ChallengeDetail() {
                       setSelectedVersionId(version.id)
                       setIsCreatingVersion(false)
                     }}
-                    className={`w-full text-left p-4 rounded-xl border transition-colors ${
+                    className={cn(
+                      'w-full text-left p-4 rounded-xl border transition-colors',
                       selectedVersionId === version.id && !isCreatingVersion
-                        ? 'border-blue-500 bg-blue-50 ring-1 ring-blue-500'
-                        : 'border-border bg-card hover:bg-muted/50'
-                    }`}
+                        ? 'border-accent-coral bg-brand-tint'
+                        : 'border-border bg-card hover:bg-muted/50',
+                    )}
                   >
                     <div className="flex items-center justify-between mb-2">
                       <div>
@@ -181,9 +181,9 @@ export function ChallengeDetail() {
             <div className="bg-card rounded-xl border border-border shadow-sm p-6">
               <div className="mb-6 pb-6 border-b border-border space-y-4">
                 <div>
-                  <h2 className="text-lg font-bold text-foreground">Create New Version</h2>
+                  <h2 className="font-heading text-lg font-bold text-foreground">Create new version</h2>
                   <p className="text-sm text-muted-foreground mt-1">
-                    Build your new challenge version below. It will be saved as v{nextVersionNumber}.
+                    Build the challenge below. It will be saved as v{nextVersionNumber}.
                   </p>
                 </div>
                 <div>
@@ -203,10 +203,10 @@ export function ChallengeDetail() {
             </div>
           ) : selectedVersion ? (
             <div className="bg-card rounded-xl border border-border shadow-sm overflow-hidden">
-              <div className="px-6 py-5 border-b border-border bg-muted/50 flex justify-between items-center">
+              <div className="px-6 py-5 border-b border-border bg-muted/50 flex justify-between items-center gap-3">
                 <div>
-                  <h2 className="text-lg font-semibold text-foreground">
-                    Version {challenge.versions.findIndex((v) => v.id === selectedVersionId) + 1} Preview
+                  <h2 className="font-heading text-lg font-semibold text-foreground">
+                    Version {challenge.versions.findIndex((v) => v.id === selectedVersionId) + 1} preview
                   </h2>
                   <p className="text-sm text-muted-foreground mt-1">
                     {selectedVersion.domain?.name ?? 'General'} · Created by{' '}
@@ -214,25 +214,26 @@ export function ChallengeDetail() {
                     {formatDateTime(selectedVersion.createdAt)}
                   </p>
                 </div>
-                <div className="flex items-center gap-3">
-                  <Tooltip label="Preview">
+                <div className="flex items-center gap-2 shrink-0">
+                  <Tooltip label="Preview as applicant">
                     <button
                       onClick={() => setShowPreviewModal(true)}
-                      aria-label="Preview"
-                      className="inline-flex items-center justify-center p-1.5 rounded-md text-blue-600 hover:text-blue-700 hover:bg-blue-50"
+                      aria-label="Preview as applicant"
+                      className="inline-flex items-center justify-center p-1.5 rounded-md text-muted-foreground hover:text-accent-coral hover:bg-muted"
                     >
                       <Eye className="w-4 h-4" />
                     </button>
                   </Tooltip>
-                  <button
+                  <Button
+                    variant="secondary"
+                    size="sm"
                     onClick={() => {
                       setSelectedDomainId(resolveDuplicateDomainId(selectedVersion))
                       setIsCreatingVersion(true)
                     }}
-                    className="text-sm text-blue-600 hover:text-blue-700 font-medium"
                   >
-                    Duplicate to New Version
-                  </button>
+                    Duplicate to new version
+                  </Button>
                 </div>
               </div>
               {/* Rubrics are now assigned at the domain+cycle level, not per challenge version */}
@@ -287,19 +288,18 @@ export function ChallengeDetail() {
               </div>
             </div>
           ) : (
-            <div className="text-center py-12 bg-card rounded-xl border border-border border-dashed">
-              <FileText className="mx-auto h-12 w-12 text-muted-foreground/70" />
-              <h3 className="mt-2 text-sm font-medium text-foreground">No versions</h3>
-              <p className="mt-1 text-sm text-muted-foreground">Get started by creating a new version.</p>
-              <div className="mt-6">
-                <button
-                  onClick={() => setIsCreatingVersion(true)}
-                  className="inline-flex items-center px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-accent-coral hover:bg-accent-coral/90"
-                >
-                  <Plus className="w-4 h-4 mr-2" />
-                  Create Version
-                </button>
-              </div>
+            <div className="flex flex-col items-center rounded-xl border border-dashed border-border bg-card px-6 py-12 text-center">
+              <span className="mb-3 flex h-11 w-11 items-center justify-center rounded-full bg-muted text-muted-foreground">
+                <FileText className="h-5 w-5" aria-hidden />
+              </span>
+              <p className="font-heading text-base font-semibold text-foreground">No versions yet</p>
+              <p className="mt-1 max-w-sm text-sm text-muted-foreground">
+                Create the first version to define the questions applicants will answer.
+              </p>
+              <Button variant="primary" size="sm" className="mt-4" onClick={() => setIsCreatingVersion(true)}>
+                <Plus className="h-4 w-4" />
+                Create version
+              </Button>
             </div>
           )}
         </div>

--- a/dali-api/app/hiring/components/ConfidentialityAgreementDetail.tsx
+++ b/dali-api/app/hiring/components/ConfidentialityAgreementDetail.tsx
@@ -5,6 +5,8 @@ import type { loader } from "~/hiring/routes/confidentiality-agreements.$id";
 import { RichTextEditor } from "~/components/RichTextEditor";
 import { RichTextViewer, isEmptyDoc } from "~/components/RichTextViewer";
 import { formatDateTime, fullName, UNKNOWN_LABEL } from "~/lib/display";
+import { Button } from "~/components/ui/Button";
+import { cn } from "~/lib/cn";
 
 const EMPTY_DOC = { type: "doc", content: [{ type: "paragraph" }] };
 
@@ -46,36 +48,33 @@ export function ConfidentialityAgreementDetail() {
                 name="name"
                 value={draftName}
                 onChange={(e) => setDraftName(e.target.value)}
-                className="px-3 py-2 text-base text-foreground border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 min-w-[16rem]"
+                className="px-3 py-2 text-base text-foreground bg-card border border-border rounded-md focus:outline-none focus:ring-2 focus:ring-accent-coral/30 min-w-[16rem]"
                 autoFocus
               />
-              <button
-                type="submit"
-                className="px-3 py-2 text-sm font-medium text-white bg-accent-coral rounded-md hover:bg-accent-coral/90"
-              >
-                Save
-              </button>
-              <button
-                type="button"
+              <Button type="submit" variant="primary" size="sm">
+                Save name
+              </Button>
+              <Button
+                variant="secondary"
+                size="sm"
                 onClick={() => {
                   setDraftName(agreement.name);
                   setIsRenaming(false);
                 }}
-                className="px-3 py-2 text-sm font-medium text-foreground/80 bg-card border border-gray-300 rounded-md hover:bg-muted/50"
               >
                 Cancel
-              </button>
+              </Button>
             </Form>
           ) : (
             <div className="flex items-center gap-3">
-              <h1 className="text-2xl font-bold text-foreground">
+              <h1 className="font-heading text-2xl font-bold text-foreground">
                 {agreement.name}
               </h1>
               {canEdit && (
                 <button
                   type="button"
                   onClick={() => setIsRenaming(true)}
-                  className="text-muted-foreground/70 hover:text-foreground"
+                  className="text-muted-foreground hover:text-foreground"
                   aria-label="Rename agreement"
                 >
                   <Pencil className="w-4 h-4" />
@@ -90,14 +89,10 @@ export function ConfidentialityAgreementDetail() {
         </div>
 
         {canEdit && !isCreatingVersion && (
-          <button
-            type="button"
-            onClick={handleStartCreate}
-            className="inline-flex items-center px-4 py-2 text-sm font-medium rounded-lg text-white bg-accent-coral hover:bg-accent-coral/90 shadow-sm"
-          >
-            <Plus className="w-4 h-4 mr-2" />
-            New Version
-          </button>
+          <Button variant="primary" onClick={handleStartCreate}>
+            <Plus className="h-4 w-4" />
+            New version
+          </Button>
         )}
       </div>
 

--- a/dali-api/app/hiring/components/ConfidentialityGate.tsx
+++ b/dali-api/app/hiring/components/ConfidentialityGate.tsx
@@ -1,5 +1,7 @@
 import { Link } from "react-router";
 import { ShieldAlert, ShieldOff } from "lucide-react";
+import { buttonClasses } from "~/components/ui/Button";
+import { cn } from "~/lib/cn";
 
 interface ConfidentialityGateProps {
   cycleId: string;
@@ -23,15 +25,17 @@ export function ConfidentialityGate({
   if (reason === "no_agreement") {
     return (
       <div
-        className={
-          "rounded-lg border border-amber-200 bg-amber-50 px-4 py-6 text-center " +
-          (className ?? "")
-        }
+        className={cn(
+          "flex flex-col items-center rounded-lg border border-dashed border-border bg-muted/30 px-4 py-6 text-center",
+          className,
+        )}
       >
-        <ShieldOff className="w-6 h-6 text-amber-500 mx-auto mb-2" />
-        <p className="text-sm text-amber-900 font-medium">
-          Sensitive data is hidden until the hiring lead binds a confidentiality
-          agreement to this cycle.
+        <span className="mb-2 flex h-10 w-10 items-center justify-center rounded-full bg-yellow-100 text-yellow-700">
+          <ShieldOff className="h-5 w-5" aria-hidden />
+        </span>
+        <p className="text-sm font-medium text-foreground">
+          This section is hidden until the hiring lead binds a confidentiality
+          agreement to the cycle.
         </p>
       </div>
     );
@@ -39,20 +43,19 @@ export function ConfidentialityGate({
 
   return (
     <div
-      className={
-        "rounded-lg border border-border bg-muted/30 px-4 py-6 text-center " +
-        (className ?? "")
-      }
+      className={cn(
+        "flex flex-col items-center rounded-lg border border-border bg-muted/30 px-4 py-6 text-center",
+        className,
+      )}
     >
-      <ShieldAlert className="w-6 h-6 text-blue-600 mx-auto mb-2" />
-      <p className="text-sm text-foreground/80 font-medium">
-        Sign the confidentiality agreement to view this section.
+      <span className="mb-2 flex h-10 w-10 items-center justify-center rounded-full bg-brand-tint text-accent-coral">
+        <ShieldAlert className="h-5 w-5" aria-hidden />
+      </span>
+      <p className="text-sm font-medium text-foreground">
+        Read and sign the confidentiality agreement to view this section.
       </p>
-      <Link
-        to={href}
-        className="mt-3 inline-block px-3 py-2 text-sm font-medium text-white bg-accent-coral rounded-md hover:bg-accent-coral/90"
-      >
-        Sign agreement
+      <Link to={href} className={buttonClasses("primary", "sm", "mt-3")}>
+        Read &amp; sign
       </Link>
     </div>
   );

--- a/dali-api/app/hiring/components/EmptyState.tsx
+++ b/dali-api/app/hiring/components/EmptyState.tsx
@@ -1,0 +1,50 @@
+import { Link } from "react-router";
+import type { LucideIcon } from "lucide-react";
+import { buttonClasses } from "~/components/ui/Button";
+import { cn } from "~/lib/cn";
+
+// A blank surface is a moment for direction, not a dead end. One icon, a plain
+// headline of what's true, one line of what happens next, and — where there is
+// a next step — a single action. Shared by every hiring dashboard so "nothing
+// here yet" always looks and reads the same way.
+export function EmptyState({
+  icon: Icon,
+  title,
+  description,
+  action,
+  className,
+}: {
+  icon?: LucideIcon;
+  title: string;
+  description?: string;
+  action?: { label: string; to: string };
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col items-center justify-center rounded-lg border border-dashed border-border bg-card px-6 py-12 text-center",
+        className,
+      )}
+    >
+      {Icon && (
+        <span className="mb-3 flex h-11 w-11 items-center justify-center rounded-full bg-muted text-muted-foreground">
+          <Icon className="h-5 w-5" aria-hidden />
+        </span>
+      )}
+      <p className="font-heading text-base font-semibold text-foreground">
+        {title}
+      </p>
+      {description && (
+        <p className="mt-1 max-w-sm text-sm text-muted-foreground">
+          {description}
+        </p>
+      )}
+      {action && (
+        <Link to={action.to} className={buttonClasses("primary", "sm", "mt-4")}>
+          {action.label}
+        </Link>
+      )}
+    </div>
+  );
+}

--- a/dali-api/app/hiring/components/InterviewNotesCard.tsx
+++ b/dali-api/app/hiring/components/InterviewNotesCard.tsx
@@ -1,7 +1,7 @@
 import type React from "react";
 import { Link } from "react-router";
 import { Calendar, MapPin, Users } from "lucide-react";
-import { INTERVIEW_STATUS_COLORS, INTERVIEW_STATUS_LABELS } from "~/hiring/lib/labels";
+import { InterviewStatusPill, RecommendationPill } from "~/hiring/components/Pill";
 
 const LOCATION_LABELS: Record<string, string> = {
   PodAppa: "Pod Appa",
@@ -73,8 +73,6 @@ export function InterviewNotesCard({
 }): React.ReactElement {
   const start = new Date(interview.startTime);
   const end = interview.endTime != null ? new Date(interview.endTime) : null;
-  const statusLabel = INTERVIEW_STATUS_LABELS[interview.status] ?? interview.status;
-  const statusClass = INTERVIEW_STATUS_COLORS[interview.status] ?? "bg-muted text-foreground/80";
   const joint = jointNotesText(interview.jointNotes);
   const interviewers = interview.interviewers ?? [];
   const interviewersWithNotes = interviewers.filter(
@@ -89,14 +87,12 @@ export function InterviewNotesCard({
             {start.toLocaleDateString(undefined, { month: "short", day: "numeric" })}{" "}
             {start.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" })}
           </span>
-          <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${statusClass}`}>
-            {statusLabel}
-          </span>
+          <InterviewStatusPill status={interview.status} />
         </div>
         {interview.recommendation && (
-          <div className="text-sm">
-            <span className="text-muted-foreground">Recommendation:</span>{" "}
-            <span className="font-medium text-foreground">{interview.recommendation}</span>
+          <div className="flex items-center gap-2 text-sm">
+            <span className="text-muted-foreground">Recommendation:</span>
+            <RecommendationPill value={interview.recommendation} />
           </div>
         )}
         {interview.recommendationNotes && (
@@ -147,11 +143,7 @@ export function InterviewNotesCard({
   return (
     <div className="px-6 py-4 space-y-3">
       <div className="flex flex-wrap items-center gap-3">
-        <span
-          className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-bold ${statusClass}`}
-        >
-          {statusLabel}
-        </span>
+        <InterviewStatusPill status={interview.status} />
         <span className="inline-flex items-center gap-1.5 text-sm text-foreground">
           <Calendar className="w-3.5 h-3.5 text-muted-foreground" aria-hidden />
           {start.toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" })}
@@ -173,7 +165,7 @@ export function InterviewNotesCard({
                 href={interview.zoomJoinUrl}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-blue-600 hover:underline ml-1"
+                className="text-accent-coral hover:underline ml-1"
               >
                 link
               </a>
@@ -195,7 +187,7 @@ export function InterviewNotesCard({
           {interview.openInInterviewerHref && (
             <Link
               to={interview.openInInterviewerHref}
-              className="text-xs text-blue-600 hover:underline"
+              className="text-xs text-accent-coral hover:underline"
             >
               Open in interviewer view
             </Link>
@@ -227,9 +219,7 @@ export function InterviewNotesCard({
           </div>
           {interview.recommendation && (
             <div className="mt-2">
-              <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-bold bg-muted text-foreground/80">
-                {interview.recommendation}
-              </span>
+              <RecommendationPill value={interview.recommendation} />
             </div>
           )}
           {interview.recommendationNotes && interview.recommendationNotes.trim().length > 0 && (

--- a/dali-api/app/hiring/components/InterviewSlotPicker.tsx
+++ b/dali-api/app/hiring/components/InterviewSlotPicker.tsx
@@ -70,9 +70,9 @@ export function InterviewSlotPicker({
                       key={slot.id}
                       onClick={() => onSelect(slot)}
                       disabled={disabled}
-                      className="px-3 py-3 text-sm font-medium rounded-lg border border-border bg-card hover:border-blue-400 hover:bg-blue-50 transition disabled:opacity-50 disabled:cursor-not-allowed"
+                      className="px-3 py-3 text-sm font-medium rounded-lg border border-border bg-card text-foreground hover:border-accent-coral hover:bg-accent-coral/5 transition disabled:opacity-50 disabled:cursor-not-allowed"
                     >
-                      {isLoading ? "Booking..." : slot.time}
+                      {isLoading ? "Booking…" : slot.time}
                     </button>
                   );
                 }

--- a/dali-api/app/hiring/components/Library.tsx
+++ b/dali-api/app/hiring/components/Library.tsx
@@ -12,6 +12,8 @@ import { Button } from "~/components/ui/Button";
 import { Modal, ModalHeader } from "~/components/Modal";
 import { hiringPills } from "~/hiring/components/hiringPills";
 import { AreaPillNav } from "~/components/AreaPillNav";
+import { PageHeader } from "~/hiring/components/PageHeader";
+import { EmptyState } from "~/hiring/components/EmptyState";
 import type { loader } from "~/hiring/routes/library";
 
 type Tab = "challenges" | "rubrics" | "agreements";
@@ -38,8 +40,12 @@ export default function Library() {
   };
 
   return (
-    <div className="space-y-8">
+    <div className="flex flex-col gap-6">
       <AreaPillNav items={hiringPills({ ...data.pillRoles, active: "library" })} />
+      <PageHeader
+        title="Library"
+        subtitle="Reusable challenges, rubrics, and confidentiality agreements — versioned independently of any hiring cycle, then bound to cycles as needed."
+      />
       <div
         className="inline-flex self-start rounded-lg border border-border bg-muted/40 p-0.5"
         role="tablist"
@@ -105,13 +111,13 @@ function ChallengesPanel({
     <div className="space-y-6">
       <div className="flex justify-between items-start gap-4 flex-wrap">
         <div className="min-w-0">
-          <h2 className="text-lg font-bold text-foreground">
-            {activeDomainName} Challenges
+          <h2 className="font-heading text-lg font-bold text-foreground">
+            {activeDomainName} challenges
           </h2>
           <p className="mt-1 text-sm text-muted-foreground">
             {isGeneral
-              ? "Manage the general application form and its versions."
-              : "Manage domain challenges and their versions independently of hiring cycles."}
+              ? "The general application form and its versions."
+              : "Domain challenges and their versions, kept separately from any cycle."}
           </p>
         </div>
         <div className="flex items-center gap-2 flex-shrink-0">
@@ -119,7 +125,7 @@ function ChallengesPanel({
             value={activeDomain}
             onChange={(e) => setActiveDomain(e.target.value)}
             aria-label="Domain"
-            className="px-3 py-2 rounded-lg border border-border bg-card text-sm font-medium text-foreground hover:bg-muted/50 focus:outline-none focus:ring-2 focus:ring-blue-500/40"
+            className="px-3 py-2 rounded-lg border border-border bg-card text-sm font-medium text-foreground hover:bg-muted/50 focus:outline-none focus:ring-2 focus:ring-accent-coral/30"
           >
             <option value={GENERAL_TAB_ID}>General</option>
             {domains.map((domain: any) => (
@@ -130,7 +136,7 @@ function ChallengesPanel({
           </select>
           <Button variant="primary" size="sm" onClick={() => setShowModal(true)}>
             <Plus className="w-4 h-4" />
-            New Challenge
+            New challenge
           </Button>
         </div>
       </div>
@@ -152,7 +158,7 @@ function ChallengesPanel({
                     <FileText className="w-6 h-6" />
                   </div>
                   <div className="min-w-0 flex-1">
-                    <h3 className="text-lg font-bold text-foreground group-hover:text-blue-600 transition-colors break-words">
+                    <h3 className="font-heading text-lg font-bold text-foreground group-hover:text-accent-coral transition-colors break-words">
                       {challenge.name}
                     </h3>
                     <p className="text-sm text-muted-foreground mt-1">
@@ -168,13 +174,14 @@ function ChallengesPanel({
                     <input type="hidden" name="id" value={challenge.id} />
                     <button
                       type="submit"
-                      className="p-1.5 text-muted-foreground/70 hover:text-red-600 hover:bg-red-50 rounded-md opacity-0 group-hover:opacity-100 transition-opacity"
+                      aria-label="Delete challenge"
+                      className="p-1.5 text-muted-foreground hover:text-destructive rounded-md opacity-0 group-hover:opacity-100 transition-opacity"
                       onClick={(e) => e.stopPropagation()}
                     >
                       <Trash2 className="w-4 h-4" />
                     </button>
                   </Form>
-                  <ChevronRight className="w-5 h-5 text-muted-foreground/70 group-hover:text-blue-500 transition-colors" />
+                  <ChevronRight className="w-5 h-5 text-muted-foreground group-hover:text-accent-coral transition-colors" />
                 </div>
               </div>
               <div className="mt-6 pt-4 border-t border-border text-sm text-muted-foreground">
@@ -184,8 +191,12 @@ function ChallengesPanel({
           );
         })}
         {filtered.length === 0 && (
-          <div className="col-span-full text-center py-12 text-muted-foreground/70 text-sm">
-            No challenges for this domain yet.
+          <div className="col-span-full">
+            <EmptyState
+              icon={FileText}
+              title={`No ${activeDomainName.toLowerCase()} challenges yet`}
+              description="Create a challenge, then add versions to it as the prompt evolves across cycles."
+            />
           </div>
         )}
       </div>
@@ -199,7 +210,7 @@ function ChallengesPanel({
       >
         <ModalHeader
           titleId="new-challenge-title"
-          title="New Challenge"
+          title="New challenge"
           onClose={() => setShowModal(false)}
           className="mb-0"
         />
@@ -221,7 +232,7 @@ function ChallengesPanel({
           )}
           <div>
             <label className="block text-sm font-medium text-foreground/80 mb-1">
-              Challenge Name <span className="text-red-500">*</span>
+              Challenge name <span className="text-destructive">*</span>
             </label>
             <input
               type="text"
@@ -232,7 +243,7 @@ function ChallengesPanel({
               required
               autoFocus
               autoComplete="off"
-              className="block w-full rounded-lg border border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm p-2.5 text-foreground bg-card placeholder-gray-400"
+              className="block w-full rounded-lg border border-border shadow-sm focus:outline-none focus:ring-2 focus:ring-accent-coral/30 sm:text-sm p-2.5 text-foreground bg-card placeholder:text-muted-foreground"
             />
           </div>
 
@@ -250,7 +261,7 @@ function ChallengesPanel({
               size="sm"
               disabled={!newChallengeName.trim()}
             >
-              Create Challenge
+              Create challenge
             </Button>
           </div>
         </Form>
@@ -265,16 +276,16 @@ function RubricsPanel({ rubrics }: { rubrics: any[] }) {
 
   return (
     <div className="space-y-6">
-      <div className="flex justify-between items-center">
+      <div className="flex justify-between items-center gap-4 flex-wrap">
         <div>
-          <h2 className="text-lg font-bold text-foreground">Evaluation Rubrics</h2>
+          <h2 className="font-heading text-lg font-bold text-foreground">Evaluation rubrics</h2>
           <p className="mt-1 text-sm text-muted-foreground">
-            Manage rubrics and their versions independently of hiring cycles.
+            Scoring rubrics and their versions, kept separately from any cycle.
           </p>
         </div>
         <Button variant="primary" size="sm" onClick={() => setShowModal(true)}>
           <Plus className="w-4 h-4" />
-          New Rubric
+          New rubric
         </Button>
       </div>
 
@@ -291,7 +302,7 @@ function RubricsPanel({ rubrics }: { rubrics: any[] }) {
                   <ListOrdered className="w-6 h-6" />
                 </div>
                 <div className="min-w-0 flex-1">
-                  <h3 className="font-bold text-foreground group-hover:text-blue-600 transition-colors break-words">
+                  <h3 className="font-heading font-bold text-foreground group-hover:text-accent-coral transition-colors break-words">
                     {rubric.name}
                   </h3>
                   <div className="flex items-center gap-2 mt-1">
@@ -302,14 +313,18 @@ function RubricsPanel({ rubrics }: { rubrics: any[] }) {
                   </div>
                 </div>
               </div>
-              <ChevronRight className="w-5 h-5 text-muted-foreground/70 group-hover:text-blue-500 flex-shrink-0" />
+              <ChevronRight className="w-5 h-5 text-muted-foreground group-hover:text-accent-coral flex-shrink-0" />
             </div>
           </Link>
         ))}
         {rubrics.length === 0 && (
-          <p className="text-muted-foreground col-span-3 text-sm italic">
-            No rubrics yet.
-          </p>
+          <div className="col-span-full">
+            <EmptyState
+              icon={ListOrdered}
+              title="No rubrics yet"
+              description="Create a rubric to define scoring criteria reviewers use during evaluation."
+            />
+          </div>
         )}
       </div>
 
@@ -321,7 +336,7 @@ function RubricsPanel({ rubrics }: { rubrics: any[] }) {
         <div className="space-y-4">
           <ModalHeader
             titleId="new-rubric-title"
-            title="New Rubric"
+            title="New rubric"
             onClose={() => setShowModal(false)}
             className="mb-0"
           />
@@ -342,7 +357,7 @@ function RubricsPanel({ rubrics }: { rubrics: any[] }) {
                 value={newRubricName}
                 onChange={(e) => setNewRubricName(e.target.value)}
                 placeholder="e.g. Design Challenge Rubric"
-                className="w-full px-3 py-2 text-sm text-foreground border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="w-full px-3 py-2 text-sm text-foreground bg-card border border-border rounded-md focus:outline-none focus:ring-2 focus:ring-accent-coral/30 placeholder:text-muted-foreground"
                 autoFocus
                 autoComplete="off"
               />
@@ -361,7 +376,7 @@ function RubricsPanel({ rubrics }: { rubrics: any[] }) {
                 size="sm"
                 disabled={!newRubricName.trim()}
               >
-                Create
+                Create rubric
               </Button>
             </div>
           </Form>
@@ -383,21 +398,21 @@ function AgreementsPanel({
 
   return (
     <div className="space-y-6">
-      <div className="flex justify-between items-center">
+      <div className="flex justify-between items-center gap-4 flex-wrap">
         <div>
-          <h2 className="text-lg font-bold text-foreground">
-            Confidentiality Agreements
+          <h2 className="font-heading text-lg font-bold text-foreground">
+            Confidentiality agreements
           </h2>
-          <p className="mt-1 text-sm text-muted-foreground">
-            Versioned confidentiality agreements. Bind a specific version to a
-            cycle from the cycle admin page; reviewers, interviewers, domain
-            leads, and admins must sign before viewing sensitive cycle data.
+          <p className="mt-1 text-sm text-muted-foreground max-w-2xl">
+            Versioned agreements. Bind a version to a cycle from its admin page;
+            reviewers, interviewers, domain leads, and admins must sign before
+            viewing sensitive cycle data.
           </p>
         </div>
         {canEdit && (
           <Button variant="primary" size="sm" onClick={() => setShowModal(true)}>
             <Plus className="w-4 h-4" />
-            New Agreement
+            New agreement
           </Button>
         )}
       </div>
@@ -417,7 +432,7 @@ function AgreementsPanel({
                     <ShieldCheck className="w-6 h-6" />
                   </div>
                   <div className="min-w-0">
-                    <h3 className="font-bold text-foreground group-hover:text-blue-600 transition-colors truncate">
+                    <h3 className="font-heading font-bold text-foreground group-hover:text-accent-coral transition-colors truncate">
                       {agreement.name}
                     </h3>
                     <div className="flex items-center gap-2 mt-1">
@@ -433,15 +448,19 @@ function AgreementsPanel({
                     </div>
                   </div>
                 </div>
-                <ChevronRight className="w-5 h-5 text-muted-foreground/70 group-hover:text-blue-500 shrink-0" />
+                <ChevronRight className="w-5 h-5 text-muted-foreground group-hover:text-accent-coral shrink-0" />
               </div>
             </Link>
           );
         })}
         {agreements.length === 0 && (
-          <p className="text-muted-foreground col-span-3 text-sm italic">
-            No agreements yet.
-          </p>
+          <div className="col-span-full">
+            <EmptyState
+              icon={ShieldCheck}
+              title="No agreements yet"
+              description="Create a confidentiality agreement, then bind a version to a cycle so the team can read and sign it."
+            />
+          </div>
         )}
       </div>
 
@@ -453,7 +472,7 @@ function AgreementsPanel({
         <div className="space-y-4">
           <ModalHeader
             titleId="new-agreement-title"
-            title="New Confidentiality Agreement"
+            title="New confidentiality agreement"
             onClose={() => setShowModal(false)}
             className="mb-0"
           />
@@ -474,7 +493,7 @@ function AgreementsPanel({
                 value={newName}
                 onChange={(e) => setNewName(e.target.value)}
                 placeholder="e.g. Hiring Confidentiality — 2026"
-                className="w-full px-3 py-2 text-sm text-foreground border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="w-full px-3 py-2 text-sm text-foreground bg-card border border-border rounded-md focus:outline-none focus:ring-2 focus:ring-accent-coral/30 placeholder:text-muted-foreground"
                 autoFocus
                 autoComplete="off"
               />
@@ -493,7 +512,7 @@ function AgreementsPanel({
                 size="sm"
                 disabled={!newName.trim()}
               >
-                Create
+                Create agreement
               </Button>
             </div>
           </Form>

--- a/dali-api/app/hiring/components/PageHeader.tsx
+++ b/dali-api/app/hiring/components/PageHeader.tsx
@@ -1,0 +1,56 @@
+import { Link } from "react-router";
+import { ChevronLeft } from "lucide-react";
+import { cn } from "~/lib/cn";
+
+// The consistent top of every hiring page: a title in Dosis, an optional
+// one-line subtitle, an optional cycle/status chip, and an optional row of
+// actions on the right. Optionally preceded by a compact "back" link for detail
+// pages. Every hiring surface opens the same way so the area reads as one
+// product rather than a dozen separately-built screens.
+export function PageHeader({
+  title,
+  subtitle,
+  chip,
+  actions,
+  back,
+  className,
+}: {
+  title: React.ReactNode;
+  subtitle?: React.ReactNode;
+  chip?: React.ReactNode;
+  actions?: React.ReactNode;
+  back?: { label: string; to: string };
+  className?: string;
+}) {
+  return (
+    <header className={cn("flex flex-col gap-3", className)}>
+      {back && (
+        <Link
+          to={back.to}
+          className="inline-flex w-fit items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-accent-coral"
+        >
+          <ChevronLeft className="h-4 w-4" aria-hidden />
+          {back.label}
+        </Link>
+      )}
+      <div className="flex flex-wrap items-start justify-between gap-x-4 gap-y-2">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+            <h1 className="font-heading text-2xl font-bold text-foreground">
+              {title}
+            </h1>
+            {chip}
+          </div>
+          {subtitle && (
+            <p className="mt-1 text-sm text-muted-foreground">{subtitle}</p>
+          )}
+        </div>
+        {actions && (
+          <div className="flex shrink-0 flex-wrap items-center gap-2">
+            {actions}
+          </div>
+        )}
+      </div>
+    </header>
+  );
+}

--- a/dali-api/app/hiring/components/Pill.tsx
+++ b/dali-api/app/hiring/components/Pill.tsx
@@ -1,0 +1,59 @@
+import {
+  STATUS_PILL_BASE,
+  STATUS_COLORS,
+  STATUS_LABELS,
+  DECISION_COLORS,
+  INTERVIEW_STATUS_COLORS,
+  INTERVIEW_STATUS_LABELS,
+  RECOMMENDATION_COLORS,
+} from "~/hiring/lib/labels";
+import { cn } from "~/lib/cn";
+
+// Typed pill helpers over the shared color/label maps in labels.ts, so callers
+// render a status the same way everywhere without reaching for the raw maps or
+// hand-rolling `bg-*-100 text-*-700` strings. New hiring UI should reach for
+// these rather than composing STATUS_PILL_BASE by hand.
+
+export function Pill({
+  color,
+  children,
+  className,
+}: {
+  color?: string;
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <span className={cn(STATUS_PILL_BASE, color ?? "bg-muted text-foreground/80", className)}>
+      {children}
+    </span>
+  );
+}
+
+export function CycleStatusPill({ status }: { status: string }) {
+  return (
+    <Pill color={STATUS_COLORS[status]}>{STATUS_LABELS[status] ?? status}</Pill>
+  );
+}
+
+export function DecisionPill({
+  type,
+  label,
+}: {
+  type: string;
+  label?: string;
+}) {
+  return <Pill color={DECISION_COLORS[type]}>{label ?? type}</Pill>;
+}
+
+export function InterviewStatusPill({ status }: { status: string }) {
+  return (
+    <Pill color={INTERVIEW_STATUS_COLORS[status]}>
+      {INTERVIEW_STATUS_LABELS[status] ?? status}
+    </Pill>
+  );
+}
+
+export function RecommendationPill({ value }: { value: string }) {
+  return <Pill color={RECOMMENDATION_COLORS[value]}>{value}</Pill>;
+}

--- a/dali-api/app/hiring/components/ReviewSummary.tsx
+++ b/dali-api/app/hiring/components/ReviewSummary.tsx
@@ -3,13 +3,11 @@
 // rationale. Shared by the applications-database detail page, the domain-lead
 // dashboard, and the interviewer page, which each wrap it in their own chrome.
 
-const DEFAULT_RECOMMENDATION_TONE: Record<string, string> = {
-  "Strong Hire": "bg-green-100 text-green-800",
-  Hire: "bg-green-50 text-green-700",
-  "Lean Hire": "bg-lime-50 text-lime-700",
-  "Lean No Hire": "bg-amber-50 text-amber-700",
-  "No Hire": "bg-red-50 text-red-700",
-};
+import { RECOMMENDATION_COLORS } from "~/hiring/lib/labels";
+
+// The recommendation badge speaks the same tones as the shared RecommendationPill
+// (see labels.ts). Callers may still override via the `recommendationTone` prop.
+const DEFAULT_RECOMMENDATION_TONE = RECOMMENDATION_COLORS;
 
 export interface ReviewSummaryProps {
   reviewerName?: string;

--- a/dali-api/app/hiring/components/RubricDetail.tsx
+++ b/dali-api/app/hiring/components/RubricDetail.tsx
@@ -10,6 +10,9 @@ import {
 import type { loader } from '~/hiring/routes/rubrics.$id'
 import type { RubricCriterion } from '~/types'
 import { formatDateTime } from '~/lib/display'
+import { Button } from '~/components/ui/Button'
+import { PageHeader } from '~/hiring/components/PageHeader'
+import { cn } from '~/lib/cn'
 
 export function RubricDetail() {
   const { rubric } = useLoaderData<typeof loader>()
@@ -59,38 +62,34 @@ export function RubricDetail() {
 
   return (
     <div className="space-y-6">
-      <div>
-        <div className="flex justify-between items-start">
-          <div>
-            <h1 className="text-2xl font-bold text-foreground">{rubric.name}</h1>
-          </div>
-          {!isCreatingVersion && (
-            <button
-              onClick={handleStartCreate}
-              className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-lg text-white bg-accent-coral hover:bg-accent-coral/90 shadow-sm"
-            >
-              <Plus className="w-4 h-4 mr-2" />
-              New Version
-            </button>
-          )}
-        </div>
-      </div>
+      <PageHeader
+        title={rubric.name}
+        subtitle="Scoring criteria reviewers use to evaluate applicants."
+        actions={
+          !isCreatingVersion && (
+            <Button variant="primary" onClick={handleStartCreate}>
+              <Plus className="h-4 w-4" />
+              New version
+            </Button>
+          )
+        }
+      />
 
       <div className="grid grid-cols-1 lg:grid-cols-[16rem_1fr] gap-6">
         {/* Left Sidebar: Versions List */}
         <div className="space-y-4">
           <div className="bg-card rounded-xl border border-border overflow-hidden shadow-sm">
             <div className="p-4 border-b border-border bg-muted/50">
-              <h3 className="font-bold text-foreground">Version History</h3>
+              <h3 className="font-heading font-bold text-foreground">Version history</h3>
             </div>
-            <div className="divide-y divide-gray-100 max-h-[600px] overflow-y-auto">
+            <div className="divide-y divide-border max-h-[600px] overflow-y-auto">
               {isCreatingVersion && (
-                <button className="w-full text-left p-4 bg-blue-50 border-l-4 border-blue-600">
+                <div className="w-full text-left p-4 bg-brand-tint border-l-4 border-accent-coral">
                   <div className="flex justify-between items-center mb-1">
-                    <span className="font-bold text-blue-900">Drafting New...</span>
+                    <span className="font-bold text-foreground">Drafting new version</span>
                   </div>
-                  <span className="text-xs text-blue-600">Unsaved changes</span>
-                </button>
+                  <span className="text-xs text-accent-coral">Unsaved changes</span>
+                </div>
               )}
               {rubric.versions
                 .slice()
@@ -103,20 +102,15 @@ export function RubricDetail() {
                         setSelectedVersionId(version.id)
                         setIsCreatingVersion(false)
                       }}
-                      className={`w-full text-left p-4 transition-colors ${
+                      className={cn(
+                        'w-full text-left p-4 transition-colors border-l-4',
                         !isCreatingVersion && selectedVersionId === version.id
-                          ? 'bg-blue-50 border-l-4 border-blue-600'
-                          : 'hover:bg-muted/50 border-l-4 border-transparent'
-                      }`}
+                          ? 'bg-brand-tint border-accent-coral'
+                          : 'hover:bg-muted/50 border-transparent',
+                      )}
                     >
                       <div className="flex justify-between items-center mb-1">
-                        <span
-                          className={`font-bold ${
-                            !isCreatingVersion && selectedVersionId === version.id
-                              ? 'text-blue-900'
-                              : 'text-foreground'
-                          }`}
-                        >
+                        <span className="font-bold text-foreground">
                           Version {version.versionNumber}
                         </span>
                       </div>
@@ -144,26 +138,20 @@ export function RubricDetail() {
         <div className="min-w-0">
           {isCreatingVersion ? (
             <div className="bg-card rounded-xl border border-border shadow-sm overflow-hidden flex flex-col min-h-[600px]">
-              <div className="p-4 border-b border-border bg-muted/50 flex justify-between items-center">
+              <div className="p-4 border-b border-border bg-muted/50 flex justify-between items-center gap-3">
                 <div className="flex items-center gap-4 flex-wrap">
-                  <h2 className="font-bold text-foreground">Drafting Version {nextVersionNumber}</h2>
+                  <h2 className="font-heading font-bold text-foreground">Drafting version {nextVersionNumber}</h2>
                 </div>
                 <div className="flex gap-2">
-                  <button
-                    onClick={() => setIsCreatingVersion(false)}
-                    className="px-3 py-1.5 text-sm font-medium text-foreground/80 hover:bg-muted rounded-md"
-                  >
+                  <Button variant="ghost" size="sm" onClick={() => setIsCreatingVersion(false)}>
                     Cancel
-                  </button>
+                  </Button>
                   <Form method="post">
                     <input type="hidden" name="intent" value="create-version" />
                     <input type="hidden" name="criteria" value={JSON.stringify(criteria)} />
-                    <button
-                      type="submit"
-                      className="px-3 py-1.5 text-sm font-medium text-white bg-accent-coral hover:bg-accent-coral/90 rounded-md"
-                    >
-                      Save Version
-                    </button>
+                    <Button type="submit" variant="primary" size="sm">
+                      Save version
+                    </Button>
                   </Form>
                 </div>
               </div>
@@ -179,10 +167,10 @@ export function RubricDetail() {
                           <GripVertical className="w-4 h-4" />
                         </div>
                         <div className="flex-1">
-                          <div className="flex justify-between items-start">
+                          <div className="flex justify-between items-start gap-2">
                             <h4 className="font-bold text-foreground">{c.label}</h4>
-                            <span className="text-xs font-medium bg-blue-50 text-blue-700 px-2 py-1 rounded">
-                              Max: {c.maxScore}
+                            <span className="text-xs font-medium bg-muted text-foreground/80 px-2 py-1 rounded whitespace-nowrap">
+                              Max {c.maxScore}
                             </span>
                           </div>
                           {c.description && (
@@ -191,21 +179,22 @@ export function RubricDetail() {
                         </div>
                         <button
                           onClick={() => handleRemoveCriterion(c.key)}
-                          className="text-muted-foreground/70 hover:text-red-500 opacity-0 group-hover:opacity-100 transition-opacity"
+                          aria-label={`Remove ${c.label}`}
+                          className="text-muted-foreground hover:text-destructive opacity-0 group-hover:opacity-100 transition-opacity"
                         >
                           <Trash2 className="w-4 h-4" />
                         </button>
                       </div>
                     ))}
                     {criteria.length === 0 && (
-                      <div className="text-center py-8 border-2 border-dashed border-gray-300 rounded-lg">
+                      <div className="text-center py-8 border-2 border-dashed border-border rounded-lg">
                         <p className="text-muted-foreground">No criteria added yet.</p>
                       </div>
                     )}
                   </div>
 
                   <div className="bg-card border border-border rounded-lg p-4">
-                    <h4 className="text-sm font-bold text-foreground mb-3">Add Criterion</h4>
+                    <h4 className="text-sm font-bold text-foreground mb-3">Add criterion</h4>
                     <div className="space-y-3">
                       <div className="grid grid-cols-4 gap-3">
                         <div className="col-span-3">
@@ -214,7 +203,7 @@ export function RubricDetail() {
                             placeholder="Label (e.g. Communication)"
                             value={newLabel}
                             onChange={(e) => setNewLabel(e.target.value)}
-                            className="w-full border border-gray-300 rounded-md p-2 text-sm text-foreground bg-card focus:ring-blue-500 focus:border-blue-500"
+                            className="w-full border border-border rounded-md p-2 text-sm text-foreground bg-card placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent-coral/30"
                           />
                         </div>
                         <div className="col-span-1">
@@ -222,10 +211,10 @@ export function RubricDetail() {
                             type="number"
                             min="1"
                             max="100"
-                            placeholder="Max Score"
+                            placeholder="Max score"
                             value={newMaxScore}
                             onChange={(e) => setNewMaxScore(parseInt(e.target.value) || 5)}
-                            className="w-full border border-gray-300 rounded-md p-2 text-sm text-foreground bg-card focus:ring-blue-500 focus:border-blue-500"
+                            className="w-full border border-border rounded-md p-2 text-sm text-foreground bg-card placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent-coral/30"
                           />
                         </div>
                       </div>
@@ -235,15 +224,17 @@ export function RubricDetail() {
                         value={newDescription}
                         onChange={(e) => setNewDescription(e.target.value)}
                         onKeyDown={(e) => e.key === 'Enter' && handleAddCriterion()}
-                        className="w-full border border-gray-300 rounded-md p-2 text-sm text-foreground bg-card focus:ring-blue-500 focus:border-blue-500"
+                        className="w-full border border-border rounded-md p-2 text-sm text-foreground bg-card placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-accent-coral/30"
                       />
-                      <button
+                      <Button
+                        variant="secondary"
+                        size="sm"
                         onClick={handleAddCriterion}
                         disabled={!newLabel.trim()}
-                        className="w-full py-2 bg-muted text-foreground/80 font-medium rounded-md text-sm hover:bg-muted disabled:opacity-50"
+                        className="w-full"
                       >
-                        Add Criterion
-                      </button>
+                        Add criterion
+                      </Button>
                     </div>
                   </div>
                 </div>
@@ -282,10 +273,10 @@ export function RubricDetail() {
                 <div className="max-w-2xl mx-auto space-y-4">
                   {(selectedVersion.criteria as unknown as RubricCriterion[]).map((c) => (
                     <div key={c.key} className="bg-card border border-border rounded-lg p-4">
-                      <div className="flex justify-between items-start">
+                      <div className="flex justify-between items-start gap-2">
                         <h4 className="font-bold text-foreground">{c.label}</h4>
-                        <span className="text-xs font-medium bg-blue-50 text-blue-700 px-2 py-1 rounded">
-                          Max: {c.maxScore}
+                        <span className="text-xs font-medium bg-muted text-foreground/80 px-2 py-1 rounded whitespace-nowrap">
+                          Max {c.maxScore}
                         </span>
                       </div>
                       {c.description && (

--- a/dali-api/app/hiring/components/Section.tsx
+++ b/dali-api/app/hiring/components/Section.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { ChevronDown } from 'lucide-react'
+import { cn } from '~/lib/cn'
 
 // Collapsible titled panel shared by the Reviews and Interviews dashboards.
 export function Section({
@@ -17,23 +18,29 @@ export function Section({
 }) {
   const [open, setOpen] = useState(defaultOpen)
   return (
-    <div className="border border-gray-200 rounded-lg overflow-hidden bg-white">
+    <div className="overflow-hidden rounded-lg border border-border bg-card">
       <button
+        type="button"
         onClick={() => setOpen(!open)}
-        className="w-full px-5 py-3 flex items-center justify-between bg-gray-50 hover:bg-gray-100 transition text-left"
+        aria-expanded={open}
+        className="flex w-full items-center justify-between gap-3 bg-muted/50 px-5 py-3 text-left transition-colors hover:bg-muted"
       >
-        <span className="flex items-center gap-2 font-semibold text-gray-900 text-sm">
+        <span className="flex items-center gap-2 font-heading text-sm font-semibold text-foreground">
           {icon}
           {title}
         </span>
         <div className="flex items-center gap-3">
           {badge}
           <ChevronDown
-            className={`w-4 h-4 text-gray-400 transition-transform ${open ? 'rotate-180' : ''}`}
+            className={cn(
+              'h-4 w-4 text-muted-foreground transition-transform',
+              open && 'rotate-180',
+            )}
+            aria-hidden
           />
         </div>
       </button>
-      {open && <div className="p-5 border-t border-gray-200">{children}</div>}
+      {open && <div className="border-t border-border p-5">{children}</div>}
     </div>
   )
 }

--- a/dali-api/app/hiring/components/StatusStepper.tsx
+++ b/dali-api/app/hiring/components/StatusStepper.tsx
@@ -1,0 +1,228 @@
+import { Check, Minus } from "lucide-react";
+import type { DomainApplicationStatus } from "~/types";
+import { cn } from "~/lib/cn";
+
+// ── The hiring pipeline, as a stepper ────────────────────────────────────────
+// Every application walks the same four-stage funnel: Apply → Review →
+// Interview → Decision. This is the one shape the whole hiring area shares — an
+// applicant reads it to know where they stand; a reviewer reads it to know how
+// far a candidate has travelled. It is driven entirely by the derived
+// `DomainApplicationStatus` (see hiring/lib/domain-application-status.ts), so it
+// never invents state the backend doesn't already assert.
+
+type StepState = "done" | "current" | "upcoming";
+type Outcome = "accepted" | "waitlisted" | "rejected" | "withdrawn" | null;
+
+const STEPS = ["Apply", "Review", "Interview", "Decision"] as const;
+
+// Which step a given status is standing on (0-based index into STEPS).
+const STEP_INDEX: Record<DomainApplicationStatus, number> = {
+  ApplicationOpen: 0,
+  Pending: 1,
+  InvitedToInterview: 2,
+  InterviewScheduled: 2,
+  PostInterviewPending: 2,
+  Withdrawn: 2,
+  Accepted: 3,
+  Rejected: 3,
+  Waitlisted: 3,
+};
+
+function outcomeOf(status: DomainApplicationStatus): Outcome {
+  switch (status) {
+    case "Accepted":
+      return "accepted";
+    case "Waitlisted":
+      return "waitlisted";
+    case "Rejected":
+      return "rejected";
+    case "Withdrawn":
+      return "withdrawn";
+    default:
+      return null;
+  }
+}
+
+// A closed track (a decision landed, or the applicant stepped away) fills its
+// current node with the outcome's tone instead of the live-coral "you are here".
+const OUTCOME_DOT: Record<Exclude<Outcome, null>, string> = {
+  accepted: "border-transparent bg-accent-teal text-white",
+  waitlisted: "border-transparent bg-accent-yellow text-navy-deep",
+  rejected: "border-transparent bg-muted-foreground/60 text-white",
+  withdrawn: "border-transparent bg-muted-foreground/40 text-white",
+};
+
+const OUTCOME_LABEL: Record<Exclude<Outcome, null>, string> = {
+  accepted: "text-accent-teal",
+  waitlisted: "text-navy",
+  rejected: "text-muted-foreground",
+  withdrawn: "text-muted-foreground",
+};
+
+export function StatusStepper({
+  status,
+  variant = "full",
+  className,
+}: {
+  status: DomainApplicationStatus;
+  variant?: "full" | "compact";
+  className?: string;
+}) {
+  const activeIndex = STEP_INDEX[status];
+  const outcome = outcomeOf(status);
+  const closed = outcome !== null;
+  const compact = variant === "compact";
+
+  return (
+    <ol
+      className={cn("flex w-full items-start", className)}
+      aria-label="Application progress"
+    >
+      {STEPS.map((label, i) => {
+        const state: StepState =
+          i < activeIndex ? "done" : i === activeIndex ? "current" : "upcoming";
+        const isLast = i === STEPS.length - 1;
+
+        // The connector to the *next* node is "filled" once this node is behind us.
+        const connectorFilled = i < activeIndex;
+
+        return (
+          <li
+            key={label}
+            className="flex flex-1 flex-col items-center last:flex-none"
+            aria-current={state === "current" ? "step" : undefined}
+          >
+            <div className="flex w-full items-center">
+              {/* leading spacer keeps the first node's connector from the edge */}
+              {i > 0 && (
+                <span
+                  className={cn(
+                    "h-0.5 flex-1 rounded-full transition-colors",
+                    i <= activeIndex ? "bg-accent-teal" : "bg-border",
+                  )}
+                  aria-hidden
+                />
+              )}
+              <StepDot
+                index={i}
+                state={state}
+                outcome={i === activeIndex ? outcome : null}
+                closed={closed}
+                compact={compact}
+              />
+              {!isLast && (
+                <span
+                  className={cn(
+                    "h-0.5 flex-1 rounded-full transition-colors",
+                    connectorFilled ? "bg-accent-teal" : "bg-border",
+                  )}
+                  aria-hidden
+                />
+              )}
+            </div>
+            <span
+              className={cn(
+                "mt-2 font-heading font-semibold",
+                compact ? "text-[11px]" : "text-xs sm:text-sm",
+                state === "current" && outcome
+                  ? OUTCOME_LABEL[outcome]
+                  : state === "current"
+                    ? "text-accent-coral"
+                    : state === "done"
+                      ? "text-foreground"
+                      : "text-muted-foreground",
+              )}
+            >
+              {label}
+            </span>
+          </li>
+        );
+      })}
+    </ol>
+  );
+}
+
+function StepDot({
+  index,
+  state,
+  outcome,
+  closed,
+  compact,
+}: {
+  index: number;
+  state: StepState;
+  outcome: Outcome;
+  closed: boolean;
+  compact: boolean;
+}) {
+  const size = compact ? "h-6 w-6 text-[11px]" : "h-8 w-8 text-sm";
+
+  // Done nodes always read as a completed checkmark.
+  if (state === "done") {
+    return (
+      <Dot className={cn(size, "border-transparent bg-accent-teal text-white")}>
+        <Check className={compact ? "h-3 w-3" : "h-4 w-4"} aria-hidden />
+      </Dot>
+    );
+  }
+
+  if (state === "current") {
+    // A landed outcome (accept/waitlist/reject) or a withdrawal colours the node.
+    if (outcome === "withdrawn") {
+      return (
+        <Dot className={cn(size, OUTCOME_DOT.withdrawn)}>
+          <Minus className={compact ? "h-3 w-3" : "h-4 w-4"} aria-hidden />
+        </Dot>
+      );
+    }
+    if (outcome) {
+      return (
+        <Dot className={cn(size, OUTCOME_DOT[outcome])}>
+          {outcome === "rejected" ? (
+            <Minus className={compact ? "h-3 w-3" : "h-4 w-4"} aria-hidden />
+          ) : (
+            <Check className={compact ? "h-3 w-3" : "h-4 w-4"} aria-hidden />
+          )}
+        </Dot>
+      );
+    }
+    // Live "you are here": coral ring with a soft pulse (unless the track is closed).
+    return (
+      <Dot
+        className={cn(
+          size,
+          "border-accent-coral bg-card text-accent-coral",
+          !closed && "ring-4 ring-accent-coral/15",
+        )}
+      >
+        <span className="font-heading font-bold">{index + 1}</span>
+      </Dot>
+    );
+  }
+
+  // upcoming
+  return (
+    <Dot className={cn(size, "border-border bg-card text-muted-foreground")}>
+      <span className="font-heading font-bold">{index + 1}</span>
+    </Dot>
+  );
+}
+
+function Dot({
+  className,
+  children,
+}: {
+  className?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <span
+      className={cn(
+        "flex shrink-0 items-center justify-center rounded-full border-2",
+        className,
+      )}
+    >
+      {children}
+    </span>
+  );
+}

--- a/dali-api/app/hiring/components/analytics/DomainToggle.tsx
+++ b/dali-api/app/hiring/components/analytics/DomainToggle.tsx
@@ -23,17 +23,19 @@ export function DomainToggle({ domains, selectedDomainId }: Props) {
   ];
 
   return (
-    <div className="flex max-w-full overflow-x-auto rounded-md border border-border bg-card p-0.5">
+    <div className="inline-flex max-w-full items-center overflow-x-auto rounded-md border border-border">
       {options.map((opt) => {
         const active = (opt.id ?? null) === (selectedDomainId ?? null);
         return (
           <button
             key={opt.id ?? "__all__"}
+            type="button"
+            aria-pressed={active}
             onClick={() => select(opt.id)}
-            className={`shrink-0 whitespace-nowrap px-3 py-1.5 text-sm rounded transition-colors ${
+            className={`shrink-0 whitespace-nowrap px-3 py-1.5 text-sm transition-colors ${
               active
-                ? "bg-accent-teal text-white"
-                : "text-foreground hover:bg-muted/50"
+                ? "bg-accent-coral/15 text-accent-coral"
+                : "text-muted-foreground hover:bg-muted"
             }`}
           >
             {opt.name}

--- a/dali-api/app/hiring/components/delibs/ApplicantContextModal.tsx
+++ b/dali-api/app/hiring/components/delibs/ApplicantContextModal.tsx
@@ -6,6 +6,7 @@ import {
   RECOMMENDATION_COLORS,
   STAGE_LABELS,
 } from "~/hiring/lib/labels";
+import { Pill, InterviewStatusPill } from "~/hiring/components/Pill";
 import { useEffect } from "react";
 
 export interface ApplicantContextModalProps {
@@ -63,13 +64,9 @@ export function ApplicantContextModal({
                 {data.decisions?.length > 0 && (
                   <>
                     {" · "}
-                    <span
-                      className={`inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold ${
-                        DECISION_COLORS[data.decisions[0].type] ?? "bg-muted text-foreground/80"
-                      }`}
-                    >
+                    <Pill color={DECISION_COLORS[data.decisions[0].type] ?? "bg-muted text-foreground/80"}>
                       {data.decisions[0].type} ({STAGE_LABELS[data.decisions[0].stage] ?? data.decisions[0].stage})
-                    </span>
+                    </Pill>
                   </>
                 )}
               </p>
@@ -91,8 +88,8 @@ export function ApplicantContextModal({
             <p className="text-sm text-muted-foreground">Loading applicant context…</p>
           )}
           {isError && (
-            <p className="text-sm text-red-600">
-              Failed to load applicant context: {data.error ?? "unknown error"}
+            <p className="text-sm text-destructive">
+              Couldn&rsquo;t load applicant context: {data.error ?? "unknown error"}. Refresh to try again.
             </p>
           )}
 
@@ -350,7 +347,7 @@ export function ReviewsSection({
           No reviewers assigned yet.
         </div>
       ) : (
-        <div className="divide-y divide-gray-100">
+        <div className="divide-y divide-border">
           {reviews.map((review) => {
             const reviewer = review.cycleReviewer?.user;
             const name = reviewer ? `${reviewer.firstName} ${reviewer.lastName}` : "Unknown";
@@ -362,24 +359,20 @@ export function ReviewsSection({
                   <div className="flex items-center gap-2">
                     <span className="text-sm font-medium text-foreground">{name}</span>
                     {isSubmitted ? (
-                      <span className="text-xs text-green-700 bg-green-100 px-1.5 py-0.5 rounded font-medium">
-                        Submitted
-                      </span>
+                      <Pill color="bg-green-100 text-green-700">Submitted</Pill>
                     ) : (
-                      <span className="text-xs text-yellow-700 bg-yellow-100 px-1.5 py-0.5 rounded font-medium">
-                        In Progress
-                      </span>
+                      <Pill color="bg-yellow-100 text-yellow-700">In progress</Pill>
                     )}
                   </div>
                   {review.overallRecommendation && (
-                    <span
-                      className={`text-xs px-2 py-0.5 rounded-full font-semibold ${
+                    <Pill
+                      color={
                         RECOMMENDATION_COLORS[review.overallRecommendation] ??
                         "bg-muted text-foreground/80"
-                      }`}
+                      }
                     >
                       {review.overallRecommendation}
-                    </span>
+                    </Pill>
                   )}
                 </div>
 
@@ -458,15 +451,7 @@ function InterviewSection({ interview }: { interview: any | null }) {
             {new Date(interview.startTime).toLocaleDateString(undefined, { month: "short", day: "numeric" })}{" "}
             {new Date(interview.startTime).toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" })}
           </span>
-          <span
-            className={`text-xs px-2 py-0.5 rounded-full font-medium ${
-              interview.status === "Completed"
-                ? "bg-green-100 text-green-700"
-                : "bg-blue-100 text-blue-700"
-            }`}
-          >
-            {interview.status}
-          </span>
+          <InterviewStatusPill status={interview.status} />
         </div>
         {interview.recommendation && (
           <div className="text-sm">
@@ -541,13 +526,9 @@ function DecisionsSection({ decisions }: { decisions: any[] }) {
           <div key={d.id} className="text-sm">
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-2">
-                <span
-                  className={`text-xs px-2 py-0.5 rounded-full font-medium ${
-                    DECISION_COLORS[d.type] ?? "bg-muted text-foreground/80"
-                  }`}
-                >
+                <Pill color={DECISION_COLORS[d.type] ?? "bg-muted text-foreground/80"}>
                   {d.type}
-                </span>
+                </Pill>
                 <span className="text-xs text-muted-foreground">
                   {STAGE_LABELS[d.stage] ?? d.stage}
                 </span>

--- a/dali-api/app/hiring/components/hiringPills.tsx
+++ b/dali-api/app/hiring/components/hiringPills.tsx
@@ -58,7 +58,7 @@ export function hiringPills(args: {
     ...(isDomainLead
       ? [
           {
-            label: "Domain",
+            label: "My Domain",
             to: "/hiring/domain-lead",
             active: active === "domain",
             icon: Globe,

--- a/dali-api/app/hiring/routes/applications.$domainApplicationId.tsx
+++ b/dali-api/app/hiring/routes/applications.$domainApplicationId.tsx
@@ -8,7 +8,8 @@ import { presignAnswers } from "~/hiring/lib/presign";
 import { ApplicationViewer } from "~/hiring/components/ApplicationViewer";
 import { ReviewSummary } from "~/hiring/components/ReviewSummary";
 import { DetailCard } from "~/hiring/components/DetailCard";
-import { ApplicantDetailHeader } from "~/hiring/components/ApplicantDetailHeader";
+import { PageHeader } from "~/hiring/components/PageHeader";
+import { Pill } from "~/hiring/components/Pill";
 import {
   InterviewNotesCard,
   type InterviewNotesData,
@@ -446,10 +447,10 @@ export default function ApplicationReadOnlyDetail() {
 
   return (
     <div className="space-y-6 pb-12">
-      <ApplicantDetailHeader
-        name={data.applicantName}
-        domainName={data.domainName}
-        cycleName={data.cycleName}
+      <PageHeader
+        title={data.applicantName}
+        subtitle={`${data.domainName} · ${data.cycleName}`}
+        back={{ label: "Back to applications", to: "/hiring/applications" }}
       />
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
@@ -667,15 +668,15 @@ function DelibsSection({ delibs }: { delibs: DelibsRef[] }) {
           {delibs.map((s) => (
             <li key={s.id} className="px-6 py-3 flex items-center gap-3">
               <span className="text-sm font-medium text-foreground">{s.type} delibs</span>
-              <span
-                className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-bold ${
+              <Pill
+                color={
                   s.status === "Active"
                     ? "bg-amber-100 text-amber-800"
                     : "bg-muted text-foreground/80"
-                }`}
+                }
               >
                 {s.status}
-              </span>
+              </Pill>
               {s.column && (
                 <span className="text-xs text-muted-foreground">in “{s.column}”</span>
               )}

--- a/dali-api/app/hiring/routes/applications.tsx
+++ b/dali-api/app/hiring/routes/applications.tsx
@@ -1,12 +1,15 @@
 import { useMemo, useState } from "react";
 import { redirect, useLoaderData, useNavigate, useSearchParams } from "react-router";
-import { Search } from "lucide-react";
+import { Search, Inbox, ChevronRight } from "lucide-react";
 import type { Route } from "./+types/applications";
 import { requireAuth } from "~/lib/auth";
 import { getUserRoles } from "~/lib/roles";
 import { prisma } from "~/lib/db";
 import { hiringPills } from "~/hiring/components/hiringPills";
 import { AreaPillNav } from "~/components/AreaPillNav";
+import { PageHeader } from "~/hiring/components/PageHeader";
+import { EmptyState } from "~/hiring/components/EmptyState";
+import { CycleStatusPill, Pill } from "~/hiring/components/Pill";
 
 export const handle = { areaPills: true };
 
@@ -206,10 +209,12 @@ function formatDate(iso: string): string {
   });
 }
 
+// Application submission status tones. Composed through the shared `Pill`
+// helper so these read the same shape as every other hiring status chip.
 const STATUS_TONE: Record<string, string> = {
-  Submitted: "bg-green-50 text-green-700 border border-green-100",
-  Draft: "bg-muted text-muted-foreground",
-  Withdrawn: "bg-red-50 text-red-700 border border-red-100",
+  Submitted: "bg-green-100 text-green-700",
+  Draft: "bg-muted text-foreground/80",
+  Withdrawn: "bg-red-100 text-red-700",
 };
 
 export default function ApplicationsDatabase() {
@@ -240,14 +245,19 @@ export default function ApplicationsDatabase() {
 
   if (data.gate === "empty") {
     return (
-      <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-5">
         {areaPills}
         <Header />
-        <p className="text-sm text-muted-foreground">
-          {data.isCore
-            ? "No application cycles exist yet."
-            : "You aren't assigned as a reviewer on any cycle yet."}
-        </p>
+        <EmptyState
+          icon={Inbox}
+          title={data.isCore ? "No cycles yet" : "No cycles assigned to you"}
+          description={
+            data.isCore
+              ? "Applications appear here once a cycle is created and applicants start submitting."
+              : "You aren't a reviewer on any cycle yet. Once you're assigned, its applicants show up here."
+          }
+          action={data.isCore ? { label: "Set up a cycle", to: "/hiring/lead" } : undefined}
+        />
       </div>
     );
   }
@@ -256,16 +266,18 @@ export default function ApplicationsDatabase() {
   // to choose between (Core/Admin, or a reviewer covering multiple domains).
   const showDomainFilter = data.domainOptions.length > 1;
 
-  return (
-    <div className="flex flex-col gap-4">
-      {areaPills}
-      <Header />
+  const selectedCycle = data.cycles.find((c) => c.id === data.selectedCycleId);
+  const isFiltered = domainId !== "" || status !== "" || query.trim() !== "";
 
-      <div className="flex flex-col sm:flex-row sm:items-center gap-2">
-        <label
-          htmlFor="cycle-select"
-          className="text-sm font-medium text-muted-foreground"
-        >
+  return (
+    <div className="flex flex-col gap-5">
+      {areaPills}
+      <Header
+        chip={selectedCycle ? <CycleStatusPill status={selectedCycle.status} /> : undefined}
+      />
+
+      <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center">
+        <label htmlFor="cycle-select" className="sr-only">
           Cycle
         </label>
         <select
@@ -279,7 +291,7 @@ export default function ApplicationsDatabase() {
             next.set("cycle", e.target.value);
             setSearchParams(next);
           }}
-          className="px-3 py-1.5 text-sm border border-border rounded-md bg-background text-foreground sm:w-72"
+          className="rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-accent-coral/30 sm:w-72"
         >
           {data.cycles.map((c) => (
             <option key={c.id} value={c.id}>
@@ -292,7 +304,7 @@ export default function ApplicationsDatabase() {
             aria-label="Filter by domain"
             value={domainId}
             onChange={(e) => setDomainId(e.target.value)}
-            className="px-3 py-1.5 text-sm border border-border rounded-md bg-background text-foreground sm:w-48"
+            className="rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-accent-coral/30 sm:w-48"
           >
             <option value="">All domains</option>
             {data.domainOptions.map((d) => (
@@ -306,7 +318,7 @@ export default function ApplicationsDatabase() {
           aria-label="Filter by status"
           value={status}
           onChange={(e) => setStatus(e.target.value)}
-          className="px-3 py-1.5 text-sm border border-border rounded-md bg-background text-foreground sm:w-40"
+          className="rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-accent-coral/30 sm:w-40"
         >
           <option value="">All statuses</option>
           {Object.keys(STATUS_TONE).map((s) => (
@@ -315,47 +327,53 @@ export default function ApplicationsDatabase() {
             </option>
           ))}
         </select>
-        <div className="relative w-full sm:ml-auto sm:w-64 min-w-[12rem]">
-          <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground/70 pointer-events-none" />
+        <div className="relative w-full min-w-[12rem] sm:ml-auto sm:w-64">
+          <Search className="pointer-events-none absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground/70" />
           <input
             type="search"
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             placeholder="Search by name or email"
             aria-label="Search applicants by name or email"
-            className="w-full pl-8 pr-3 py-1.5 text-sm border border-border rounded-md bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-accent-coral/30"
+            className="w-full rounded-md border border-border bg-background py-2 pl-8 pr-3 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-accent-coral/30"
           />
         </div>
       </div>
 
-      <div className="bg-card border border-border rounded-lg overflow-hidden">
-        {filteredRows.length === 0 ? (
-          <div className="px-4 py-8 text-center text-sm text-muted-foreground">
-            {rows.length === 0 ? (
-              <>
-                No submissions for {data.selectedCycleName}
-                {data.isCore ? "" : " in your domains"}.
-              </>
-            ) : (
-              "No applicants match the current filters."
-            )}
-          </div>
-        ) : (
+      {filteredRows.length === 0 ? (
+        <EmptyState
+          icon={rows.length === 0 ? Inbox : Search}
+          title={
+            rows.length === 0 ? "No submissions yet" : "No matching applicants"
+          }
+          description={
+            rows.length === 0
+              ? `Nothing has been submitted for ${data.selectedCycleName}${
+                  data.isCore ? "" : " in your domains"
+                } yet.`
+              : "No applicants match the current filters. Try clearing your search or status filter."
+          }
+        />
+      ) : (
+        <div className="overflow-hidden rounded-lg border border-border bg-card">
           <div className="overflow-x-auto">
-            <table className="w-full text-sm min-w-[640px]">
-              <thead className="bg-muted/30 text-muted-foreground text-xs uppercase tracking-wide">
+            <table className="w-full min-w-[640px] text-sm">
+              <thead className="border-b border-border bg-muted/40 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
                 <tr>
-                  <th className="text-left font-medium px-4 py-2">
-                    Applicant ({filteredRows.length}
-                    {filteredRows.length === data.rows.length
-                      ? ""
-                      : ` of ${data.rows.length}`}
-                    )
+                  <th scope="col" className="px-4 py-3 text-left">
+                    Applicant
+                    <span className="ml-1.5 font-normal normal-case text-muted-foreground/70">
+                      {filteredRows.length}
+                      {isFiltered ? ` of ${data.rows.length}` : ""}
+                    </span>
                   </th>
-                  <th className="text-left font-medium px-4 py-2">Domain</th>
-                  <th className="text-left font-medium px-4 py-2">Status</th>
-                  <th className="text-left font-medium px-4 py-2">Submitted</th>
-                  <th className="text-left font-medium px-4 py-2">Reviews</th>
+                  <th scope="col" className="px-4 py-3 text-left">Domain</th>
+                  <th scope="col" className="px-4 py-3 text-left">Status</th>
+                  <th scope="col" className="px-4 py-3 text-left">Submitted</th>
+                  <th scope="col" className="px-4 py-3 text-left">Reviews</th>
+                  <th scope="col" className="w-10 px-4 py-3">
+                    <span className="sr-only">Open</span>
+                  </th>
                 </tr>
               </thead>
               <tbody>
@@ -363,45 +381,49 @@ export default function ApplicationsDatabase() {
                   <tr
                     key={r.id}
                     onClick={() => navigate(`/hiring/applications/${r.id}`)}
-                    className="border-t border-border hover:bg-muted/20 cursor-pointer"
+                    className="group cursor-pointer border-t border-border transition-colors hover:bg-muted/40"
                   >
-                    <td className="px-4 py-2 text-foreground">{r.name}</td>
-                    <td className="px-4 py-2 text-foreground">{r.domain}</td>
-                    <td className="px-4 py-2">
-                      <span
-                        className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
-                          STATUS_TONE[r.status] ?? "bg-muted text-muted-foreground"
-                        }`}
-                      >
-                        {r.status}
-                      </span>
+                    <td className="px-4 py-3 font-medium text-foreground">
+                      {r.name}
+                      {r.email && (
+                        <span className="ml-2 hidden font-normal text-muted-foreground sm:inline">
+                          {r.email}
+                        </span>
+                      )}
                     </td>
-                    <td className="px-4 py-2 text-muted-foreground">
+                    <td className="px-4 py-3 text-foreground">{r.domain}</td>
+                    <td className="px-4 py-3">
+                      <Pill color={STATUS_TONE[r.status]}>{r.status}</Pill>
+                    </td>
+                    <td className="px-4 py-3 text-muted-foreground">
                       {r.submittedAt ? formatDate(r.submittedAt) : "—"}
                     </td>
-                    <td className="px-4 py-2 text-muted-foreground">
+                    <td className="px-4 py-3 text-muted-foreground">
                       {r.reviewCount}
+                    </td>
+                    <td className="px-4 py-3 text-right">
+                      <ChevronRight
+                        className="ml-auto h-4 w-4 text-muted-foreground/40 transition-colors group-hover:text-accent-coral"
+                        aria-hidden
+                      />
                     </td>
                   </tr>
                 ))}
               </tbody>
             </table>
           </div>
-        )}
-      </div>
+        </div>
+      )}
     </div>
   );
 }
 
-function Header() {
+function Header({ chip }: { chip?: React.ReactNode }) {
   return (
-    <header>
-      <h1 className="font-heading text-2xl font-bold text-foreground">
-        Applications
-      </h1>
-      <p className="text-sm text-muted-foreground mt-1">
-        Every submission for a cycle. Pick a cycle to view its applicants.
-      </p>
-    </header>
+    <PageHeader
+      title="Applications"
+      subtitle="Every submission for a cycle. Pick a cycle to browse its applicants."
+      chip={chip}
+    />
   );
 }

--- a/dali-api/app/hiring/routes/cycles.$cycleId.confidentiality.tsx
+++ b/dali-api/app/hiring/routes/cycles.$cycleId.confidentiality.tsx
@@ -6,6 +6,7 @@ import { requireAuth } from "~/lib/auth";
 import { logAuditEvent } from "~/lib/audit";
 import { getCycleConfidentialityState } from "~/hiring/lib/confidentiality";
 import { RichTextViewer, isEmptyDoc } from "~/components/RichTextViewer";
+import { Button, buttonClasses } from "~/components/ui/Button";
 
 export const meta: Route.MetaFunction = () => [
   { title: "Confidentiality agreement · DALI OS" },
@@ -113,23 +114,23 @@ export default function CycleConfidentialityPage() {
 
   if (state.status === "no_agreement") {
     return (
-      <div className="max-w-3xl mx-auto py-10 space-y-6">
+      <div className="max-w-3xl mx-auto py-10 space-y-5">
         <div className="flex items-center gap-3">
-          <AlertTriangle className="w-6 h-6 text-amber-500" />
-          <h1 className="text-2xl font-bold text-foreground">
-            Confidentiality agreement unavailable
+          <span className="flex h-10 w-10 items-center justify-center rounded-full bg-yellow-100 text-yellow-700">
+            <AlertTriangle className="h-5 w-5" aria-hidden />
+          </span>
+          <h1 className="font-heading text-2xl font-bold text-foreground">
+            Nothing to sign yet
           </h1>
         </div>
         <p className="text-muted-foreground">
-          The hiring lead has not yet attached a confidentiality agreement to
-          the {cycle.name} cycle. Until they do, sensitive cycle data is hidden
-          from everyone — please ask the hiring lead to bind one.
+          The hiring lead hasn't attached a confidentiality agreement to the{" "}
+          <strong className="text-foreground">{cycle.name}</strong> cycle yet.
+          Until they do, sensitive cycle data stays hidden from everyone. Ask the
+          hiring lead to bind one, then come back to sign.
         </p>
-        <Link
-          to="/"
-          className="inline-block text-sm font-medium text-blue-600 hover:text-blue-700"
-        >
-          Open home
+        <Link to="/" className={buttonClasses("secondary")}>
+          Back to home
         </Link>
       </div>
     );
@@ -137,22 +138,22 @@ export default function CycleConfidentialityPage() {
 
   if (state.status === "signed") {
     return (
-      <div className="max-w-3xl mx-auto py-10 space-y-6">
+      <div className="max-w-3xl mx-auto py-10 space-y-5">
         <div className="flex items-center gap-3">
-          <ShieldCheck className="w-6 h-6 text-green-600" />
-          <h1 className="text-2xl font-bold text-foreground">
-            You have signed the confidentiality agreement
+          <span className="flex h-10 w-10 items-center justify-center rounded-full bg-green-100 text-green-700">
+            <ShieldCheck className="h-5 w-5" aria-hidden />
+          </span>
+          <h1 className="font-heading text-2xl font-bold text-foreground">
+            You're signed in for this cycle
           </h1>
         </div>
         <p className="text-muted-foreground">
-          You have already signed the current version of the confidentiality
-          agreement for {cycle.name}.
+          You've already signed the current confidentiality agreement for{" "}
+          <strong className="text-foreground">{cycle.name}</strong>. You can
+          view its sensitive data.
         </p>
         {next && (
-          <Link
-            to={next}
-            className="inline-block px-4 py-2 text-sm font-medium text-white bg-accent-coral rounded-md hover:bg-accent-coral/90"
-          >
+          <Link to={next} className={buttonClasses("primary")}>
             Continue
           </Link>
         )}
@@ -164,18 +165,21 @@ export default function CycleConfidentialityPage() {
   const empty = !agreementVersion || isEmptyDoc(agreementVersion.body);
 
   return (
-    <div className="max-w-3xl mx-auto py-10 space-y-6">
+    <div className="max-w-3xl mx-auto py-10 space-y-5">
       <div className="flex items-center gap-3">
-        <ShieldCheck className="w-6 h-6 text-blue-600" />
-        <h1 className="text-2xl font-bold text-foreground">
-          Confidentiality agreement
+        <span className="flex h-10 w-10 items-center justify-center rounded-full bg-brand-tint text-accent-coral">
+          <ShieldCheck className="h-5 w-5" aria-hidden />
+        </span>
+        <h1 className="font-heading text-2xl font-bold text-foreground">
+          Read &amp; sign the confidentiality agreement
         </h1>
       </div>
       <p className="text-sm text-muted-foreground">
-        To view sensitive data for the <strong>{cycle.name}</strong> cycle —
+        Before you can view sensitive data for the{" "}
+        <strong className="text-foreground">{cycle.name}</strong> cycle —
         submitted applications, reviews, scheduled interviews, interview notes,
-        and decisions — you must read and sign the agreement below. This applies
-        to everyone, including hiring leads and admins.
+        and decisions — read the agreement below and sign it. This applies to
+        everyone, including hiring leads and admins.
       </p>
 
       <article className="bg-card border border-border rounded-lg p-6">
@@ -192,13 +196,9 @@ export default function CycleConfidentialityPage() {
       <Form method="post" className="flex items-center justify-end gap-3">
         <input type="hidden" name="intent" value="sign" />
         {next && <input type="hidden" name="next" value={next} />}
-        <button
-          type="submit"
-          disabled={empty}
-          className="px-4 py-2 text-sm font-medium text-white bg-accent-coral rounded-md hover:bg-accent-coral/90 disabled:opacity-50"
-        >
-          I agree and sign
-        </button>
+        <Button type="submit" variant="primary" disabled={empty}>
+          Agree and sign
+        </Button>
       </Form>
     </div>
   );

--- a/dali-api/app/hiring/routes/domain-lead.application.$id.tsx
+++ b/dali-api/app/hiring/routes/domain-lead.application.$id.tsx
@@ -9,7 +9,9 @@ import { ChevronDown } from "lucide-react";
 import { ApplicationViewer } from "~/hiring/components/ApplicationViewer";
 import { ReviewSummary } from "~/hiring/components/ReviewSummary";
 import { DetailCard } from "~/hiring/components/DetailCard";
-import { ApplicantDetailHeader } from "~/hiring/components/ApplicantDetailHeader";
+import { PageHeader } from "~/hiring/components/PageHeader";
+import { StatusStepper } from "~/hiring/components/StatusStepper";
+import { Pill, RecommendationPill } from "~/hiring/components/Pill";
 import {
   InterviewNotesCard,
   type InterviewNotesData,
@@ -25,22 +27,6 @@ import {
 } from "~/hiring/lib/domain-application-status";
 import type { ApplicationCycleStatus } from "~/generated/prisma/enums";
 import type { Question } from "~/types";
-import { RECOMMENDATION_COLORS } from "~/hiring/lib/labels";
-
-// bg + text + an explicit same-hue border (e.g. red pill → red border), so the
-// outline always matches the pill and never falls back to the neutral gray
-// border from the global `*` rule. Mirrors the dashboard's DECISION_COLORS:
-// `-300` light borders read clearly (not the faint `-200`), with dark variants.
-const STATUS_BADGE: Record<string, { bg: string; label: string }> = {
-  ApplicationOpen: { bg: "bg-muted text-foreground/80 border-current/30", label: "Draft" },
-  Pending: { bg: "bg-yellow-100 text-yellow-800 border-yellow-300 dark:border-yellow-700", label: "Pending Review" },
-  Rejected: { bg: "bg-red-100 text-red-700 border-red-300 dark:bg-red-900/30 dark:text-red-400 dark:border-red-700", label: "Rejected" },
-  InvitedToInterview: { bg: "bg-blue-100 text-blue-700 border-blue-300 dark:bg-blue-900/30 dark:text-blue-400 dark:border-blue-700", label: "Invited to Interview" },
-  InterviewScheduled: { bg: "bg-blue-100 text-blue-700 border-blue-300 dark:bg-blue-900/30 dark:text-blue-400 dark:border-blue-700", label: "Interview Scheduled" },
-  PostInterviewPending: { bg: "bg-purple-100 text-purple-700 border-purple-300 dark:bg-purple-900/30 dark:text-purple-400 dark:border-purple-700", label: "Post-Interview" },
-  Accepted: { bg: "bg-green-100 text-green-700 border-green-300 dark:bg-green-900/30 dark:text-green-400 dark:border-green-700", label: "Accepted" },
-  Waitlisted: { bg: "bg-yellow-100 text-yellow-700 border-yellow-300 dark:bg-yellow-900/30 dark:text-yellow-400 dark:border-yellow-700", label: "Waitlisted" },
-};
 
 export const meta: Route.MetaFunction = ({ data }) => {
   const user = (data as any)?.application?.user;
@@ -244,7 +230,6 @@ export default function DomainLeadApplicationView() {
   const reviews: any[] = da.reviews ?? [];
   const decisions: any[] = da.decisions ?? [];
   const interview = da.interviews?.[0] ?? null;
-  const statusInfo = STATUS_BADGE[inferredStatus] ?? STATUS_BADGE.Pending;
 
   const questionLabels: Record<string, string> = {};
   for (const q of [...generalQuestions, ...challengeQuestions]) {
@@ -278,16 +263,16 @@ export default function DomainLeadApplicationView() {
   return (
     <div className="space-y-6 pb-12">
       {/* Header */}
-      <ApplicantDetailHeader
-        name={`${application.user.firstName} ${application.user.lastName}`}
-        domainName={da.challengeVersion.domain?.name}
-        cycleName={application.applicationCycle.name}
-        statusSlot={
-          <span className={`inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold border ${statusInfo.bg}`}>
-            {statusInfo.label}
-          </span>
-        }
+      <PageHeader
+        title={`${application.user.firstName} ${application.user.lastName}`}
+        subtitle={`${da.challengeVersion.domain?.name ?? "Domain"} · ${application.applicationCycle.name}`}
+        back={{ label: "Back to dashboard", to: "/hiring/domain-lead" }}
       />
+
+      {/* Where this applicant stands in the pipeline. */}
+      <div className="rounded-xl border border-border bg-card px-5 py-4">
+        <StatusStepper status={inferredStatus} variant="compact" className="max-w-2xl" />
+      </div>
 
       {/* Two-column layout */}
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
@@ -313,7 +298,7 @@ export default function DomainLeadApplicationView() {
             className="overflow-hidden"
           >
             {reviews.length > 0 && (
-              <div className="divide-y divide-gray-100">
+              <div className="divide-y divide-border">
                 {reviews.map((review: any) => (
                   <ReviewCard key={review.id} review={review} criteriaByKey={criteriaByKey} />
                 ))}
@@ -393,15 +378,13 @@ function ReviewCard({
         <div className="flex items-center gap-2">
           <span className="text-sm font-medium text-foreground">{name}</span>
           {isSubmitted ? (
-            <span className="text-xs text-green-700 bg-green-100 px-1.5 py-0.5 rounded font-medium">Submitted</span>
+            <Pill color="bg-green-100 text-green-700">Submitted</Pill>
           ) : (
-            <span className="text-xs text-yellow-700 bg-yellow-100 px-1.5 py-0.5 rounded font-medium">In Progress</span>
+            <Pill color="bg-yellow-100 text-yellow-700">In progress</Pill>
           )}
         </div>
         {review.overallRecommendation && (
-          <span className={`text-xs px-2 py-0.5 rounded-full font-semibold ${RECOMMENDATION_COLORS[review.overallRecommendation] ?? "bg-muted text-foreground/80"}`}>
-            {review.overallRecommendation}
-          </span>
+          <RecommendationPill value={review.overallRecommendation} />
         )}
       </div>
 

--- a/dali-api/app/hiring/routes/domain-lead.delibs.$id.tsx
+++ b/dali-api/app/hiring/routes/domain-lead.delibs.$id.tsx
@@ -7,11 +7,15 @@ import { requireAuth } from "~/lib/auth";
 import { parseSessionCookie } from "~/lib/cookies";
 import { isDomainLead } from "~/lib/roles";
 import { requirePageSignedOrRedirect } from "~/hiring/lib/confidentiality";
-import { GripVertical } from "lucide-react";
+import { GripVertical, Users } from "lucide-react";
 import { KanbanBoard, type KanbanColumn } from "~/components/board/KanbanBoard";
 import { INITIAL_COLUMNS, FINAL_COLUMNS, buildColumnOrder } from "~/hiring/lib/delibs";
 import { inReviewPipelineFilter } from "~/hiring/lib/application-pipeline-filter";
 import { ApplicantContextModal } from "~/hiring/components/delibs/ApplicantContextModal";
+import { PageHeader } from "~/hiring/components/PageHeader";
+import { EmptyState } from "~/hiring/components/EmptyState";
+import { Button } from "~/components/ui/Button";
+import { Pill } from "~/hiring/components/Pill";
 
 // Same recommendation scale + tones used by the ApplicantContextModal, so the
 // card's reviewer/interviewer recommendation pills read consistently.
@@ -331,8 +335,10 @@ export default function DelibsKanban() {
             </span>
           ),
           renderEmpty: () => (
-            <div className="py-8 text-center border-2 border-dashed border-gray-300 rounded-lg bg-card/50">
-              <p className="text-sm text-muted-foreground/70 italic">Empty</p>
+            <div className="rounded-lg border-2 border-dashed border-border bg-card/50 py-8 text-center">
+              <p className="text-sm italic text-muted-foreground/70">
+                {isClosed ? "Empty" : "Drop applicants here"}
+              </p>
             </div>
           ),
         };
@@ -345,43 +351,35 @@ export default function DelibsKanban() {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-bold text-foreground">
-            {session.type === "Initial" ? "Initial" : "Final"} Deliberations —{" "}
-            {session.domain.name}
-          </h1>
-          <p className="text-sm text-muted-foreground mt-1">
-            Drag applications between columns. Changes save automatically.
-          </p>
-        </div>
-        <div className="flex items-center gap-3">
-          {saving && (
-            <span className="text-xs text-muted-foreground/70">Saving...</span>
-          )}
-          {isClosed ? (
-            <span className="px-3 py-1.5 text-sm font-medium bg-muted text-muted-foreground rounded-lg">
-              Closed
-            </span>
-          ) : (
-            <button
-              onClick={() => setShowCloseConfirm(true)}
-              className="px-4 py-2 text-sm font-medium rounded-lg bg-red-600 hover:bg-red-700 text-white transition"
-            >
-              Close Delibs
-            </button>
-          )}
-        </div>
-      </div>
+      <PageHeader
+        title={`${session.type === "Initial" ? "Initial" : "Final"} deliberations`}
+        subtitle="Drag applicants between columns. Changes save automatically."
+        chip={<Pill color="bg-brand-tint text-navy">{session.domain.name}</Pill>}
+        back={{ label: "Back to dashboard", to: "/hiring/domain-lead" }}
+        actions={
+          <>
+            {saving && (
+              <span className="text-xs text-muted-foreground/70">Saving…</span>
+            )}
+            {isClosed ? (
+              <Pill color="bg-muted text-muted-foreground">Closed</Pill>
+            ) : (
+              <Button variant="destructive" onClick={() => setShowCloseConfirm(true)}>
+                Close delibs
+              </Button>
+            )}
+          </>
+        }
+      />
 
       {/* Close confirmation */}
       {showCloseConfirm && (
-        <div className="bg-red-50 border border-red-200 rounded-xl p-4 flex items-center justify-between">
+        <div className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-red-200 bg-red-50 p-4">
           <div>
             <p className="text-sm font-bold text-red-900">
               Close deliberations and create Draft decisions?
             </p>
-            <p className="text-xs text-red-700 mt-0.5">
+            <p className="mt-0.5 text-xs text-red-700">
               {columns
                 .filter((c) => c !== defaultColumn)
                 .map(
@@ -393,19 +391,17 @@ export default function DelibsKanban() {
             </p>
           </div>
           <div className="flex items-center gap-2">
-            <button
-              onClick={() => setShowCloseConfirm(false)}
-              className="px-3 py-1.5 text-sm font-medium text-foreground/80 bg-card border border-gray-300 rounded-lg hover:bg-muted/50"
-            >
-              Cancel
-            </button>
-            <button
+            <Button variant="secondary" size="sm" onClick={() => setShowCloseConfirm(false)}>
+              Keep open
+            </Button>
+            <Button
+              variant="destructive"
+              size="sm"
               onClick={handleClose}
               disabled={closing}
-              className="px-3 py-1.5 text-sm font-medium text-white bg-red-600 rounded-lg hover:bg-red-700 disabled:opacity-50"
             >
-              {closing ? "Closing..." : "Confirm & Close"}
-            </button>
+              {closing ? "Closing…" : "Confirm & close"}
+            </Button>
           </div>
         </div>
       )}
@@ -420,11 +416,22 @@ export default function DelibsKanban() {
         />
       )}
 
-      {/* Kanban Board. Migrated from native HTML5 drag to @dnd-kit via the
+      {domainApplications.length === 0 ? (
+        <EmptyState
+          icon={Users}
+          title="No applicants to deliberate yet"
+          description={
+            session.type === "Initial"
+              ? "Applicants appear here once their reviews are all submitted. Check back as reviewing wraps up."
+              : "Applicants appear here once their interviews are complete."
+          }
+        />
+      ) : (
+      /* Kanban Board. Migrated from native HTML5 drag to @dnd-kit via the
           shared KanbanBoard primitive: keyboard drag now works, the stray
           post-drag click is gone (activation-distance sensor), and the drop
           ring is the shared coral instead of the old blue-400. Per-column
-          color theming is preserved through each column's className. */}
+          color theming is preserved through each column's className. */
       <KanbanBoard<DomainApp>
         id={`delibs-board-${session.id}`}
         layout="grid"
@@ -461,6 +468,7 @@ export default function DelibsKanban() {
           ) : null;
         }}
       />
+      )}
     </div>
   );
 }

--- a/dali-api/app/hiring/routes/domain-lead.tsx
+++ b/dali-api/app/hiring/routes/domain-lead.tsx
@@ -8,7 +8,7 @@ import { getUserRoles } from "~/lib/roles";
 import { hiringPills } from "~/hiring/components/hiringPills";
 import { AreaPillNav } from "~/components/AreaPillNav";
 import { requireAuth } from "~/lib/auth";
-import { CheckCircle, Plus, Trash2, Check, Clock, X, CircleDashed, ChevronDown, Eye, Send, Search, ChevronUp } from "lucide-react";
+import { CheckCircle, Plus, Trash2, Check, Clock, X, CircleDashed, ChevronDown, Eye, Send, Search, ChevronUp, Users } from "lucide-react";
 import { inferDomainApplicationStatus } from "~/hiring/lib/domain-application-status";
 import { inReviewPipelineFilter } from "~/hiring/lib/application-pipeline-filter";
 import { getReviewStatus } from "~/hiring/lib/review-status";
@@ -20,6 +20,10 @@ import { Modal } from "~/components/Modal";
 import { ChallengePreviewModal } from "~/hiring/components/ChallengePreviewModal";
 import { Tooltip } from "~/components/ui/IconButton";
 import { CycleSelector } from "~/hiring/components/CycleSelector";
+import { PageHeader } from "~/hiring/components/PageHeader";
+import { EmptyState } from "~/hiring/components/EmptyState";
+import { CycleStatusPill } from "~/hiring/components/Pill";
+import { Button, buttonClasses } from "~/components/ui/Button";
 import {
   summarizeDecisionPills,
   synthesizePrePipelinePill,
@@ -31,7 +35,7 @@ import type { ApplicationCycleStatus } from "~/generated/prisma/enums";
 import type { DecisionType } from "~/types";
 import { formatVersionLabel, buildVersionNumberMap } from "~/lib/formatVersion";
 import { selectActiveCycleForDomainLead } from "~/hiring/lib/cycle-picker";
-import { STATUS_LABELS, DECISION_LABELS, STATUS_COLORS, DECISION_COLORS } from "~/hiring/lib/labels";
+import { DECISION_LABELS, DECISION_COLORS } from "~/hiring/lib/labels";
 
 const STATUS_MESSAGES: Record<string, string> = {
   Draft: "This cycle is still being set up.",
@@ -671,9 +675,17 @@ export default function DomainLeadDashboard() {
 
   if (domainData.length === 0) {
     return (
-      <div className="text-center py-16">
-        <h1 className="font-heading text-2xl font-bold text-foreground mb-2">Domain Lead Dashboard</h1>
-        <p className="text-muted-foreground">You are not assigned as a domain lead for any domain.</p>
+      <div className="flex flex-col gap-5">
+        {areaPills}
+        <PageHeader
+          title="Domain lead"
+          subtitle="Your dashboard for running a domain's hiring cycle."
+        />
+        <EmptyState
+          icon={Users}
+          title="No domains assigned to you"
+          description="You aren't a domain lead for any domain yet. Once you're assigned, your domain's setup, reviews, interviews, and decisions live here."
+        />
       </div>
     );
   }
@@ -681,7 +693,10 @@ export default function DomainLeadDashboard() {
   return (
     <div className="space-y-8">
       {areaPills}
-      <h1 className="font-heading text-2xl font-bold text-foreground">Domain Lead Dashboard</h1>
+      <PageHeader
+        title="Domain lead"
+        subtitle="Run each domain's hiring cycle — setup, reviews, interviews, and decisions."
+      />
 
       {domainData.map(({ assignment, cycle, availableCycles, apps, challengeVersionOptions, linkedChallengeVersions, isChallengeReady, interviews, reviewers: cycleReviewers, delibsSessions, draftDecisions, cycleReviewersForDomain, initialDelibsCount, finalDelibsCount, rubricVersionOptions, currentRubricVersionId, rubricCriteria, interviewers, hasApplicationReviews, confidentialityRequired }: any, idx: number) => {
         const isInternToFull = cycle?.cycleType === "InternToFull";
@@ -724,11 +739,7 @@ export default function DomainLeadDashboard() {
                       <h2 className="font-heading text-2xl font-bold text-foreground">{assignment.domain.name}</h2>
                       <span className="text-muted-foreground/70 hidden sm:inline">·</span>
                       <span className="text-lg text-muted-foreground">{cycle.name}</span>
-                      {currentStatus && (
-                        <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium border border-current/30 ${STATUS_COLORS[currentStatus]}`}>
-                          {STATUS_LABELS[currentStatus]}
-                        </span>
-                      )}
+                      {currentStatus && <CycleStatusPill status={currentStatus} />}
                       <CycleSelector cycles={availableCycles ?? []} activeId={cycle.id} />
                     </div>
                     {currentStatus !== "Draft" && !confidentialityRequired && (
@@ -970,9 +981,11 @@ export default function DomainLeadDashboard() {
                           rubricCriteria={rubricCriteria ?? []}
                         />
                       ) : (
-                        <div className="text-center text-muted-foreground text-sm py-6">
-                          No applicants in review. Anyone invited to interview appears under Interviews.
-                        </div>
+                        <EmptyState
+                          icon={Users}
+                          title="No applicants in review"
+                          description="Anyone invited to interview moves down to the Interviews section."
+                        />
                       )}
                     </Section>
                     );
@@ -1099,12 +1112,14 @@ export default function DomainLeadDashboard() {
                                   {" "}— drafts from final delibs. Finalizing locks them in for the hiring lead to release.
                                 </span>
                               </div>
-                              <button
+                              <Button
+                                variant="primary"
+                                size="sm"
                                 onClick={finalizeAll}
-                                className="flex-shrink-0 px-3 py-1.5 text-xs font-medium rounded-lg bg-accent-coral hover:bg-accent-coral/90 text-white transition self-start sm:self-auto"
+                                className="shrink-0 self-start sm:self-auto"
                               >
-                                Finalize All ({finalizableCount})
-                              </button>
+                                Finalize all ({finalizableCount})
+                              </Button>
                             </div>
                           )}
 
@@ -1254,12 +1269,13 @@ export default function DomainLeadDashboard() {
                                           <td className="px-6 py-4 text-muted-foreground text-xs">{row.crossDomain}</td>
                                           <td className="px-6 py-4 text-right">
                                             {canFinalize && row.daId && finalizableByDaId.has(row.daId) ? (
-                                              <button
+                                              <Button
+                                                variant="primary"
+                                                size="sm"
                                                 onClick={(e) => { e.stopPropagation(); finalizeOne(row.daId); }}
-                                                className="px-2 py-1 text-xs font-medium rounded bg-accent-coral hover:bg-accent-coral/90 text-white transition"
                                               >
                                                 Finalize
-                                              </button>
+                                              </Button>
                                             ) : (
                                               <span className="text-xs text-muted-foreground/60">—</span>
                                             )}
@@ -1303,12 +1319,13 @@ export default function DomainLeadDashboard() {
                                       </div>
                                       {canFinalize && row.daId && finalizableByDaId.has(row.daId) && (
                                         <div className="flex flex-wrap items-center gap-2">
-                                          <button
+                                          <Button
+                                            variant="primary"
+                                            size="sm"
                                             onClick={(e) => { e.stopPropagation(); finalizeOne(row.daId); }}
-                                            className="px-2 py-1 text-xs font-medium rounded bg-accent-coral hover:bg-accent-coral/90 text-white transition"
                                           >
                                             Finalize
-                                          </button>
+                                          </Button>
                                         </div>
                                       )}
                                     </li>
@@ -2459,13 +2476,14 @@ function ApplicationsTable({ apps, draftDecisions, cycleReviewersForDomain, cycl
                 <td className="px-6 py-4 text-right">
                   <div className="flex flex-wrap items-center justify-end gap-2">
                   {isUnderReview && draftToFinalize ? (
-                    <button
+                    <Button
+                      variant="primary"
+                      size="sm"
                       onClick={() => handleFinalize(draftToFinalize.id)}
                       disabled={finalizingId === draftToFinalize.id}
-                      className="px-2 py-1 text-xs font-medium rounded bg-accent-coral hover:bg-accent-coral/90 text-white transition disabled:opacity-50 disabled:cursor-not-allowed"
                     >
                       {finalizingId === draftToFinalize.id ? "Finalizing…" : "Finalize"}
-                    </button>
+                    </Button>
                   ) : (
                     <span className="text-xs text-muted-foreground/60">—</span>
                   )}
@@ -2475,14 +2493,16 @@ function ApplicationsTable({ apps, draftDecisions, cycleReviewersForDomain, cycl
             );
           })}
           {displayedApps.length === 0 && (
-            <tr><td colSpan={isUnderReview && canAssignReviewers ? 5 : 4} className="px-6 py-8 text-center text-muted-foreground/70 text-sm">
-              {filter === "finalize" ? "No applications need finalization." : "No applications."}
+            <tr><td colSpan={isUnderReview && canAssignReviewers ? 5 : 4} className="px-6 py-10 text-center text-muted-foreground text-sm">
+              {filter === "finalize"
+                ? "Nothing to finalize right now. Draft decisions from delibs show up here, ready to lock in."
+                : "No applicants in this view yet."}
             </td></tr>
           )}
         </tbody>
       </table>
       </div>
-      <ul className="sm:hidden divide-y divide-gray-100">
+      <ul className="sm:hidden divide-y divide-border">
         {displayedApps.map((app: any) => {
           const da = app.domainApplications[0];
           const reviews = da?.reviews ?? [];
@@ -2552,21 +2572,24 @@ function ApplicationsTable({ apps, draftDecisions, cycleReviewersForDomain, cycl
               </div>
               {isUnderReview && draftToFinalize && (
                 <div className="flex flex-wrap items-center gap-2">
-                  <button
+                  <Button
+                    variant="primary"
+                    size="sm"
                     onClick={() => handleFinalize(draftToFinalize.id)}
                     disabled={finalizingId === draftToFinalize.id}
-                    className="px-2 py-1 text-xs font-medium rounded bg-accent-coral hover:bg-accent-coral/90 text-white transition disabled:opacity-50 disabled:cursor-not-allowed"
                   >
                     {finalizingId === draftToFinalize.id ? "Finalizing…" : "Finalize"}
-                  </button>
+                  </Button>
                 </div>
               )}
             </li>
           );
         })}
         {displayedApps.length === 0 && (
-          <li className="px-6 py-8 text-center text-muted-foreground/70 text-sm">
-            {filter === "finalize" ? "No applications need finalization." : "No applications."}
+          <li className="px-6 py-10 text-center text-muted-foreground text-sm">
+            {filter === "finalize"
+              ? "Nothing to finalize right now. Draft decisions from delibs show up here, ready to lock in."
+              : "No applicants in this view yet."}
           </li>
         )}
       </ul>

--- a/dali-api/app/hiring/routes/hiring.tsx
+++ b/dali-api/app/hiring/routes/hiring.tsx
@@ -6,9 +6,21 @@ import { getPipelineData } from "~/hiring/lib/pipeline.server";
 import { hiringPills } from "~/hiring/components/hiringPills";
 import { AreaPillNav } from "~/components/AreaPillNav";
 import { PipelinePanel } from "~/hiring/components/analytics/PipelinePanel";
+import { PageHeader } from "~/hiring/components/PageHeader";
+import { EmptyState } from "~/hiring/components/EmptyState";
+import { CycleStatusPill } from "~/hiring/components/Pill";
 import { buttonClasses } from "~/components/ui/Button";
 import { formatInterviewDate, formatInterviewTimeRange } from "~/hiring/lib/interview-time";
-import { cn } from "~/lib/cn";
+import {
+  CheckCircle2,
+  ClipboardList,
+  Mic,
+  Users,
+  Send,
+  Activity,
+  ShieldCheck,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 
 export const handle = { areaPills: true };
 
@@ -34,24 +46,36 @@ export async function loader({ request }: Route.LoaderArgs) {
   return { ...hub, pipeline };
 }
 
-const STAGE_STYLES: Record<string, string> = {
-  Open: "bg-green-100 text-green-800",
-  UnderReview: "bg-amber-100 text-amber-800",
-  Draft: "bg-muted text-muted-foreground",
-};
-
 function Card({
   title,
+  icon: Icon,
+  count,
   children,
   cta,
 }: {
   title: string;
+  icon?: LucideIcon;
+  count?: number;
   children: React.ReactNode;
   cta?: { label: string; to: string };
 }) {
   return (
-    <section className="bg-card border border-border rounded-lg p-5 flex flex-col gap-3">
-      <h2 className="font-heading font-semibold text-foreground">{title}</h2>
+    <section className="bg-card border border-border rounded-lg p-5 flex flex-col gap-3 transition-colors hover:border-accent-coral/40">
+      <div className="flex items-center justify-between gap-2">
+        <h2 className="flex items-center gap-2 font-heading font-semibold text-foreground">
+          {Icon && (
+            <span className="flex h-7 w-7 items-center justify-center rounded-md bg-brand-tint text-navy">
+              <Icon className="h-4 w-4" aria-hidden />
+            </span>
+          )}
+          {title}
+        </h2>
+        {count != null && count > 0 && (
+          <span className="inline-flex min-w-6 items-center justify-center rounded-full bg-accent-coral/12 px-2 py-0.5 text-xs font-bold text-accent-coral">
+            {count}
+          </span>
+        )}
+      </div>
       <div className="flex-1 text-sm text-foreground">{children}</div>
       {cta && (
         <Link to={cta.to} className={buttonClasses("secondary", "sm") + " self-start"}>
@@ -89,44 +113,39 @@ export default function HiringHub() {
     hub.core !== null;
 
   return (
-    <div className="flex flex-col gap-5">
+    <div>
       <AreaPillNav items={hiringPills({ ...hub.roles, active: "hub" })} />
 
-      <header>
-        <h1 className="font-heading text-2xl font-bold text-foreground">Hiring</h1>
-        {hub.cycle ? (
-          <p className="text-sm text-muted-foreground mt-1 flex items-center gap-2">
-            {hub.cycle.name}
-            <span
-              className={cn(
-                "inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-semibold",
-                STAGE_STYLES[hub.cycle.status] ?? "bg-muted text-muted-foreground",
+      <div className="flex flex-col gap-5">
+      <PageHeader
+        title="Hiring"
+        chip={hub.cycle ? <CycleStatusPill status={hub.cycle.status} /> : undefined}
+        subtitle={
+          hub.cycle ? (
+            <>
+              {hub.cycle.name}
+              {hub.cycle.closeDate && hub.cycle.status === "Open" && (
+                <>
+                  {" · closes "}
+                  {new Date(hub.cycle.closeDate).toLocaleDateString(undefined, {
+                    month: "short",
+                    day: "numeric",
+                  })}
+                </>
               )}
-            >
-              {hub.cycle.status === "UnderReview" ? "Under review" : hub.cycle.status}
-            </span>
-            {hub.cycle.closeDate && hub.cycle.status === "Open" && (
-              <span>
-                closes{" "}
-                {new Date(hub.cycle.closeDate).toLocaleDateString(undefined, {
-                  month: "short",
-                  day: "numeric",
-                })}
-              </span>
-            )}
-          </p>
-        ) : (
-          <p className="text-sm text-muted-foreground mt-1">
-            No active application cycle.
-          </p>
-        )}
-      </header>
+            </>
+          ) : (
+            "No cycle is open right now."
+          )
+        }
+      />
 
       {hasCards && (
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {showConfidentialityCard && hub.cycle && (
             <Card
               title="Confidentiality agreement"
+              icon={ShieldCheck}
               cta={{
                 label: "Read & sign",
                 to: `/hiring/cycles/${hub.needsConfidentialitySignature}/confidentiality`,
@@ -140,7 +159,7 @@ export default function HiringHub() {
           )}
 
           {hub.pendingReviews.count > 0 && (
-            <Card title="My reviews">
+            <Card title="My reviews" icon={ClipboardList} count={hub.pendingReviews.count}>
               <ul className="flex flex-col gap-2">
                 {hub.pendingReviews.items.map((item) => (
                   <li key={item.reviewId}>
@@ -168,7 +187,7 @@ export default function HiringHub() {
           )}
 
           {hub.upcomingInterviews.length > 0 && (
-            <Card title="My interviews">
+            <Card title="My interviews" icon={Mic} count={hub.upcomingInterviews.length}>
               <ul className="flex flex-col gap-2">
                 {hub.upcomingInterviews.map((iv) => (
                   <li key={iv.id}>
@@ -197,6 +216,7 @@ export default function HiringHub() {
             <Card
               key={session.id}
               title={`${session.domainName} delibs`}
+              icon={Users}
               cta={{
                 label: "Open board",
                 to: `/hiring/domain-lead/delibs/${session.id}`,
@@ -209,6 +229,8 @@ export default function HiringHub() {
           {hub.core && hub.core.releaseQueue > 0 && (
             <Card
               title="Release queue"
+              icon={Send}
+              count={hub.core.releaseQueue}
               cta={{
                 label: "Manage cycle",
                 to: hub.cycle ? `/hiring/lead/cycle/${hub.cycle.id}` : "/hiring/lead",
@@ -225,7 +247,7 @@ export default function HiringHub() {
           )}
 
           {hub.core && (
-            <Card title="Cycle health">
+            <Card title="Cycle health" icon={Activity}>
               <ul className="flex flex-col gap-1.5">
                 <HealthRow
                   count={hub.core.health.submitted}
@@ -268,15 +290,13 @@ export default function HiringHub() {
       {hub.pipeline && <PipelinePanel data={hub.pipeline} />}
 
       {!hasCards && !hub.pipeline && (
-        <div className="bg-card border border-border rounded-lg p-8 text-center">
-          <p className="font-heading font-semibold text-foreground">
-            Nothing needs you right now
-          </p>
-          <p className="text-sm text-muted-foreground mt-1">
-            Reviews and interviews you're assigned to will show up here.
-          </p>
-        </div>
+        <EmptyState
+          icon={CheckCircle2}
+          title="You're all caught up"
+          description="Reviews and interviews you're assigned to will show up here as cycles get underway."
+        />
       )}
+      </div>
     </div>
   );
 }

--- a/dali-api/app/hiring/routes/interviews.$interviewId.tsx
+++ b/dali-api/app/hiring/routes/interviews.$interviewId.tsx
@@ -5,7 +5,6 @@ import {
   Clock,
   Check,
   Video,
-  ChevronDown,
   FileText,
   MapPin,
   MessageSquare,
@@ -23,10 +22,15 @@ import { PresenceBar } from '~/components/collab/PresenceBar'
 import { useSharedString } from '~/components/collab/useSharedString'
 import { ApplicationViewer } from '~/hiring/components/ApplicationViewer'
 import { ReviewSummary } from '~/hiring/components/ReviewSummary'
+import { PageHeader } from '~/hiring/components/PageHeader'
+import { Section } from '~/hiring/components/Section'
+import { DetailCard } from '~/hiring/components/DetailCard'
+import { StatusStepper } from '~/hiring/components/StatusStepper'
+import { InterviewStatusPill, RecommendationPill } from '~/hiring/components/Pill'
+import { Button } from '~/components/ui/Button'
 import { buildCriteriaLabelMap } from '~/hiring/lib/rubric-criteria'
 import type { Route } from './+types/interviews.$interviewId'
-import type { Question } from '~/types'
-import { INTERVIEW_STATUS_COLORS } from '~/hiring/lib/labels'
+import type { Question, DomainApplicationStatus } from '~/types'
 
 const RECOMMENDATION_OPTIONS = [
   'Strong Hire',
@@ -217,10 +221,6 @@ export default function InterviewDetailPage() {
       return { id: a.id, name, roleLabel: ROLE_LABELS[a.role] ?? a.role }
     })
 
-  // Collapsible panel state
-  const [showApplication, setShowApplication] = useState(false)
-  const [showReviews, setShowReviews] = useState(false)
-
   const application = interview.domainApplication?.application
   const generalQuestions: any[] =
     application?.generalChallengeVersion?.questions ?? []
@@ -323,6 +323,24 @@ export default function InterviewDetailPage() {
     }
   }, [interview.id])
 
+  const displayStatus = isCompleted ? 'Completed' : interview.status
+  // The interview surface always sits on the Interview stage of the funnel; once
+  // it's completed the application moves to post-interview review. Both land on
+  // the same stepper node, so this mirrors real backend state without inventing
+  // any — it's just how far this application has travelled.
+  const pipelineStatus: DomainApplicationStatus = isCompleted
+    ? 'PostInterviewPending'
+    : 'InterviewScheduled'
+
+  const locationLabel =
+    interview.location === 'PodAppa'
+      ? 'Pod Appa'
+      : interview.location === 'PodMomo'
+        ? 'Pod Momo'
+        : interview.location === 'Online'
+          ? 'Online'
+          : null
+
   return (
     <PresenceProvider
       pageId={`interview:${interview.id}`}
@@ -332,281 +350,237 @@ export default function InterviewDetailPage() {
       photoUrl={presencePhotoUrl}
       subtitle={presenceSubtitle}
     >
-    <div className="space-y-8 max-w-6xl mx-auto">
-      <div className="flex items-center justify-end">
-        <PresenceBar />
-      </div>
+    <div className="space-y-6 max-w-6xl mx-auto">
+      <PageHeader
+        back={{ label: 'Back to interviews', to: '/hiring/interviews' }}
+        title={applicant ? `${applicant.firstName} ${applicant.lastName}` : 'Applicant'}
+        subtitle={domain ? `${domain} interview` : 'Interview'}
+        chip={<InterviewStatusPill status={displayStatus} />}
+        actions={<PresenceBar />}
+      />
 
-      {/* Header */}
-      <div className="bg-card rounded-xl border border-border shadow-sm p-6">
-        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-          <div>
-            <h1 className="text-xl font-bold text-foreground flex items-center">
-              <Video className="w-5 h-5 mr-2 text-blue-600" />
-              Interview:{' '}
-              {applicant
-                ? `${applicant.firstName} ${applicant.lastName}`
-                : 'Applicant'}
-            </h1>
-            <div className="mt-2 flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
-              <span className="flex items-center">
-                <Clock className="w-4 h-4 mr-1 text-muted-foreground/70" />
-                {startDate.toLocaleDateString(undefined, {
-                  weekday: 'long',
-                  month: 'long',
-                  day: 'numeric',
-                  year: 'numeric',
-                })}{' '}
-                {startDate.toLocaleTimeString(undefined, {
-                  hour: 'numeric',
-                  minute: '2-digit',
-                })}{' '}
-                -{' '}
-                {endDate.toLocaleTimeString(undefined, {
-                  hour: 'numeric',
-                  minute: '2-digit',
-                })}
+      {/* Logistics + pipeline position */}
+      <DetailCard title="Interview details">
+        <div className="px-6 py-5 space-y-5">
+          <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-sm text-muted-foreground">
+            <span className="inline-flex items-center gap-1.5">
+              <Clock className="w-4 h-4 text-muted-foreground" aria-hidden />
+              {startDate.toLocaleDateString(undefined, {
+                weekday: 'long',
+                month: 'long',
+                day: 'numeric',
+                year: 'numeric',
+              })}{' '}
+              {startDate.toLocaleTimeString(undefined, {
+                hour: 'numeric',
+                minute: '2-digit',
+              })}{' '}
+              -{' '}
+              {endDate.toLocaleTimeString(undefined, {
+                hour: 'numeric',
+                minute: '2-digit',
+              })}
+            </span>
+            {locationLabel && (
+              <span className="inline-flex items-center gap-1.5">
+                <MapPin className="w-4 h-4 text-muted-foreground" aria-hidden />
+                {locationLabel}
               </span>
-              {domain && (
-                <span className="px-2 py-0.5 bg-muted text-foreground/80 rounded text-xs font-medium">
-                  {domain}
-                </span>
-              )}
-              {interview.location && (
-                <span className="flex items-center">
-                  <MapPin className="w-4 h-4 mr-1 text-muted-foreground/70" />
-                  {interview.location === 'PodAppa'
-                    ? 'Pod Appa'
-                    : interview.location === 'PodMomo'
-                      ? 'Pod Momo'
-                      : 'Online'}
-                </span>
-              )}
-              {interview.location === 'Online' && interview.zoomJoinUrl && (
-                <a href={interview.zoomJoinUrl} target="_blank" rel="noopener noreferrer"
-                   className="flex items-center text-sm text-blue-600 hover:underline">
-                  <Video className="w-4 h-4 mr-1" />
-                  Join Zoom
-                </a>
-              )}
-              <span
-                className={`px-2 py-0.5 rounded text-xs font-medium ${
-                  isCompleted
-                    ? 'bg-green-100 text-green-700'
-                    : INTERVIEW_STATUS_COLORS[interview.status] ??
-                      'bg-muted text-foreground/80'
-                }`}
+            )}
+            {interview.location === 'Online' && interview.zoomJoinUrl && (
+              <a
+                href={interview.zoomJoinUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1.5 text-accent-coral hover:underline"
               >
-                {isCompleted ? 'Completed' : interview.status}
-              </span>
-              <span className="flex items-center">
-                <Users className="w-4 h-4 mr-1 text-muted-foreground/70" />
-                {coInterviewers.length > 0 ? (
-                  <>
-                    with{' '}
-                    {coInterviewers
-                      .map(
-                        (c: { name: string; roleLabel: string }) =>
-                          `${c.name} (${c.roleLabel})`,
-                      )
-                      .join(', ')}
-                  </>
-                ) : (
-                  'No co-interviewer assigned'
-                )}
-              </span>
-            </div>
+                <Video className="w-4 h-4" aria-hidden />
+                Join Zoom call
+              </a>
+            )}
+            <span className="inline-flex items-center gap-1.5">
+              <Users className="w-4 h-4 text-muted-foreground" aria-hidden />
+              {coInterviewers.length > 0
+                ? `With ${coInterviewers
+                    .map(
+                      (c: { name: string; roleLabel: string }) =>
+                        `${c.name} (${c.roleLabel})`,
+                    )
+                    .join(', ')}`
+                : 'No co-interviewer assigned'}
+            </span>
           </div>
+          <StatusStepper
+            status={pipelineStatus}
+            variant="compact"
+            className="max-w-md"
+          />
         </div>
-      </div>
+      </DetailCard>
 
       {/* Prep note from deliberations (read-only) */}
       {interview.domainApplication?.interviewPrepNote?.trim() && (
-        <div className="bg-blue-50 rounded-xl border border-blue-200 shadow-sm p-6">
-          <h2 className="text-sm font-semibold text-blue-900 uppercase tracking-wide mb-2">
-            From deliberations — to bring up in the interview
+        <div className="bg-brand-tint rounded-xl border border-border p-6">
+          <h2 className="font-heading text-sm font-semibold text-foreground mb-2">
+            From deliberations — bring this up in the interview
           </h2>
-          <p className="text-sm text-blue-900 whitespace-pre-wrap">
+          <p className="text-sm text-foreground whitespace-pre-wrap">
             {interview.domainApplication.interviewPrepNote}
           </p>
         </div>
       )}
 
       {/* Application (collapsible) */}
-      <div className="bg-card rounded-xl border border-border shadow-sm">
-        <button
-          onClick={() => setShowApplication(!showApplication)}
-          className="w-full flex items-center justify-between px-6 py-4 text-left hover:bg-muted/50 rounded-xl"
-        >
-          <span className="flex items-center text-lg font-semibold text-foreground">
-            <FileText className="w-5 h-5 mr-2 text-blue-600" />
-            Application
+      <Section
+        title="Application"
+        icon={<FileText className="w-4 h-4 text-muted-foreground" />}
+        defaultOpen={false}
+      >
+        <ApplicationViewer
+          application={viewerApplication}
+          questionLabels={questionLabels}
+          readOnly
+        />
+      </Section>
+
+      {/* Reviewer notes (collapsible) */}
+      <Section
+        title="Reviewer notes"
+        icon={<MessageSquare className="w-4 h-4 text-muted-foreground" />}
+        badge={
+          <span className="text-xs font-medium text-muted-foreground">
+            {submittedReviews.length}
           </span>
-          <ChevronDown
-            className={`w-5 h-5 text-muted-foreground/70 transition-transform ${
-              showApplication ? 'rotate-180' : ''
-            }`}
-          />
-        </button>
-        {showApplication && (
-          <div className="px-6 pb-6 border-t border-border pt-6">
-            <ApplicationViewer
-              application={viewerApplication}
-              questionLabels={questionLabels}
-              readOnly
+        }
+        defaultOpen={false}
+      >
+        {submittedReviews.length === 0 ? (
+          <p className="text-sm text-muted-foreground italic">
+            No submitted reviews for this applicant yet.
+          </p>
+        ) : (
+          <div className="space-y-6">
+            {submittedReviews.map((review: any) => {
+              const m = review.cycleReviewer?.user
+              const reviewerName =
+                m?.firstName && m?.lastName
+                  ? `${m.firstName} ${m.lastName}`
+                  : m?.daliEmail ?? 'Reviewer'
+              return (
+                <div
+                  key={review.id}
+                  className="border border-border rounded-lg p-4"
+                >
+                  <ReviewSummary
+                    reviewerName={reviewerName}
+                    submittedAt={review.submittedAt}
+                    overallRecommendation={review.overallRecommendation}
+                    scores={review.scores}
+                    criteria={criteriaByKey}
+                    feedback={review.feedback}
+                    rejectionRationale={review.rejectionRationale}
+                  />
+                </div>
+              )
+            })}
+          </div>
+        )}
+      </Section>
+
+      {/* Joint interview notes — collaborative editor */}
+      <DetailCard
+        title="Interview notes"
+        subtitle="Shared in real time — both interviewers edit the same document."
+      >
+        <div className="p-6">
+          {collabToken ? (
+            <CollaborativeEditor
+              editorId="notes"
+              documentName={`interview:${interview.id}:notes`}
+              token={collabToken}
+              userName={userName}
+              disabled={isCompleted}
+              placeholder="Write your interview notes here…"
             />
-          </div>
-        )}
-      </div>
+          ) : (
+            <div className="p-4 bg-accent-yellow/10 rounded-lg border border-accent-yellow/40 text-sm text-foreground">
+              Your session expired. Refresh the page to keep editing these notes together.
+            </div>
+          )}
+        </div>
+      </DetailCard>
 
-      {/* Reviewer Notes (collapsible) */}
-      <div className="bg-card rounded-xl border border-border shadow-sm">
-        <button
-          onClick={() => setShowReviews(!showReviews)}
-          className="w-full flex items-center justify-between px-6 py-4 text-left hover:bg-muted/50 rounded-xl"
-        >
-          <span className="flex items-center text-lg font-semibold text-foreground">
-            <MessageSquare className="w-5 h-5 mr-2 text-blue-600" />
-            Reviewer Notes ({submittedReviews.length})
-          </span>
-          <ChevronDown
-            className={`w-5 h-5 text-muted-foreground/70 transition-transform ${
-              showReviews ? 'rotate-180' : ''
-            }`}
-          />
-        </button>
-        {showReviews && (
-          <div className="px-6 pb-6 border-t border-border pt-6">
-            {submittedReviews.length === 0 ? (
-              <p className="text-sm text-muted-foreground italic">
-                No submitted reviews for this applicant.
-              </p>
-            ) : (
-              <div className="space-y-6">
-                {submittedReviews.map((review: any) => {
-                  const m = review.cycleReviewer?.user
-                  const reviewerName =
-                    m?.firstName && m?.lastName
-                      ? `${m.firstName} ${m.lastName}`
-                      : m?.daliEmail ?? 'Reviewer'
-                  return (
-                    <div
-                      key={review.id}
-                      className="border border-border rounded-lg p-4"
-                    >
-                      <ReviewSummary
-                        reviewerName={reviewerName}
-                        submittedAt={review.submittedAt}
-                        overallRecommendation={review.overallRecommendation}
-                        scores={review.scores}
-                        criteria={criteriaByKey}
-                        feedback={review.feedback}
-                        rejectionRationale={review.rejectionRationale}
-                      />
-                    </div>
-                  )
-                })}
-              </div>
-            )}
-          </div>
-        )}
-      </div>
-
-      {/* Joint Interview Notes — collaborative editor */}
-      <div className="bg-card rounded-xl border border-border shadow-sm p-6">
-        <h2 className="text-lg font-semibold text-foreground mb-4">
-          Interview Notes
-        </h2>
-        <p className="text-xs text-muted-foreground mb-3">
-          Shared notes — both interviewers edit this document in real-time.
-        </p>
-        {collabToken ? (
-          <CollaborativeEditor
-            editorId="notes"
-            documentName={`interview:${interview.id}:notes`}
-            token={collabToken}
-            userName={userName}
-            disabled={isCompleted}
-            placeholder="Write your interview notes here..."
-          />
-        ) : (
-          <div className="p-4 bg-yellow-50 rounded-lg border border-yellow-200 text-sm text-yellow-800">
-            Session expired — please refresh to enable collaborative editing.
-          </div>
-        )}
-      </div>
-
-      {/* Joint Recommendation */}
-      <div className="bg-card rounded-xl border border-border shadow-sm p-6">
-        <h2 className="text-lg font-semibold text-foreground mb-1">
-          Joint Recommendation
-        </h2>
-        <p className="text-xs text-muted-foreground mb-4">
-          One shared recommendation for this interview. Either interviewer
-          submits it on behalf of both — only one of you needs to mark it
-          complete.
-        </p>
-
-        {isCompleted ? (
-          <div className="p-4 bg-green-50 rounded-lg border border-green-200">
-            <div className="flex items-start justify-between mb-2">
-              <div className="flex items-center">
-                <Check className="w-5 h-5 text-green-600 mr-2" />
-                <span className="font-medium text-green-800">
-                  Interview Completed
+      {/* Joint recommendation */}
+      <DetailCard
+        title="Joint recommendation"
+        subtitle="One shared recommendation for this interview — either interviewer submits it on behalf of both."
+      >
+        <div className="p-6">
+          {isCompleted ? (
+            <div className="rounded-lg border border-border bg-brand-tint p-4">
+              <div className="flex items-start justify-between gap-3 mb-3">
+                <span className="inline-flex items-center gap-2 font-heading font-semibold text-foreground">
+                  <Check className="w-5 h-5 text-accent-teal" aria-hidden />
+                  Interview completed
                 </span>
+                <button
+                  onClick={handleReopen}
+                  disabled={completing}
+                  className="text-xs font-medium text-accent-coral hover:underline disabled:text-muted-foreground disabled:no-underline"
+                >
+                  {completing ? 'Reopening…' : 'Reopen interview'}
+                </button>
               </div>
-              <button
-                onClick={handleReopen}
-                disabled={completing}
-                className="text-xs font-medium text-green-700 hover:text-green-900 underline disabled:text-muted-foreground/70 disabled:no-underline"
-              >
-                {completing ? 'Reopening…' : 'Reopen'}
-              </button>
+              <div className="flex flex-wrap items-center gap-2 text-sm text-foreground">
+                <span className="text-muted-foreground">Recommendation:</span>
+                {(interview.recommendation ?? recommendation) ? (
+                  <RecommendationPill value={interview.recommendation ?? recommendation} />
+                ) : (
+                  <span className="text-muted-foreground">Not recorded</span>
+                )}
+              </div>
+              {interview.recommendationNotes && (
+                <p className="mt-2 text-sm text-foreground whitespace-pre-wrap">
+                  {interview.recommendationNotes}
+                </p>
+              )}
             </div>
-            <p className="text-sm text-green-700">
-              <strong>Recommendation:</strong>{' '}
-              {interview.recommendation ?? recommendation}
-            </p>
-            {interview.recommendationNotes && (
-              <p className="text-sm text-green-700 mt-1">
-                <strong>Notes:</strong> {interview.recommendationNotes}
-              </p>
-            )}
-          </div>
-        ) : (
-          <div className="space-y-4">
-            <div>
-              <label className="block text-sm font-medium text-foreground/80 mb-1">
-                Recommendation
-              </label>
-              <select
-                value={recommendation}
-                onChange={(e) => setRecommendation(e.target.value)}
-                className="w-full sm:w-64 px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-              >
-                <option value="">Select a recommendation...</option>
-                {RECOMMENDATION_OPTIONS.map((opt) => (
-                  <option key={opt} value={opt}>
-                    {opt}
-                  </option>
-                ))}
-              </select>
-            </div>
+          ) : (
+            <div className="space-y-4">
+              <div>
+                <label
+                  htmlFor="recommendation"
+                  className="block text-sm font-medium text-foreground mb-1.5"
+                >
+                  Recommendation
+                </label>
+                <select
+                  id="recommendation"
+                  value={recommendation}
+                  onChange={(e) => setRecommendation(e.target.value)}
+                  className="w-full sm:w-64 px-3 py-2 bg-card border border-border rounded-lg text-sm text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-coral/30 focus-visible:ring-offset-2"
+                >
+                  <option value="">Select a recommendation…</option>
+                  {RECOMMENDATION_OPTIONS.map((opt) => (
+                    <option key={opt} value={opt}>
+                      {opt}
+                    </option>
+                  ))}
+                </select>
+              </div>
 
-            <div className="flex items-center gap-3">
-              <button
+              <Button
                 onClick={handleMarkComplete}
                 disabled={!recommendation || completing}
-                className="inline-flex items-center px-4 py-2 text-sm font-medium text-white bg-green-600 rounded-lg hover:bg-green-700 disabled:opacity-50"
+                variant="primary"
               >
-                <Check className="w-4 h-4 mr-1.5" />
-                {completing ? 'Completing...' : 'Mark Complete'}
-              </button>
+                <Check className="w-4 h-4" aria-hidden />
+                {completing ? 'Completing interview…' : 'Complete interview'}
+              </Button>
             </div>
-          </div>
-        )}
-      </div>
+          )}
+        </div>
+      </DetailCard>
     </div>
     </PresenceProvider>
   )

--- a/dali-api/app/hiring/routes/interviews.tsx
+++ b/dali-api/app/hiring/routes/interviews.tsx
@@ -6,6 +6,10 @@ import { hiringPills } from '~/hiring/components/hiringPills'
 import { AreaPillNav } from '~/components/AreaPillNav'
 import { CycleSelector } from '~/hiring/components/CycleSelector'
 import { Section } from '~/hiring/components/Section'
+import { PageHeader } from '~/hiring/components/PageHeader'
+import { EmptyState } from '~/hiring/components/EmptyState'
+import { InterviewStatusPill } from '~/hiring/components/Pill'
+import { buttonClasses } from '~/components/ui/Button'
 import { getActiveCycle } from '~/hiring/lib/cycles'
 import CalendarGrid from '~/hiring/components/CalendarGrid'
 import { zonedWallTimeUtc } from '~/lib/timezone'
@@ -312,12 +316,17 @@ export default function InterviewsDashboard() {
 
   if (!activeCycle) {
     return (
-      <div className="space-y-8">
+      <div className="space-y-6">
         {areaPills}
-        <h1 className="text-2xl font-bold text-foreground">Interviews</h1>
-        <div className="bg-card rounded-xl border border-border shadow-sm p-8 text-center">
-          <p className="text-muted-foreground">You are not assigned as an interviewer for any active cycle.</p>
-        </div>
+        <PageHeader
+          title="Interviews"
+          subtitle="Your assigned interviews and availability."
+        />
+        <EmptyState
+          icon={Video}
+          title="You're not interviewing this cycle"
+          description="You aren't assigned as an interviewer for any active cycle. Once a hiring lead adds you, your interviews and availability will show up here."
+        />
       </div>
     )
   }
@@ -325,34 +334,31 @@ export default function InterviewsDashboard() {
   return (
     <div className="space-y-6">
       {areaPills}
-      <div className="flex items-start justify-between gap-4">
-        <div>
-          <h1 className="text-2xl font-bold text-foreground">Interviews</h1>
-          <p className="mt-1 text-muted-foreground">
-            Your assigned interviews and availability.
-          </p>
-        </div>
-        <CycleSelector cycles={availableCycles} activeId={activeCycle.id} />
-      </div>
+      <PageHeader
+        title="Interviews"
+        subtitle="Your assigned interviews and availability."
+        actions={<CycleSelector cycles={availableCycles} activeId={activeCycle.id} />}
+      />
 
       <Section
-        title="Assigned Interviews"
-        icon={<Video className="w-4 h-4 text-blue-600" />}
+        title="Assigned interviews"
+        icon={<Video className="w-4 h-4 text-muted-foreground" />}
         badge={
           scheduledInterviews.length > 0 ? (
-            <span className="text-xs font-medium text-gray-500">
+            <span className="text-xs font-medium text-muted-foreground">
               {scheduledInterviews.length} scheduled
             </span>
           ) : null
         }
       >
         {scheduledInterviews.length === 0 ? (
-          <p className="text-sm text-gray-500">
-            No interviews have been scheduled with you yet. Once applicants book
-            interviews on your availability, they'll appear here.
-          </p>
+          <EmptyState
+            icon={Video}
+            title="No interviews scheduled yet"
+            description="Once applicants book interviews on your availability, they'll appear here."
+          />
         ) : (
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
           {scheduledInterviews.map((assignment: any) => {
             const interview = assignment.interview
             if (!interview) return null
@@ -364,26 +370,29 @@ export default function InterviewsDashboard() {
             return (
               <div
                 key={assignment.id}
-                className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden flex flex-col"
+                className="bg-card rounded-xl border border-border shadow-sm overflow-hidden flex flex-col"
               >
-                <div className="p-6 border-b border-gray-200 bg-gray-50 flex justify-between items-start">
-                  <div>
-                    <h3 className="text-lg font-bold text-gray-900 mb-1">
+                <div className="p-5 border-b border-border bg-muted/50 flex justify-between items-start gap-3">
+                  <div className="min-w-0">
+                    <h3 className="font-heading text-lg font-semibold text-foreground">
                       {applicant ? `${applicant.firstName} ${applicant.lastName}` : 'Applicant'}
                     </h3>
-                    {domains && (
-                      <p className="text-xs text-gray-500">{domains}</p>
-                    )}
+                    <div className="mt-1 flex flex-wrap items-center gap-2">
+                      {domains && (
+                        <span className="text-xs text-muted-foreground">{domains}</span>
+                      )}
+                      <InterviewStatusPill status={interview.status} />
+                    </div>
                   </div>
-                  <div className="text-right bg-white px-3 py-2 rounded-lg border shadow-sm">
-                    <p className="text-sm font-bold text-gray-900">
+                  <div className="shrink-0 text-right bg-card px-3 py-2 rounded-lg border border-border">
+                    <p className="text-sm font-semibold text-foreground">
                       {startDate.toLocaleDateString(undefined, {
                         weekday: 'short',
                         month: 'short',
                         day: 'numeric',
                       })}
                     </p>
-                    <p className="text-sm text-gray-500">
+                    <p className="text-sm text-muted-foreground">
                       {startDate.toLocaleTimeString(undefined, {
                         hour: 'numeric',
                         minute: '2-digit',
@@ -396,20 +405,20 @@ export default function InterviewsDashboard() {
                     </p>
                   </div>
                 </div>
-                <div className="p-6 flex-1 flex items-end gap-3">
+                <div className="p-5 flex-1 flex flex-wrap items-end gap-2">
                   <Link
                     to={`/hiring/interviews/${interview.id}`}
-                    className="inline-flex items-center justify-center px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-lg text-white bg-accent-coral hover:bg-accent-coral/90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+                    className={buttonClasses('primary', 'md')}
                   >
-                    Open Interview
+                    Open interview
                   </Link>
                   <button
                     type="button"
                     onClick={() => handleDeclineInterview(interview.id)}
                     disabled={decliningId === interview.id}
-                    className="inline-flex items-center justify-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-lg text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+                    className={buttonClasses('secondary', 'md')}
                   >
-                    {decliningId === interview.id ? 'Marking…' : 'Mark Unavailable'}
+                    {decliningId === interview.id ? 'Marking…' : 'Mark unavailable'}
                   </button>
                 </div>
               </div>
@@ -420,15 +429,15 @@ export default function InterviewsDashboard() {
       </Section>
 
       <Section
-        title="Interview Availability"
-        icon={<CalendarDays className="w-4 h-4 text-blue-600" />}
+        title="Interview availability"
+        icon={<CalendarDays className="w-4 h-4 text-muted-foreground" />}
         badge={
           needsAvailabilityPrompt ? (
             <span className="text-xs font-medium text-accent-coral">
               Action needed
             </span>
           ) : savedAvailability.length > 0 ? (
-            <span className="text-xs font-medium text-green-700">
+            <span className="text-xs font-medium text-muted-foreground">
               {savedAvailability.length} blocks saved
             </span>
           ) : null
@@ -437,11 +446,11 @@ export default function InterviewsDashboard() {
         {interviewConfig ? (
           <div className="space-y-3">
             {importError && (
-              <div className="p-3 rounded-lg bg-red-50 border border-red-200 text-sm text-red-700">
+              <div className="p-3 rounded-lg bg-destructive/10 border border-destructive/30 text-sm text-destructive">
                 {importError}
               </div>
             )}
-            <p className="text-sm text-gray-500">
+            <p className="text-sm text-muted-foreground">
               Click or drag to select the times you are available to conduct
               interviews. 15-minute blocks.
             </p>
@@ -461,11 +470,11 @@ export default function InterviewsDashboard() {
             />
           </div>
         ) : (
-          <p className="text-sm text-gray-500">
-            Interview dates have not been configured yet. You'll be able to
-            set your availability once your Hiring Lead configures the
-            interview window.
-          </p>
+          <EmptyState
+            icon={CalendarDays}
+            title="Availability isn't open yet"
+            description="You'll be able to set the times you can interview once your hiring lead configures the interview window."
+          />
         )}
       </Section>
     </div>

--- a/dali-api/app/hiring/routes/lead.tsx
+++ b/dali-api/app/hiring/routes/lead.tsx
@@ -6,9 +6,12 @@ import { requireAuth } from "~/lib/auth";
 import { isCore, getUserRoles } from "~/lib/roles";
 import { hiringPills } from "~/hiring/components/hiringPills";
 import { AreaPillNav } from "~/components/AreaPillNav";
-import { ChevronRight, ChevronDown, Plus } from "lucide-react";
+import { ChevronRight, ChevronDown, Plus, Layers } from "lucide-react";
 import { Modal, ModalHeader } from "~/components/Modal";
-import { STATUS_COLORS, STATUS_LABELS } from "~/hiring/lib/labels";
+import { Button } from "~/components/ui/Button";
+import { PageHeader } from "~/hiring/components/PageHeader";
+import { EmptyState } from "~/hiring/components/EmptyState";
+import { CycleStatusPill } from "~/hiring/components/Pill";
 
 export const handle = { areaPills: true };
 
@@ -73,22 +76,20 @@ export default function HiringLeadDashboard() {
   const [showModal, setShowModal] = useState(false);
 
   return (
-    <div className="space-y-6">
+    <div className="flex flex-col gap-5">
       {data?.pillRoles && (
         <AreaPillNav items={hiringPills({ ...data.pillRoles, active: "cycles" })} />
       )}
-      <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold text-foreground">Hiring Cycles</h1>
-        <div className="flex items-center gap-2">
-          <button
-            onClick={() => setShowModal(true)}
-            className="flex items-center gap-1.5 px-3 py-2 bg-accent-coral text-white text-sm font-medium rounded-md hover:bg-accent-coral/90 focus:outline-none focus:ring-2 focus:ring-blue-500"
-          >
-            <Plus className="w-4 h-4" />
-            New Cycle
-          </button>
-        </div>
-      </div>
+      <PageHeader
+        title="Hiring cycles"
+        subtitle="Set up, run, and revisit each recruiting cycle."
+        actions={
+          <Button variant="primary" onClick={() => setShowModal(true)}>
+            <Plus className="h-4 w-4" />
+            New cycle
+          </Button>
+        }
+      />
 
       <Modal
         open={showModal}
@@ -115,7 +116,7 @@ export default function HiringLeadDashboard() {
                     required
                     autoFocus
                     autoComplete="off"
-                    className="w-full px-3 py-2 text-sm text-foreground border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    className="w-full px-3 py-2 text-sm text-foreground bg-card border border-border rounded-md focus:outline-none focus:ring-2 focus:ring-accent-coral/30"
                   />
                 </div>
                 <div>
@@ -126,7 +127,7 @@ export default function HiringLeadDashboard() {
                     id="cycle-type"
                     name="cycleType"
                     defaultValue="Standard"
-                    className="w-full px-3 py-2 text-sm text-foreground border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    className="w-full px-3 py-2 text-sm text-foreground bg-card border border-border rounded-md focus:outline-none focus:ring-2 focus:ring-accent-coral/30"
                   >
                     <option value="Standard">Standard hire</option>
                     <option value="InternToFull">Fellowship</option>
@@ -136,19 +137,12 @@ export default function HiringLeadDashboard() {
                   </p>
                 </div>
                 <div className="flex justify-end gap-2">
-                  <button
-                    type="button"
-                    onClick={() => setShowModal(false)}
-                    className="px-3 py-2 text-sm font-medium text-foreground/80 bg-card border border-gray-300 rounded-md hover:bg-muted/50"
-                  >
+                  <Button variant="secondary" onClick={() => setShowModal(false)}>
                     Cancel
-                  </button>
-                  <button
-                    type="submit"
-                    className="px-3 py-2 text-sm font-medium text-white bg-accent-coral rounded-md hover:bg-accent-coral/90"
-                  >
-                    Create
-                  </button>
+                  </Button>
+                  <Button type="submit" variant="primary">
+                    Create cycle
+                  </Button>
                 </div>
               </Form>
         </>
@@ -202,10 +196,11 @@ function ActiveCycleHero({ cycles }: { cycles: any[] }) {
 
   if (heroes.length === 0) {
     return (
-      <div className="bg-card border-2 border-dashed border-gray-300 rounded-xl p-8 text-center">
-        <p className="text-muted-foreground mb-1">No active hiring cycle.</p>
-        <p className="text-sm text-muted-foreground/70">Create a new cycle to get started.</p>
-      </div>
+      <EmptyState
+        icon={Layers}
+        title="No active hiring cycle"
+        description="Create a cycle to open applications, assign reviewers, and start moving candidates through the funnel."
+      />
     );
   }
 
@@ -218,18 +213,16 @@ function ActiveCycleHero({ cycles }: { cycles: any[] }) {
           <Link
             key={c.id}
             to={heroLinkFor(c)}
-            className="block bg-card border border-border rounded-xl p-6 hover:border-blue-300 hover:shadow-md transition-all"
+            className="block bg-card border border-border rounded-xl p-6 hover:border-accent-coral/40 hover:shadow-md transition-all"
           >
-            <div className="flex items-start justify-between">
+            <div className="flex items-start justify-between gap-4">
               <div className="space-y-2">
                 <div className="flex items-center gap-3 flex-wrap">
                   <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
                     {CYCLE_TYPE_LABELS[c.cycleType] ?? c.cycleType}
                   </span>
-                  <span className="text-xl font-bold text-foreground">{c.name}</span>
-                  <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${STATUS_COLORS[currentStatus]}`}>
-                    {STATUS_LABELS[currentStatus]}
-                  </span>
+                  <span className="font-heading text-xl font-bold text-foreground">{c.name}</span>
+                  <CycleStatusPill status={currentStatus} />
                 </div>
                 <div className="flex items-center gap-4 text-sm text-muted-foreground">
                   <span>{domains.join(", ") || "No domains"}</span>
@@ -237,8 +230,8 @@ function ActiveCycleHero({ cycles }: { cycles: any[] }) {
                   <span>{c._count.applications} application{c._count.applications !== 1 ? "s" : ""}</span>
                 </div>
               </div>
-              <div className="flex items-center gap-2 text-blue-600 font-medium text-sm">
-                Manage Cycle
+              <div className="flex shrink-0 items-center gap-2 text-accent-coral font-medium text-sm">
+                Manage cycle
                 <ChevronRight className="w-4 h-4" />
               </div>
             </div>
@@ -262,13 +255,14 @@ function PastCycles({ cycles }: { cycles: any[] }) {
     <div className="border border-border rounded-lg overflow-hidden">
       <button
         onClick={() => setOpen(!open)}
+        aria-expanded={open}
         className="w-full px-5 py-3 flex items-center justify-between bg-muted/50 hover:bg-muted transition text-left"
       >
-        <span className="text-sm font-semibold text-foreground/80">Past Cycles ({pastCycles.length})</span>
-        <ChevronDown className={`w-4 h-4 text-muted-foreground/70 transition-transform ${open ? "rotate-180" : ""}`} />
+        <span className="text-sm font-semibold text-foreground/80">Past cycles ({pastCycles.length})</span>
+        <ChevronDown className={`w-4 h-4 text-muted-foreground transition-transform ${open ? "rotate-180" : ""}`} />
       </button>
       {open && (
-        <div className="divide-y divide-gray-100">
+        <div className="divide-y divide-border">
           {pastCycles.map((cycle: any) => {
             const currentStatus = cycle.statusUpdates[0]?.newStatus ?? "Draft";
             const domains = cycle.domains.map((d: any) => d.domain.name);
@@ -279,18 +273,16 @@ function PastCycles({ cycles }: { cycles: any[] }) {
                 className="flex items-center justify-between px-5 py-3 hover:bg-muted/50 transition-colors"
               >
                 <div className="flex items-center gap-3 flex-wrap">
-                  <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/70">
+                  <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
                     {CYCLE_TYPE_LABELS[cycle.cycleType] ?? cycle.cycleType}
                   </span>
                   <span className="text-sm font-medium text-foreground">{cycle.name}</span>
-                  <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${STATUS_COLORS[currentStatus]}`}>
-                    {STATUS_LABELS[currentStatus]}
-                  </span>
-                  <span className="text-xs text-muted-foreground/70">
+                  <CycleStatusPill status={currentStatus} />
+                  <span className="text-xs text-muted-foreground">
                     {domains.join(", ")} · {cycle._count.applications} app{cycle._count.applications !== 1 ? "s" : ""}
                   </span>
                 </div>
-                <ChevronRight className="w-4 h-4 text-muted-foreground/70" />
+                <ChevronRight className="w-4 h-4 text-muted-foreground" />
               </Link>
             );
           })}

--- a/dali-api/app/hiring/routes/onboarding.tsx
+++ b/dali-api/app/hiring/routes/onboarding.tsx
@@ -4,6 +4,9 @@ import { requireAuth, unauthorized, forbidden } from "~/lib/auth";
 import { isCore, getUserRoles } from "~/lib/roles";
 import { hiringPills } from "~/hiring/components/hiringPills";
 import { AreaPillNav } from "~/components/AreaPillNav";
+import { PageHeader } from "~/hiring/components/PageHeader";
+import { EmptyState } from "~/hiring/components/EmptyState";
+import { UserPlus } from "lucide-react";
 import { prisma } from "~/lib/db";
 
 export const handle = { areaPills: true };
@@ -228,58 +231,66 @@ export default function HiringOnboarding() {
   }
 
   return (
-    <div className="flex flex-col gap-4">
+    <div className="flex flex-col gap-5">
       <AreaPillNav items={hiringPills({ ...pillRoles, active: "onboarding" })} />
-      <div className="flex flex-wrap items-center justify-between gap-4">
-        <div>
-          <h1 className="font-heading text-2xl font-bold text-foreground">Onboarding</h1>
-          <p className="text-sm text-muted-foreground mt-1">
-            Accepted applicants and their onboarding progress.
-          </p>
-        </div>
-        <div className="flex flex-wrap items-center gap-3">
-          {domains.length > 0 && (
-            <select
-              value={selectedDomain ?? ""}
-              onChange={(e) => setParam("domain", e.target.value || null)}
-              className="rounded-lg border border-border bg-card px-3 py-2 text-sm font-medium text-dark-blue"
-            >
-              <option value="">All domains</option>
-              {domains.map((d) => (
-                <option key={d.key} value={d.key}>
-                  {d.label}
-                </option>
-              ))}
-            </select>
-          )}
-          {cycles.length > 0 && (
-            <select
-              value={selectedCycleId ?? ""}
-              onChange={(e) => setParam("cycle", e.target.value)}
-              className="rounded-lg border border-border bg-card px-3 py-2 text-sm font-medium text-dark-blue"
-            >
-              {cycles.map((c) => (
-                <option key={c.id} value={c.id}>
-                  {c.name}
-                </option>
-              ))}
-            </select>
-          )}
-        </div>
-      </div>
+      <PageHeader
+        title="Onboarding"
+        subtitle="Accepted members and where each one stands on account setup."
+        actions={
+          <>
+            {domains.length > 0 && (
+              <select
+                value={selectedDomain ?? ""}
+                onChange={(e) => setParam("domain", e.target.value || null)}
+                aria-label="Filter by domain"
+                className="rounded-lg border border-border bg-card px-3 py-2 text-sm font-medium text-dark-blue"
+              >
+                <option value="">All domains</option>
+                {domains.map((d) => (
+                  <option key={d.key} value={d.key}>
+                    {d.label}
+                  </option>
+                ))}
+              </select>
+            )}
+            {cycles.length > 0 && (
+              <select
+                value={selectedCycleId ?? ""}
+                onChange={(e) => setParam("cycle", e.target.value)}
+                aria-label="Filter by cycle"
+                className="rounded-lg border border-border bg-card px-3 py-2 text-sm font-medium text-dark-blue"
+              >
+                {cycles.map((c) => (
+                  <option key={c.id} value={c.id}>
+                    {c.name}
+                  </option>
+                ))}
+              </select>
+            )}
+          </>
+        }
+      />
 
       {!selectedCycleId ? (
-        <div className="rounded-2xl border border-border bg-card py-16 text-center">
-          <p className="text-muted-foreground">No application cycles yet.</p>
-        </div>
+        <EmptyState
+          icon={UserPlus}
+          title="No application cycles yet"
+          description="Once a cycle runs and accepts applicants, the new members and their onboarding progress will show up here."
+        />
       ) : rows.length === 0 ? (
-        <div className="rounded-2xl border border-border bg-card py-16 text-center">
-          <p className="text-muted-foreground">
-            {selectedDomain
-              ? "No accepted applicants in this domain for the selected cycle."
-              : "No accepted applicants in this cycle yet."}
-          </p>
-        </div>
+        <EmptyState
+          icon={UserPlus}
+          title={
+            selectedDomain
+              ? "No accepted members in this domain"
+              : "No accepted members yet"
+          }
+          description={
+            selectedDomain
+              ? "No one in this domain has been released as accepted for the selected cycle."
+              : "Release accepted decisions from the cycle page and new members will appear here to onboard."
+          }
+        />
       ) : (
         <div className="overflow-x-auto rounded-2xl border border-border">
           <table className="w-full text-sm">

--- a/dali-api/app/hiring/routes/reviewer.application.$id.tsx
+++ b/dali-api/app/hiring/routes/reviewer.application.$id.tsx
@@ -11,6 +11,9 @@ import { presignAnswers } from '~/hiring/lib/presign'
 import type { Route } from './+types/reviewer.application.$id'
 import { ApplicationViewer } from '~/hiring/components/ApplicationViewer'
 import { SaveStatusIndicator } from '~/hiring/components/SaveStatusIndicator'
+import { PageHeader } from '~/hiring/components/PageHeader'
+import { Pill } from '~/hiring/components/Pill'
+import { Button } from '~/components/ui/Button'
 import { CollaborativeEditor } from '~/components/CollaborativeEditor'
 import { PresenceProvider } from '~/components/collab/PresenceProvider'
 import { PresenceBar } from '~/components/collab/PresenceBar'
@@ -392,19 +395,19 @@ export default function ReviewerApplicationReview() {
       subtitle={presenceSubtitle}
     >
     <div className="space-y-6 pb-12 relative">
-      <div>
-        <div className="flex items-center justify-end mb-4">
-          <PresenceBar />
-        </div>
-        <div className="flex justify-between items-end">
-          <div>
-            <h1 className="text-2xl font-bold text-foreground">
-              Review: {application.user.firstName} {application.user.lastName}
-            </h1>
-            <p className="mt-1 text-muted-foreground">{cycle.name}</p>
-          </div>
-        </div>
-      </div>
+      <PageHeader
+        back={{ label: 'Back to reviews', to: '/hiring/reviewer' }}
+        title={`Review: ${application.user.firstName} ${application.user.lastName}`}
+        subtitle={cycle.name}
+        chip={
+          isSubmitted ? (
+            <Pill color="bg-green-100 text-green-700">Submitted</Pill>
+          ) : (
+            <Pill color="bg-yellow-100 text-yellow-700">In progress</Pill>
+          )
+        }
+        actions={<PresenceBar />}
+      />
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
         {/* Left: Application Content */}
@@ -421,8 +424,8 @@ export default function ReviewerApplicationReview() {
         {/* Right: Review Form */}
         <div className="space-y-6">
           <div className="bg-card rounded-xl border border-border shadow-sm sticky top-24">
-            <div className="px-6 py-4 border-b border-border bg-blue-50 flex items-center justify-between">
-              <h2 className="text-lg font-bold text-blue-900">Your Review</h2>
+            <div className="px-6 py-4 border-b border-border bg-muted/50 flex items-center justify-between">
+              <h2 className="font-heading text-lg font-semibold text-foreground">Your review</h2>
               {!isSubmitted && (
                 <SaveStatusIndicator saving={isSaving} lastSaved={lastSaved} />
               )}
@@ -431,7 +434,7 @@ export default function ReviewerApplicationReview() {
 
               {/* Scoring */}
               <div>
-                <h3 className="text-sm font-bold text-foreground uppercase tracking-wider mb-4">Scoring</h3>
+                <h3 className="font-heading text-sm font-semibold text-foreground uppercase tracking-wider mb-4">Scoring</h3>
                 {flatCriteria.length === 0 ? (
                   <p className="text-sm text-muted-foreground/70 italic">No rubric attached to this application.</p>
                 ) : (
@@ -446,7 +449,7 @@ export default function ReviewerApplicationReview() {
                             <div key={criterion.key}>
                               <div className="flex justify-between items-center mb-1">
                                 <label className="text-sm font-medium text-foreground">{criterion.label}</label>
-                                <span className="text-xs font-bold text-blue-600 bg-blue-50 px-2 py-1 rounded">
+                                <span className="text-xs font-bold text-foreground bg-muted px-2 py-1 rounded">
                                   {scores[criterion.key] ?? 0} / {criterion.maxScore}
                                 </span>
                               </div>
@@ -457,7 +460,7 @@ export default function ReviewerApplicationReview() {
                                 type="range" min="0" max={criterion.maxScore}
                                 value={scores[criterion.key] ?? 0}
                                 onChange={(e) => setScores((prev) => ({ ...prev, [criterion.key]: parseInt(e.target.value) }))}
-                                className="w-full h-2 bg-muted rounded-lg appearance-none cursor-pointer accent-blue-600"
+                                className="w-full h-2 bg-muted rounded-lg appearance-none cursor-pointer accent-accent-coral"
                               />
                               <div className="flex justify-between text-xs text-muted-foreground/70 mt-1"><span>0</span><span>{criterion.maxScore}</span></div>
                             </div>
@@ -471,8 +474,8 @@ export default function ReviewerApplicationReview() {
 
               {/* Feedback — collaborative editor */}
               <div>
-                <h3 className="text-sm font-bold text-foreground uppercase tracking-wider mb-2">Internal Feedback</h3>
-                <p className="text-xs text-muted-foreground mb-2">Notes for other reviewers. Not visible to applicant.</p>
+                <h3 className="font-heading text-sm font-semibold text-foreground uppercase tracking-wider mb-2">Internal feedback</h3>
+                <p className="text-xs text-muted-foreground mb-2">Notes for other reviewers. Not visible to the applicant.</p>
                 {existingReview && collabToken ? (
                   <CollaborativeEditor
                     editorId="feedback"
@@ -486,7 +489,7 @@ export default function ReviewerApplicationReview() {
                   <textarea
                     rows={4}
                     disabled
-                    className="block w-full rounded-md border-gray-300 shadow-sm sm:text-sm border p-2 text-foreground bg-muted/50"
+                    className="block w-full rounded-md border-border shadow-sm sm:text-sm border p-2 text-foreground bg-muted/50"
                     placeholder="Save the review first to enable collaborative editing..."
                   />
                 )}
@@ -494,8 +497,8 @@ export default function ReviewerApplicationReview() {
 
               {/* Rejection Rationale — collaborative editor */}
               <div>
-                <h3 className="text-sm font-bold text-foreground uppercase tracking-wider mb-2">
-                  Rejection Rationale <span className="text-xs font-normal text-muted-foreground normal-case">(Optional)</span>
+                <h3 className="font-heading text-sm font-semibold text-foreground uppercase tracking-wider mb-2">
+                  Rejection rationale <span className="text-xs font-normal text-muted-foreground normal-case">(optional)</span>
                 </h3>
                 {existingReview && collabToken ? (
                   <CollaborativeEditor
@@ -510,7 +513,7 @@ export default function ReviewerApplicationReview() {
                   <textarea
                     rows={3}
                     disabled
-                    className="block w-full rounded-md border-gray-300 shadow-sm sm:text-sm border p-2 text-foreground bg-muted/50"
+                    className="block w-full rounded-md border-border shadow-sm sm:text-sm border p-2 text-foreground bg-muted/50"
                     placeholder="Save the review first to enable collaborative editing..."
                   />
                 )}
@@ -518,15 +521,15 @@ export default function ReviewerApplicationReview() {
 
               {/* Overall Recommendation */}
               <div className="pt-4 border-t border-border">
-                <h3 className="text-sm font-bold text-foreground uppercase tracking-wider mb-3">Overall Recommendation</h3>
+                <h3 className="font-heading text-sm font-semibold text-foreground uppercase tracking-wider mb-3">Overall recommendation</h3>
                 <div className="space-y-2">
                   {RECOMMENDATIONS.map((rec) => (
-                    <label key={rec} className={`flex items-center p-3 border rounded-lg cursor-pointer transition-colors ${overallRecommendation === rec ? 'border-blue-500 bg-blue-50' : 'border-border hover:bg-muted/50'}`}>
+                    <label key={rec} className={`flex items-center p-3 border rounded-lg cursor-pointer transition-colors ${overallRecommendation === rec ? 'border-accent-coral bg-brand-tint' : 'border-border hover:bg-muted/50'}`}>
                       <input
                         type="radio" name="recommendation" value={rec}
                         checked={overallRecommendation === rec}
                         onChange={() => setOverallRecommendation(rec)}
-                        className="h-4 w-4 text-blue-600 border-gray-300 focus:ring-blue-500"
+                        className="h-4 w-4 accent-accent-coral border-border focus:ring-accent-coral"
                       />
                       <span className="ml-3 text-sm font-medium text-foreground">{rec}</span>
                     </label>
@@ -539,7 +542,9 @@ export default function ReviewerApplicationReview() {
                 {!existingReview?.submittedAt ? (
                   <>
                     {existingReview && (
-                      <button
+                      <Button
+                        variant="primary"
+                        className="w-full"
                         onClick={async () => {
                           flushSave()
                           const res = await fetch(`/api/hiring/reviews/${existingReview.id}/submit`, {
@@ -547,29 +552,29 @@ export default function ReviewerApplicationReview() {
                           })
                           if (res.ok) window.location.reload()
                         }}
-                        className="w-full flex justify-center items-center px-4 py-3 text-sm font-medium rounded-lg text-white bg-green-600 hover:bg-green-700 shadow-sm"
                       >
-                        Submit Review
-                      </button>
+                        Submit review
+                      </Button>
                     )}
                   </>
                 ) : (
                   <div className="space-y-2">
                     <div className="flex items-center justify-center gap-2 py-3 bg-green-50 border border-green-200 rounded-lg">
                       <Check className="w-4 h-4 text-green-600" />
-                      <span className="text-sm font-medium text-green-800">Review Submitted</span>
+                      <span className="text-sm font-medium text-green-800">Review submitted</span>
                     </div>
-                    <button
+                    <Button
+                      variant="secondary"
+                      className="w-full"
                       onClick={async () => {
                         const res = await fetch(`/api/hiring/reviews/${existingReview.id}/unsubmit`, {
                           method: 'POST', credentials: 'include',
                         })
                         if (res.ok) window.location.reload()
                       }}
-                      className="w-full flex justify-center items-center px-4 py-2 text-sm font-medium rounded-lg text-foreground/80 bg-card border border-gray-300 hover:bg-muted/50"
                     >
-                      Unsubmit & Edit
-                    </button>
+                      Unsubmit to edit
+                    </Button>
                   </div>
                 )}
               </div>
@@ -582,8 +587,8 @@ export default function ReviewerApplicationReview() {
       <div className="fixed bottom-6 right-4 sm:bottom-8 sm:right-8 flex flex-col gap-4 z-50">
         <button
           onClick={() => setShowRubric(!showRubric)}
-          className={`w-14 h-14 rounded-full flex items-center justify-center shadow-lg transition-all ${showRubric ? 'bg-blue-600 text-white' : 'bg-card text-blue-600 hover:bg-blue-50 border border-border'}`}
-          title="Scoring Guide"
+          className={`w-14 h-14 rounded-full flex items-center justify-center shadow-lg transition-all ${showRubric ? 'bg-accent-coral text-white' : 'bg-card text-accent-coral hover:bg-brand-tint border border-border'}`}
+          title="Scoring guide"
         >
           {showRubric ? <X className="w-6 h-6" /> : <HelpCircle className="w-6 h-6" />}
         </button>
@@ -591,17 +596,17 @@ export default function ReviewerApplicationReview() {
 
       {showRubric && (
         <div className="fixed bottom-20 right-4 sm:bottom-24 sm:right-8 w-80 max-w-[calc(100vw-2rem)] bg-card rounded-xl shadow-2xl border border-border overflow-hidden z-50">
-          <div className="bg-blue-600 px-4 py-3 flex justify-between items-center">
-            <h3 className="font-bold text-white flex items-center"><HelpCircle className="w-4 h-4 mr-2" />Scoring Guide</h3>
+          <div className="bg-accent-coral px-4 py-3 flex justify-between items-center">
+            <h3 className="font-heading font-semibold text-white flex items-center"><HelpCircle className="w-4 h-4 mr-2" />Scoring guide</h3>
           </div>
-          <ul className="divide-y divide-gray-100 max-h-[50vh] overflow-y-auto">
+          <ul className="divide-y divide-border max-h-[50vh] overflow-y-auto">
             {flatCriteria.length === 0 ? (
               <li className="p-4 text-sm text-muted-foreground/70 italic">No rubric attached.</li>
             ) : flatCriteria.map((c) => (
               <li key={c.key} className="p-4 hover:bg-muted/50">
                 <div className="flex justify-between items-start mb-1">
-                  <h4 className="font-bold text-foreground">{c.label}</h4>
-                  <span className="text-xs font-bold text-blue-600 bg-blue-50 px-2 py-1 rounded">Max: {c.maxScore}</span>
+                  <h4 className="font-heading font-semibold text-foreground">{c.label}</h4>
+                  <span className="text-xs font-bold text-foreground bg-muted px-2 py-1 rounded">Max: {c.maxScore}</span>
                 </div>
                 {c.description && <p className="text-xs text-muted-foreground">{c.description}</p>}
               </li>

--- a/dali-api/app/hiring/routes/reviewer.tsx
+++ b/dali-api/app/hiring/routes/reviewer.tsx
@@ -7,6 +7,10 @@ import { hiringPills } from '~/hiring/components/hiringPills'
 import { AreaPillNav } from '~/components/AreaPillNav'
 import { CycleSelector } from '~/hiring/components/CycleSelector'
 import { Section } from '~/hiring/components/Section'
+import { PageHeader } from '~/hiring/components/PageHeader'
+import { EmptyState } from '~/hiring/components/EmptyState'
+import { Pill, RecommendationPill } from '~/hiring/components/Pill'
+import { buttonClasses } from '~/components/ui/Button'
 import { getActiveCycle, cycleStatusToStage, inferUnderReviewStage } from '~/hiring/lib/cycles'
 import { getCycleConfidentialityState } from '~/hiring/lib/confidentiality'
 import { ConfidentialityGate } from '~/hiring/components/ConfidentialityGate'
@@ -258,12 +262,14 @@ export default function ReviewerDashboard() {
 
   if (!activeCycle) {
     return (
-      <div className="space-y-8">
+      <div className="space-y-6">
         {areaPills}
-        <h1 className="text-2xl font-bold text-foreground">Reviews</h1>
-        <div className="bg-card rounded-xl border border-border shadow-sm p-8 text-center">
-          <p className="text-muted-foreground">You are not assigned as a reviewer for any active cycle.</p>
-        </div>
+        <PageHeader title="Reviews" subtitle="Score the applications assigned to you." />
+        <EmptyState
+          icon={FileText}
+          title="No reviews assigned yet"
+          description="You're not assigned as a reviewer for any active cycle. Assignments from your domain lead will show up here."
+        />
       </div>
     )
   }
@@ -330,17 +336,11 @@ export default function ReviewerDashboard() {
   return (
     <div className="space-y-6">
       {areaPills}
-      <div className="flex items-start justify-between gap-4">
-        <div>
-          <h1 className="text-2xl font-bold text-foreground">
-            Reviews
-          </h1>
-          <p className="mt-1 text-muted-foreground">
-            Your assigned applications and live delibs.
-          </p>
-        </div>
-        <CycleSelector cycles={availableCycles} activeId={activeCycle.id} />
-      </div>
+      <PageHeader
+        title="Reviews"
+        subtitle="Score the applications assigned to you, and watch live delibs."
+        actions={<CycleSelector cycles={availableCycles} activeId={activeCycle.id} />}
+      />
 
       {/* View pills — Review vs the live Delibs mirror. Delibs only gets a
           pill while a session is live; with one view the bar collapses. */}
@@ -365,11 +365,11 @@ export default function ReviewerDashboard() {
 
       {view === 'review' && (
       <Section
-        title="Assigned Written Applications"
-        icon={<FileText className="w-4 h-4 text-blue-600" />}
+        title="Assigned written applications"
+        icon={<FileText className="w-4 h-4 text-muted-foreground" />}
         badge={
           !confidentialityRequired && reviews.length > 0 ? (
-            <span className="text-xs font-medium text-gray-500">
+            <span className="text-xs font-medium text-muted-foreground">
               {submittedReviews.length}/{reviews.length} submitted
             </span>
           ) : null
@@ -382,62 +382,28 @@ export default function ReviewerDashboard() {
             next="/hiring/reviewer"
           />
         ) : reviews.length === 0 ? (
-          <p className="text-sm text-gray-500">
-            You don't have any assigned applications yet. You'll see them here
-            once your Domain Lead assigns reviewers.
-          </p>
+          <EmptyState
+            icon={FileText}
+            title="No applications assigned yet"
+            description="Once your domain lead assigns you reviewers, your applications appear here."
+          />
         ) : (
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-            <div className="bg-gray-50 rounded-xl border border-gray-200 p-4 flex flex-col gap-3 min-h-[300px]">
-              <div className="flex items-center justify-between border-b border-gray-200 pb-2 mb-2">
-                <h3 className="font-bold text-gray-700">Pending</h3>
-                <span className="bg-white px-2.5 py-0.5 rounded-full text-xs font-bold border shadow-sm text-gray-600">
-                  {pendingReviews.length}
-                </span>
-              </div>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <ReviewColumn title="Pending" count={pendingReviews.length} emptyLabel="Nothing pending">
               {pendingReviews.map((r: any) => (
                 <ReviewCard key={r.id} review={r} variant="pending" />
               ))}
-              {pendingReviews.length === 0 && (
-                <div className="py-6 text-center border-2 border-dashed border-gray-300 rounded-lg bg-white/50">
-                  <p className="text-sm text-gray-500 italic">No pending reviews</p>
-                </div>
-              )}
-            </div>
-
-            <div className="bg-blue-50/50 rounded-xl border border-blue-100 p-4 flex flex-col gap-3 min-h-[300px]">
-              <div className="flex items-center justify-between border-b border-blue-200 pb-2 mb-2">
-                <h3 className="font-bold text-blue-800">In Progress</h3>
-                <span className="bg-white px-2.5 py-0.5 rounded-full text-xs font-bold border border-blue-200 shadow-sm text-blue-700">
-                  {inProgressReviews.length}
-                </span>
-              </div>
+            </ReviewColumn>
+            <ReviewColumn title="In progress" count={inProgressReviews.length} emptyLabel="Nothing in progress">
               {inProgressReviews.map((r: any) => (
                 <ReviewCard key={r.id} review={r} variant="inProgress" />
               ))}
-              {inProgressReviews.length === 0 && (
-                <div className="py-6 text-center border-2 border-dashed border-blue-200 rounded-lg bg-white/50">
-                  <p className="text-sm text-blue-400 italic">None in progress</p>
-                </div>
-              )}
-            </div>
-
-            <div className="bg-green-50/50 rounded-xl border border-green-100 p-4 flex flex-col gap-3 min-h-[300px]">
-              <div className="flex items-center justify-between border-b border-green-200 pb-2 mb-2">
-                <h3 className="font-bold text-green-800">Submitted</h3>
-                <span className="bg-white px-2.5 py-0.5 rounded-full text-xs font-bold border border-green-200 shadow-sm text-green-700">
-                  {submittedReviews.length}
-                </span>
-              </div>
+            </ReviewColumn>
+            <ReviewColumn title="Submitted" count={submittedReviews.length} emptyLabel="Nothing submitted yet">
               {submittedReviews.map((r: any) => (
                 <ReviewCard key={r.id} review={r} variant="submitted" />
               ))}
-              {submittedReviews.length === 0 && (
-                <div className="py-6 text-center border-2 border-dashed border-green-200 rounded-lg bg-white/50">
-                  <p className="text-sm text-green-500 italic">No submitted reviews</p>
-                </div>
-              )}
-            </div>
+            </ReviewColumn>
           </div>
         )}
       </Section>
@@ -445,14 +411,14 @@ export default function ReviewerDashboard() {
 
       {view === 'delibs' && (
       <Section
-        title="Delibs View"
-        icon={<ListOrdered className="w-4 h-4 text-blue-600" />}
+        title="Delibs view"
+        icon={<ListOrdered className="w-4 h-4 text-muted-foreground" />}
         badge={
           !confidentialityRequired && (delibsSessions?.length ?? 0) > 0 ? (
-            <span className="text-xs text-gray-500 bg-gray-100 px-2 py-0.5 rounded-full flex items-center">
-              <EyeOff className="w-3 h-3 mr-1" />
-              Live · Read-only
-            </span>
+            <Pill className="gap-1">
+              <EyeOff className="w-3 h-3" />
+              Live · read-only
+            </Pill>
           ) : null
         }
       >
@@ -463,10 +429,11 @@ export default function ReviewerDashboard() {
             next="/hiring/reviewer"
           />
         ) : (delibsSessions?.length ?? 0) === 0 ? (
-          <p className="text-sm text-gray-500">
-            No active deliberations. Once your Domain Lead opens a delibs
-            session, you'll see a live, read-only view of the buckets here.
-          </p>
+          <EmptyState
+            icon={ListOrdered}
+            title="No active deliberations"
+            description="When your domain lead opens a delibs session, you'll see a live, read-only view of the buckets here."
+          />
         ) : (
           <div className="space-y-8">
             {(delibsSessions as any[]).map((session: any) => (
@@ -495,8 +462,8 @@ export default function ReviewerDashboard() {
 const INITIAL_COLUMN_STYLES: Record<string, { label: string; classes: string; heading: string }> = {
   'No Decision': {
     label: 'No Decision',
-    classes: 'border-gray-200 bg-gray-50',
-    heading: 'text-gray-700',
+    classes: 'border-border bg-muted/40',
+    heading: 'text-foreground',
   },
   Interview: {
     label: 'Interview',
@@ -545,8 +512,8 @@ function DelibsSessionView({
   return (
     <div>
       <div className="flex items-center justify-between mb-3">
-        <h3 className="font-semibold text-gray-900">
-          {session.domain?.name ?? 'Domain'} · {isInitial ? 'Written Delibs' : 'Final Delibs'}
+        <h3 className="font-heading font-semibold text-foreground">
+          {session.domain?.name ?? 'Domain'} · {isInitial ? 'Written delibs' : 'Final delibs'}
         </h3>
       </div>
       <div
@@ -558,10 +525,8 @@ function DelibsSessionView({
           return (
             <div key={col} className={`rounded-xl border p-4 min-h-[160px] ${style.classes}`}>
               <div className="flex items-center justify-between mb-3">
-                <h4 className={`font-bold text-sm ${style.heading}`}>{style.label}</h4>
-                <span className="bg-white px-2 py-0.5 rounded-full text-xs font-bold border shadow-sm">
-                  {ids.length}
-                </span>
+                <h4 className={`font-heading font-semibold text-sm ${style.heading}`}>{style.label}</h4>
+                <Pill>{ids.length}</Pill>
               </div>
               <div className="space-y-2">
                 {ids.map((id, i) => {
@@ -573,18 +538,18 @@ function DelibsSessionView({
                       key={id}
                       type="button"
                       onClick={() => onSelect(id)}
-                      className="w-full text-left bg-white p-3 rounded-md border border-gray-200 shadow-sm flex items-center gap-2 hover:shadow-md hover:border-blue-300 transition cursor-pointer"
+                      className="w-full text-left bg-card p-3 rounded-md border border-border shadow-sm flex items-center gap-2 hover:shadow-md hover:border-accent-coral/40 transition cursor-pointer"
                     >
                       {!isInitial && col === 'Waitlist' && (
-                        <span className="text-gray-400 font-bold text-xs w-4">{i + 1}.</span>
+                        <span className="text-muted-foreground font-bold text-xs w-4">{i + 1}.</span>
                       )}
-                      <span className="font-medium text-gray-900 text-sm">{label}</span>
+                      <span className="font-medium text-foreground text-sm">{label}</span>
                     </button>
                   )
                 })}
                 {ids.length === 0 && (
-                  <div className="py-4 text-center border-2 border-dashed border-gray-300 rounded-md bg-white/50">
-                    <p className="text-xs text-gray-500 italic">Empty</p>
+                  <div className="py-4 text-center border-2 border-dashed border-border rounded-md bg-card/50">
+                    <p className="text-xs text-muted-foreground italic">Empty</p>
                   </div>
                 )}
               </div>
@@ -596,44 +561,65 @@ function DelibsSessionView({
   )
 }
 
+// A quiet, neutral column shell for the review kanban. Boldness lives in the
+// cards' single primary action, not in painted column backgrounds.
+function ReviewColumn({
+  title,
+  count,
+  emptyLabel,
+  children,
+}: {
+  title: string
+  count: number
+  emptyLabel: string
+  children: React.ReactNode
+}) {
+  return (
+    <div className="flex flex-col gap-3 rounded-xl border border-border bg-muted/30 p-4 min-h-[280px]">
+      <div className="flex items-center justify-between border-b border-border pb-2">
+        <h3 className="font-heading text-sm font-semibold text-foreground">{title}</h3>
+        <Pill>{count}</Pill>
+      </div>
+      {count === 0 ? (
+        <p className="py-6 text-center text-sm text-muted-foreground">{emptyLabel}</p>
+      ) : (
+        children
+      )}
+    </div>
+  )
+}
+
 function ReviewCard({ review, variant }: { review: any; variant: 'pending' | 'inProgress' | 'submitted' }) {
   const da = review.domainApplication
   const user = da?.application?.user
   const domain = da?.challengeVersion?.domain
   const appId = da?.applicationId ?? da?.application?.id
+  const name = `${user?.firstName ?? '?'} ${user?.lastName ?? ''}`.trim()
 
-  const borderClass = variant === 'submitted'
-    ? 'border-green-200'
-    : variant === 'inProgress'
-    ? 'border-blue-200 ring-1 ring-blue-100'
-    : 'border-border'
+  // The in-progress card carries the one coral action — the review you should
+  // pick back up. Pending and submitted stay secondary.
+  const ctaLabel =
+    variant === 'pending' ? 'Start review' : variant === 'inProgress' ? 'Continue review' : 'View review'
+  const ctaVariant = variant === 'inProgress' ? 'primary' : 'secondary'
 
   return (
-    <div className={`bg-card p-4 rounded-lg border ${borderClass} shadow-sm hover:shadow-md transition-shadow`}>
-      <div className="flex justify-between items-start mb-1">
-        <h4 className="font-bold text-foreground">
-          {user?.firstName ?? '?'} {user?.lastName ?? ''}
-        </h4>
-        {variant === 'submitted' && <CheckCircle className="w-4 h-4 text-green-500" />}
+    <div className="flex flex-col gap-2 rounded-lg border border-border bg-card p-4 shadow-sm hover:shadow-md transition-shadow">
+      <div className="flex justify-between items-start gap-2">
+        <h4 className="font-heading font-semibold text-foreground">{name}</h4>
+        {variant === 'submitted' && <CheckCircle className="w-4 h-4 shrink-0 text-accent-teal" />}
       </div>
-      <p className="text-xs text-muted-foreground mb-3">{domain?.name ?? 'Unknown Domain'}</p>
+      <p className="text-xs text-muted-foreground">{domain?.name ?? 'Unknown domain'}</p>
       {variant === 'submitted' && review.overallRecommendation && (
-        <p className="text-xs font-medium text-muted-foreground mb-3 bg-muted inline-block px-2 py-0.5 rounded">
-          {review.overallRecommendation}
-        </p>
+        <div>
+          <RecommendationPill value={review.overallRecommendation} />
+        </div>
       )}
       {appId && (
         <Link
           to={`/hiring/reviewer/application/${appId}`}
-          className={`block w-full text-center px-3 py-1.5 rounded-md text-xs font-medium transition-colors ${
-            variant === 'pending'
-              ? 'bg-blue-50 text-blue-700 hover:bg-blue-100'
-              : variant === 'inProgress'
-              ? 'bg-accent-coral text-white hover:bg-accent-coral/90'
-              : 'bg-card border border-gray-300 text-foreground/80 hover:bg-muted/50'
-          }`}
+          className={buttonClasses(ctaVariant, 'sm', 'mt-1 w-full')}
         >
-          {variant === 'pending' ? 'Start Review' : variant === 'inProgress' ? 'Continue Review' : 'View Review'}
+          {ctaLabel}
         </Link>
       )}
     </div>

--- a/dali-api/app/hiring/routes/waitlists.tsx
+++ b/dali-api/app/hiring/routes/waitlists.tsx
@@ -1,7 +1,10 @@
 import { useMemo, useState } from "react";
 import { Link, redirect, useFetcher, useLoaderData } from "react-router";
-import { Check, X } from "lucide-react";
+import { Check, X, ListChecks } from "lucide-react";
 import { Tooltip } from "~/components/ui/IconButton";
+import { Button } from "~/components/ui/Button";
+import { PageHeader } from "~/hiring/components/PageHeader";
+import { EmptyState } from "~/hiring/components/EmptyState";
 import type { Route } from "./+types/waitlists";
 import { requireAuth } from "~/lib/auth";
 import { getUserRoles } from "~/lib/roles";
@@ -92,21 +95,17 @@ export default function WaitlistsPage() {
   }, [filtered]);
 
   return (
-    <div className="space-y-6">
+    <div className="flex flex-col gap-5">
       <AreaPillNav items={hiringPills({ ...pillRoles, active: "waitlists" })} />
-      <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold text-foreground">Waitlists</h1>
-        <span className="text-sm text-muted-foreground">
-          {entries.length} active waitlister{entries.length === 1 ? "" : "s"}
-        </span>
-      </div>
-
-      <p className="text-sm text-muted-foreground max-w-2xl">
-        Everyone currently waitlisted across all cycles. Accepting from here
-        runs the full release flow — member promotion, account provisioning,
-        and the acceptance email — even if the cycle is already completed.
-        Removing closes the waitlist entry without notifying the applicant.
-      </p>
+      <PageHeader
+        title="Waitlists"
+        subtitle="Everyone currently waitlisted across all cycles. Accepting runs the full release flow — member promotion, account provisioning, and the acceptance email — even after a cycle is completed. Removing closes the entry without notifying the applicant."
+        chip={
+          <span className="rounded-full bg-muted px-2.5 py-0.5 text-xs font-bold text-foreground/80">
+            {entries.length} active
+          </span>
+        }
+      />
 
       {cycleOptions.length > 1 && (
         <div className="flex flex-wrap items-center gap-2">
@@ -140,13 +139,19 @@ export default function WaitlistsPage() {
       )}
 
       {byDomain.length === 0 ? (
-        <div className="bg-card border-2 border-dashed border-gray-300 rounded-xl p-8 text-center">
-          <p className="text-muted-foreground mb-1">
-            {entries.length === 0
-              ? "No one is currently on a waitlist."
-              : "No waitlisters match the selected cycle."}
-          </p>
-        </div>
+        <EmptyState
+          icon={ListChecks}
+          title={
+            entries.length === 0
+              ? "No one is on a waitlist"
+              : "No waitlisters in this cycle"
+          }
+          description={
+            entries.length === 0
+              ? "Applicants waitlisted during delibs will appear here, ranked within their domain."
+              : "Choose a different cycle to see its waitlisted applicants."
+          }
+        />
       ) : (
         <div className="space-y-6">
           {byDomain.map((group) => (
@@ -185,7 +190,7 @@ function DomainSection({
             <th className="px-5 py-2 w-44 text-right">Actions</th>
           </tr>
         </thead>
-        <tbody className="divide-y divide-gray-100">
+        <tbody className="divide-y divide-border">
           {rows.map((r) => (
             <WaitlistRow key={r.domainApplicationId} entry={r} />
           ))}
@@ -250,7 +255,7 @@ function WaitlistRow({ entry }: { entry: WaitlistEntry }) {
       <td className="px-5 py-3">
         <Link
           to={`/hiring/applications/${entry.domainApplicationId}`}
-          className="font-medium text-foreground hover:text-blue-600"
+          className="font-medium text-foreground hover:text-accent-coral"
         >
           {fullName(entry)}
         </Link>
@@ -260,7 +265,7 @@ function WaitlistRow({ entry }: { entry: WaitlistEntry }) {
           </div>
         )}
         {(acceptError || removeError) && (
-          <div className="mt-1 text-xs text-red-600">
+          <div className="mt-1 text-xs text-destructive">
             {acceptError ?? removeError}
           </div>
         )}
@@ -275,23 +280,21 @@ function WaitlistRow({ entry }: { entry: WaitlistEntry }) {
       </td>
       <td className="px-5 py-3">
         <div className="flex items-center justify-end gap-2">
-          <button
-            onClick={onAccept}
-            disabled={busy}
-            className="inline-flex items-center gap-1 px-2.5 py-1 text-xs font-medium text-white bg-green-600 rounded-md hover:bg-green-700 disabled:opacity-50"
-          >
-            <Check className="w-3.5 h-3.5" />
+          <Button variant="primary" size="sm" onClick={onAccept} disabled={busy}>
+            <Check className="h-3.5 w-3.5" />
             Accept
-          </button>
-          <Tooltip label="Remove">
-            <button
+          </Button>
+          <Tooltip label="Remove from waitlist">
+            <Button
+              variant="secondary"
+              size="sm"
               onClick={onRemove}
               disabled={busy}
-              aria-label="Remove"
-              className="inline-flex items-center justify-center p-1.5 text-xs font-medium text-foreground/80 bg-card border border-border rounded-md hover:bg-muted disabled:opacity-50"
+              aria-label="Remove from waitlist"
+              className="px-2"
             >
-              <X className="w-3.5 h-3.5" />
-            </button>
+              <X className="h-3.5 w-3.5" />
+            </Button>
           </Tooltip>
         </div>
       </td>

--- a/dali-api/app/routes/applicant-layout.tsx
+++ b/dali-api/app/routes/applicant-layout.tsx
@@ -1,9 +1,16 @@
-import { Outlet, redirect, useLoaderData, Link } from "react-router";
+import { Outlet, redirect, useLoaderData, Link, NavLink } from "react-router";
 import type { Route } from "./+types/applicant-layout";
 import { requireAuth, redirectPartnerToPortal } from "~/lib/auth";
 import { userInitials } from "~/lib/display";
 import { ApplicantErrorBoundary } from "~/components/ApplicantErrorBoundary";
 import { PortalProfileMenu } from "~/components/PortalProfileMenu";
+import { cn } from "~/lib/cn";
+
+const portalNavLinkClass = ({ isActive }: { isActive: boolean }) =>
+  cn(
+    "transition-colors",
+    isActive ? "text-accent-coral" : "text-dark-blue hover:text-accent-coral",
+  );
 
 export async function loader({ request }: Route.LoaderArgs) {
   const auth = await requireAuth(request);
@@ -37,12 +44,12 @@ export default function ApplicantLayout() {
         </Link>
 
         <div className="ml-6 flex items-center gap-4 text-sm font-medium">
-          <Link to="/portal/hiring" className="text-dark-blue hover:text-accent-coral transition">
+          <NavLink to="/portal/hiring" className={portalNavLinkClass}>
             Apply
-          </Link>
-          <Link to="/portal/education" className="text-dark-blue hover:text-accent-coral transition">
+          </NavLink>
+          <NavLink to="/portal/education" className={portalNavLinkClass}>
             Education
-          </Link>
+          </NavLink>
         </div>
 
         <PortalProfileMenu

--- a/dali-api/app/routes/intern-to-full.tsx
+++ b/dali-api/app/routes/intern-to-full.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { redirect, useLoaderData, useFetcher, Link } from "react-router";
+import { redirect, useLoaderData, useFetcher } from "react-router";
 import type { Route } from "./+types/intern-to-full";
 import { prisma } from "~/lib/db";
 import { requireAuth } from "~/lib/auth";
@@ -14,6 +14,10 @@ import type { Question } from "~/types";
 import { FormFieldList } from "~/forms/components/FormField";
 import { findMissingRequired } from "~/lib/form-answers";
 import { APPLICATION_TZ, APPLICATION_TZ_LABEL } from "~/lib/timezone";
+import { PageHeader } from "~/hiring/components/PageHeader";
+import { EmptyState } from "~/hiring/components/EmptyState";
+import { Button } from "~/components/ui/Button";
+import { Info } from "lucide-react";
 
 export const meta: Route.MetaFunction = () => [
   { title: "Fellowship · DALI OS" },
@@ -254,20 +258,22 @@ export default function InternToFullRoute() {
 
   return (
     <div className="max-w-3xl mx-auto py-10 px-6">
-      <header className="mb-8">
-        <h1 className="font-heading text-2xl font-bold text-dark-blue mb-1">
-          Fellowship Application
-        </h1>
-        <p className="text-sm text-muted-foreground">
-          {cycle.name}
-          {cycle.closeDate &&
-            ` · closes ${new Date(cycle.closeDate).toLocaleDateString("en-US", {
-              month: "long",
-              day: "numeric",
-              year: "numeric",
-              timeZone: APPLICATION_TZ,
-            })} ${APPLICATION_TZ_LABEL}`}
-        </p>
+      <div className="mb-8">
+        <PageHeader
+          title="Fellowship application"
+          subtitle={
+            <>
+              {cycle.name}
+              {cycle.closeDate &&
+                ` · closes ${new Date(cycle.closeDate).toLocaleDateString("en-US", {
+                  month: "long",
+                  day: "numeric",
+                  year: "numeric",
+                  timeZone: APPLICATION_TZ,
+                })} ${APPLICATION_TZ_LABEL}`}
+            </>
+          }
+        />
         {internDomains.length > 0 && (
           <p className="mt-2 text-xs text-muted-foreground">
             You're currently in{" "}
@@ -280,7 +286,7 @@ export default function InternToFullRoute() {
             .
           </p>
         )}
-      </header>
+      </div>
 
       {withdrawn ? (
         <Message title="Application withdrawn">
@@ -296,14 +302,15 @@ export default function InternToFullRoute() {
   );
 }
 
-function Message({ title, children }: { title: string; children: React.ReactNode }) {
+function Message({ title, children }: { title: string; children: string }) {
   return (
-    <div className="max-w-2xl mx-auto py-16 px-6 text-center">
-      <h2 className="font-heading text-xl font-bold text-dark-blue mb-2">{title}</h2>
-      <p className="text-sm text-muted-foreground">{children}</p>
-      <Link to="/" className="mt-6 inline-block text-sm text-accent-coral hover:underline">
-        Open home
-      </Link>
+    <div className="max-w-2xl mx-auto py-16 px-6">
+      <EmptyState
+        icon={Info}
+        title={title}
+        description={children}
+        action={{ label: "Back to dashboard", to: "/" }}
+      />
     </div>
   );
 }
@@ -411,27 +418,25 @@ function FormView({
       )}
       {justSaved && !error && (
         <div className="rounded-lg border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-800">
-          Draft saved.
+          Draft saved — you can come back and finish any time.
         </div>
       )}
 
       <div className="flex flex-wrap items-center gap-3">
-        <button
-          type="button"
+        <Button
+          variant="secondary"
           onClick={() => submitForm("save-draft")}
           disabled={busy}
-          className="px-5 py-2 rounded-full border-2 border-border text-sm font-semibold text-muted-foreground hover:border-accent-coral hover:text-accent-coral transition disabled:opacity-50"
         >
           {busy && fetcher.formData?.get("intent") === "save-draft" ? "Saving…" : "Save draft"}
-        </button>
-        <button
-          type="button"
+        </Button>
+        <Button
+          variant="primary"
           onClick={() => submitForm("submit")}
           disabled={busy}
-          className="px-6 py-2.5 rounded-full bg-accent-coral text-white text-sm font-semibold hover:bg-accent-coral/90 transition disabled:opacity-50"
         >
-          {busy && fetcher.formData?.get("intent") === "submit" ? "Submitting…" : "Submit"}
-        </button>
+          {busy && fetcher.formData?.get("intent") === "submit" ? "Submitting…" : "Submit application"}
+        </Button>
       </div>
     </div>
   );
@@ -445,11 +450,11 @@ function SubmittedView({ draftId }: { draftId?: string } = {}) {
     <div className="space-y-6">
       <div className="rounded-2xl border border-green-200 bg-green-50/50 px-6 py-8 text-center">
         <h2 className="font-heading text-xl font-bold text-dark-blue mb-2">
-          Submitted
+          Your application is in
         </h2>
         <p className="text-sm text-muted-foreground">
-          Your fellowship application is in. Hiring leads will review it and reach out
-          with a decision.
+          Thanks for applying. Hiring leads will review your fellowship application and
+          reach out with a decision.
         </p>
       </div>
       <div className="flex justify-end">
@@ -457,17 +462,18 @@ function SubmittedView({ draftId }: { draftId?: string } = {}) {
           <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 space-y-2">
             <p className="text-sm font-semibold text-red-700">Withdraw this application?</p>
             <p className="text-xs text-red-600/80">You can't reopen it without contacting the hiring lead.</p>
-            <div className="flex gap-3">
-              <button
+            <div className="flex items-center gap-3">
+              <Button
+                variant="destructive"
+                size="sm"
                 onClick={() => fetcher.submit({ intent: "withdraw" }, { method: "post" })}
                 disabled={busy}
-                className="px-4 py-1.5 rounded-full bg-red-600 text-white text-sm font-semibold disabled:opacity-50"
               >
                 {busy ? "Withdrawing…" : "Yes, withdraw"}
-              </button>
-              <button onClick={() => setConfirming(false)} className="text-sm text-muted-foreground hover:underline">
-                Cancel
-              </button>
+              </Button>
+              <Button variant="ghost" size="sm" onClick={() => setConfirming(false)}>
+                Keep my application
+              </Button>
             </div>
           </div>
         ) : (

--- a/dali-api/app/routes/portal.application.tsx
+++ b/dali-api/app/routes/portal.application.tsx
@@ -10,6 +10,7 @@ import { ApplicantErrorBoundary } from "~/components/ApplicantErrorBoundary";
 import { Modal } from "~/components/Modal";
 import { QuestionList } from "~/hiring/components/ApplicationAnswers";
 import { sendInterviewCancelEmails } from "~/hiring/lib/interview-emails";
+import { Button } from "~/components/ui/Button";
 
 export const meta: Route.MetaFunction = () => [{ title: "My application · DALI OS" }];
 
@@ -246,9 +247,9 @@ export default function PortalApplication() {
             </svg>
             Back to portal
           </Link>
-          <h1 className="font-heading text-xl font-bold text-dark-blue">Your Application</h1>
+          <h1 className="font-heading text-xl font-bold text-dark-blue">Your application</h1>
           <p className="text-sm text-muted-foreground mt-1">
-            Submitted {submittedDate} — this view reflects your most recently saved answers.
+            Submitted {submittedDate}. This is exactly what the DALI team sees — your most recently saved answers.
           </p>
         </div>
       </div>
@@ -275,21 +276,21 @@ export default function PortalApplication() {
               </div>
             </div>
           ) : canWithdraw ? (
-            <div className="rounded-2xl border border-border px-6 py-5 flex items-center justify-between gap-4">
+            <div className="rounded-2xl border border-border px-6 py-5 flex flex-wrap items-center justify-between gap-4">
               <div>
                 <p className="text-sm font-semibold text-dark-blue">No longer want to be considered?</p>
                 <p className="text-sm text-muted-foreground mt-1">
-                  Withdrawing removes your application from review. This cannot be undone from the portal.
+                  Withdrawing removes your application from review. You can't undo this from the portal.
                 </p>
               </div>
-              <button
-                type="button"
+              <Button
+                variant="secondary"
                 onClick={() => setShowWithdrawModal(true)}
                 disabled={submittingWithdraw}
-                className="shrink-0 px-5 py-2 rounded-full border-2 border-red-500 text-red-500 text-sm font-semibold hover:bg-red-500 hover:text-white transition disabled:opacity-50"
+                className="shrink-0"
               >
-                Withdraw Application
-              </button>
+                Withdraw application
+              </Button>
             </div>
           ) : null}
 
@@ -334,22 +335,20 @@ export default function PortalApplication() {
           Your application will be removed from review. You can't undo this from the portal — you'd need to contact the DALI team to reverse it.
         </p>
         <div className="flex gap-3 justify-end">
-          <button
-            type="button"
+          <Button
+            variant="secondary"
             onClick={() => setShowWithdrawModal(false)}
             disabled={submittingWithdraw}
-            className="px-5 py-2 rounded-full border-2 border-border text-sm font-semibold text-muted-foreground hover:border-accent-coral hover:text-accent-coral transition disabled:opacity-50"
           >
-            Cancel
-          </button>
-          <button
-            type="button"
+            Keep my application
+          </Button>
+          <Button
+            variant="destructive"
             onClick={confirmWithdraw}
             disabled={submittingWithdraw}
-            className="px-5 py-2 rounded-full bg-red-500 text-white text-sm font-semibold hover:bg-red-500/90 transition disabled:opacity-50"
           >
-            {submittingWithdraw ? "Withdrawing..." : "Withdraw"}
-          </button>
+            {submittingWithdraw ? "Withdrawing…" : "Withdraw application"}
+          </Button>
         </div>
       </Modal>
     </div>

--- a/dali-api/app/routes/portal.apply.tsx
+++ b/dali-api/app/routes/portal.apply.tsx
@@ -20,6 +20,8 @@ import { QuestionList } from "~/hiring/components/ApplicationAnswers";
 import { RichTextViewer, isEmptyDoc } from "~/components/RichTextViewer";
 import { type UrlCheckState } from "~/components/form-builder/QuestionField";
 import { FormField } from "~/forms/components/FormField";
+import { Button } from "~/components/ui/Button";
+import { Pill } from "~/hiring/components/Pill";
 
 export const meta: Route.MetaFunction = () => [{ title: "Apply · DALI OS" }];
 
@@ -1284,25 +1286,26 @@ export default function PortalApply() {
     return (
       <div className="max-w-3xl mx-auto px-6 py-10">
         <div className="flex items-center justify-between mb-2">
-          <h2 className="font-heading text-xl font-bold text-dark-blue">{cycleName} Application</h2>
+          <h2 className="font-heading text-xl font-bold text-dark-blue">{cycleName} application</h2>
         </div>
         <p className="text-sm text-muted-foreground mb-8">
-          Select the domains you'd like to apply for, then start your application.
+          Pick the domains you'd like to apply for, then start your application. You can add or remove domains any time before you submit.
         </p>
 
         <div className="space-y-8">
           {renderDomainSelector()}
 
-          {error && <p className="text-sm text-red-500">{error}</p>}
+          {error && <p className="text-sm text-red-600">{error}</p>}
 
           <div>
-            <button
+            <Button
+              variant="primary"
+              size="md"
               onClick={handleCreateDraft}
               disabled={selectedDomainIds.length === 0}
-              className="px-6 py-2.5 rounded-full bg-accent-coral text-white text-sm font-semibold hover:bg-accent-coral/90 transition disabled:opacity-50"
             >
-              Start Application
-            </button>
+              Start application
+            </Button>
           </div>
         </div>
       </div>
@@ -1319,25 +1322,25 @@ export default function PortalApply() {
 
       <div className="lg:grid lg:grid-cols-[minmax(0,1fr)_220px] lg:gap-10">
         <div className="max-w-3xl">
-          <div className="flex items-center justify-between mb-2">
-            <h2 className="font-heading text-xl font-bold text-dark-blue">{cycleName} Application</h2>
+          <div className="flex items-center justify-between gap-3 mb-2">
+            <h2 className="font-heading text-xl font-bold text-dark-blue">{cycleName} application</h2>
             {submitting ? (
-              <span className="text-xs px-2.5 py-0.5 rounded-full font-semibold bg-muted text-muted-foreground flex items-center gap-1">
-                <span className="inline-block w-3 h-3 border-2 border-border border-t-muted-foreground rounded-full animate-spin" />
-                Submitting...
-              </span>
+              <Pill color="bg-muted text-muted-foreground">
+                <span className="inline-block w-3 h-3 border-2 border-border border-t-muted-foreground rounded-full animate-spin mr-1.5" />
+                Submitting…
+              </Pill>
             ) : Object.keys(wordCountErrors).length > 0 ? (
-              <span className="text-xs px-2.5 py-0.5 rounded-full font-semibold bg-red-100 text-red-700">Action required</span>
+              <Pill color="bg-red-100 text-red-700">Action needed</Pill>
             ) : Object.keys(urlWarnings).length > 0 ? (
-              <span className="text-xs px-2.5 py-0.5 rounded-full font-semibold bg-amber-100 text-amber-700">Action required</span>
+              <Pill color="bg-amber-100 text-amber-700">Action needed</Pill>
             ) : isAlreadySubmitted ? (
-              <span className="text-xs px-2.5 py-0.5 rounded-full font-semibold bg-green-100 text-green-700">Submitted</span>
+              <Pill color="bg-green-100 text-green-700">Submitted</Pill>
             ) : (
-              <span className="text-xs px-2.5 py-0.5 rounded-full font-semibold bg-blue-100 text-blue-700">Draft</span>
+              <Pill color="bg-blue-100 text-blue-700">Draft</Pill>
             )}
           </div>
           <p className="text-sm text-muted-foreground mb-8">
-            Fill out the form below. Your progress is saved automatically.
+            Work through each section below. There's no submit until you're ready — your answers save automatically as you go.
           </p>
 
           <div className="space-y-8">
@@ -1509,14 +1512,14 @@ export default function PortalApply() {
           ) : null;
         })()}
 
-        {error && <p className="text-sm text-red-500">{error}</p>}
+        {error && <p className="text-sm text-red-600">{error}</p>}
 
         {/* Word-count errors banner — hard error, blocks submission */}
         {Object.keys(wordCountErrors).length > 0 && (
           <div ref={warningBannerRef} className="rounded-xl border border-red-200 bg-red-50 px-5 py-4">
-            <p className="text-sm font-semibold text-red-800 mb-1">Some answers exceed the word limit</p>
+            <p className="text-sm font-semibold text-red-800 mb-1">A couple of answers run long</p>
             <p className="text-xs text-red-700">
-              The following answers are over the allowed word count. Trim them down before submitting.
+              These answers are over the word limit — trim them down and you'll be ready to submit.
             </p>
             <ul className="text-xs text-red-700 mt-2 list-disc list-inside space-y-0.5">
               {Object.entries(wordCountErrors).map(([key, v]) => (
@@ -1539,38 +1542,39 @@ export default function PortalApply() {
         )}
 
         {/* Actions */}
-        <div className="flex items-center gap-3 pt-2">
-          <button
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-2 pt-2">
+          <Button
+            variant="primary"
+            size="md"
             onClick={() => openReviewIfValid()}
             disabled={submitting || checkingUrls}
-            className="px-6 py-2.5 rounded-full bg-accent-coral text-white text-sm font-semibold hover:bg-accent-coral/90 transition disabled:opacity-50 flex items-center gap-2"
           >
             {checkingUrls && (
               <span className="inline-block w-3.5 h-3.5 border-2 border-white/40 border-t-white rounded-full animate-spin" />
             )}
             {submitting
-              ? "Submitting..."
+              ? "Submitting…"
               : checkingUrls
-                ? "Checking links..."
+                ? "Checking links…"
                 : isAlreadySubmitted
-                  ? "Review Updates"
-                  : "Review Application"}
-          </button>
-          <span className="text-xs text-muted-foreground/70 flex items-center gap-1.5">
+                  ? "Review your updates"
+                  : "Review your application"}
+          </Button>
+          <span className="text-xs text-muted-foreground flex items-center gap-1.5">
             {saving ? (
               <>
                 <span className="inline-block w-3 h-3 border-2 border-border border-t-accent-coral rounded-full animate-spin" />
-                Saving...
+                Saving…
               </>
             ) : hasSavedOnce ? (
               <>
-                <svg className="w-3.5 h-3.5 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <svg className="w-3.5 h-3.5 text-accent-teal" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                   <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
                 </svg>
-                Draft auto-saved
+                All changes saved
               </>
             ) : (
-              <>Changes will be saved automatically</>
+              <>Your answers save automatically</>
             )}
           </span>
         </div>
@@ -1651,22 +1655,20 @@ export default function PortalApply() {
         </div>
 
         <div className="flex gap-3 justify-end pt-5 mt-5 border-t border-border">
-          <button
-            type="button"
+          <Button
+            variant="secondary"
             onClick={() => setShowReviewModal(false)}
             disabled={submitting}
-            className="px-5 py-2 rounded-full border-2 border-border text-sm font-semibold text-muted-foreground hover:border-accent-coral hover:text-accent-coral transition disabled:opacity-50"
           >
-            Go Back and Edit
-          </button>
-          <button
-            type="button"
+            Keep editing
+          </Button>
+          <Button
+            variant="primary"
             onClick={() => { setShowReviewModal(false); doSubmit(acceptedUrlWarnings); }}
             disabled={submitting}
-            className="px-5 py-2 rounded-full bg-accent-coral text-white text-sm font-semibold hover:bg-accent-coral/90 transition disabled:opacity-50"
           >
-            {submitting ? "Submitting..." : "Confirm Submission"}
-          </button>
+            {submitting ? "Submitting…" : isAlreadySubmitted ? "Update application" : "Submit application"}
+          </Button>
         </div>
       </Modal>
 
@@ -1700,26 +1702,26 @@ export default function PortalApply() {
           })}
         </ul>
         <div className="flex gap-3 justify-end">
-          <button
+          <Button
+            variant="secondary"
             onClick={() => {
               setShowWarningModal(false);
               scrollToFirstWarning();
             }}
-            className="px-5 py-2 rounded-full border-2 border-border text-sm font-semibold text-muted-foreground hover:border-accent-coral hover:text-accent-coral transition"
           >
-            Go Back and Fix
-          </button>
-          <button
+            Go back and fix the links
+          </Button>
+          <Button
+            variant="primary"
             onClick={() => {
               setAcceptedUrlWarnings(true);
               setShowWarningModal(false);
               setShowReviewModal(true);
             }}
             disabled={submitting}
-            className="px-5 py-2 rounded-full bg-accent-coral text-white text-sm font-semibold hover:bg-accent-coral/90 transition disabled:opacity-50"
           >
-            Submit Anyway
-          </button>
+            Continue anyway
+          </Button>
         </div>
       </Modal>
 
@@ -1737,23 +1739,23 @@ export default function PortalApply() {
           for this domain, since each challenge has its own questions. This can't be undone.
         </p>
         <div className="flex gap-3 justify-end">
-          <button
+          <Button
+            variant="secondary"
             onClick={() => setPendingChallengeChange(null)}
-            className="px-5 py-2 rounded-full border-2 border-border text-sm font-semibold text-muted-foreground hover:border-accent-coral hover:text-accent-coral transition"
           >
-            Cancel
-          </button>
-          <button
+            Keep this challenge
+          </Button>
+          <Button
+            variant="destructive"
             onClick={() => {
               if (pendingChallengeChange) {
                 applyChallengePick(pendingChallengeChange.domainId, pendingChallengeChange.toCvId);
               }
               setPendingChallengeChange(null);
             }}
-            className="px-5 py-2 rounded-full bg-accent-coral text-white text-sm font-semibold hover:bg-accent-coral/90 transition"
           >
-            Switch and Clear Answers
-          </button>
+            Switch and clear answers
+          </Button>
         </div>
       </Modal>
     </div>

--- a/dali-api/app/routes/portal.hiring.tsx
+++ b/dali-api/app/routes/portal.hiring.tsx
@@ -16,7 +16,11 @@ import { ApplicantErrorBoundary } from "~/components/ApplicantErrorBoundary";
 import { Confetti } from "~/components/Confetti";
 import { formatInterviewDate, formatInterviewTimeRange } from "~/hiring/lib/interview-time";
 import { APPLICATIONS_FROM_EMAIL } from "~/lib/app-env";
-import { Button } from "~/components/ui/Button";
+import { Button, buttonClasses } from "~/components/ui/Button";
+import { StatusStepper } from "~/hiring/components/StatusStepper";
+import { EmptyState } from "~/hiring/components/EmptyState";
+import { Pill, InterviewStatusPill } from "~/hiring/components/Pill";
+import { CalendarClock } from "lucide-react";
 
 export const meta: Route.MetaFunction = () => [{ title: "Apply to DALI · DALI OS" }];
 
@@ -285,21 +289,6 @@ function DeadlineLine({ closeDate, originalCloseDate }: { closeDate: string; ori
 
 const cardBg = "bg-brand-tint";
 
-function StatusBadge({ label, variant }: { label: string; variant: "blue" | "green" | "yellow" | "red" | "gray" }) {
-  const styles: Record<string, string> = {
-    blue: "bg-blue-100 text-blue-700",
-    green: "bg-green-100 text-green-700",
-    yellow: "bg-yellow-100 text-yellow-800",
-    red: "bg-red-100 text-red-700",
-    gray: "bg-muted text-muted-foreground",
-  };
-  return (
-    <span className={`text-xs px-2.5 py-0.5 rounded-full font-semibold ${styles[variant]}`}>
-      {label}
-    </span>
-  );
-}
-
 function PulsingDot({ color }: { color: string }) {
   return <span className={`w-2 h-2 rounded-full ${color} animate-pulse`} />;
 }
@@ -315,11 +304,7 @@ function StageIndicator({ stage }: { stage: DomainApplicationStatus | "Applicati
   const currentStep = steps.find(s => s.keys.includes(stage));
   if (!currentStep) return null;
 
-  return (
-    <div className="px-2.5 py-1 rounded-full text-xs font-medium bg-accent-teal text-white">
-      {currentStep.label}
-    </div>
-  );
+  return <Pill color="bg-accent-teal text-white">{currentStep.label}</Pill>;
 }
 
 // ─── Stage Views ─────────────────────────────────────────────────────────────
@@ -332,12 +317,12 @@ function ApplicationOpenView({ cycleName, closeDate }: { cycleName: string; clos
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
         </svg>
       </div>
-      <h2 className="font-heading text-2xl font-bold text-dark-blue mb-3">Applications Are Open</h2>
+      <h2 className="font-heading text-2xl font-bold text-dark-blue mb-3">Applications are open</h2>
       <p className="text-muted-foreground mb-8 leading-relaxed">
-        The {cycleName} application cycle is now accepting applications. Start yours to join the DALI Lab!
+        The {cycleName} cycle is accepting applications right now. Start yours to join the DALI Lab — you can save your progress and come back any time.
       </p>
-      <Link to="/portal/apply" className="px-8 py-3 rounded-full bg-accent-coral text-white font-semibold font-heading tracking-wider hover:bg-accent-coral/90 transition shadow-lg hover:shadow-xl">
-        Start Application
+      <Link to="/portal/apply" className={buttonClasses("primary", "md")}>
+        Start your application
       </Link>
     </div>
   );
@@ -351,12 +336,12 @@ function ApplicationDraftView({ cycleName, closeDate }: { cycleName: string; clo
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
         </svg>
       </div>
-      <h2 className="font-heading text-2xl font-bold text-dark-blue mb-3">Application In Progress</h2>
+      <h2 className="font-heading text-2xl font-bold text-dark-blue mb-3">Your application is in progress</h2>
       <p className="text-muted-foreground mb-8 leading-relaxed">
-        You have a draft application for {cycleName}. Complete and submit it to be considered!
+        You have a saved draft for {cycleName}. Pick up where you left off and submit it to be considered.
       </p>
-      <Link to="/portal/apply" className="px-8 py-3 rounded-full bg-accent-coral text-white font-semibold font-heading tracking-wider hover:bg-accent-coral/90 transition shadow-lg hover:shadow-xl">
-        Continue Application
+      <Link to="/portal/apply" className={buttonClasses("primary", "md")}>
+        Continue your application
       </Link>
     </div>
   );
@@ -371,13 +356,13 @@ function WithdrawnView({ cycleName }: { cycleName: string }) {
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
           </svg>
         </div>
-        <h2 className="font-heading text-2xl font-bold text-dark-blue mb-3">Application Withdrawn</h2>
+        <h2 className="font-heading text-2xl font-bold text-dark-blue mb-3">Application withdrawn</h2>
         <p className="text-muted-foreground leading-relaxed">
           You withdrew your application for {cycleName}. If you change your mind, contact the DALI team.
         </p>
         <div className="mt-4">
-          <Link to="/portal/application" className="text-sm text-accent-coral hover:underline">
-            View your submission →
+          <Link to="/portal/application" className="text-sm font-semibold text-accent-coral hover:underline">
+            View your submitted application
           </Link>
         </div>
       </div>
@@ -394,7 +379,7 @@ function PendingView({ cycleName }: { cycleName: string }) {
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
           </svg>
         </div>
-        <h2 className="font-heading text-2xl font-bold text-dark-blue mb-3">Application Pending Review</h2>
+        <h2 className="font-heading text-2xl font-bold text-dark-blue mb-3">Application under review</h2>
         <p className="text-muted-foreground leading-relaxed">
           Your application is being reviewed by the DALI team. We'll update you here once a decision has been made.
         </p>
@@ -418,7 +403,7 @@ function RejectedView({ cycleName }: { cycleName: string }) {
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20 12H4" />
           </svg>
         </div>
-        <h2 className="font-heading text-2xl font-bold text-dark-blue mb-3">Thank You for Applying</h2>
+        <h2 className="font-heading text-2xl font-bold text-dark-blue mb-3">Thank you for applying</h2>
         <p className="text-muted-foreground leading-relaxed max-w-lg mx-auto">
           Unfortunately, we are unable to move your application forward for {cycleName}. The applicant pool was extremely competitive this cycle.
         </p>
@@ -432,19 +417,16 @@ function RejectedView({ cycleName }: { cycleName: string }) {
           You can request feedback on your application. A member of the DALI team will follow up with you via email.
         </p>
         {feedbackRequested ? (
-          <div className="flex items-center gap-2 text-sm text-green-600 font-medium">
+          <div className="flex items-center gap-2 text-sm text-accent-teal font-medium">
             <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
             </svg>
             Feedback requested — we'll be in touch soon.
           </div>
         ) : (
-          <button
-            onClick={() => setFeedbackRequested(true)}
-            className="px-5 py-2 rounded-full border-2 border-accent-coral text-accent-coral text-sm font-semibold hover:bg-accent-coral hover:text-white transition"
-          >
-            Request Feedback
-          </button>
+          <Button variant="secondary" size="md" onClick={() => setFeedbackRequested(true)}>
+            Request feedback
+          </Button>
         )}
       </div>
     </div>
@@ -522,9 +504,9 @@ function InvitedToInterviewView({
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
           </svg>
         </div>
-        <h2 className="font-heading text-2xl font-bold text-dark-blue mb-3">You're Invited to Interview!</h2>
+        <h2 className="font-heading text-2xl font-bold text-dark-blue mb-3">You're invited to interview</h2>
         <p className="text-muted-foreground leading-relaxed">
-          Congratulations! The DALI team would like to interview you for <span className="font-medium text-dark-blue">{domainApp.domainName}</span>. Please select a time slot below.
+          Congratulations! The DALI team would like to interview you for <span className="font-medium text-dark-blue">{domainApp.domainName}</span>. Pick a time that works for you below.
         </p>
       </div>
 
@@ -559,7 +541,7 @@ function InvitedToInterviewView({
             onClick={handleConfirm}
             disabled={!selectedSlot || booking}
           >
-            {booking ? "Booking..." : "Confirm Time"}
+            {booking ? "Booking…" : "Confirm this time"}
           </Button>
         </>
       )}
@@ -680,9 +662,9 @@ function InterviewScheduledView({
     const grouped = groupSlotsByDate(rescheduleSlots);
     return (
       <div className="max-w-2xl mx-auto py-12">
-        <h2 className="font-heading text-xl font-bold text-dark-blue mb-2">Reschedule Interview</h2>
+        <h2 className="font-heading text-xl font-bold text-dark-blue mb-2">Reschedule your interview</h2>
         <p className="text-sm text-muted-foreground mb-6">
-          Currently scheduled: <strong>{slot.date}, {slot.time}</strong> ({formatInterviewLocation(interview.location)}). Choose a format and new time.
+          Currently scheduled: <strong>{slot.date}, {slot.time}</strong> ({formatInterviewLocation(interview.location)}). Pick a new time below.
         </p>
 
         {rescheduleError && (
@@ -717,13 +699,13 @@ function InterviewScheduledView({
               disabled={!selectedRescheduleSlotId || confirmingReschedule}
               className="mr-3"
             >
-              {confirmingReschedule ? "Rescheduling..." : "Confirm Reschedule"}
+              {confirmingReschedule ? "Rescheduling…" : "Confirm new time"}
             </Button>
           </>
         )}
-        <button onClick={exitRescheduling} className="text-sm font-semibold text-muted-foreground hover:underline">
-          Cancel
-        </button>
+        <Button variant="ghost" size="md" onClick={exitRescheduling}>
+          Keep my current time
+        </Button>
       </div>
     );
   }
@@ -736,7 +718,7 @@ function InterviewScheduledView({
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
           </svg>
         </div>
-        <h2 className="font-heading text-2xl font-bold text-dark-blue mb-3">Interview Confirmed</h2>
+        <h2 className="font-heading text-2xl font-bold text-dark-blue mb-3">Interview confirmed</h2>
         <p className="text-muted-foreground leading-relaxed">
           You're all set for your <span className="font-medium text-dark-blue">{domainApp.domainName}</span> interview!
         </p>
@@ -749,7 +731,7 @@ function InterviewScheduledView({
             <p className="text-lg font-bold text-dark-blue mt-1">{slot.date}</p>
             <p className="text-sm text-dark-blue">{slot.time}</p>
           </div>
-          <StatusBadge label="Scheduled" variant="green" />
+          <InterviewStatusPill status="Scheduled" />
         </div>
         <div className="pt-4 border-t border-border/60">
           <span className="text-xs text-muted-foreground uppercase tracking-wider font-medium">Location</span>
@@ -772,23 +754,23 @@ function InterviewScheduledView({
       <p className="text-sm text-muted-foreground mb-4">A calendar invite has been sent to your Dartmouth email.</p>
 
       <div className="flex flex-wrap items-center gap-3">
-        <button onClick={() => setRescheduling(true)} className="px-5 py-2.5 rounded-full border-2 border-border text-sm font-semibold text-muted-foreground hover:border-accent-coral hover:text-accent-coral transition">
-          Reschedule
-        </button>
+        <Button variant="secondary" size="md" onClick={() => setRescheduling(true)}>
+          Reschedule interview
+        </Button>
         {declining ? (
           <div className="rounded-xl border-2 border-red-200 bg-red-50 px-4 py-3 text-left space-y-2">
-            <p className="text-sm font-semibold text-red-700">This action is final</p>
-            <p className="text-xs text-red-600/80">Cancelling your interview will withdraw you from the interview process for this domain. You will not be able to rebook.</p>
+            <p className="text-sm font-semibold text-red-700">This can't be undone</p>
+            <p className="text-xs text-red-600/80">Cancelling withdraws you from the interview process for this domain, and you won't be able to rebook.</p>
             <div className="flex items-center gap-3 pt-1">
-              <button onClick={handleCancel} disabled={cancelling} className="px-4 py-1.5 rounded-full bg-red-600 text-white text-sm font-semibold hover:bg-red-700 transition disabled:opacity-50">
-                {cancelling ? "Cancelling..." : "Yes, withdraw"}
-              </button>
-              <button onClick={() => setDeclining(false)} className="text-sm font-semibold text-muted-foreground hover:underline">Go back</button>
+              <Button variant="destructive" size="sm" onClick={handleCancel} disabled={cancelling}>
+                {cancelling ? "Cancelling…" : "Yes, cancel my interview"}
+              </Button>
+              <Button variant="ghost" size="sm" onClick={() => setDeclining(false)}>Keep my interview</Button>
             </div>
           </div>
         ) : (
           <button onClick={() => setDeclining(true)} className="text-sm font-semibold text-muted-foreground hover:text-red-500 transition">
-            Cancel Interview
+            Cancel interview
           </button>
         )}
         {cancelError && (
@@ -810,7 +792,7 @@ function PostInterviewPendingView() {
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
         </svg>
       </div>
-      <h2 className="font-heading text-2xl font-bold text-dark-blue mb-3">Interview Complete</h2>
+      <h2 className="font-heading text-2xl font-bold text-dark-blue mb-3">Interview complete</h2>
       <p className="text-muted-foreground leading-relaxed mb-4">
         Thanks for interviewing with us! The team is reviewing all candidates and will share a final decision soon.
       </p>
@@ -900,7 +882,7 @@ function WaitlistedView({ cycleName }: { cycleName: string }) {
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
           </svg>
         </div>
-        <h2 className="font-heading text-2xl font-bold text-dark-blue mb-3">You're on the Waitlist</h2>
+        <h2 className="font-heading text-2xl font-bold text-dark-blue mb-3">You're on the waitlist</h2>
         <p className="text-muted-foreground leading-relaxed max-w-lg mx-auto">
           You performed well in the interview process and we'd love to have you at DALI. We've placed you on the waitlist for {cycleName} and will reach out if a spot becomes available.
         </p>
@@ -963,6 +945,9 @@ function DomainApplicationCard({
       </button>
       {isExpanded && (
         <div className="px-2">
+          <div className="px-4 pt-6 pb-2 sm:px-8">
+            <StatusStepper status={stage} />
+          </div>
           {stage === "Pending" && <PendingView cycleName={cycleName} />}
           {stage === "Rejected" && <RejectedView cycleName={cycleName} />}
           {stage === "InvitedToInterview" && (
@@ -1021,9 +1006,12 @@ export default function Portal() {
 
   if (!cycleId) {
     return (
-      <div className="max-w-2xl mx-auto py-16 text-center px-6">
-        <h2 className="font-heading text-2xl font-bold text-dark-blue mb-3">No Active Cycle</h2>
-        <p className="text-muted-foreground">There is no active application cycle right now. Check back later!</p>
+      <div className="max-w-2xl mx-auto py-16 px-6">
+        <EmptyState
+          icon={CalendarClock}
+          title="No application cycle is open right now"
+          description="There's no active DALI application cycle at the moment. Check back soon — the next one will show up here as soon as it opens."
+        />
       </div>
     );
   }
@@ -1064,16 +1052,12 @@ export default function Portal() {
       {/* Content */}
       <div className="px-6 md:px-16 lg:px-24 py-10">
         {topLevelStage === "ApplicationsClosed" && (
-          <div className="max-w-2xl mx-auto text-center py-16">
-            <div className="w-16 h-16 mx-auto mb-6 rounded-full bg-muted flex items-center justify-center">
-              <svg className="w-8 h-8 text-muted-foreground/70" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
-              </svg>
-            </div>
-            <h2 className="font-heading text-2xl font-bold text-dark-blue mb-3">Applications Closed</h2>
-            <p className="text-muted-foreground leading-relaxed">
-              The application window for {cycleName} has closed. Check back for future application cycles!
-            </p>
+          <div className="max-w-2xl mx-auto py-16">
+            <EmptyState
+              icon={CalendarClock}
+              title="Applications are closed"
+              description={`The application window for ${cycleName} has closed. Check back here for future cycles — we'd love to see you apply next time.`}
+            />
           </div>
         )}
         {topLevelStage === "ApplicationOpen" && <ApplicationOpenView cycleName={cycleName} closeDate={closeDate} />}
@@ -1085,11 +1069,8 @@ export default function Portal() {
                 <p className="text-sm text-blue-800">
                   The cycle is still open — you can still update your application.
                 </p>
-                <Link
-                  to="/portal/apply"
-                  className="shrink-0 px-4 py-2 rounded-full bg-accent-coral text-white text-sm font-semibold hover:bg-accent-coral/90 transition"
-                >
-                  Edit Application
+                <Link to="/portal/apply" className={buttonClasses("primary", "sm", "shrink-0")}>
+                  Edit your application
                 </Link>
               </div>
             )}
@@ -1105,17 +1086,14 @@ export default function Portal() {
                 <p className="text-sm text-blue-800">
                   The cycle is still open — you can still update your application.
                 </p>
-                <Link
-                  to="/portal/apply"
-                  className="shrink-0 px-4 py-2 rounded-full bg-accent-coral text-white text-sm font-semibold hover:bg-accent-coral/90 transition"
-                >
-                  Edit Application
+                <Link to="/portal/apply" className={buttonClasses("primary", "sm", "shrink-0")}>
+                  Edit your application
                 </Link>
               </div>
             )}
             <div className="flex justify-end">
-              <Link to="/portal/application" className="text-sm text-accent-coral hover:underline">
-                View your submission →
+              <Link to="/portal/application" className="text-sm font-semibold text-accent-coral hover:underline">
+                View your submitted application
               </Link>
             </div>
             {das.map(da => (


### PR DESCRIPTION
A **presentation-only** redesign across the whole hiring module — the internal staff dashboards and the applicant-facing portal — staying inside the existing DALI brand (coral/Dosis/semantic tokens). **No changes** to loaders, actions, API/resource routes, form field names, Prisma queries, business logic, derived statuses (`inferDomainApplicationStatus`), the append-only decision model, or role gates.

## Shared design foundation (new)
- **`StatusStepper`** — the signature element: a 4-stage pipeline stepper (Apply → Review → Interview → Decision) driven entirely by the derived `DomainApplicationStatus`, with outcome-toned terminal states (accept / waitlist / reject / withdrawn). Used on the applicant portal and detail views.
- **`PageHeader`**, **`EmptyState`**, and typed **`Pill`** helpers over `labels.ts` — so every surface opens the same way and speaks status the same way, instead of ad-hoc headers and hand-rolled `bg-*-100` chips.
- **`Section`** fixed to semantic tokens (it hardcoded `gray-*`/`white`, which broke dark mode).

## Applied consistently across the module
Hub · reviewer dashboard + review editor · applications table + detail · domain-lead + delibs board · interviews + scheduling · lead cycle management · waitlists · onboarding · library · and the applicant portal (status tracker, application form, submitted view):

- Consistent `PageHeader` + real `EmptyState`s with next steps.
- All status/decision/interview chips routed through the shared `Pill`/`labels.ts` maps (removed local color maps that had drifted).
- One coral primary action per context; everything else secondary/ghost.
- Tightened button/label copy to active voice, sentence case.
- Domain toggle aligned to the app-wide `ViewToggle` style; the **"Domain"** subtab relabeled **"My Domain"** to distinguish it from the all-domains Applications view (route + role gate unchanged).

## Notes
- 38 files, `dali-api/app/**` only. **Presentation-only** — flagged per the realtime/collab caveat: no collaboratively-edited document schemas were touched.
- `npm run typecheck` clean (0 errors across the changed files).
- Branch cut from `origin/dev`, which is currently even with `staging`, so this diff is exactly the redesign.
- Built and reviewed live in a local dev instance during development.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/965"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787264520&installation_model_id=21824&pr_number=965&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F965&signature=14dba99fdf89c3ddcf875f297cf1e055a845fc41b8753164739bd08adb7a8bbc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->