### PR TITLE
Fix meeting reminders stuck in Tasks with no way to dismiss.

### DIFF
--- a/dali-api/app/jobs/__tests__/meeting-reminders.test.ts
+++ b/dali-api/app/jobs/__tests__/meeting-reminders.test.ts
@@ -56,6 +56,7 @@ describe("runMeetingReminders", () => {
           kind: "MeetingReminder",
           title: "Starting soon: Design sync",
           scheduledMeetingId: "m1",
+          dueAt: IN_10_MIN,
         }),
       }),
     );

--- a/dali-api/app/jobs/meeting-reminders.server.ts
+++ b/dali-api/app/jobs/meeting-reminders.server.ts
@@ -93,6 +93,9 @@ export async function runMeetingReminders({ now, settings }: JobContext): Promis
               body: `Starts ${formatApplicationDateTime(occ.start)}.`,
               link: `/calendar?meeting=${meeting.id}`,
               scheduledMeetingId: meeting.id,
+              // Stamp the occurrence start so past reminders drop off Tasks
+              // once the meeting has begun (see listOpenTasks).
+              dueAt: occ.start,
             },
             recipients: [{ userId }],
           });

--- a/dali-api/app/lib/__tests__/tasks.test.ts
+++ b/dali-api/app/lib/__tests__/tasks.test.ts
@@ -38,7 +38,8 @@ beforeEach(() => {
 });
 
 // The where clause the Tasks views filter on. Cancelled-meeting invites and
-// stale interview-assignment notifications must both be excluded.
+// stale interview-assignment notifications must both be excluded. Past
+// MeetingReminder rows (dueAt in the past) drop off live Tasks too.
 function expectedWhere(userId: string) {
   return {
     recipientUserId: userId,
@@ -48,6 +49,23 @@ function expectedWhere(userId: string) {
         OR: [
           { scheduledMeetingId: null },
           { scheduledMeeting: { status: { not: "Cancelled" } } },
+        ],
+      },
+      {
+        OR: [
+          { kind: { not: "MeetingReminder" } },
+          { dueAt: { gt: expect.any(Date) } },
+          {
+            AND: [
+              { dueAt: null },
+              {
+                OR: [
+                  { scheduledMeeting: { selectedAt: { gt: expect.any(Date) } } },
+                  { scheduledMeeting: { selectedAt: null } },
+                ],
+              },
+            ],
+          },
         ],
       },
     ],
@@ -119,6 +137,37 @@ describe("listOpenTasks", () => {
       id: "n2",
       source: "general",
       hasAction: false,
+    });
+  });
+
+  it("treats MeetingReminder as dismissible (hasAction false) even with scheduledMeetingId", async () => {
+    mockPrisma.notification.findMany.mockResolvedValue([
+      {
+        id: "n3",
+        kind: "MeetingReminder",
+        title: "Starting soon: Design sync",
+        body: "Starts Fri, May 22, 11:00 AM",
+        link: "/calendar?meeting=m1",
+        dueAt: new Date("2026-05-22T15:00:00Z"),
+        createdAt: new Date("2026-05-22T14:45:00Z"),
+        readAt: null,
+        formId: null,
+        scheduledMeetingId: "m1",
+        scheduledMeeting: {
+          selectedAt: new Date("2026-05-22T15:00:00Z"),
+          status: "Confirmed",
+        },
+        interviewAssignment: null,
+        form: null,
+      },
+    ]);
+
+    const tasks = await listOpenTasks("user-1");
+    expect(tasks[0]).toMatchObject({
+      id: "n3",
+      source: "reminder",
+      hasAction: false,
+      dueAt: "2026-05-22T15:00:00.000Z",
     });
   });
 });

--- a/dali-api/app/lib/tasks.ts
+++ b/dali-api/app/lib/tasks.ts
@@ -11,7 +11,9 @@ import { fullName } from "~/lib/display";
 // link, submitting the attached form, or hitting "mark all read") clears it
 // from tasks. Meeting invites are the exception: they only clear once the
 // recipient RSVPs (Accept/Maybe/Decline), and they drop off automatically once
