### PR TITLE
Staffing: multi-domain assign + soft-skip mentorship gaps (#978)

### DIFF
--- a/dali-api/app/projects/components/FinalizeModal.tsx
+++ b/dali-api/app/projects/components/FinalizeModal.tsx
@@ -91,9 +91,12 @@ export function FinalizeModal({
     let cancelled = false;
     (async () => {
       try {
-        const res = await fetch(`/api/staffing/mentor-role?cycleId=${encodeURIComponent(cycleId)}`, {
-          credentials: "include",
-        });
+        const res = await fetch(
+          `/api/staffing/mentor-role?cycleId=${encodeURIComponent(cycleId)}&projectId=${encodeURIComponent(projectId)}`,
+          {
+            credentials: "include",
+          },
+        );
         if (!res.ok) return;
         const d = (await res.json()) as {
           nonP3Mentors: { userId: string; firstName: string; lastName: string }[];
@@ -110,7 +113,7 @@ export function FinalizeModal({
     return () => {
       cancelled = true;
     };
-  }, [open, cycleId]);
+  }, [open, cycleId, projectId]);
 
   // Persist the channel name + GitHub slug to the Project WITHOUT running
   // automations (keeps the project details page in sync). Cancel reverts edits.

--- a/dali-api/app/projects/components/MemberCard.tsx
+++ b/dali-api/app/projects/components/MemberCard.tsx
@@ -47,8 +47,13 @@ type Props = {
   allDomains?: DomainOption[];
   onChangeDomainLevel?: (domainId: string, level: Level) => void;
   onAddDomain?: (domainId: string, level: Level) => void;
-  /** Highlight the domain used by the live staffing assignment. */
-  assignmentDomainId?: string | null;
+  /** Domain ids selected for the live staffing assignment (multi allowed). */
+  assignmentDomainIds?: string[];
+  /**
+   * Toggle a domain into / out of the staffing assignment. Only wired on
+   * project columns — Unassigned cards have no assignment to edit.
+   */
+  onToggleAssignmentDomain?: (domainId: string) => void;
 };
 
 export function MemberCard({
@@ -66,7 +71,8 @@ export function MemberCard({
   allDomains,
   onChangeDomainLevel,
   onAddDomain,
-  assignmentDomainId,
+  assignmentDomainIds,
+  onToggleAssignmentDomain,
 }: Props) {
   const fullName = buildFullName(card);
 
@@ -122,7 +128,8 @@ export function MemberCard({
         allDomains={allDomains}
         onChangeDomainLevel={onChangeDomainLevel}
         onAddDomain={onAddDomain}
-        assignmentDomainId={assignmentDomainId}
+        assignmentDomainIds={assignmentDomainIds}
+        onToggleAssignmentDomain={onToggleAssignmentDomain}
       />
       {mentorSlot && (
         // Keep drag/click off the mentorship control: a press here must not
@@ -198,7 +205,8 @@ function MemberCardBody({
   allDomains,
   onChangeDomainLevel,
   onAddDomain,
-  assignmentDomainId,
+  assignmentDomainIds,
+  onToggleAssignmentDomain,
 }: {
   card: MemberCardModel;
   fullName: string;
@@ -209,7 +217,8 @@ function MemberCardBody({
   allDomains?: DomainOption[];
   onChangeDomainLevel?: (domainId: string, level: Level) => void;
   onAddDomain?: (domainId: string, level: Level) => void;
-  assignmentDomainId?: string | null;
+  assignmentDomainIds?: string[];
+  onToggleAssignmentDomain?: (domainId: string) => void;
 }) {
   return (
     <>
@@ -268,7 +277,8 @@ function MemberCardBody({
         allDomains={allDomains}
         onChangeLevel={onChangeDomainLevel}
         onAddDomain={onAddDomain}
-        assignmentDomainId={assignmentDomainId}
+        assignmentDomainIds={assignmentDomainIds}
+        onToggleAssignmentDomain={onToggleAssignmentDomain}
       />
       <BidStrip card={card} projectNames={projectNames} domainNames={domainNames} />
     </>
@@ -305,14 +315,16 @@ function DomainLevelStrip({
   allDomains,
   onChangeLevel,
   onAddDomain,
-  assignmentDomainId,
+  assignmentDomainIds,
+  onToggleAssignmentDomain,
 }: {
   card: MemberCardModel;
   canEdit?: boolean;
   allDomains?: DomainOption[];
   onChangeLevel?: (domainId: string, level: Level) => void;
   onAddDomain?: (domainId: string, level: Level) => void;
-  assignmentDomainId?: string | null;
+  assignmentDomainIds?: string[];
+  onToggleAssignmentDomain?: (domainId: string) => void;
 }) {
   const [adding, setAdding] = useState(false);
   const [newDomainId, setNewDomainId] = useState("");
@@ -320,6 +332,7 @@ function DomainLevelStrip({
 
   const haveIds = new Set(card.domainLevels.map((d) => d.domainId));
   const available = (allDomains ?? []).filter((d) => !haveIds.has(d.id));
+  const selected = new Set(assignmentDomainIds ?? card.assignmentDomainIds ?? []);
 
   if (card.domainLevels.length === 0 && !canEdit) {
     return <p className="text-[11px] text-muted-foreground italic">No domain eligibility</p>;
@@ -338,7 +351,9 @@ function DomainLevelStrip({
           key={d.domainId}
           domain={d}
           canEdit={!!canEdit && !!onChangeLevel}
-          isAssignment={assignmentDomainId === d.domainId}
+          isAssignment={selected.has(d.domainId)}
+          canToggleAssignment={!!onToggleAssignmentDomain}
+          onToggleAssignment={() => onToggleAssignmentDomain?.(d.domainId)}
           onChangeLevel={(level) => onChangeLevel?.(d.domainId, level)}
         />
       ))}
@@ -419,13 +434,35 @@ function DomainLevelChip({
   domain,
   canEdit,
   isAssignment,
+  canToggleAssignment,
+  onToggleAssignment,
   onChangeLevel,
 }: {
   domain: DomainLevel;
   canEdit: boolean;
   isAssignment: boolean;
+  canToggleAssignment: boolean;
+  onToggleAssignment: () => void;
   onChangeLevel: (level: Level) => void;
 }) {
+  const nameButton = canToggleAssignment ? (
+    <button
+      type="button"
+      onClick={onToggleAssignment}
+      title={
+        isAssignment
+          ? `Remove ${domain.domainName} from staffing assignment`
+          : `Staff in ${domain.domainName}`
+      }
+      aria-pressed={isAssignment}
+      className="hover:underline focus:outline-none focus:underline"
+    >
+      {domain.domainName}
+    </button>
+  ) : (
+    <span>{domain.domainName}</span>
+  );
+
   return (
     <span
       className={`inline-flex items-center gap-1 px-1.5 py-0.5 text-[10px] font-medium rounded ${
@@ -436,10 +473,12 @@ function DomainLevelChip({
       title={
         isAssignment
           ? `${domain.domainName} · ${domain.level} (staffing assignment)`
-          : `${domain.domainName} · ${domain.level}`
+          : canToggleAssignment
+            ? `Click ${domain.domainName} to staff in this domain · ${domain.level}`
+            : `${domain.domainName} · ${domain.level}`
       }
     >
-      {domain.domainName}
+      {nameButton}
       {canEdit ? (
         <select
           value={domain.level}

--- a/dali-api/app/projects/components/StaffingBoard.tsx
+++ b/dali-api/app/projects/components/StaffingBoard.tsx
@@ -4,7 +4,7 @@ import type { DragEndEvent } from "@dnd-kit/core";
 import { KanbanBoard, type KanbanColumn } from "~/components/board/KanbanBoard";
 import {
   buildBoard,
-  resolveAssignmentInputs,
+  resolveAssignmentDomains,
   UNASSIGNED,
   type MemberCardModel,
   type MemberInput,
@@ -152,12 +152,13 @@ export function StaffingBoard({
         : [...prev, { domainId, domainName, level }];
       setDomainLevelsByUser((map) => ({ ...map, [userId]: next }));
 
-      // Keep live assignment level in sync when editing the assigned domain.
-      const assignment = assignments.find((a) => a.userId === userId);
+      // Keep live assignment level in sync when editing an assigned domain.
       const prevAssignments = assignments;
-      if (assignment && assignment.domainId === domainId && assignment.level !== level) {
+      if (assignments.some((a) => a.userId === userId && a.domainId === domainId && a.level !== level)) {
         setAssignments((list) =>
-          list.map((a) => (a.userId === userId ? { ...a, level } : a)),
+          list.map((a) =>
+            a.userId === userId && a.domainId === domainId ? { ...a, level } : a,
+          ),
         );
       }
 
@@ -181,6 +182,49 @@ export function StaffingBoard({
       }
     },
     [assignments, cycleId, domainLevelsByUser, revalidator],
+  );
+
+  const toggleAssignmentDomain = useCallback(
+    async (userId: string, domainId: string) => {
+      const current = assignments.filter((a) => a.userId === userId);
+      const projectId = current[0]?.projectId;
+      if (!projectId) return;
+
+      const has = current.some((a) => a.domainId === domainId);
+      let next: Assignment[];
+      if (has) {
+        if (current.length === 1) {
+          setError("Keep at least one domain, or drag the card to Unassigned.");
+          return;
+        }
+        next = current.filter((a) => a.domainId !== domainId);
+      } else {
+        const levels = domainLevelsByUser[userId] ?? members.find((m) => m.userId === userId)?.domainLevels ?? [];
+        const dl = levels.find((d) => d.domainId === domainId);
+        if (!dl) {
+          setError("Add that domain to their eligibility first.");
+          return;
+        }
+        next = [...current, { userId, projectId, domainId, level: dl.level }];
+      }
+
+      const prevAssignments = assignments;
+      setAssignments((list) => [...list.filter((a) => a.userId !== userId), ...next]);
+      setError(null);
+      try {
+        await persist({
+          cycleId,
+          userId,
+          projectId,
+          domains: next.map((a) => ({ domainId: a.domainId, level: a.level })),
+        });
+        revalidator.revalidate();
+      } catch (err) {
+        setAssignments(prevAssignments);
+        setError(err instanceof Error ? err.message : "Failed to update domains");
+      }
+    },
+    [assignments, cycleId, domainLevelsByUser, members, revalidator],
   );
 
   // Non-roster external mentors placed on project columns. Managers only.
@@ -310,6 +354,7 @@ export function StaffingBoard({
           { domainId: e.domainId, domainName: domainNames[e.domainId] ?? "?", level: "P3" },
         ],
         level: "P3",
+        assignmentDomainIds: [e.domainId],
         topPreferences: [],
         unresolvedBid: false,
         manuallyAdded: false,
@@ -373,19 +418,15 @@ export function StaffingBoard({
       ...withoutMoved.slice(insertAt),
     ];
 
-    // A cross-column move also needs the assignment updated. Resolve domain +
-    // level for a project column; UNASSIGNED clears the assignment.
+    // A cross-column move also needs the assignment updated. Resolve domain(s)
+    // + level for a project column; UNASSIGNED clears the assignment.
     const targetProjectId = toColumn === UNASSIGNED ? null : toColumn;
-    let assignmentBody: { domainId: string; level: "P1" | "P2" | "P3" } | null = null;
+    let assignmentDomains: { domainId: string; level: "P1" | "P2" | "P3" }[] | null = null;
     if (!movedWithinColumn && targetProjectId !== null) {
-      assignmentBody = resolveAssignmentInputs(member, targetProjectId);
-      if (!assignmentBody) {
+      assignmentDomains = resolveAssignmentDomains(member, targetProjectId);
+      if (!assignmentDomains) {
         setError(
-          `Can't infer a domain + level for ${member.firstName} ${member.lastName}: they have no bid and ${
-            member.domainLevels.length === 0
-              ? "no domain eligibility"
-              : "are eligible in multiple domains"
-          }. Add a bid, or set their eligibility to a single domain.`,
+          `Can't infer a domain + level for ${member.firstName} ${member.lastName}: they have no bid and no domain eligibility. Add a bid or set their eligibility.`,
         );
         return;
       }
@@ -402,7 +443,12 @@ export function StaffingBoard({
           ? withoutOld
           : [
               ...withoutOld,
-              { userId, projectId: targetProjectId, domainId: assignmentBody!.domainId, level: assignmentBody!.level },
+              ...assignmentDomains!.map((d) => ({
+                userId,
+                projectId: targetProjectId,
+                domainId: d.domainId,
+                level: d.level,
+              })),
             ],
       );
     }
@@ -419,8 +465,7 @@ export function StaffingBoard({
           cycleId,
           userId,
           projectId: targetProjectId,
-          domainId: assignmentBody?.domainId,
-          level: assignmentBody?.level,
+          domains: assignmentDomains ?? undefined,
         });
       }
       await persistOrder({ cycleId, columnKey: toColumn, userIds: nextDestIds });
@@ -659,8 +704,11 @@ export function StaffingBoard({
             })()}
             canEditDomains={canManage && !card.isExternalMentor}
             allDomains={domains}
-            assignmentDomainId={
-              assignments.find((a) => a.userId === card.userId)?.domainId ?? null
+            assignmentDomainIds={card.assignmentDomainIds}
+            onToggleAssignmentDomain={
+              canManage && !card.isExternalMentor && columnIdOf.get(card.userId) !== UNASSIGNED
+                ? (domainId) => void toggleAssignmentDomain(card.userId, domainId)
+                : undefined
             }
             onChangeDomainLevel={(domainId, level) => {
               const name =
@@ -925,6 +973,7 @@ async function persist(args: {
   projectId: string | null;
   domainId?: string;
   level?: Preference["level"];
+  domains?: { domainId: string; level: Preference["level"] }[];
 }): Promise<void> {
   const res = await fetch("/api/staffing/assign", {
     method: "POST",

--- a/dali-api/app/projects/lib/__tests__/staffing-board.test.ts
+++ b/dali-api/app/projects/lib/__tests__/staffing-board.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   buildBoard,
   dedupeLiveAssignments,
+  resolveAssignmentDomains,
   resolveAssignmentInputs,
   UNASSIGNED,
   type MemberInput,
@@ -295,7 +296,7 @@ describe("resolveAssignmentInputs", () => {
     expect(out).toBeNull();
   });
 
-  it("returns null when the member has no bid and multiple eligibilities (ambiguous)", () => {
+  it("seeds the first eligibility when the member has no bid and multiple eligibilities", () => {
     const out = resolveAssignmentInputs(
       member({
         preferences: [],
@@ -306,15 +307,39 @@ describe("resolveAssignmentInputs", () => {
       }),
       "p1",
     );
-    expect(out).toBeNull();
+    expect(out).toEqual({ domainId: "d1", level: "P2" });
+  });
+});
+
+describe("resolveAssignmentDomains", () => {
+  it("returns every bid domain for the target project", () => {
+    const out = resolveAssignmentDomains(
+      member({
+        preferences: [
+          { projectId: "p1", domainId: "d1", level: "P1", preferenceRank: 1, notes: null },
+          { projectId: "p1", domainId: "d2", level: "P2", preferenceRank: 1, notes: null },
+        ],
+      }),
+      "p1",
+    );
+    expect(out).toEqual([
+      { domainId: "d1", level: "P1" },
+      { domainId: "d2", level: "P2" },
+    ]);
   });
 });
 
 describe("dedupeLiveAssignments", () => {
-  const row = (userId: string, status: "Proposed" | "Confirmed", projectId: string) => ({
+  const row = (
+    userId: string,
+    status: "Proposed" | "Confirmed",
+    projectId: string,
+    domainId = "d1",
+  ) => ({
     userId,
     status,
     projectId,
+    domainId,
   });
 
   it("keeps a lone Confirmed row so a finalized roster stays on the board", () => {
@@ -322,7 +347,7 @@ describe("dedupeLiveAssignments", () => {
     expect(out).toEqual([row("u1", "Confirmed", "p1")]);
   });
 
-  it("prefers Proposed over Confirmed for the same user (in-progress re-edit wins)", () => {
+  it("prefers Proposed over Confirmed for the same user+domain (in-progress re-edit wins)", () => {
     // User was confirmed on p1, then dragged to p2 (fresh Proposed row).
     const out = dedupeLiveAssignments([
       row("u1", "Confirmed", "p1"),
@@ -339,7 +364,25 @@ describe("dedupeLiveAssignments", () => {
     expect(out).toEqual([row("u1", "Proposed", "p2")]);
   });
 
-  it("returns one row per user across a mixed set", () => {
+  it("keeps multiple Proposed domains for the same user on one project", () => {
+    const out = dedupeLiveAssignments([
+      row("u1", "Proposed", "p1", "d1"),
+      row("u1", "Proposed", "p1", "d2"),
+    ]);
+    expect(out).toHaveLength(2);
+    expect(out.map((r) => r.domainId).sort()).toEqual(["d1", "d2"]);
+  });
+
+  it("drops Confirmed domains when the user has any Proposed (re-edit wins)", () => {
+    const out = dedupeLiveAssignments([
+      row("u1", "Confirmed", "p1", "d1"),
+      row("u1", "Confirmed", "p1", "d2"),
+      row("u1", "Proposed", "p2", "d1"),
+    ]);
+    expect(out).toEqual([row("u1", "Proposed", "p2", "d1")]);
+  });
+
+  it("returns live rows across a mixed set (one per user+domain)", () => {
     const out = dedupeLiveAssignments([
       row("u1", "Confirmed", "p1"),
       row("u2", "Proposed", "p1"),

--- a/dali-api/app/projects/lib/staffing-board.ts
+++ b/dali-api/app/projects/lib/staffing-board.ts
@@ -73,8 +73,12 @@ export type MemberCardModel = {
   // chips on the card regardless of column.
   domainLevels: DomainLevel[];
   // Level to display on the card. For Unassigned, the top-preference level.
-  // For an assigned column, the level recorded on the assignment row.
+  // For an assigned column, the highest assignment level (P3 > P2 > P1) among
+  // selected domains — drives the default Mentor badge.
   level: Level | null;
+  // Domain ids selected for the live staffing assignment on this project.
+  // Empty when Unassigned. Clicking a domain chip toggles membership here.
+  assignmentDomainIds: string[];
   // Member's top 3 project preferences in rank order. Always shown on the card.
   // Deduped by (projectId, rank): a member can bid the same project at one rank
   // in multiple domains (e.g. Evergreen #1 as both Fullstack and UI/UX) — those
@@ -99,23 +103,33 @@ export const UNASSIGNED = "__unassigned__";
  * A member can hold both a Proposed and a Confirmed StaffingAssignment in the
  * same cycle: dragging after finalize writes a fresh Proposed row without
  * touching the audit-trail Confirmed one. The board (and finalize) treat a
- * member's LIVE assignment as their Proposed row if present, else Confirmed —
+ * member's LIVE assignment(s) as their Proposed rows if any, else Confirmed —
  * so an in-progress re-edit wins over the already-finalized position. Declined
  * rows are audit only and must be filtered out before calling this.
  *
- * Returns one row per userId. Input order is otherwise preserved.
+ * Multiple domains per user on one project are allowed (one row per
+ * userId+domainId). When the user has any Proposed row, Confirmed rows for
+ * other domains/projects are dropped so a drag-away doesn't leave them on
+ * two projects at once.
  */
-export function dedupeLiveAssignments<T extends { userId: string; status: string }>(
-  rows: T[],
-): T[] {
-  const byUser = new Map<string, T>();
+export function dedupeLiveAssignments<
+  T extends { userId: string; status: string; domainId?: string },
+>(rows: T[]): T[] {
+  const byDomain = new Map<string, T>();
   for (const r of rows) {
-    const existing = byUser.get(r.userId);
+    const key = `${r.userId}|${r.domainId ?? ""}`;
+    const existing = byDomain.get(key);
     if (!existing || (existing.status === "Confirmed" && r.status === "Proposed")) {
-      byUser.set(r.userId, r);
+      byDomain.set(key, r);
     }
   }
-  return Array.from(byUser.values());
+  const collapsed = Array.from(byDomain.values());
+  const usersWithProposed = new Set(
+    collapsed.filter((r) => r.status === "Proposed").map((r) => r.userId),
+  );
+  return collapsed.filter(
+    (r) => r.status === "Proposed" || !usersWithProposed.has(r.userId),
+  );
 }
 
 /**
@@ -147,11 +161,11 @@ export function buildBoard(args: {
     m.set(o.userId, o.sortKey);
   }
 
-  const byUser = new Map<string, Assignment>();
+  const byUser = new Map<string, Assignment[]>();
   for (const a of assignments) {
-    // If multiple proposals exist for the same user (shouldn't, but be
-    // defensive), the latest write wins. Loader sorts to make this stable.
-    byUser.set(a.userId, a);
+    const list = byUser.get(a.userId) ?? [];
+    list.push(a);
+    byUser.set(a.userId, list);
   }
 
   // Initialise columns even when empty so the UI can render placeholders.
@@ -159,12 +173,15 @@ export function buildBoard(args: {
   for (const pid of projectIds) columns[pid] = [];
 
   for (const m of members) {
-    const assignment = byUser.get(m.userId) ?? null;
-    const columnKey = assignment?.projectId && columns[assignment.projectId]
-      ? assignment.projectId
-      : UNASSIGNED;
+    const userAssignments = byUser.get(m.userId) ?? [];
+    // All live domains for a user share one project (assign API enforces that).
+    const primary = userAssignments[0] ?? null;
+    const columnKey =
+      primary?.projectId && columns[primary.projectId]
+        ? primary.projectId
+        : UNASSIGNED;
 
-    const card = toCard(m, columnKey, assignment);
+    const card = toCard(m, columnKey, primary, userAssignments);
     columns[columnKey].push(card);
   }
 
@@ -193,15 +210,22 @@ export function buildBoard(args: {
 function toCard(
   member: MemberInput,
   columnKey: string,
-  assignment: Assignment | null,
+  primary: Assignment | null,
+  userAssignments: Assignment[],
 ): MemberCardModel {
   const prefsByProject = new Map(member.preferences.map((p) => [p.projectId, p]));
+  const rank = { P1: 1, P2: 2, P3: 3 } as const;
 
   let level: Level | null;
   if (columnKey === UNASSIGNED) {
     level = topPreference(member.preferences)?.level ?? null;
+  } else if (userAssignments.length > 0) {
+    level = userAssignments.reduce<Level>(
+      (best, a) => (rank[a.level] > rank[best] ? a.level : best),
+      userAssignments[0].level,
+    );
   } else {
-    level = assignment?.level ?? prefsByProject.get(columnKey)?.level ?? null;
+    level = primary?.level ?? prefsByProject.get(columnKey)?.level ?? null;
   }
 
   return {
@@ -214,6 +238,7 @@ function toCard(
     coreTitles: member.coreTitles,
     domainLevels: member.domainLevels,
     level,
+    assignmentDomainIds: userAssignments.map((a) => a.domainId),
     topPreferences: topPreferences(member.preferences),
     unresolvedBid: member.unresolvedBid ?? false,
     manuallyAdded: member.manuallyAdded ?? false,
@@ -252,28 +277,50 @@ function topPreference(prefs: Preference[]): Preference | null {
 }
 
 /**
- * Resolve which (domainId, level) to record on a new StaffingAssignment when
- * a member is dragged into a project column. Preference order:
- *   1. The member's existing preference for that project (the bid).
+ * Resolve which (domainId, level) rows to record when a member is dragged into
+ * a project column. Preference order:
+ *   1. All of the member's preferences for that project (multi-domain bids →
+ *      multi-domain assignment).
  *   2. The member's top-ranked preference overall (fallback when they didn't
  *      bid on this project but a lead is staffing them anyway).
- *   3. The member's DomainEligibility when they have exactly one — lets a lead
- *      place a manually-added, non-bidding member (their eligibility is the
- *      only domain+level they could be staffed at).
- *   4. null → caller must reject (no bid and no single eligibility to infer
- *      from; a member eligible in multiple domains is ambiguous here).
+ *   3. DomainEligibility: every eligibility when they have one or more — with
+ *      multiple domains the board seeds the first and the lead clicks chips to
+ *      add/remove. (Returning null only when there is nothing to infer.)
  */
+export function resolveAssignmentDomains(
+  member: MemberInput,
+  targetProjectId: string,
+): { domainId: string; level: Level }[] | null {
+  const matching = member.preferences.filter((p) => p.projectId === targetProjectId);
+  if (matching.length > 0) {
+    const rank = { P1: 1, P2: 2, P3: 3 } as const;
+    const byDomain = new Map<string, Level>();
+    for (const p of matching) {
+      const prev = byDomain.get(p.domainId);
+      if (!prev || rank[p.level] > rank[prev]) byDomain.set(p.domainId, p.level);
+    }
+    return [...byDomain.entries()].map(([domainId, level]) => ({ domainId, level }));
+  }
+  const top = topPreference(member.preferences);
+  if (top) return [{ domainId: top.domainId, level: top.level }];
+  if (member.domainLevels.length === 1) {
+    const only = member.domainLevels[0];
+    return [{ domainId: only.domainId, level: only.level }];
+  }
+  if (member.domainLevels.length > 1) {
+    // Ambiguous: seed with the first eligibility so the card can land on the
+    // column; the lead clicks other domain chips to add (or deselect).
+    const first = member.domainLevels[0];
+    return [{ domainId: first.domainId, level: first.level }];
+  }
+  return null;
+}
+
+/** @deprecated Prefer resolveAssignmentDomains — kept for callers that want one. */
 export function resolveAssignmentInputs(
   member: MemberInput,
   targetProjectId: string,
 ): { domainId: string; level: Level } | null {
-  const matching = member.preferences.find((p) => p.projectId === targetProjectId);
-  if (matching) return { domainId: matching.domainId, level: matching.level };
-  const top = topPreference(member.preferences);
-  if (top) return { domainId: top.domainId, level: top.level };
-  if (member.domainLevels.length === 1) {
-    const only = member.domainLevels[0];
-    return { domainId: only.domainId, level: only.level };
-  }
-  return null;
+  const domains = resolveAssignmentDomains(member, targetProjectId);
+  return domains?.[0] ?? null;
 }

--- a/dali-api/app/projects/routes/api.staffing.assign.ts
+++ b/dali-api/app/projects/routes/api.staffing.assign.ts
@@ -9,17 +9,19 @@ import { publishCycleChange } from "../lib/staffing-events.server";
 
 // POST /api/staffing/assign
 //
-// Body: { userId, cycleId, projectId | null, domainId, level }
+// Body: { userId, cycleId, projectId | null, domainId?, level?, domains? }
 //   - projectId === null → move the member back to Unassigned (delete their
 //     Proposed StaffingAssignment for this cycle).
-//   - projectId set → upsert a Proposed StaffingAssignment for (userId, cycleId)
-//     pointing at the target project. The board is the single source of
-//     proposed state, so we clear any prior Proposed row for the same
-//     user+cycle in the same transaction.
+//   - projectId set → replace Proposed rows for (userId, cycleId) with one
+//     Proposed StaffingAssignment per domain (all on the same project). Pass
+//     `domains: [{ domainId, level }, ...]` for multi-domain staffing, or the
+//     legacy single `domainId` + `level`.
 //
 // The schema has no (userId, staffingCycleId) unique constraint — multiple
-// proposals across history are fine; we just want "at most one Proposed at a
-// time per (user, cycle)".
+// proposals across history are fine; we just want "at most one Proposed set at
+// a time per (user, cycle)" covering every selected domain.
+
+type DomainLevelBody = { domainId: string; level: Level };
 
 type Body = {
   userId: string;
@@ -27,7 +29,26 @@ type Body = {
   projectId: string | null;
   domainId?: string;
   level?: Level;
+  domains?: DomainLevelBody[];
 };
+
+function parseDomains(o: Record<string, unknown>): DomainLevelBody[] | null {
+  if (Array.isArray(o.domains)) {
+    if (o.domains.length === 0) return null;
+    const out: DomainLevelBody[] = [];
+    for (const item of o.domains) {
+      if (!item || typeof item !== "object") return null;
+      const d = item as Record<string, unknown>;
+      if (typeof d.domainId !== "string" || !isLevel(d.level)) return null;
+      out.push({ domainId: d.domainId, level: d.level });
+    }
+    return out;
+  }
+  if (typeof o.domainId === "string" && isLevel(o.level)) {
+    return [{ domainId: o.domainId, level: o.level }];
+  }
+  return null;
+}
 
 function isBody(x: unknown): x is Body {
   if (!x || typeof x !== "object") return false;
@@ -36,8 +57,9 @@ function isBody(x: unknown): x is Body {
   if (typeof o.cycleId !== "string") return false;
   if (o.projectId !== null && typeof o.projectId !== "string") return false;
   if (o.projectId !== null) {
-    if (typeof o.domainId !== "string") return false;
-    if (!isLevel(o.level)) return false;
+    const domains = parseDomains(o);
+    if (!domains) return false;
+    (o as Body).domains = domains;
   }
   return true;
 }
@@ -76,9 +98,10 @@ export async function action({ request }: Route.ActionArgs) {
   }
 
   const assignerId = auth.user.sub;
+  const domains = body.domains ?? [];
 
   await prisma.$transaction(async (tx) => {
-    // Drop any prior Proposed row for this (userId, cycle). Confirmed +
+    // Drop any prior Proposed rows for this (userId, cycle). Confirmed +
     // Declined rows are kept as audit trail.
     await tx.staffingAssignment.deleteMany({
       where: {
@@ -89,18 +112,20 @@ export async function action({ request }: Route.ActionArgs) {
     });
 
     if (body.projectId !== null) {
-      await tx.staffingAssignment.create({
-        data: {
-          userId: body.userId,
-          staffingCycleId: body.cycleId,
-          projectId: body.projectId,
-          termId: cycle.termId,
-          domainId: body.domainId!,
-          level: body.level!,
-          status: "Proposed",
-          assignedById: assignerId,
-        },
-      });
+      for (const d of domains) {
+        await tx.staffingAssignment.create({
+          data: {
+            userId: body.userId,
+            staffingCycleId: body.cycleId,
+            projectId: body.projectId,
+            termId: cycle.termId,
+            domainId: d.domainId,
+            level: d.level,
+            status: "Proposed",
+            assignedById: assignerId,
+          },
+        });
+      }
     }
   });
 
@@ -111,8 +136,12 @@ export async function action({ request }: Route.ActionArgs) {
     metadata: {
       cycleId: body.cycleId,
       projectId: body.projectId,
-      domainId: body.domainId ?? null,
-      level: body.level ?? null,
+      domains:
+        body.projectId === null
+          ? null
+          : domains.map((d) => ({ domainId: d.domainId, level: d.level })),
+      domainId: domains[0]?.domainId ?? null,
+      level: domains[0]?.level ?? null,
     },
     request,
   });

--- a/dali-api/app/projects/routes/api.staffing.eligibility.ts
+++ b/dali-api/app/projects/routes/api.staffing.eligibility.ts
@@ -91,7 +91,8 @@ export async function action({ request }: Route.ActionArgs) {
   });
 
   // If they're live-assigned in this domain, keep the board assignment level
-  // in sync so Propagate / mentorship pairing sees the new level.
+  // in sync so Propagate / mentorship pairing sees the new level. Preserve any
+  // other selected domains on the same project (multi-domain staffing).
   const cycleRows = await prisma.staffingAssignment.findMany({
     where: {
       staffingCycleId: cycle.id,
@@ -107,8 +108,15 @@ export async function action({ request }: Route.ActionArgs) {
       status: true,
     },
   });
-  const live = dedupeLiveAssignments(cycleRows)[0] ?? null;
-  if (live && live.domainId === body.domainId && live.level !== body.level && live.projectId) {
+  const liveRows = dedupeLiveAssignments(cycleRows);
+  const match = liveRows.find((r) => r.domainId === body.domainId) ?? null;
+  if (match && match.level !== body.level && match.projectId) {
+    const siblings = liveRows.filter((r) => r.projectId === match.projectId);
+    const nextDomains = siblings.map((r) =>
+      r.domainId === body.domainId
+        ? { domainId: r.domainId, level: body.level }
+        : { domainId: r.domainId, level: r.level },
+    );
     await prisma.$transaction(async (tx) => {
       await tx.staffingAssignment.deleteMany({
         where: {
@@ -117,18 +125,20 @@ export async function action({ request }: Route.ActionArgs) {
           status: "Proposed",
         },
       });
-      await tx.staffingAssignment.create({
-        data: {
-          userId: body.userId,
-          staffingCycleId: cycle.id,
-          projectId: live.projectId,
-          termId: cycle.termId,
-          domainId: body.domainId,
-          level: body.level,
-          status: "Proposed",
-          assignedById: auth.user.sub,
-        },
-      });
+      for (const d of nextDomains) {
+        await tx.staffingAssignment.create({
+          data: {
+            userId: body.userId,
+            staffingCycleId: cycle.id,
+            projectId: match.projectId,
+            termId: cycle.termId,
+            domainId: d.domainId,
+            level: d.level,
+            status: "Proposed",
+            assignedById: auth.user.sub,
+          },
+        });
+      }
     });
   }
 

--- a/dali-api/app/projects/routes/api.staffing.finalize.ts
+++ b/dali-api/app/projects/routes/api.staffing.finalize.ts
@@ -190,9 +190,10 @@ export async function action({ request }: Route.ActionArgs) {
         where: { staffingCycleId: cycle.id, status: { in: ["Proposed", "Confirmed"] } },
         select: { id: true, userId: true, projectId: true, domainId: true, level: true, status: true },
       });
-      // Target roster = members whose live assignment points at THIS project.
+      // Target roster = members whose live assignment points at THIS project
+      // (one row per userId+domainId — multi-domain staffing is allowed).
       const liveTarget = dedupeLiveAssignments(cycleRows).filter((r) => r.projectId === project.id);
-      const targetUserIds = new Set(liveTarget.map((r) => r.userId));
+      const targetKeys = new Set(liveTarget.map((r) => `${r.userId}|${r.domainId}`));
 
       // An assignment's domainId is unguarded (StaffingAssignment has no FK to
       // Domain), so a blank/stale value can slip in — e.g. a bid whose domain
@@ -211,13 +212,16 @@ export async function action({ request }: Route.ActionArgs) {
         })
       ).map((u) => `${u.firstName} ${u.lastName}`.trim());
 
-      // Members currently Confirmed on this project who are no longer in the
-      // target roster (dragged off / to another project / unassigned). Decline
-      // their stale Confirmed rows and drop the ProjectAssignment for this
-      // project+cycle. DomainEligibility is left intact — it's monotonic and a
-      // promotion already granted isn't revoked by re-staffing.
+      // Confirmed rows on this project whose (user, domain) is no longer live —
+      // member dragged off, or a domain chip deselected while they stay on the
+      // project. Decline those rows and drop the matching ProjectAssignment.
+      // DomainEligibility is left intact — it's monotonic and a promotion
+      // already granted isn't revoked by re-staffing.
       const droppedRows = cycleRows.filter(
-        (r) => r.status === "Confirmed" && r.projectId === project.id && !targetUserIds.has(r.userId),
+        (r) =>
+          r.status === "Confirmed" &&
+          r.projectId === project.id &&
+          !targetKeys.has(`${r.userId}|${r.domainId}`),
       );
 
       let droppedCount = 0;
@@ -394,8 +398,10 @@ export async function action({ request }: Route.ActionArgs) {
         const nameById = new Map(
           menteeUsers.map((u) => [u.id, `${u.firstName} ${u.lastName}`.trim()]),
         );
+        // Soft-skip: other domains still paired; surface a warning, not a
+        // hard error, so the rest of Propagate isn't treated as failed.
         mentorshipGapNote =
-          " Mentorship not created for " +
+          " Skipped mentorship for " +
           mentorshipGaps
             .map((g) => {
               const domain = domainNameById.get(g.domainId) ?? "Unknown domain";
@@ -403,13 +409,13 @@ export async function action({ request }: Route.ActionArgs) {
               return `${domain} (mentees but no P3/Mentor: ${names})`;
             })
             .join("; ") +
-          ". Raise someone to P3 on their domain chip (or mark Mentor / add an external mentor), then re-run Propagate.";
+          " — other domains were paired. Raise someone to P3 on their domain chip (or mark Mentor / add an external mentor), then re-run Propagate.";
       }
 
       results.assignments = {
-        // Flag as error when anyone was skipped or mentorship could not be
-        // derived for a multi-person domain — assignments still went through.
-        status: skippedNames.length > 0 || mentorshipGaps.length > 0 ? "error" : "ok",
+        // Invalid/blank domains are a real data error; mentorship gaps for
+        // individual domains are soft-skipped and stay status ok.
+        status: skippedNames.length > 0 ? "error" : "ok",
         message:
           (confirmedCount === 0 && droppedCount === 0
             ? "No proposed assignments for this project."

--- a/dali-api/app/projects/routes/api.staffing.mentor-role.ts
+++ b/dali-api/app/projects/routes/api.staffing.mentor-role.ts
@@ -10,10 +10,12 @@ import { publishCycleChange } from "../lib/staffing-events.server";
 // to their level (P3 → mentor, else mentee); a StaffingMentorRole row overrides
 // it when a manager clicks the card's role badge. Gated to staffing managers.
 //
-//   GET  ?cycleId=
+//   GET  ?cycleId=&projectId=
 //          → { overrides: { [userId]: boolean }, nonP3Mentors: [{ userId, firstName, lastName }] }
-//        overrides drives each card's badge; nonP3Mentors are effective mentors
-//        who aren't P3 yet (finalize offers to promote them).
+//        overrides drives each card's badge (cycle-wide). nonP3Mentors are
+//        override mentors on the given project who aren't P3 there yet
+//        (finalize offers to promote them). Without projectId, nonP3Mentors
+//        is empty — avoid surfacing mentors from other projects.
 //   POST { cycleId, userId, isMentor }
 //          → upsert the override (idempotent on cycle+user).
 
@@ -38,6 +40,7 @@ export async function loader({ request }: Route.LoaderArgs) {
 
   const url = new URL(request.url);
   const cycleId = url.searchParams.get("cycleId");
+  const projectId = url.searchParams.get("projectId");
   if (!cycleId) {
     return withCors(request, Response.json({ error: "cycleId required" }, { status: 400 }));
   }
@@ -51,6 +54,7 @@ export async function loader({ request }: Route.LoaderArgs) {
       where: { staffingCycleId: cycleId, status: { not: "Declined" } },
       select: {
         userId: true,
+        projectId: true,
         level: true,
         user: { select: { firstName: true, lastName: true } },
       },
@@ -60,21 +64,26 @@ export async function loader({ request }: Route.LoaderArgs) {
   const overrides: Record<string, boolean> = {};
   for (const r of overrideRows) overrides[r.userId] = r.isMentor;
 
-  // Effective mentors who aren't P3 in any staffed domain — finalize can promote
-  // them. Only override-driven mentors qualify: a default mentor is P3 already.
-  const isP3Somewhere = new Set<string>();
-  const nameByUser = new Map<string, { firstName: string; lastName: string }>();
-  for (const a of assignments) {
-    nameByUser.set(a.userId, a.user);
-    if (a.level === "P3") isP3Somewhere.add(a.userId);
+  // Finalize promote list is project-scoped: only override mentors live-assigned
+  // to this project who aren't P3 on that project. Cycle-wide overrides for
+  // people on other projects must not appear when finalizing an unrelated one.
+  let nonP3Mentors: { userId: string; firstName: string; lastName: string }[] = [];
+  if (projectId) {
+    const onProject = assignments.filter((a) => a.projectId === projectId);
+    const onProjectIds = new Set(onProject.map((a) => a.userId));
+    const isP3OnProject = new Set(
+      onProject.filter((a) => a.level === "P3").map((a) => a.userId),
+    );
+    const nameByUser = new Map<string, { firstName: string; lastName: string }>();
+    for (const a of onProject) nameByUser.set(a.userId, a.user);
+    nonP3Mentors = overrideRows
+      .filter((r) => r.isMentor && onProjectIds.has(r.userId) && !isP3OnProject.has(r.userId))
+      .map((r) => ({
+        userId: r.userId,
+        firstName: nameByUser.get(r.userId)?.firstName ?? "",
+        lastName: nameByUser.get(r.userId)?.lastName ?? "",
+      }));
   }
-  const nonP3Mentors = overrideRows
-    .filter((r) => r.isMentor && !isP3Somewhere.has(r.userId))
-    .map((r) => ({
-      userId: r.userId,
-      firstName: nameByUser.get(r.userId)?.firstName ?? "",
-      lastName: nameByUser.get(r.userId)?.lastName ?? "",
-    }));
 
   return withCors(request, Response.json({ overrides, nonP3Mentors }));
 }


### PR DESCRIPTION
* Staffing: edit domain·level chips on cards instead of a separate level control.

Remove the P1/P2/P3 LevelBadge. Managers change eligibility per domain on the existing chip strip and can add a domain; live assignment level stays in sync when that domain is the staffing assignment.



* Staffing: multi-domain assign, soft-skip mentorship gaps, project-scoped promote list.

Allow clicking domain chips to staff in one or more domains; skip pairing for domains without a mentor while finishing the rest; and only show non-P3 mentors who are actually on the project being finalized.



---------

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/979"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787274553&installation_model_id=21824&pr_number=979&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F979&signature=cc2f42bacc430c5cb27f5da93516562e05a26d01926ccc881c3bc4567ae6d430"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->