### PR TITLE
Term-scoped project board + epic target term

### DIFF
--- a/dali-api/app/projects/components/EpicSprintManager.tsx
+++ b/dali-api/app/projects/components/EpicSprintManager.tsx
@@ -35,12 +35,19 @@ export type EditableEpic = {
   // these over sprint-derived dates.
   startsAt: string | null;
   endsAt: string | null;
+  // Optional target term for cross-term epics — a planning signal ("we intend
+  // to land this in 26F"), not a hard scope. Null when unset. The board's term
+  // filter treats it as one of the terms an epic counts toward.
+  targetTermId: string | null;
   // Collab-doc reference for the epic's rich description (Notion-style),
   // same pattern as the project Overview/PRD pages. Null when none attached.
   descriptionDocId: string | null;
   // User stories under this epic, ordered by position.
   stories: EditableStory[];
 };
+
+// A term the project runs, for the epic target-term picker. Newest first.
+export type EpicTermOption = { id: string; code: string };
 
 export type EditableSprint = {
   id: string;
@@ -59,6 +66,9 @@ type Props = {
   projectId: string;
   epics: EditableEpic[];
   sprints: EditableSprint[];
+  // The project's planned terms (newest first) — options for an epic's
+  // optional target term. Empty hides the picker.
+  terms: EpicTermOption[];
   // Per-epic task progress keyed by epic id (Cancelled tasks excluded from
   // both numbers). Epics with no counted tasks may simply be absent.
   taskCounts: Record<string, { done: number; total: number }>;
@@ -109,6 +119,7 @@ export function EpicSprintManager({
   projectId,
   epics,
   sprints,
+  terms,
   taskCounts,
   canManage,
   collabToken,
@@ -284,6 +295,7 @@ export function EpicSprintManager({
         </p>
         <EpicForm
           busy={busy}
+          terms={terms}
           onCancel={() => setNewEpicOpen(false)}
           onSubmit={(values) =>
             run(async () => {
@@ -315,6 +327,7 @@ export function EpicSprintManager({
             projectId={projectId}
             epic={activeEpic}
             sprints={sprints.filter((s) => s.epicId === activeEpic.id)}
+            terms={terms}
             canManage={canManage}
             busy={busy}
             startInEdit={openInEdit}
@@ -748,6 +761,7 @@ function EpicDetail({
   projectId,
   epic,
   sprints,
+  terms,
   canManage,
   busy,
   startInEdit,
@@ -763,6 +777,7 @@ function EpicDetail({
   projectId: string;
   epic: EditableEpic;
   sprints: EditableSprint[];
+  terms: EpicTermOption[];
   canManage: boolean;
   busy: boolean;
   // When true the detail panel opens with the epic edit form already
@@ -954,6 +969,7 @@ function EpicDetail({
           <EpicForm
             busy={busy}
             initial={epic}
+            terms={terms}
             title={draftTitle}
             hideTitle
             onCancel={() => {
@@ -971,6 +987,15 @@ function EpicDetail({
           <div className="flex items-center justify-between text-xs">
             <div className="flex flex-wrap items-center gap-3 text-muted-foreground">
               <span>Status: <span className="text-foreground">{epic.status}</span></span>
+              {epic.targetTermId && (
+                <span>
+                  Target term:{" "}
+                  <span className="text-foreground">
+                    {terms.find((t) => t.id === epic.targetTermId)?.code ??
+                      "—"}
+                  </span>
+                </span>
+              )}
               {epic.startsAt && (
                 <span>
                   Start:{" "}
@@ -1258,6 +1283,7 @@ function EpicDetail({
 function EpicForm({
   initial,
   busy,
+  terms,
   onSubmit,
   onCancel,
   hideTitle = false,
@@ -1265,9 +1291,11 @@ function EpicForm({
 }: {
   initial?: EditableEpic;
   busy: boolean;
+  terms: EpicTermOption[];
   onSubmit: (values: {
     title: string;
     status: string;
+    targetTermId: string | null;
     startsAt: string | null;
     endsAt: string | null;
   }) => void;
@@ -1279,6 +1307,7 @@ function EpicForm({
   const [titleInternal, setTitleInternal] = useState(initial?.title ?? "");
   const title = hideTitle ? (titleProp ?? "") : titleInternal;
   const [status, setStatus] = useState(initial?.status ?? "Open");
+  const [targetTermId, setTargetTermId] = useState(initial?.targetTermId ?? "");
   const [startsAt, setStartsAt] = useState(
     initial?.startsAt ? dateInputValue(initial.startsAt) : "",
   );
@@ -1293,6 +1322,8 @@ function EpicForm({
         onSubmit({
           title,
           status,
+          // Empty → null clears the target term.
+          targetTermId: targetTermId || null,
           // Dates are optional for epics; empty → null clears the field.
           startsAt: startsAt ? new Date(startsAt).toISOString() : null,
           endsAt: endsAt ? new Date(endsAt).toISOString() : null,
@@ -1326,6 +1357,25 @@ function EpicForm({
             ))}
           </select>
         </label>
+        {/* Optional target term — a planning signal for cross-term epics, not
+            a hard scope. Only offered once the project has terms. */}
+        {terms.length > 0 && (
+          <label className="flex flex-col gap-1 text-xs">
+            <span className="text-muted-foreground">Target term (optional)</span>
+            <select
+              value={targetTermId}
+              onChange={(e) => setTargetTermId(e.target.value)}
+              className="px-2 py-1.5 text-sm border border-border rounded-md bg-background text-foreground"
+            >
+              <option value="">No target term</option>
+              {terms.map((t) => (
+                <option key={t.id} value={t.id}>
+                  {t.code}
+                </option>
+              ))}
+            </select>
+          </label>
+        )}
         {/* Start + End stay paired on one line even when the row wraps. */}
         <div className="flex items-end gap-2">
           <label className="flex flex-col gap-1 text-xs">

--- a/dali-api/app/projects/components/TaskBoard.tsx
+++ b/dali-api/app/projects/components/TaskBoard.tsx
@@ -44,6 +44,9 @@ const PRIORITY_TONE: Record<Priority, string> = {
 
 // The `?epic=` filter value for tasks with no epic.
 const NO_EPIC = "none";
+// The `?term=` filter value that shows every term (opts out of the default
+// current-term scoping).
+const ALL_TERMS = "all";
 
 export function TaskBoard({
   projectId,
@@ -82,6 +85,31 @@ export function TaskBoard({
   const openTaskId = searchParams.get("task");
   const epicFilter = searchParams.get("epic");
   const sprintFilter = searchParams.get("sprint");
+  const termParam = searchParams.get("term");
+
+  // The term filter only makes sense once the project spans more than one term
+  // (its options are the project's terms + any term a sprint lands in). With
+  // one term there's nothing to slice between, so it's hidden and the board
+  // shows everything.
+  const termFilterEnabled = options.terms.length >= 2;
+  // Effective term: an explicit `?term=` wins; otherwise default to the lab's
+  // current term when the project runs it (the whole point — open the board on
+  // this term's work, not the full multi-term backlog). `all` opts out.
+  const effectiveTerm = useMemo(() => {
+    if (!termFilterEnabled) return ALL_TERMS;
+    if (termParam === ALL_TERMS) return ALL_TERMS;
+    if (termParam && options.terms.some((t) => t.id === termParam)) {
+      return termParam;
+    }
+    return options.currentTermId ?? ALL_TERMS;
+  }, [termFilterEnabled, termParam, options.terms, options.currentTermId]);
+
+  const sprintTermById = useMemo(() => {
+    const m = new Map<string, string | null>();
+    for (const s of options.sprints) m.set(s.id, s.termId);
+    return m;
+  }, [options.sprints]);
+
   const setParam = useCallback(
     (key: string, value: string | null) => {
       setSearchParams(
@@ -112,19 +140,54 @@ export function TaskBoard({
     },
     [setSearchParams],
   );
+  // Changing term drops the sprint sub-filter (a sprint from another term
+  // would otherwise leave the board empty) — the epic filter stays put; its
+  // pill is kept visible below even when pruned so it can still be cleared.
+  const setTermFilter = useCallback(
+    (value: string) => {
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          next.set("term", value);
+          next.delete("sprint");
+          return next;
+        },
+        { replace: true, preventScrollReset: true },
+      );
+    },
+    [setSearchParams],
+  );
   const setOpenTaskId = useCallback(
     (id: string | null) => setParam("task", id),
     [setParam],
   );
 
   // Sprint sub-filter only applies within a concrete epic; its options are that
-  // epic's sprints.
+  // epic's sprints, scoped to the selected term so the sub-pills never offer a
+  // sprint that the term filter would then hide.
   const epicSprints = useMemo(
     () =>
       epicFilter && epicFilter !== NO_EPIC
-        ? options.sprints.filter((s) => s.epicId === epicFilter)
+        ? options.sprints.filter(
+            (s) =>
+              s.epicId === epicFilter &&
+              (effectiveTerm === ALL_TERMS || s.termId === effectiveTerm),
+          )
         : [],
-    [options.sprints, epicFilter],
+    [options.sprints, epicFilter, effectiveTerm],
+  );
+
+  // Epic pills for the selected term: an epic shows only if it has work in the
+  // term (its termIds cover it). The currently-selected epic is always kept so
+  // it stays deselectable even when it has nothing in this term.
+  const visibleEpics = useMemo(
+    () =>
+      effectiveTerm === ALL_TERMS
+        ? options.epics
+        : options.epics.filter(
+            (e) => e.termIds.includes(effectiveTerm) || e.id === epicFilter,
+          ),
+    [options.epics, effectiveTerm, epicFilter],
   );
 
   const filteredTasks = useMemo(() => {
@@ -132,8 +195,18 @@ export function TaskBoard({
     if (epicFilter === NO_EPIC) ts = ts.filter((t) => t.epicId === null);
     else if (epicFilter) ts = ts.filter((t) => t.epicId === epicFilter);
     if (sprintFilter) ts = ts.filter((t) => t.sprintId === sprintFilter);
+    if (effectiveTerm !== ALL_TERMS) {
+      ts = ts.filter((t) =>
+        // Backlog (no sprint) is term-less — always visible so it stays the
+        // pool you plan the term from. A sprinted task shows only if its
+        // sprint resolves to the selected term.
+        t.sprintId === null
+          ? true
+          : sprintTermById.get(t.sprintId) === effectiveTerm,
+      );
+    }
     return ts;
-  }, [tasks, epicFilter, sprintFilter]);
+  }, [tasks, epicFilter, sprintFilter, effectiveTerm, sprintTermById]);
 
   const board = useMemo(() => buildTaskBoard(filteredTasks), [filteredTasks]);
   const openTask = openTaskId ? tasks.find((t) => t.id === openTaskId) ?? null : null;
@@ -321,21 +394,47 @@ export function TaskBoard({
   }));
 
   // Epic pills slice the board to one epic's tasks, plus "No epic" for tasks
-  // that aren't in any epic.
-  const showEpicFilter = options.epics.length > 0;
+  // that aren't in any epic. Under a term filter the pill set is pruned to
+  // epics with work in that term.
+  const showEpicFilter = visibleEpics.length > 0;
 
   return (
     <div className="flex flex-col gap-3">
       <Confetti trigger={celebrate} onFire={() => setCelebrate(false)} />
       <div className="flex flex-wrap items-center gap-2">
+        {termFilterEnabled && (
+          <label className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
+            <span className="font-medium">Term</span>
+            <select
+              value={effectiveTerm}
+              onChange={(e) => setTermFilter(e.target.value)}
+              aria-label="Filter board by term"
+              className="px-2 py-1 text-xs border border-border rounded-full bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-accent-coral/30"
+            >
+              {options.terms.map((t) => (
+                <option key={t.id} value={t.id}>
+                  {t.code}
+                  {t.id === options.currentTermId ? " · current" : ""}
+                </option>
+              ))}
+              <option value={ALL_TERMS}>All terms</option>
+            </select>
+          </label>
+        )}
         {showEpicFilter && (
-          <div className="flex flex-wrap items-center gap-1.5" role="group" aria-label="Filter by epic">
+          <div
+            className={`flex flex-wrap items-center gap-1.5 ${
+              termFilterEnabled ? "pl-2 border-l border-border" : ""
+            }`}
+            role="group"
+            aria-label="Filter by epic"
+          >
             <FilterPill
               label="All"
               active={epicFilter === null}
               onClick={() => setEpicFilter(null)}
             />
-            {options.epics.map((e) => (
+            {visibleEpics.map((e) => (
               <FilterPill
                 key={e.id}
                 label={e.title}

--- a/dali-api/app/projects/lib/__tests__/task-board.test.ts
+++ b/dali-api/app/projects/lib/__tests__/task-board.test.ts
@@ -3,7 +3,10 @@ import {
   buildTaskBoard,
   moveTaskInBoard,
   nextPositionInColumn,
+  resolveTermIdForDate,
+  termIdsInRange,
   type TaskCardModel,
+  type TermWindow,
 } from "../task-board";
 
 function task(
@@ -94,5 +97,94 @@ describe("nextPositionInColumn", () => {
     const board = buildTaskBoard(TASKS);
     expect(nextPositionInColumn(board, "Done")).toBe(0);
     expect(nextPositionInColumn(board, "Todo")).toBe(3);
+  });
+});
+
+// Three consecutive terms with a one-week gap between each (the inter-term
+// break). Ascending, as the resolvers require.
+const TERMS: TermWindow[] = [
+  {
+    id: "spring",
+    startDate: new Date("2026-03-30T00:00:00.000Z"),
+    endDate: new Date("2026-06-01T00:00:00.000Z"),
+  },
+  {
+    id: "summer",
+    startDate: new Date("2026-06-22T00:00:00.000Z"),
+    endDate: new Date("2026-08-31T00:00:00.000Z"),
+  },
+  {
+    id: "fall",
+    startDate: new Date("2026-09-14T00:00:00.000Z"),
+    endDate: new Date("2026-12-01T00:00:00.000Z"),
+  },
+];
+
+describe("resolveTermIdForDate", () => {
+  it("resolves a date inside a term's window to that term", () => {
+    expect(resolveTermIdForDate(TERMS, new Date("2026-07-15T00:00:00Z"))).toBe(
+      "summer",
+    );
+  });
+
+  it("rolls a break-week date forward to the next term", () => {
+    // Between Spring's end and Summer's start — counts toward Summer.
+    expect(resolveTermIdForDate(TERMS, new Date("2026-06-10T00:00:00Z"))).toBe(
+      "summer",
+    );
+  });
+
+  it("resolves a date before every term to the first term", () => {
+    expect(resolveTermIdForDate(TERMS, new Date("2026-01-01T00:00:00Z"))).toBe(
+      "spring",
+    );
+  });
+
+  it("returns null for a date after the last term ends", () => {
+    expect(
+      resolveTermIdForDate(TERMS, new Date("2027-01-01T00:00:00Z")),
+    ).toBeNull();
+  });
+
+  it("treats the endDate boundary as still in-term", () => {
+    expect(resolveTermIdForDate(TERMS, TERMS[0].endDate)).toBe("spring");
+  });
+});
+
+describe("termIdsInRange", () => {
+  it("returns terms whose windows overlap the span", () => {
+    expect(
+      termIdsInRange(
+        TERMS,
+        new Date("2026-05-15T00:00:00Z"),
+        new Date("2026-07-15T00:00:00Z"),
+      ),
+    ).toEqual(["spring", "summer"]);
+  });
+
+  it("treats a null start as open-ended on the left", () => {
+    expect(
+      termIdsInRange(TERMS, null, new Date("2026-06-25T00:00:00Z")),
+    ).toEqual(["spring", "summer"]);
+  });
+
+  it("treats a null end as open-ended on the right", () => {
+    expect(
+      termIdsInRange(TERMS, new Date("2026-08-01T00:00:00Z"), null),
+    ).toEqual(["summer", "fall"]);
+  });
+
+  it("returns nothing when both bounds are null (no dated span)", () => {
+    expect(termIdsInRange(TERMS, null, null)).toEqual([]);
+  });
+
+  it("returns a single term for a span fully inside one window", () => {
+    expect(
+      termIdsInRange(
+        TERMS,
+        new Date("2026-07-01T00:00:00Z"),
+        new Date("2026-07-10T00:00:00Z"),
+      ),
+    ).toEqual(["summer"]);
   });
 });

--- a/dali-api/app/projects/lib/task-board.ts
+++ b/dali-api/app/projects/lib/task-board.ts
@@ -68,9 +68,20 @@ export type BoardSprint = {
   // The epic this sprint belongs to (null = standalone). Powers the modal's
   // cascading Epic → Sprint picker: pick an epic, then only its sprints show.
   epicId: string | null;
+  // The Term this sprint falls in, resolved from its start date by the loader
+  // (see resolveTermIdForDate). Null when the Term table has no term at or
+  // after the sprint's start. Powers the board's term filter.
+  termId: string | null;
 };
 
-export type BoardEpic = { id: string; title: string };
+export type BoardEpic = {
+  id: string;
+  title: string;
+  // Terms this epic has work in — union of its sprints' resolved terms, terms
+  // overlapping its effective date span, and its explicit target term. The
+  // board's term filter prunes epic pills whose termIds miss the selected term.
+  termIds: string[];
+};
 
 // Choices the TaskModal needs to populate its assignee + domain dropdowns.
 // Loader fetches once per board render and passes through to TaskBoard.
@@ -86,7 +97,52 @@ export type TaskBoardOptions = {
   epics: BoardEpic[];
   // Live project files for the modal's "attach existing artifact" picker.
   projectFiles: { id: string; title: string }[];
+  // Term filter options: the project's planned terms plus any term a sprint
+  // resolves to, newest first. Fewer than two terms hides the filter.
+  terms: { id: string; code: string }[];
+  // The lab's current term when it appears in `terms` — the board's default
+  // filter selection. Null (project doesn't run this term) defaults to All.
+  currentTermId: string | null;
 };
+
+// Minimal Term shape the resolvers need. Callers pass terms sorted
+// chronologically (ascending sortKey/startDate).
+export type TermWindow = { id: string; startDate: Date; endDate: Date };
+
+/**
+ * Resolve the term a date falls in: the term whose [startDate, endDate]
+ * window contains it, or — for dates in an inter-term gap (break weeks) —
+ * the next upcoming term, mirroring currentTerm()'s roll-forward so a sprint
+ * planned during the break before a term counts toward that term. Null when
+ * the date is after every term's end.
+ */
+export function resolveTermIdForDate(
+  terms: TermWindow[],
+  date: Date,
+): string | null {
+  for (const t of terms) {
+    if (date <= t.endDate) return t.id;
+  }
+  return null;
+}
+
+/**
+ * Terms whose windows overlap [start, end]. Either bound may be null
+ * (open-ended): a null start matches every term up to `end`, a null end every
+ * term from `start` on. Both null = no dated span = no terms.
+ */
+export function termIdsInRange(
+  terms: TermWindow[],
+  start: Date | null,
+  end: Date | null,
+): string[] {
+  if (!start && !end) return [];
+  return terms
+    .filter(
+      (t) => (!start || t.endDate >= start) && (!end || t.startDate <= end),
+    )
+    .map((t) => t.id);
+}
 
 export type TaskBoard = Record<TaskStatus, TaskCardModel[]>;
 

--- a/dali-api/app/projects/routes/projects.$id.tsx
+++ b/dali-api/app/projects/routes/projects.$id.tsx
@@ -48,11 +48,13 @@ import {
   type EditableEpic,
   type EditableSprint,
 } from "../components/EpicSprintManager";
-import type {
-  TaskBoardOptions,
-  TaskCardModel,
-  TaskStatus,
-  Priority,
+import {
+  resolveTermIdForDate,
+  termIdsInRange,
+  type TaskBoardOptions,
+  type TaskCardModel,
+  type TaskStatus,
+  type Priority,
 } from "../lib/task-board";
 import { groupFilesByEpic } from "../lib/file-groups";
 
@@ -237,6 +239,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
           status: true,
           startsAt: true,
           endsAt: true,
+          targetTermId: true,
           descriptionDocId: true,
           stories: {
             orderBy: { position: "asc" },
@@ -463,6 +466,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     status: e.status as EditableEpic["status"],
     startsAt: e.startsAt ? e.startsAt.toISOString() : null,
     endsAt: e.endsAt ? e.endsAt.toISOString() : null,
+    targetTermId: e.targetTermId,
     descriptionDocId: e.descriptionDocId,
     stories: e.stories.map((s) => ({
       id: s.id,
@@ -509,40 +513,6 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     createdBy: { id: t.createdBy.id, name: fullName(t.createdBy) },
     createdAt: t.createdAt.toISOString(),
   }));
-
-  // Board option lists for the TaskModal: members assignable on this project
-  // (deduped across terms — same person across multiple terms shows once) and
-  // every active domain.
-  const memberMap = new Map<string, string>();
-  for (const a of project.assignments) {
-    const id = a.user.id;
-    if (!memberMap.has(id)) {
-      memberMap.set(id, fullName(a.user));
-    }
-  }
-  const sprintFilterOrder = { Active: 0, Planned: 1, Closed: 2 } as const;
-  const boardOptions: TaskBoardOptions = {
-    members: [...memberMap.entries()]
-      .map(([id, name]) => ({ id, name }))
-      .sort((a, b) => a.name.localeCompare(b.name)),
-    domains: (
-      await prisma.domain.findMany({
-        where: { active: true },
-        orderBy: { displayName: "asc" },
-        select: { id: true, displayName: true },
-      })
-    ).map((d) => ({ id: d.id, name: d.displayName })),
-    repoUrls: project.repoUrls,
-    sprints: [...sprints]
-      .sort(
-        (a, b) =>
-          sprintFilterOrder[a.status] - sprintFilterOrder[b.status] ||
-          a.startsAt.localeCompare(b.startsAt),
-      )
-      .map((s) => ({ id: s.id, name: s.name, status: s.status, epicId: s.epicId })),
-    epics: project.epics.map((e) => ({ id: e.id, title: e.title })),
-    projectFiles: files.map((f) => ({ id: f.id, title: f.title })),
-  };
 
   // Per-epic task progress for the epic list rows + timeline tooltips.
   // Cancelled tasks don't count toward either side.
@@ -656,9 +626,17 @@ export async function loader({ request, params }: Route.LoaderArgs) {
       select: { domainId: true },
       distinct: ["domainId"],
     }),
+    // Ascending (chronological) for the sprint→term resolvers below; the
+    // display option lists re-sort to newest-first where needed.
     prisma.term.findMany({
-      orderBy: { sortKey: "desc" },
-      select: { id: true, code: true },
+      orderBy: { sortKey: "asc" },
+      select: {
+        id: true,
+        code: true,
+        sortKey: true,
+        startDate: true,
+        endDate: true,
+      },
     }),
   ]);
   const declaredDomains = project.domains.map((d) => ({
@@ -684,6 +662,85 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   const current = await currentTerm();
   const isActiveThisTerm =
     current !== null && plannedTerms.some((t) => t.id === current.id);
+
+  // ─── Board term derivation ───────────────────────────────────────────────
+  // Term-ness on the board is derived, not stored: a sprint's term is the one
+  // its start date falls in (roll-forward through break weeks, mirroring
+  // currentTerm()), and an epic's term footprint is the union of its sprints'
+  // terms, the terms its effective span overlaps, and its explicit target
+  // term. Term.startDate/endDate stays the single source of truth, so a sprint
+  // can never drift out of sync with "its" term. `allTerms` is ascending here,
+  // which resolveTermIdForDate/termIdsInRange rely on.
+  const sprintTermId = new Map<string, string | null>();
+  for (const s of project.sprints) {
+    sprintTermId.set(s.id, resolveTermIdForDate(allTerms, s.startsAt));
+  }
+  // Effective epic span (explicit dates expanded by sprint union) is already
+  // computed as ISO strings on `epics`; index it for the range overlap.
+  const epicSpanById = new Map(
+    epics.map((e) => [e.id, { startsAt: e.startsAt, endsAt: e.endsAt }]),
+  );
+  const boardEpics = project.epics.map((e) => {
+    const ids = new Set<string>();
+    for (const s of project.sprints) {
+      if (s.epicId !== e.id) continue;
+      const tid = sprintTermId.get(s.id);
+      if (tid) ids.add(tid);
+    }
+    const span = epicSpanById.get(e.id);
+    const start = span?.startsAt ? new Date(span.startsAt) : null;
+    const end = span?.endsAt ? new Date(span.endsAt) : null;
+    for (const tid of termIdsInRange(allTerms, start, end)) ids.add(tid);
+    if (e.targetTermId) ids.add(e.targetTermId);
+    return { id: e.id, title: e.title, termIds: [...ids] };
+  });
+  // Term filter options: the project's planned terms plus any term a sprint
+  // actually resolves to (a sprint may land in a term not in the planned set).
+  const boardTermIds = new Set<string>();
+  for (const t of plannedTerms) boardTermIds.add(t.id);
+  for (const tid of sprintTermId.values()) if (tid) boardTermIds.add(tid);
+  const boardTerms = allTerms
+    .filter((t) => boardTermIds.has(t.id))
+    .sort((a, b) => b.sortKey - a.sortKey)
+    .map((t) => ({ id: t.id, code: t.code }));
+  const boardCurrentTermId =
+    current && boardTermIds.has(current.id) ? current.id : null;
+
+  // Board option lists for the TaskModal: members assignable on this project
+  // (deduped across terms — same person across multiple terms shows once) and
+  // every active domain (reuses the `allDomains` fetch above).
+  const memberMap = new Map<string, string>();
+  for (const a of project.assignments) {
+    const id = a.user.id;
+    if (!memberMap.has(id)) {
+      memberMap.set(id, fullName(a.user));
+    }
+  }
+  const sprintFilterOrder = { Active: 0, Planned: 1, Closed: 2 } as const;
+  const boardOptions: TaskBoardOptions = {
+    members: [...memberMap.entries()]
+      .map(([id, name]) => ({ id, name }))
+      .sort((a, b) => a.name.localeCompare(b.name)),
+    domains: allDomains.map((d) => ({ id: d.id, name: d.displayName })),
+    repoUrls: project.repoUrls,
+    sprints: [...sprints]
+      .sort(
+        (a, b) =>
+          sprintFilterOrder[a.status] - sprintFilterOrder[b.status] ||
+          a.startsAt.localeCompare(b.startsAt),
+      )
+      .map((s) => ({
+        id: s.id,
+        name: s.name,
+        status: s.status,
+        epicId: s.epicId,
+        termId: sprintTermId.get(s.id) ?? null,
+      })),
+    epics: boardEpics,
+    projectFiles: files.map((f) => ({ id: f.id, title: f.title })),
+    terms: boardTerms,
+    currentTermId: boardCurrentTermId,
+  };
 
   // Fetch all scope rows for this project (small N — at most |declared| ×
   // termCount, both single-digit in practice). Keyed by domainId+termId so
@@ -860,7 +917,9 @@ export async function loader({ request, params }: Route.LoaderArgs) {
       code: t.code,
       sortKey: t.sortKey,
     })),
-    allTermOptions: allTerms,
+    allTermOptions: [...allTerms]
+      .sort((a, b) => b.sortKey - a.sortKey)
+      .map((t) => ({ id: t.id, code: t.code })),
     domainScopeGrid,
     teams,
     termStatuses,
@@ -1363,6 +1422,7 @@ export default function ProjectDetail() {
           epics={epics}
           editableEpics={editableEpics}
           sprints={sprints}
+          terms={plannedTerms}
           taskCountsByEpic={taskCountsByEpic}
           canEdit={canEdit}
           collabToken={collabToken}
@@ -3574,6 +3634,7 @@ function PlanningTab({
   epics,
   editableEpics,
   sprints,
+  terms,
   taskCountsByEpic,
   canEdit,
   collabToken,
@@ -3583,6 +3644,7 @@ function PlanningTab({
   epics: TimelineEpic[];
   editableEpics: EditableEpic[];
   sprints: EditableSprint[];
+  terms: { id: string; code: string }[];
   taskCountsByEpic: Record<string, { done: number; total: number }>;
   canEdit: boolean;
   collabToken: string | null;
@@ -3608,6 +3670,7 @@ function PlanningTab({
         projectId={projectId}
         epics={editableEpics}
         sprints={sprints}
+        terms={terms}
         taskCounts={taskCountsByEpic}
         canManage={canEdit}
         collabToken={collabToken}


### PR DESCRIPTION
## Why

Projects run across multiple terms, but the taskboard showed **every** task from every sprint at once — a busy, undifferentiated board — and the term concept lived only at the project-planning level. This strengthens the tie between terms and project work: the board can now focus on the current term's work, and epics can carry an optional target term.

Two questions drove the design:

- **Should epics be term-tied?** No — not with a required term. Epics are exactly the thing that *crosses* terms, and a hard tie forces close-and-clone busywork at every term boundary. Instead, **sprints** are the term-shaped unit (short, dated, sit inside a term by construction), and a sprint's term is *derived* from its dates. Epics get a derived term footprint plus the already-existing (but never surfaced) `Epic.targetTermId` as an optional planning signal.
- **Filter to reduce a busy board?** Yes — a term filter that **defaults to the current term**, so the board opens on this term's work rather than the full multi-term backlog.

No schema change: `Term.startDate/endDate` stays the single source of truth, so a sprint can never drift out of sync with "its" term.

## What changed

**Loader (`projects.$id.tsx`)**
- Resolve each sprint's term from its start date against Term windows, with the same break-week roll-forward as `currentTerm()` (a sprint planned during the break before a term counts toward that term).
- Roll each epic up to the set of terms it touches: union of its sprints' terms, terms overlapping its effective span, and its explicit target term.
- Pass term options (project's planned terms + any term a sprint lands in) and the default current-term id into board options.
- Reuse the existing active-domains fetch for board options — drops one duplicate query.

**Board (`TaskBoard.tsx`)**
- Term selector, gated to projects spanning ≥2 terms, defaulting to the lab's current term when the project runs it; `?term=` keeps it shareable; **All terms** opts out.
- Tasks filter by their sprint's resolved term. **Backlog (sprintless) tasks stay visible under any term** — they're the pool you plan the term from.
- Epic pills with no work in the selected term are pruned (the currently-selected epic pill is always kept so it stays deselectable). Sprint sub-pills are term-scoped too.

**Epic form (`EpicSprintManager.tsx`)**
- Optional **Target term** select in the epic create/edit form, and the target term shown in the epic detail read view. The API routes and MCP tools already accepted `targetTermId` — only the web UI field was missing.

## Tests
- Unit tests for the new `resolveTermIdForDate` / `termIdsInRange` helpers (17 in the task-board suite; full projects + MCP epic suites green — 256 tests).
- `typecheck` adds no new errors (3 pre-existing failures in unrelated Modal test + seed files remain).

## Notes for review
- Purely derived term-ness — **no migration**.
- Behavior is unchanged for single-term projects (filter hidden) and for viewers on a project that doesn't run the current term (defaults to All terms, shows everything).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/969"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787269221&installation_model_id=21824&pr_number=969&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F969&signature=c1e505413ed77545122b0912487453af6c472ce248de55f988e632d061e2dc97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->