### PR TITLE
Staffing: edit assignment levels and error when mentorship can't pair.

### DIFF
--- a/dali-api/app/projects/components/FinalizeModal.tsx
+++ b/dali-api/app/projects/components/FinalizeModal.tsx
@@ -21,7 +21,7 @@ const AUTOMATIONS: {
     id: "assignments",
     label: "Propagate assignments",
     description:
-      "Confirm proposed staffing rows and write canonical ProjectAssignment + DomainEligibility.",
+      "Confirm proposed staffing rows and write ProjectAssignment, DomainEligibility, and MentorshipPair links (P3 or Mentor-badge mentors paired to same-domain mentees). Change levels on the board if a domain has mentees but no mentor.",
     configured: true,
   },
   {

--- a/dali-api/app/projects/components/LevelBadge.tsx
+++ b/dali-api/app/projects/components/LevelBadge.tsx
@@ -1,0 +1,49 @@
+import type { Level } from "~/lib/level";
+import { ALL_LEVELS } from "~/lib/level";
+
+const LEVEL_CLS: Record<Level, string> = {
+  P1: "border-border bg-muted text-muted-foreground",
+  P2: "border-accent-teal/40 bg-accent-teal/10 text-accent-teal",
+  P3: "border-accent-coral/40 bg-accent-coral/10 text-accent-coral",
+};
+
+// Compact P1/P2/P3 control for an assigned staffing card. Changing level
+// rewrites the live StaffingAssignment (Proposed) so Propagate can confirm it.
+export function LevelBadge({
+  level,
+  onChange,
+}: {
+  level: Level;
+  onChange: (next: Level) => void;
+}) {
+  return (
+    <div
+      role="group"
+      aria-label="Assignment level"
+      className="inline-flex items-center gap-0.5"
+    >
+      {ALL_LEVELS.map((l) => {
+        const active = l === level;
+        return (
+          <button
+            key={l}
+            type="button"
+            aria-pressed={active}
+            title={`Set level to ${l}`}
+            aria-label={`Level ${l}${active ? " (current)" : ""}`}
+            onClick={() => {
+              if (!active) onChange(l);
+            }}
+            className={`rounded border px-1.5 py-0.5 text-[10px] font-bold transition-colors ${
+              active
+                ? LEVEL_CLS[l]
+                : "border-transparent text-muted-foreground/60 hover:text-foreground hover:bg-muted"
+            }`}
+          >
+            {l}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/dali-api/app/projects/components/MemberCard.tsx
+++ b/dali-api/app/projects/components/MemberCard.tsx
@@ -29,11 +29,15 @@ type Props = {
   /** The card is the one being dragged — dim it; the DragOverlay floats a copy. */
   isDragging: boolean;
   /**
-   * Optional mentorship control (the "Mentor" dropdown badge) rendered below
-   * the card body. It's interactive, so it lives outside the card's drag/click
-   * surface and stops propagation itself.
+   * Optional mentorship control (the Mentor/Mentee badge) rendered below the
+   * card body. Interactive — lives outside the card's drag/click surface.
    */
   mentorSlot?: ReactNode;
+  /**
+   * Optional assignment-level control (P1/P2/P3) for project-column cards.
+   * Same stop-propagation wrapper as mentorSlot.
+   */
+  levelSlot?: ReactNode;
   /**
    * Tint the card as an external mentor — this member mentors someone on
    * another team. A distinct teal edge marks the cross-team relationship.
@@ -51,6 +55,7 @@ export function MemberCard({
   dragHandleProps,
   isDragging,
   mentorSlot,
+  levelSlot,
   accentExternal,
 }: Props) {
   const fullName = buildFullName(card);
@@ -104,16 +109,17 @@ export function MemberCard({
         domainNames={domainNames}
         onRemove={onRemove}
       />
-      {mentorSlot && (
-        // Keep drag/click off the mentorship control: a press here must not
+      {(levelSlot || mentorSlot) && (
+        // Keep drag/click off interactive controls: a press here must not
         // start a card drag or open the bid modal.
         <div
           onClick={(e) => e.stopPropagation()}
           onKeyDown={(e) => e.stopPropagation()}
           onPointerDown={(e) => e.stopPropagation()}
           onMouseDown={(e) => e.stopPropagation()}
-          className="cursor-default"
+          className="flex flex-wrap items-center gap-1.5 cursor-default"
         >
+          {levelSlot}
           {mentorSlot}
         </div>
       )}

--- a/dali-api/app/projects/components/StaffingBoard.tsx
+++ b/dali-api/app/projects/components/StaffingBoard.tsx
@@ -15,12 +15,14 @@ import { CheckCircle2, UserPlus } from "lucide-react";
 import { Button } from "~/components/ui/Button";
 import { MemberCard, MemberCardPreview } from "./MemberCard";
 import { RoleBadge } from "./RoleBadge";
+import { LevelBadge } from "./LevelBadge";
 import { BidModal } from "./BidModal";
 import { FinalizeModal } from "./FinalizeModal";
 import { AddMemberControl } from "./AddMemberControl";
 import { AddExternalMentorModal } from "./AddExternalMentorModal";
 import { DomainFilter } from "./DomainFilter";
 import { sanitizeChannelName } from "~/slack/lib/channel-name";
+import type { Level } from "~/lib/level";
 
 type ProjectMeta = {
   id: string;
@@ -120,6 +122,34 @@ export function StaffingBoard({
       }
     },
     [cycleId],
+  );
+
+  // Change an assigned member's level on the live board (Proposed row). Used so
+  // leads can raise someone to P3 before Propagate creates MentorshipPairs.
+  const changeAssignmentLevel = useCallback(
+    async (userId: string, next: Level) => {
+      const current = assignments.find((a) => a.userId === userId);
+      if (!current || current.level === next) return;
+      const prev = assignments;
+      setAssignments((list) =>
+        list.map((a) => (a.userId === userId ? { ...a, level: next } : a)),
+      );
+      setError(null);
+      try {
+        await persist({
+          cycleId,
+          userId,
+          projectId: current.projectId,
+          domainId: current.domainId,
+          level: next,
+        });
+        revalidator.revalidate();
+      } catch (err) {
+        setAssignments(prev);
+        setError(err instanceof Error ? err.message : "Failed to update level");
+      }
+    },
+    [assignments, cycleId, revalidator],
   );
 
   // Non-roster external mentors placed on project columns. Managers only.
@@ -583,16 +613,28 @@ export function StaffingBoard({
             isDragging={isDragging}
             mentorSlot={(() => {
               // Mentor/mentee role badge, on project-column cards for managers.
-              // Default role follows level (P3 → mentor); the override flips it.
-              // External mentors are inherently mentors — no toggle.
+              // Default role follows the assignment level (P3 → mentor); the
+              // override flips it. External mentors are inherently mentors.
               if (!canManage || card.isExternalMentor) return undefined;
               if (columnIdOf.get(card.userId) === UNASSIGNED) return undefined;
-              const defaultMentor = card.domainLevels.some((d) => d.level === "P3");
+              const defaultMentor = card.level === "P3";
               const isMentor = mentorRoles[card.userId] ?? defaultMentor;
               return (
                 <RoleBadge
                   isMentor={isMentor}
                   onToggle={() => void toggleMentorRole(card.userId, !isMentor)}
+                />
+              );
+            })()}
+            levelSlot={(() => {
+              if (!canManage || card.isExternalMentor) return undefined;
+              if (columnIdOf.get(card.userId) === UNASSIGNED) return undefined;
+              const assignment = assignments.find((a) => a.userId === card.userId);
+              if (!assignment) return undefined;
+              return (
+                <LevelBadge
+                  level={assignment.level}
+                  onChange={(next) => void changeAssignmentLevel(card.userId, next)}
                 />
               );
             })()}

--- a/dali-api/app/projects/lib/__tests__/mentorship-pairings.test.ts
+++ b/dali-api/app/projects/lib/__tests__/mentorship-pairings.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { derivePairings } from "../mentorship-pairings";
+import { derivePairings, findDomainsMissingMentors } from "../mentorship-pairings";
 
 type Row = { userId: string; domainId: string; level: "P1" | "P2" | "P3" };
 type Pair = { menteeUserId: string; mentorUserId: string; domainId: string };
@@ -134,5 +134,54 @@ describe("derivePairings", () => {
     expect(created).toEqual([
       { menteeUserId: "p3-demoted", mentorUserId: "mentor-x", domainId: "d1" },
     ]);
+  });
+});
+
+describe("findDomainsMissingMentors", () => {
+  it("flags a domain with multiple mentees and no mentor", () => {
+    const gaps = findDomainsMissingMentors([
+      { userId: "oscar", domainId: "uiux", level: "P2" },
+      { userId: "emma", domainId: "uiux", level: "P1" },
+    ]);
+    expect(gaps).toEqual([
+      { domainId: "uiux", menteeUserIds: ["oscar", "emma"] },
+    ]);
+  });
+
+  it("ignores solo mentee domains", () => {
+    const gaps = findDomainsMissingMentors([
+      { userId: "claire", domainId: "arvr", level: "P2" },
+    ]);
+    expect(gaps).toEqual([]);
+  });
+
+  it("ignores domains that have a P3 mentor", () => {
+    const gaps = findDomainsMissingMentors([
+      { userId: "oscar", domainId: "uiux", level: "P3" },
+      { userId: "emma", domainId: "uiux", level: "P1" },
+    ]);
+    expect(gaps).toEqual([]);
+  });
+
+  it("honours mentor role override and external mentors", () => {
+    expect(
+      findDomainsMissingMentors(
+        [
+          { userId: "oscar", domainId: "uiux", level: "P2" },
+          { userId: "emma", domainId: "uiux", level: "P1" },
+        ],
+        { roleOverride: new Map([["oscar", true]]) },
+      ),
+    ).toEqual([]);
+
+    expect(
+      findDomainsMissingMentors(
+        [
+          { userId: "emma", domainId: "uiux", level: "P1" },
+          { userId: "other", domainId: "uiux", level: "P1" },
+        ],
+        { externalMentors: [{ userId: "ext", domainId: "uiux" }] },
+      ),
+    ).toEqual([]);
   });
 });

--- a/dali-api/app/projects/lib/mentorship-pairings.ts
+++ b/dali-api/app/projects/lib/mentorship-pairings.ts
@@ -103,3 +103,47 @@ export async function derivePairings(
   await tx.mentorshipPair.createMany({ data: toCreate });
   return toCreate.length;
 }
+
+export type DomainMissingMentor = {
+  domainId: string;
+  menteeUserIds: string[];
+};
+
+// Domains where mentorship pairing cannot run: zero mentors and more than one
+// mentee. Solo mentee domains are fine (nothing to pair with). External mentors
+// and role overrides count. Used by finalize to surface a level/role gap.
+export function findDomainsMissingMentors(
+  assignments: { userId: string; domainId: string; level: "P1" | "P2" | "P3" }[],
+  opts?: {
+    roleOverride?: Map<string, boolean>;
+    externalMentors?: { userId: string; domainId: string }[];
+  },
+): DomainMissingMentor[] {
+  const override = opts?.roleOverride;
+  const byDomain = new Map<string, { mentees: string[]; mentors: string[] }>();
+  const bucketFor = (domainId: string) => {
+    let bucket = byDomain.get(domainId);
+    if (!bucket) {
+      bucket = { mentees: [], mentors: [] };
+      byDomain.set(domainId, bucket);
+    }
+    return bucket;
+  };
+  for (const a of assignments) {
+    const bucket = bucketFor(a.domainId);
+    const isMentor = override?.get(a.userId) ?? a.level === "P3";
+    if (isMentor) bucket.mentors.push(a.userId);
+    else bucket.mentees.push(a.userId);
+  }
+  for (const em of opts?.externalMentors ?? []) {
+    bucketFor(em.domainId).mentors.push(em.userId);
+  }
+
+  const gaps: DomainMissingMentor[] = [];
+  for (const [domainId, { mentees, mentors }] of byDomain) {
+    if (mentors.length > 0) continue;
+    if (mentees.length <= 1) continue;
+    gaps.push({ domainId, menteeUserIds: mentees });
+  }
+  return gaps;
+}

--- a/dali-api/app/projects/routes/api.staffing.finalize.ts
+++ b/dali-api/app/projects/routes/api.staffing.finalize.ts
@@ -23,7 +23,7 @@ import { logAuditEvent } from "~/lib/audit";
 import { notify } from "~/lib/notify.server";
 import { dedupeLiveAssignments } from "../lib/staffing-board";
 import { publishCycleChange } from "../lib/staffing-events.server";
-import { derivePairings } from "../lib/mentorship-pairings";
+import { derivePairings, findDomainsMissingMentors } from "../lib/mentorship-pairings";
 
 // POST /api/staffing/finalize
 //
@@ -223,6 +223,7 @@ export async function action({ request }: Route.ActionArgs) {
       let droppedCount = 0;
       let pairsCreated = 0;
       let mentorsPromoted = 0;
+      let mentorshipGaps: { domainId: string; menteeUserIds: string[] }[] = [];
       const promoteMentors = body.promoteMentors === true;
       await prisma.$transaction(async (tx) => {
         for (const a of target) {
@@ -339,6 +340,17 @@ export async function action({ request }: Route.ActionArgs) {
           roleOverride,
           externalMentors,
         });
+
+        // After promotes + pairing: domains that still have multiple mentees
+        // and no mentor need a level (or Mentor badge / external) fix.
+        const roster = await tx.projectAssignment.findMany({
+          where: { projectId: project.id, termId: cycle.termId },
+          select: { userId: true, domainId: true, level: true },
+        });
+        mentorshipGaps = findDomainsMissingMentors(roster, {
+          roleOverride,
+          externalMentors,
+        });
       });
 
       // Tell each newly-confirmed member (rows that were still Proposed when
@@ -364,22 +376,46 @@ export async function action({ request }: Route.ActionArgs) {
       }
 
       const dropNote = droppedCount > 0 ? `, removed ${droppedCount}` : "";
-      const pairNote = pairsCreated > 0 ? `, paired ${pairsCreated} mentor link${pairsCreated === 1 ? "" : "s"}` : "";
+      const pairNote = `, paired ${pairsCreated} mentor link${pairsCreated === 1 ? "" : "s"}`;
       const promoteNote =
         mentorsPromoted > 0 ? `, promoted ${mentorsPromoted} mentor${mentorsPromoted === 1 ? "" : "s"} to P3` : "";
       const skipNote =
         skippedNames.length > 0
           ? ` Skipped ${skippedNames.length} with an invalid/blank domain (fix their bid): ${skippedNames.join(", ")}.`
           : "";
+
+      let mentorshipGapNote = "";
+      if (mentorshipGaps.length > 0) {
+        const menteeIds = [...new Set(mentorshipGaps.flatMap((g) => g.menteeUserIds))];
+        const menteeUsers = await prisma.user.findMany({
+          where: { id: { in: menteeIds } },
+          select: { id: true, firstName: true, lastName: true },
+        });
+        const nameById = new Map(
+          menteeUsers.map((u) => [u.id, `${u.firstName} ${u.lastName}`.trim()]),
+        );
+        mentorshipGapNote =
+          " Mentorship not created for " +
+          mentorshipGaps
+            .map((g) => {
+              const domain = domainNameById.get(g.domainId) ?? "Unknown domain";
+              const names = g.menteeUserIds.map((id) => nameById.get(id) ?? id).join(", ");
+              return `${domain} (mentees but no P3/Mentor: ${names})`;
+            })
+            .join("; ") +
+          ". Raise someone to P3 on the board (or mark Mentor / add an external mentor), then re-run Propagate.";
+      }
+
       results.assignments = {
-        // Flag as error when anyone was skipped so the lead sees the warning and
-        // follows up — the valid assignments still went through.
-        status: skippedNames.length > 0 ? "error" : "ok",
+        // Flag as error when anyone was skipped or mentorship could not be
+        // derived for a multi-person domain — assignments still went through.
+        status: skippedNames.length > 0 || mentorshipGaps.length > 0 ? "error" : "ok",
         message:
           (confirmedCount === 0 && droppedCount === 0
             ? "No proposed assignments for this project."
             : `Confirmed ${confirmedCount} assignment${confirmedCount === 1 ? "" : "s"}${dropNote}${pairNote}${promoteNote} → ProjectAssignment.`) +
-          skipNote,
+          skipNote +
+          mentorshipGapNote,
       };
     } catch (err) {
       results.assignments = { status: "error", message: slackErrorMessage(err) };


### PR DESCRIPTION
MakeOS-style rosters with only P1/P2 produced silent zero MentorshipPairs. Leads can raise someone to P3 on the board; Propagate now always reports pair count and errors when a domain has mentees but no mentor.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/972"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787269525&installation_model_id=21824&pr_number=972&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F972&signature=4f746643f7aeb37fdcc43e72b0fcea0141b02425264eec110f3939a676f524e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->