### PR TITLE
Fix slow/unresponsive form-builder drag-and-drop (#970)

### DIFF
--- a/dali-api/app/components/form-builder/FormBuilder.tsx
+++ b/dali-api/app/components/form-builder/FormBuilder.tsx
@@ -1,5 +1,15 @@
-import React, { useState, useEffect } from 'react'
+import { useState, useEffect, type CSSProperties, type ReactNode } from 'react'
 import { GripVertical, Plus, Pencil, Trash2, Save, Check, Loader2 } from 'lucide-react'
+import {
+  DndContext,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core'
+import { SortableContext, arrayMove, useSortable, verticalListSortingStrategy } from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
 import type { Question } from '~/types'
 import { RichTextEditor } from '~/components/RichTextEditor'
 import { Tooltip } from '~/components/ui/IconButton'
@@ -148,38 +158,24 @@ export function FormBuilderTab({
   const [maxWordsValue, setMaxWordsValue] = useState<string>('')
   const [acceptPresets, setAcceptPresets] = useState<Set<string>>(new Set())
   const [acceptCustom, setAcceptCustom] = useState('')
-  // Drag and drop state. Track the source by key (stable across reorders) so
-  // mid-drag splices don't invalidate it. Reorder happens on dragover of each
-  // row, picking before/after based on whether the cursor is past the row's
-  // vertical midpoint — more stable than dragenter, which can fire on inner
-  // children and skip rows.
-  const [dragKey, setDragKey] = useState<string | null>(null)
-  const handleDragStart = (e: React.DragEvent, key: string) => {
-    setDragKey(key)
-    e.dataTransfer.effectAllowed = 'move'
-    e.dataTransfer.setData('text/plain', key)
-  }
-  const handleRowDragOver = (e: React.DragEvent, overKey: string) => {
-    e.preventDefault()
-    e.dataTransfer.dropEffect = 'move'
-    if (!dragKey || dragKey === overKey) return
-    const rect = e.currentTarget.getBoundingClientRect()
-    const after = e.clientY > rect.top + rect.height / 2
+  // Drag-to-reorder via dnd-kit (same idiom as EpicSprintManager / KanbanBoard).
+  // The reorder commits once, on drop — no per-move state churn — and the live
+  // move is a CSS transform, so long forms stay responsive while dragging.
+  // `activeId` only tints sibling borders for the duration of a drag.
+  const [activeId, setActiveId] = useState<string | null>(null)
+  const dragSensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+  )
+  const handleDragEnd = (event: DragEndEvent) => {
+    setActiveId(null)
+    const { active, over } = event
+    if (!over || active.id === over.id) return
     setQuestions((prev) => {
-      const from = prev.findIndex((q) => q.key === dragKey)
-      const overIdx = prev.findIndex((q) => q.key === overKey)
-      if (from === -1 || overIdx === -1) return prev
-      let to = after ? overIdx + 1 : overIdx
-      if (from < to) to -= 1
-      if (from === to) return prev
-      const updated = [...prev]
-      const [moved] = updated.splice(from, 1)
-      updated.splice(to, 0, moved)
-      return updated
+      const from = prev.findIndex((q) => q.key === active.id)
+      const to = prev.findIndex((q) => q.key === over.id)
+      if (from === -1 || to === -1) return prev
+      return arrayMove(prev, from, to)
     })
-  }
-  const handleDragEnd = () => {
-    setDragKey(null)
   }
   const resetEditState = () => {
     setEditingKey(null)
@@ -572,96 +568,109 @@ export function FormBuilderTab({
         />
       </div>
       <div className="space-y-2">
-        {questions.map((q, index) => (
-          <div
-            key={q.key}
-            draggable={editingKey !== q.key}
-            onDragStart={(e) => handleDragStart(e, q.key)}
-            onDragOver={(e) => handleRowDragOver(e, q.key)}
-            onDragEnd={handleDragEnd}
-            onDrop={(e) => e.preventDefault()}
-            className={`rounded-xl ${dragKey === q.key ? 'opacity-40' : ''}`}
+        <DndContext
+          sensors={dragSensors}
+          collisionDetection={closestCenter}
+          onDragStart={(e) => setActiveId(String(e.active.id))}
+          onDragEnd={handleDragEnd}
+          onDragCancel={() => setActiveId(null)}
+        >
+          <SortableContext
+            items={questions.map((q) => q.key)}
+            strategy={verticalListSortingStrategy}
           >
-            {editingKey === q.key ? (
-              renderEditForm()
-            ) : (
-              <div
-                className={`flex items-start gap-4 bg-card p-4 rounded-xl border shadow-sm group transition-colors duration-150 ${dragKey ? 'border-gray-300' : 'border-border'}`}
-              >
-                <div className="mt-1 cursor-grab active:cursor-grabbing text-muted-foreground/70 hover:text-muted-foreground select-none">
-                  <GripVertical className="w-5 h-5" />
-                </div>
-
-                <div className="flex-1">
-                  <div className="flex items-center gap-3 mb-1">
-                    <span className="text-sm font-medium text-muted-foreground">
-                      Q{index + 1}
-                    </span>
-                    <h4 className="text-base font-medium text-foreground">
-                      {q.data.label}
-                    </h4>
-                    {q.required && (
-                      <span className="text-xs font-medium text-red-600 bg-red-50 px-2 py-0.5 rounded-full">
-                        Required
-                      </span>
-                    )}
-                    {q.data.afterDomains && (
-                      <span className="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-medium bg-amber-100 text-amber-800">
-                        After Domains
-                      </span>
-                    )}
-                    {q.type === 'textarea' && q.data.maxWords !== undefined && (
-                      <span className="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-medium bg-blue-100 text-blue-800">
-                        Max {q.data.maxWords} words
-                      </span>
-                    )}
-                    <span className="text-xs font-medium text-muted-foreground bg-muted px-2 py-0.5 rounded-full capitalize">
-                      {q.type}
-                    </span>
-                  </div>
-
-                  {q.data.description && (
-                    <p className="text-sm text-muted-foreground mb-2">
-                      {q.data.description}
-                    </p>
-                  )}
-
-                  {(q.type === 'select' || q.type === 'skills_rating' || q.type === 'checkbox') && q.data.options && (
-                    <div className="mt-2 flex flex-wrap gap-2">
-                      {q.data.options.map((opt) => (
-                        <span
-                          key={opt}
-                          className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-50 text-blue-700 border border-blue-100"
+            {questions.map((q, index) => (
+              <SortableQuestionRow key={q.key} id={q.key} disabled={editingKey === q.key}>
+                {(dragHandleProps, isDragging) => (
+                  <div className={`rounded-xl ${isDragging ? 'opacity-40' : ''}`}>
+                    {editingKey === q.key ? (
+                      renderEditForm()
+                    ) : (
+                      <div
+                        className={`flex items-start gap-4 bg-card p-4 rounded-xl border shadow-sm group transition-colors duration-150 ${activeId ? 'border-gray-300' : 'border-border'}`}
+                      >
+                        <div
+                          {...dragHandleProps}
+                          aria-label={`Reorder ${q.data.label || 'question'}`}
+                          className="mt-1 cursor-grab active:cursor-grabbing text-muted-foreground/70 hover:text-muted-foreground select-none touch-none"
                         >
-                          {opt}
-                        </span>
-                      ))}
-                    </div>
-                  )}
+                          <GripVertical className="w-5 h-5" />
+                        </div>
 
-                  {q.type === 'file' && q.data.accept && (
-                    <p className="text-xs text-gray-500 mt-1">Accepts: {q.data.accept}</p>
-                  )}
-                </div>
+                        <div className="flex-1">
+                          <div className="flex items-center gap-3 mb-1">
+                            <span className="text-sm font-medium text-muted-foreground">
+                              Q{index + 1}
+                            </span>
+                            <h4 className="text-base font-medium text-foreground">
+                              {q.data.label}
+                            </h4>
+                            {q.required && (
+                              <span className="text-xs font-medium text-red-600 bg-red-50 px-2 py-0.5 rounded-full">
+                                Required
+                              </span>
+                            )}
+                            {q.data.afterDomains && (
+                              <span className="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-medium bg-amber-100 text-amber-800">
+                                After Domains
+                              </span>
+                            )}
+                            {q.type === 'textarea' && q.data.maxWords !== undefined && (
+                              <span className="inline-flex items-center px-2 py-0.5 rounded text-[10px] font-medium bg-blue-100 text-blue-800">
+                                Max {q.data.maxWords} words
+                              </span>
+                            )}
+                            <span className="text-xs font-medium text-muted-foreground bg-muted px-2 py-0.5 rounded-full capitalize">
+                              {q.type}
+                            </span>
+                          </div>
 
-                <div className="flex items-center gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
-                  <button
-                    onClick={() => handleEdit(q)}
-                    className="p-1.5 text-muted-foreground/70 hover:text-blue-600 rounded-md hover:bg-blue-50"
-                  >
-                    <Pencil className="w-4 h-4" />
-                  </button>
-                  <button
-                    onClick={() => handleDelete(q.key)}
-                    className="p-1.5 text-muted-foreground/70 hover:text-red-600 rounded-md hover:bg-red-50"
-                  >
-                    <Trash2 className="w-4 h-4" />
-                  </button>
-                </div>
-              </div>
-            )}
-          </div>
-        ))}
+                          {q.data.description && (
+                            <p className="text-sm text-muted-foreground mb-2">
+                              {q.data.description}
+                            </p>
+                          )}
+
+                          {(q.type === 'select' || q.type === 'skills_rating' || q.type === 'checkbox') && q.data.options && (
+                            <div className="mt-2 flex flex-wrap gap-2">
+                              {q.data.options.map((opt) => (
+                                <span
+                                  key={opt}
+                                  className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-50 text-blue-700 border border-blue-100"
+                                >
+                                  {opt}
+                                </span>
+                              ))}
+                            </div>
+                          )}
+
+                          {q.type === 'file' && q.data.accept && (
+                            <p className="text-xs text-gray-500 mt-1">Accepts: {q.data.accept}</p>
+                          )}
+                        </div>
+
+                        <div className="flex items-center gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
+                          <button
+                            onClick={() => handleEdit(q)}
+                            className="p-1.5 text-muted-foreground/70 hover:text-blue-600 rounded-md hover:bg-blue-50"
+                          >
+                            <Pencil className="w-4 h-4" />
+                          </button>
+                          <button
+                            onClick={() => handleDelete(q.key)}
+                            className="p-1.5 text-muted-foreground/70 hover:text-red-600 rounded-md hover:bg-red-50"
+                          >
+                            <Trash2 className="w-4 h-4" />
+                          </button>
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                )}
+              </SortableQuestionRow>
+            ))}
+          </SortableContext>
+        </DndContext>
 
         <button
           onClick={handleAddQuestion}
@@ -720,6 +729,38 @@ export function FormBuilderTab({
           )
         })()}
       </div>
+    </div>
+  )
+}
+
+// Sortable wrapper for a question row. Owns the dnd-kit node ref + transform;
+// hands the drag-handle props to the grip via a render prop so the rest of the
+// row (edit/delete buttons, links) stays non-draggable. Disabled while the row
+// is being inline-edited.
+function SortableQuestionRow({
+  id,
+  disabled,
+  children,
+}: {
+  id: string
+  disabled: boolean
+  children: (dragHandleProps: Record<string, unknown>, isDragging: boolean) => ReactNode
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id,
+    disabled,
+  })
+  const style: CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  }
+  const dragHandleProps = disabled
+    ? {}
+    : ({ ...attributes, ...listeners } as Record<string, unknown>)
+
+  return (
+    <div ref={setNodeRef} style={style}>
+      {children(dragHandleProps, isDragging)}
     </div>
   )
 }

--- a/dali-api/app/forms/components/FormsBrowser.tsx
+++ b/dali-api/app/forms/components/FormsBrowser.tsx
@@ -616,6 +616,10 @@ function FolderCardView({
           ? {
               transform: `translate3d(${drag.transform.x}px, ${drag.transform.y}px, 0)`,
               zIndex: 50,
+              // Kill the `transition-all` while dragging — otherwise every
+              // per-frame transform update animates over 150ms and the card
+              // trails the cursor, which reads as laggy/unresponsive.
+              transition: "none",
             }
           : undefined
       }
@@ -683,6 +687,9 @@ function FormCardView({
           ? {
               transform: `translate3d(${drag.transform.x}px, ${drag.transform.y}px, 0)`,
               zIndex: 50,
+              // See FolderCardView: disable the transition mid-drag so the card
+              // tracks the cursor instead of easing behind it.
+              transition: "none",
             }
           : undefined
       }

--- a/dali-api/app/forms/components/FormsBrowser.tsx
+++ b/dali-api/app/forms/components/FormsBrowser.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState, type MouseEvent } from "react";
 import { Link, useFetcher, useNavigate } from "react-router";
 import {
   DndContext,
@@ -217,11 +217,33 @@ export function FormsBrowser({
     }
   }
 
+  // dnd-kit captures the pointer on the drag source, so pointerup synthesizes a
+  // native click on the card *after* the drag — which would follow its <Link>
+  // and open the form/folder. Flag it the moment a drag ends (synchronous, so
+  // it's set before the click fires) and swallow that one click in the capture
+  // phase; React Router's Link skips navigation once the click is defaultPrevented.
+  const suppressClickRef = useRef(false);
+  function endDrag() {
+    setDragging(null);
+    suppressClickRef.current = true;
+    // Safety net: clear on the next tick if no click follows (e.g. keyboard end).
+    setTimeout(() => {
+      suppressClickRef.current = false;
+    }, 0);
+  }
+  function guardCardClick(e: MouseEvent) {
+    if (suppressClickRef.current) {
+      e.preventDefault();
+      e.stopPropagation();
+      suppressClickRef.current = false;
+    }
+  }
+
   function handleDragStart(event: DragStartEvent) {
     setDragging((event.active.data.current as DragItem | undefined) ?? null);
   }
   function handleDragEnd(event: DragEndEvent) {
-    setDragging(null);
+    endDrag();
     const item = event.active.data.current as DragItem | undefined;
     const dest = event.over?.data.current as
       | { folderId: string | null }
@@ -360,7 +382,7 @@ export function FormsBrowser({
           sensors={sensors}
           onDragStart={handleDragStart}
           onDragEnd={handleDragEnd}
-          onDragCancel={() => setDragging(null)}
+          onDragCancel={endDrag}
         >
           {folderId !== null && dragging !== null && (
             <MoveUpDropZone
@@ -376,6 +398,7 @@ export function FormsBrowser({
                 key={d.id}
                 folder={d}
                 busy={busy}
+                onClickCapture={guardCardClick}
                 dropDisabled={
                   dragging?.type === "folder" && dragging.id === d.id
                 }
@@ -396,6 +419,7 @@ export function FormsBrowser({
                 key={f.id}
                 form={f}
                 busy={busy}
+                onClickCapture={guardCardClick}
                 onRename={() => renameForm(f)}
                 onDelete={() => deleteForm(f)}
                 onMove={() =>
@@ -576,6 +600,7 @@ function FolderCardView({
   folder,
   busy,
   dropDisabled,
+  onClickCapture,
   onRename,
   onDelete,
   onMove,
@@ -585,6 +610,8 @@ function FolderCardView({
   // True while this folder itself is being dragged: no self-drop highlight,
   // no self-drop request.
   dropDisabled: boolean;
+  // Swallows the click synthesized after a drag so it doesn't navigate.
+  onClickCapture: (e: MouseEvent) => void;
   onRename: () => void;
   onDelete: () => void;
   onMove: () => void;
@@ -607,6 +634,7 @@ function FolderCardView({
         drag.setNodeRef(node);
         drop.setNodeRef(node);
       }}
+      onClickCapture={onClickCapture}
       // Only the listeners: spreading dnd-kit's attributes would put
       // role="button" on the anchor. Drag stays pointer-driven (no keyboard
       // sensor is configured), matching the other boards.
@@ -661,6 +689,7 @@ function FolderCardView({
 function FormCardView({
   form,
   busy,
+  onClickCapture,
   onRename,
   onDelete,
   onMove,
@@ -668,6 +697,8 @@ function FormCardView({
 }: {
   form: FormCard;
   busy: boolean;
+  // Swallows the click synthesized after a drag so it doesn't navigate.
+  onClickCapture: (e: MouseEvent) => void;
   onRename: () => void;
   onDelete: () => void;
   onMove: () => void;
@@ -682,6 +713,7 @@ function FormCardView({
     <div
       ref={drag.setNodeRef}
       {...drag.listeners}
+      onClickCapture={onClickCapture}
       style={
         drag.transform
           ? {


### PR DESCRIPTION
Closes #970 — "Forms UI is really slow/unresponsive with dnd". Two independent dnd perf issues in the Forms UI:

## 1. FormsBrowser — laggy card drag (the reported symptom)
Dragging a form/folder card between folders or to the top level felt slow/floaty. The dragged card carried `transition-all` while dnd-kit rewrote its inline `transform` every frame, so **each per-frame transform change animated over ~150ms** — the card eased *behind* the cursor instead of tracking it (classic dnd-kit gotcha).

Fix: disable the transition (`transition: "none"`, inline so it beats the class) while a card is actively being dragged, in both `FolderCardView` and `FormCardView`. The hover border/shadow transition stays on at rest.

## 2. FormBuilder — reorder-on-every-`dragover`
The form builder was the last forms surface on **native HTML5 dnd that reordered React state on every `dragover`**: each event forced a synchronous layout (`getBoundingClientRect`) and, on every midpoint crossing, re-rendered the whole unmemoized question list, physically reordered the DOM under a live drag (disrupting the browser's hit-testing), and re-rendered the Tiptap description editor above it.

Fix: ported to **`@dnd-kit/sortable`** (already a dependency; same idiom as `EpicSprintManager` / `KanbanBoard`). The live move is a GPU CSS transform (no per-move React render), the reorder commits once on drop via `arrayMove`, and drag lives on the grip handle (disabled while a row is inline-edited). Benefits both `FormBuilderTab` consumers: Forms (`FormDetail`) and hiring challenges (`ChallengeDetail`).

## Verification
- `npm run typecheck` — clean for both changed files.
- `vitest` form-builder + forms suites pass; no FormsBrowser component test exists to break.

Note: dropping a card still round-trips to the server before the move shows (no optimistic update, unlike `EpicSprintManager`). If the post-drop pause is still noticeable on cold Neon, an optimistic move + reconcile would be a clean follow-up — happy to add it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)