### PR TITLE
Finalize: replace mentorship pairs for project+term

### DIFF
--- a/dali-api/app/projects/lib/__tests__/mentorship-pairings.test.ts
+++ b/dali-api/app/projects/lib/__tests__/mentorship-pairings.test.ts
@@ -4,14 +4,18 @@ import { derivePairings, findDomainsMissingMentors } from "../mentorship-pairing
 type Row = { userId: string; domainId: string; level: "P1" | "P2" | "P3" };
 type Pair = { menteeUserId: string; mentorUserId: string; domainId: string };
 
-function mkTx(assignments: Row[], existing: Pair[]) {
+function mkTx(assignments: Row[]) {
   const created: Pair[] = [];
+  let deletedWhere: { projectId: string; termId: string } | null = null;
   const tx = {
     projectAssignment: {
       findMany: vi.fn().mockResolvedValue(assignments),
     },
     mentorshipPair: {
-      findMany: vi.fn().mockResolvedValue(existing),
+      deleteMany: vi.fn().mockImplementation(async ({ where }: any) => {
+        deletedWhere = where;
+        return { count: 1 };
+      }),
       createMany: vi.fn().mockImplementation(async ({ data }: any) => {
         for (const d of data) {
           created.push({
@@ -24,20 +28,22 @@ function mkTx(assignments: Row[], existing: Pair[]) {
       }),
     },
   };
-  return { tx, created };
+  return {
+    tx,
+    created,
+    getDeletedWhere: () => deletedWhere,
+  };
 }
 
 describe("derivePairings", () => {
   it("creates one pair per (mentee, mentor) in the same domain", async () => {
-    const { tx, created } = mkTx(
-      [
-        { userId: "mentee-a", domainId: "d1", level: "P1" },
-        { userId: "mentee-b", domainId: "d1", level: "P2" },
-        { userId: "mentor-x", domainId: "d1", level: "P3" },
-      ],
-      [],
-    );
+    const { tx, created, getDeletedWhere } = mkTx([
+      { userId: "mentee-a", domainId: "d1", level: "P1" },
+      { userId: "mentee-b", domainId: "d1", level: "P2" },
+      { userId: "mentor-x", domainId: "d1", level: "P3" },
+    ]);
     const n = await derivePairings(tx as any, "proj1", "term1");
+    expect(getDeletedWhere()).toEqual({ projectId: "proj1", termId: "term1" });
     expect(n).toBe(2);
     expect(created).toEqual([
       { menteeUserId: "mentee-a", mentorUserId: "mentor-x", domainId: "d1" },
@@ -46,70 +52,67 @@ describe("derivePairings", () => {
   });
 
   it("does not cross domain boundaries", async () => {
-    const { tx, created } = mkTx(
-      [
-        { userId: "mentee-a", domainId: "d1", level: "P1" },
-        { userId: "mentor-x", domainId: "d2", level: "P3" },
-      ],
-      [],
-    );
+    const { tx, created } = mkTx([
+      { userId: "mentee-a", domainId: "d1", level: "P1" },
+      { userId: "mentor-x", domainId: "d2", level: "P3" },
+    ]);
     const n = await derivePairings(tx as any, "proj1", "term1");
     expect(n).toBe(0);
     expect(created).toEqual([]);
   });
 
   it("pairs to multiple mentors in the same domain", async () => {
-    const { tx, created } = mkTx(
-      [
-        { userId: "mentee-a", domainId: "d1", level: "P1" },
-        { userId: "mentor-x", domainId: "d1", level: "P3" },
-        { userId: "mentor-y", domainId: "d1", level: "P3" },
-      ],
-      [],
-    );
+    const { tx, created } = mkTx([
+      { userId: "mentee-a", domainId: "d1", level: "P1" },
+      { userId: "mentor-x", domainId: "d1", level: "P3" },
+      { userId: "mentor-y", domainId: "d1", level: "P3" },
+    ]);
     const n = await derivePairings(tx as any, "proj1", "term1");
     expect(n).toBe(2);
   });
 
-  it("is additive: skips pairs that already exist (Core override preserved)", async () => {
-    const { tx, created } = mkTx(
-      [
-        { userId: "mentee-a", domainId: "d1", level: "P1" },
-        { userId: "mentor-x", domainId: "d1", level: "P3" },
-        { userId: "mentor-y", domainId: "d1", level: "P3" },
-      ],
-      [
-        { menteeUserId: "mentee-a", mentorUserId: "mentor-x", domainId: "d1" },
-      ],
-    );
+  it("replaces prior pairs for the project+term (domain moves drop old links)", async () => {
+    // Even with no new pairs to create, prior rows for this project+term are cleared.
+    const { tx, created, getDeletedWhere } = mkTx([
+      { userId: "gaelle", domainId: "uiux", level: "P1" },
+      { userId: "moiz", domainId: "fullstack", level: "P3" },
+    ]);
+    const n = await derivePairings(tx as any, "evergreen", "26x");
+    expect(getDeletedWhere()).toEqual({ projectId: "evergreen", termId: "26x" });
+    expect(n).toBe(0);
+    expect(created).toEqual([]);
+  });
+
+  it("rebuilds the full derived set after clearing prior pairs", async () => {
+    const { tx, created } = mkTx([
+      { userId: "mentee-a", domainId: "d1", level: "P1" },
+      { userId: "mentor-x", domainId: "d1", level: "P3" },
+      { userId: "mentor-y", domainId: "d1", level: "P3" },
+    ]);
     const n = await derivePairings(tx as any, "proj1", "term1");
-    expect(n).toBe(1);
+    expect(n).toBe(2);
     expect(created).toEqual([
+      { menteeUserId: "mentee-a", mentorUserId: "mentor-x", domainId: "d1" },
       { menteeUserId: "mentee-a", mentorUserId: "mentor-y", domainId: "d1" },
     ]);
   });
 
   it("never creates pairs when there is no P3 in the domain", async () => {
-    const { tx, created } = mkTx(
-      [
-        { userId: "mentee-a", domainId: "d1", level: "P1" },
-        { userId: "mentee-b", domainId: "d1", level: "P2" },
-      ],
-      [],
-    );
+    const { tx, created, getDeletedWhere } = mkTx([
+      { userId: "mentee-a", domainId: "d1", level: "P1" },
+      { userId: "mentee-b", domainId: "d1", level: "P2" },
+    ]);
     const n = await derivePairings(tx as any, "proj1", "term1");
+    expect(getDeletedWhere()).toEqual({ projectId: "proj1", termId: "term1" });
     expect(n).toBe(0);
     expect(created).toEqual([]);
   });
 
   it("role override promotes a non-P3 to mentor", async () => {
-    const { tx, created } = mkTx(
-      [
-        { userId: "mentee-a", domainId: "d1", level: "P1" },
-        { userId: "mentor-p2", domainId: "d1", level: "P2" },
-      ],
-      [],
-    );
+    const { tx, created } = mkTx([
+      { userId: "mentee-a", domainId: "d1", level: "P1" },
+      { userId: "mentor-p2", domainId: "d1", level: "P2" },
+    ]);
     const n = await derivePairings(tx as any, "proj1", "term1", {
       roleOverride: new Map([["mentor-p2", true]]),
     });
@@ -120,13 +123,10 @@ describe("derivePairings", () => {
   });
 
   it("role override demotes a P3 to mentee", async () => {
-    const { tx, created } = mkTx(
-      [
-        { userId: "p3-demoted", domainId: "d1", level: "P3" },
-        { userId: "mentor-x", domainId: "d1", level: "P3" },
-      ],
-      [],
-    );
+    const { tx, created } = mkTx([
+      { userId: "p3-demoted", domainId: "d1", level: "P3" },
+      { userId: "mentor-x", domainId: "d1", level: "P3" },
+    ]);
     const n = await derivePairings(tx as any, "proj1", "term1", {
       roleOverride: new Map([["p3-demoted", false]]),
     });

--- a/dali-api/app/projects/lib/mentorship-pairings.ts
+++ b/dali-api/app/projects/lib/mentorship-pairings.ts
@@ -11,12 +11,9 @@ type Tx = {
     >;
   };
   mentorshipPair: {
-    findMany: (args: {
+    deleteMany: (args: {
       where: { projectId: string; termId: string };
-      select: { menteeUserId: true; mentorUserId: true; domainId: true };
-    }) => Promise<
-      { menteeUserId: string; mentorUserId: string; domainId: string }[]
-    >;
+    }) => Promise<{ count: number }>;
     createMany: (args: {
       data: {
         menteeUserId: string;
@@ -33,9 +30,11 @@ type Tx = {
 // staffed on the project: every mentee gets paired to every mentor in the same
 // domain. A member's role defaults to their level (P3 → mentor, P1/P2 →
 // mentee); `roleOverride` (from the staffing board's per-card role badge, keyed
-// by userId) flips it when present. Additive only — existing pairs are never
-// deleted, so Core overrides (manual adds/removals via the /mentorship/pairs
-// UI) are preserved across re-finalizes. Returns the count of new pairs created.
+// by userId) flips it when present.
+//
+// Replaces all existing MentorshipPair rows for this project+term, then writes
+// the derived set — so a domain move (e.g. Fullstack → UI/UX) drops the old
+// mentor link instead of leaving it behind. Returns the count of pairs created.
 export async function derivePairings(
   tx: Tx,
   projectId: string,
@@ -72,14 +71,6 @@ export async function derivePairings(
     bucketFor(em.domainId).mentors.push(em.userId);
   }
 
-  const existing = await tx.mentorshipPair.findMany({
-    where: { projectId, termId },
-    select: { menteeUserId: true, mentorUserId: true, domainId: true },
-  });
-  const seen = new Set(
-    existing.map((p) => `${p.menteeUserId}|${p.mentorUserId}|${p.domainId}`),
-  );
-
   const toCreate: {
     menteeUserId: string;
     mentorUserId: string;
@@ -91,13 +82,14 @@ export async function derivePairings(
     if (mentors.length === 0) continue;
     for (const menteeUserId of mentees) {
       for (const mentorUserId of mentors) {
-        const key = `${menteeUserId}|${mentorUserId}|${domainId}`;
-        if (seen.has(key)) continue;
-        seen.add(key);
         toCreate.push({ menteeUserId, mentorUserId, projectId, termId, domainId });
       }
     }
   }
+
+  // Clear prior pairs for this project+term so re-finalize reflects the current
+  // roster (domain chips / mentor badges), not leftover links from earlier runs.
+  await tx.mentorshipPair.deleteMany({ where: { projectId, termId } });
 
   if (toCreate.length === 0) return 0;
   await tx.mentorshipPair.createMany({ data: toCreate });


### PR DESCRIPTION
## Summary
- On Propagate/finalize, **delete all existing `MentorshipPair` rows for that project + term**, then recreate from the current roster.
- Fixes stale mentor links after domain moves (e.g. Gaelle Fullstack → UI/UX still paired under Moiz).

## Test plan
- [ ] Staff someone in Fullstack, finalize (pair created), move them to UI/UX on the same project, finalize again — old Fullstack pair is gone; new same-domain pairs match the roster.
- [ ] Finalize with no mentors in a multi-mentee domain — prior pairs for the project+term are cleared; gap note still shows.
- [ ] Re-finalize an unchanged project — pairs still match mentor/mentee roster (idempotent replace).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/980"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787275783&installation_model_id=21824&pr_number=980&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F980&signature=4914071e62dc6a4c0c23cca135e81046a21b44893688211376b985d42421a69d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->