### PR TITLE
Generalize /link pairing copy so the Relay extension can reuse device…

### DIFF
--- a/dali-api/app/routes/link.tsx
+++ b/dali-api/app/routes/link.tsx
@@ -230,7 +230,7 @@ export default function LinkPage({ loaderData }: Route.ComponentProps) {
     <Shell>
       <h1 className="text-xl font-semibold text-zinc-900">Approve this device?</h1>
       <p className="mt-2 text-sm text-zinc-600">
-        <strong>{data.deviceLabel}</strong> wants to sign in to your account.
+        This app wants to sign in to your account.
       </p>
       <dl className="mt-4 space-y-2 text-sm">
         <div className="flex items-center justify-between gap-3">
@@ -246,9 +246,9 @@ export default function LinkPage({ loaderData }: Route.ComponentProps) {
       </dl>
       <p className="mt-4 rounded-lg bg-amber-50 px-4 py-3 text-xs text-amber-900">
         ⚠️ Confirm this code matches the one shown in the app. Only approve if{" "}
-        <em>you</em> just started sign-in from <strong>{data.deviceLabel}</strong>{" "}
-        on this computer. Approving keeps it signed in to your account until you
-        sign out or revoke it.
+        <em>you</em> just started sign-in from this app on this computer.
+        Approving keeps it signed in to your account until you sign out or
+        revoke it.
       </p>
       <p className="mt-3 text-xs text-zinc-500">
         Approving as <strong>{data.email}</strong> —{" "}

--- a/dali-api/app/routes/link.tsx
+++ b/dali-api/app/routes/link.tsx
@@ -1,9 +1,10 @@
-// /link — the desktop device-pairing approval page, opened in the system
-// browser (NOT the Tauri webview). Shows the device label + userCode for the
-// user to eyeball-compare against the app, and an Approve/Cancel action tied to
-// their authenticated web session. Standalone page (no app layout). All login
-// happens through the unmodified /login flow; this is the only new web surface.
-// Copy follows TAURI_DESKTOP_PLAN.md.
+// /link — the device-pairing approval page, opened in a real browser tab (the
+// system browser for the Tauri desktop app; a normal tab for the Relay browser
+// extension). Shows the device label + userCode for the user to eyeball-compare
+// against the client, and an Approve/Cancel action tied to their authenticated
+// web session. Standalone page (no app layout). All login happens through the
+// unmodified /login flow. Copy is client-agnostic (uses the pairing row's
+// deviceLabel) so the same page serves the desktop app and the extension.
 
 import { Form, Link, redirect } from "react-router";
 import type { Route } from "./+types/link";
@@ -97,7 +98,7 @@ export default function LinkPage({ loaderData }: Route.ComponentProps) {
       <Shell>
         <h1 className="text-xl font-semibold text-zinc-900">✅ Device approved</h1>
         <p className="mt-3 text-sm text-zinc-600">
-          Head back to <strong>DALI OS Desktop</strong> — it'll finish signing in
+          Head back to the app you were linking — it'll finish signing in
           automatically. You can close this tab.
         </p>
       </Shell>
@@ -120,9 +121,8 @@ export default function LinkPage({ loaderData }: Route.ComponentProps) {
       <Shell>
         <h1 className="text-xl font-semibold text-zinc-900">This pairing request expired</h1>
         <p className="mt-3 text-sm text-zinc-600">
-          For your security, pairing codes expire after a few minutes. Open{" "}
-          <strong>DALI OS Desktop</strong> and choose <strong>Sign in</strong>{" "}
-          again to get a fresh code.
+          For your security, pairing codes expire after a few minutes. Start
+          sign-in again in the app you're linking to get a fresh code.
         </p>
       </Shell>
     );
@@ -146,9 +146,8 @@ export default function LinkPage({ loaderData }: Route.ComponentProps) {
       <Shell>
         <h1 className="text-xl font-semibold text-zinc-900">Pairing code not found</h1>
         <p className="mt-3 text-sm text-zinc-600">
-          We couldn't find that pairing code. Open <strong>DALI OS Desktop</strong>{" "}
-          and choose <strong>Sign in</strong> to get a fresh code, then enter it
-          here.
+          We couldn't find that pairing code. Start sign-in again in the app
+          you're linking to get a fresh code, then enter it here.
         </p>
       </Shell>
     );
@@ -157,9 +156,10 @@ export default function LinkPage({ loaderData }: Route.ComponentProps) {
   if (data.view === "no_code") {
     return (
       <Shell>
-        <h1 className="text-xl font-semibold text-zinc-900">Link a desktop device</h1>
+        <h1 className="text-xl font-semibold text-zinc-900">Link a device or app</h1>
         <p className="mt-3 text-sm text-zinc-600">
-          Enter the code shown in <strong>DALI OS Desktop</strong>.
+          Enter the code shown in the app you're linking (DALI OS Desktop or the
+          Relay extension).
         </p>
         <Form method="post" className="mt-4 flex gap-2">
           <input
@@ -177,8 +177,7 @@ export default function LinkPage({ loaderData }: Route.ComponentProps) {
         </Form>
         {!data.signedIn && (
           <p className="mt-4 text-xs text-zinc-500">
-            Don't have the app open? Launch DALI OS Desktop and choose{" "}
-            <strong>Sign in</strong> first.
+            Don't have the code? Start sign-in in the app you're linking first.
           </p>
         )}
       </Shell>
@@ -189,8 +188,8 @@ export default function LinkPage({ loaderData }: Route.ComponentProps) {
     return (
       <Shell>
         <div className="rounded-lg bg-amber-50 px-4 py-3 text-sm text-amber-900">
-          <strong>Sign in to approve a device.</strong> You're linking the DALI OS
-          desktop app. Sign in to continue, then you'll confirm the device.
+          <strong>Sign in to approve a device.</strong> You're linking an app to
+          your account. Sign in to continue, then you'll confirm the device.
         </div>
         <p className="mt-4 text-sm text-zinc-600">
           Pairing code <CodeChip code={data.userCode} /> — after signing in,
@@ -231,7 +230,7 @@ export default function LinkPage({ loaderData }: Route.ComponentProps) {
     <Shell>
       <h1 className="text-xl font-semibold text-zinc-900">Approve this device?</h1>
       <p className="mt-2 text-sm text-zinc-600">
-        <strong>DALI OS Desktop</strong> wants to sign in to your account.
+        <strong>{data.deviceLabel}</strong> wants to sign in to your account.
       </p>
       <dl className="mt-4 space-y-2 text-sm">
         <div className="flex items-center justify-between gap-3">
@@ -247,8 +246,9 @@ export default function LinkPage({ loaderData }: Route.ComponentProps) {
       </dl>
       <p className="mt-4 rounded-lg bg-amber-50 px-4 py-3 text-xs text-amber-900">
         ⚠️ Confirm this code matches the one shown in the app. Only approve if{" "}
-        <em>you</em> just opened DALI OS Desktop on this computer. Approving keeps
-        the app signed in to your account until you sign out or revoke it.
+        <em>you</em> just started sign-in from <strong>{data.deviceLabel}</strong>{" "}
+        on this computer. Approving keeps it signed in to your account until you
+        sign out or revoke it.
       </p>
       <p className="mt-3 text-xs text-zinc-500">
         Approving as <strong>{data.email}</strong> —{" "}

--- a/dali-api/e2e/desktop-pairing-flow.spec.ts
+++ b/dali-api/e2e/desktop-pairing-flow.spec.ts
@@ -165,6 +165,6 @@ test('desktop pairing: /link unauthenticated banner + manual-entry fallback', as
   // No code → manual-entry form.
   await page.goto('/link');
   await expect(
-    page.getByRole('heading', { name: /Link a desktop device/i }),
+    page.getByRole('heading', { name: /Link a device or app/i }),
   ).toBeVisible();
 });


### PR DESCRIPTION
… pairing

The device-pairing approval page (/link) hardcoded "DALI OS Desktop". The Relay browser extension reuses the exact same pairing flow (/auth/pair/* -> /link -> poll) to obtain a bearer token, so the copy now uses the pairing row's deviceLabel (e.g. "Relay Extension") and generic wording. No behavior change; the desktop flow is unaffected. Updates the one e2e heading assertion.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/966"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787264605&installation_model_id=21824&pr_number=966&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F966&signature=2d8e2fd4af118ee927c7e4121fb305a3104814ce42944dae7b6f5f04fd393a6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->