-// the meeting is Cancelled — see TASK_WHERE.
+// the meeting is Cancelled — see TASK_WHERE. Meeting reminders ("Starting
+// soon") are dismissible like any other ping, and also drop off once their
+// occurrence time (dueAt) has passed.
 //
 //   MeetingInvite + scheduledMeetingId → "meeting"  (carries RSVP target)
 //   kind === MeetingReminder           → "reminder" (calendar fan-out)
@@ -98,7 +100,10 @@ export function resolveNotificationState(
   return "Open";
 }
 
-const TASK_WHERE = (userId: string): Prisma.NotificationWhereInput => ({
+const TASK_WHERE = (
+  userId: string,
+  now = new Date(),
+): Prisma.NotificationWhereInput => ({
   recipientUserId: userId,
   readAt: null,
   // A meeting-invite notification drops off Tasks the moment its meeting is
@@ -109,6 +114,27 @@ const TASK_WHERE = (userId: string): Prisma.NotificationWhereInput => ({
       OR: [
         { scheduledMeetingId: null },
         { scheduledMeeting: { status: { not: "Cancelled" } } },
+      ],
+    },
+    // "Starting soon" reminders stamp dueAt to the occurrence start. Once that
+    // time has passed the ping is stale — drop it from live Tasks. Pre-fix
+    // reminders with null dueAt fall back to the meeting's selectedAt so
+    // already-started one-offs clear without a manual dismiss.
+    {
+      OR: [
+        { kind: { not: "MeetingReminder" } },
+        { dueAt: { gt: now } },
+        {
+          AND: [
+            { dueAt: null },
+            {
+              OR: [
+                { scheduledMeeting: { selectedAt: { gt: now } } },
+                { scheduledMeeting: { selectedAt: null } },
+              ],
+            },
+          ],
+        },
       ],
     },
   ],
@@ -232,7 +258,13 @@ export async function listOpenTasks(userId: string): Promise<Task[]> {
             : "general";
 
     const meetingDue = n.scheduledMeeting?.selectedAt?.toISOString() ?? null;
-    const dueAt = meetingDue ?? (n.dueAt ? n.dueAt.toISOString() : null);
+    const notifDue = n.dueAt ? n.dueAt.toISOString() : null;
+    // Reminders stamp dueAt to the specific occurrence; prefer that over the
+    // series selectedAt so recurring meetings show the right chip.
+    const dueAt =
+      n.kind === "MeetingReminder"
+        ? notifDue ?? meetingDue
+        : meetingDue ?? notifDue;
 
     // Authenticated fill route (not the public /f/ one): the recipient is a
     // logged-in user, and the authed submit is what marks this todo read so
@@ -247,9 +279,13 @@ export async function listOpenTasks(userId: string): Promise<Task[]> {
     // bare link doesn't count: opening it isn't the same as being done. The
     // onboarding task clears only when the member completes the profile form
     // (see submitMemberForm), so it must NOT offer a manual Confirm.
+    // Meeting reminders carry scheduledMeetingId but clear by Confirm / mark-
+    // read, not RSVP — only invites are self-clearing via the meeting link.
     const isOnboarding =
       n.kind === "SystemAnnouncement" && n.link === ONBOARDING_LINK;
-    const hasAction = !!n.scheduledMeetingId || !!formLink || isOnboarding;
+    const isMeetingInvite =
+      n.kind === "MeetingInvite" && !!n.scheduledMeetingId;
+    const hasAction = isMeetingInvite || !!formLink || isOnboarding;
 
     return {
       id: n.id,

--- a/dali-api/app/mcp/tools/__tests__/mark-notification-read.test.ts
+++ b/dali-api/app/mcp/tools/__tests__/mark-notification-read.test.ts
@@ -30,6 +30,7 @@ describe("mark_notification_read", () => {
     mockPrisma.notification.findUnique.mockResolvedValue({
       recipientUserId: "u1",
       readAt: null,
+      kind: "General",
       scheduledMeetingId: null,
     });
     mockPrisma.notification.update.mockResolvedValue({});
@@ -42,6 +43,7 @@ describe("mark_notification_read", () => {
     mockPrisma.notification.findUnique.mockResolvedValue({
       recipientUserId: "u1",
       readAt: null,
+      kind: "MeetingInvite",
       scheduledMeetingId: "m1",
     });
     const out = await runMarkNotificationRead("u1", { notificationId: "n1" });
@@ -49,10 +51,24 @@ describe("mark_notification_read", () => {
     expect(mockPrisma.notification.update).not.toHaveBeenCalled();
   });
 
+  it("marks a MeetingReminder read even when it has scheduledMeetingId", async () => {
+    mockPrisma.notification.findUnique.mockResolvedValue({
+      recipientUserId: "u1",
+      readAt: null,
+      kind: "MeetingReminder",
+      scheduledMeetingId: "m1",
+    });
+    mockPrisma.notification.update.mockResolvedValue({});
+    const out = await runMarkNotificationRead("u1", { notificationId: "n1" });
+    expect(out).toEqual({ ok: true, alreadyRead: false });
+    expect(mockPrisma.notification.update).toHaveBeenCalled();
+  });
+
   it("is idempotent for already-read", async () => {
     mockPrisma.notification.findUnique.mockResolvedValue({
       recipientUserId: "u1",
       readAt: new Date(),
+      kind: "General",
       scheduledMeetingId: null,
     });
     const out = await runMarkNotificationRead("u1", { notificationId: "n1" });
@@ -71,6 +87,7 @@ describe("mark_notification_read", () => {
     mockPrisma.notification.findUnique.mockResolvedValue({
       recipientUserId: "u2",
       readAt: null,
+      kind: "General",
       scheduledMeetingId: null,
     });
     await expect(

--- a/dali-api/app/mcp/tools/mark-notification-read.ts
+++ b/dali-api/app/mcp/tools/mark-notification-read.ts
@@ -51,13 +51,21 @@ export async function runMarkNotificationRead(
 ): Promise<MarkNotificationReadResult> {
   const existing = await prisma.notification.findUnique({
     where: { id: input.notificationId },
-    select: { recipientUserId: true, readAt: true, scheduledMeetingId: true },
+    select: {
+      recipientUserId: true,
+      readAt: true,
+      kind: true,
+      scheduledMeetingId: true,
+    },
   });
   if (!existing) throw new NotificationNotFoundError(input.notificationId);
   if (existing.recipientUserId !== callerId) throw new NotificationForbiddenError();
 
   // Mirror api.notifications.$id.read.ts: meeting invites only clear via RSVP.
-  if (existing.scheduledMeetingId) return { ok: true, skipped: "meeting-invite" };
+  // Meeting reminders also have scheduledMeetingId but are dismissible.
+  if (existing.kind === "MeetingInvite" && existing.scheduledMeetingId) {
+    return { ok: true, skipped: "meeting-invite" };
+  }
 
   if (existing.readAt) return { ok: true, alreadyRead: true };
   await prisma.notification.update({

--- a/dali-api/app/routes/__tests__/api.notifications.$id.read.test.ts
+++ b/dali-api/app/routes/__tests__/api.notifications.$id.read.test.ts
@@ -97,6 +97,25 @@ describe("POST /api/notifications/:id/read intent=unread", () => {
     expect(mockPrisma.notification.update).not.toHaveBeenCalled();
   });
 
+  it("allows unread for a MeetingReminder that has scheduledMeetingId", async () => {
+    mockPrisma.notification.findUnique.mockResolvedValue({
+      recipientUserId: USER_ID,
+      readAt: new Date(),
+      scheduledMeetingId: "m1",
+      kind: "MeetingReminder",
+      link: "/calendar?meeting=m1",
+    });
+    const res = await action({
+      request: unreadReq("n1"),
+      params: { id: "n1" },
+    } as any);
+    expect(res.status).toBe(200);
+    expect(mockPrisma.notification.update).toHaveBeenCalledWith({
+      where: { id: "n1" },
+      data: { readAt: null },
+    });
+  });
+
   it("is a no-op echo for the onboarding task", async () => {
     mockPrisma.notification.findUnique.mockResolvedValue({
       recipientUserId: USER_ID,
@@ -127,6 +146,50 @@ describe("POST /api/notifications/:id/read intent=unread", () => {
       params: { id: "n1" },
     } as any);
     expect(res.status).toBe(200);
+    expect(mockPrisma.notification.update).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/notifications/:id/read", () => {
+  function readReq(id: string) {
+    return new Request(`http://localhost/api/notifications/${id}/read`, {
+      method: "POST",
+    });
+  }
+
+  it("marks a MeetingReminder read even when it has scheduledMeetingId", async () => {
+    mockPrisma.notification.findUnique.mockResolvedValue({
+      recipientUserId: USER_ID,
+      readAt: null,
+      scheduledMeetingId: "m1",
+      kind: "MeetingReminder",
+      link: "/calendar?meeting=m1",
+    });
+    const res = await action({
+      request: readReq("n1"),
+      params: { id: "n1" },
+    } as any);
+    expect(res.status).toBe(200);
+    expect(mockPrisma.notification.update).toHaveBeenCalledWith({
+      where: { id: "n1" },
+      data: { readAt: expect.any(Date) },
+    });
+  });
+
+  it("still skips MeetingInvite on plain read", async () => {
+    mockPrisma.notification.findUnique.mockResolvedValue({
+      recipientUserId: USER_ID,
+      readAt: null,
+      scheduledMeetingId: "m1",
+      kind: "MeetingInvite",
+      link: null,
+    });
+    const res = await action({
+      request: readReq("n1"),
+      params: { id: "n1" },
+    } as any);
+    const json = await res.json();
+    expect(json).toMatchObject({ ok: true, skipped: "meeting-invite" });
     expect(mockPrisma.notification.update).not.toHaveBeenCalled();
   });
 });

--- a/dali-api/app/routes/api.notifications.$id.read.ts
+++ b/dali-api/app/routes/api.notifications.$id.read.ts
@@ -55,12 +55,17 @@ export async function action({ request, params }: Route.ActionArgs) {
     return forbidden(request);
   }
 
+  // Meeting invites (only) clear via RSVP, not mark-read. Meeting reminders
+  // also carry scheduledMeetingId but are dismissible like any other ping.
+  const isMeetingInvite =
+    existing.kind === "MeetingInvite" && !!existing.scheduledMeetingId;
+
   // Re-open path: flip readAt back to null so the row returns to Open in
   // History + the Tasks list. Self-clearing rows (meeting invites / onboarding)
   // own their own read state, so re-opening them is a no-op echo — mirrors the
   // skips below for the read path.
   if (intent === "unread") {
-    if (existing.scheduledMeetingId) {
+    if (isMeetingInvite) {
       return withCors(request, Response.json({ ok: true, skipped: "meeting-invite" }));
     }
     if (existing.kind === "SystemAnnouncement" && existing.link === ONBOARDING_LINK) {
@@ -80,7 +85,7 @@ export async function action({ request, params }: Route.ActionArgs) {
   // A meeting invite only clears once the recipient RSVPs (via the rsvp
   // endpoint, which sets readAt itself). A plain read — opening its link —
   // must not dismiss it, so it stays a todo until an Accept/Maybe/Decline.
-  if (existing.scheduledMeetingId) {
+  if (isMeetingInvite) {
     return withCors(request, Response.json({ ok: true, skipped: "meeting-invite" }));
   }
 

--- a/dali-api/app/routes/api.notifications.ts
+++ b/dali-api/app/routes/api.notifications.ts
@@ -96,13 +96,16 @@ export async function action({ request }: Route.ActionArgs) {
 
   // POST with no id = "mark all read". Excluded: meeting invites (clear only on
   // RSVP) and the onboarding task (clears only when onboarding is finished), so
-  // neither is dismissed by a blanket read.
+  // neither is dismissed by a blanket read. Meeting reminders share
+  // scheduledMeetingId with invites but are dismissible — leave them in.
   await prisma.notification.updateMany({
     where: {
       recipientUserId: auth.user.sub,
       readAt: null,
-      scheduledMeetingId: null,
-      NOT: { kind: "SystemAnnouncement", link: ONBOARDING_LINK },
+      NOT: [
+        { kind: "MeetingInvite", scheduledMeetingId: { not: null } },
+        { kind: "SystemAnnouncement", link: ONBOARDING_LINK },
+      ],
     },
     data: { readAt: new Date() },
   });


### PR DESCRIPTION
MeetingReminder rows share scheduledMeetingId with invites, so mark-read treated them as RSVP-only and past "Starting soon" pings never cleared.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/971"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787269325&installation_model_id=21824&pr_number=971&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F971&signature=0c726f8af682f5f70e4d2658f9c6d3996066c3c09ebe549f29dd946ee719c849"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->