### PR TITLE
Fix taskboard scrolling to top when opening a task

### DIFF
--- a/dali-api/app/routes/layout.tsx
+++ b/dali-api/app/routes/layout.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { Outlet, redirect, useLoaderData, useLocation, useMatches, useNavigate, useSearchParams, type ShouldRevalidateFunctionArgs } from 'react-router'
+import { Outlet, redirect, useLoaderData, useLocation, useMatches, useNavigate, useNavigationType, useSearchParams, type ShouldRevalidateFunctionArgs } from 'react-router'
 import { cn } from '~/lib/cn'
 import { Layout } from '~/components/Layout'
 import { Breadcrumbs } from '~/components/Breadcrumbs'
@@ -143,6 +143,7 @@ export default function AppLayoutRoute() {
   const { user, photoUrl, hasCalendarLink, shouldShowTour, isCore, isAdmin, isDomainLead, canViewForms, canViewStaffing, isInterviewer, hasHiringAccess, isLabMentor: isLabMentorFlag, isEmbedded, tabless, focus } = useLoaderData<typeof loader>()
   const [searchParams] = useSearchParams()
   const location = useLocation()
+  const navigationType = useNavigationType()
   const matches = useMatches()
   const navigate = useNavigate()
   const hasAreaSubnav = matches.some(
@@ -244,14 +245,22 @@ export default function AppLayoutRoute() {
 
     // Restore on entering this location. rAF waits for the new route's content
     // to paint so the target offset exists; fall back to top when unseen.
+    // A REPLACE navigation is an in-place URL update on the same page — opening
+    // a task drawer (`?task=`) or toggling a board filter, both via
+    // `setSearchParams({ replace: true })`. React Router mints a fresh
+    // location.key for it, so restoring/resetting here would yank the current
+    // view to the top (the reported taskboard jump); leave scroll untouched and
+    // only (re)attach the recorder below. POP restores; PUSH lands at top.
     let raf = 0;
-    try {
-      const saved = window.sessionStorage.getItem(key);
-      raf = window.requestAnimationFrame(() => {
-        window.scrollTo(0, saved ? parseInt(saved, 10) || 0 : 0);
-      });
-    } catch {
-      // sessionStorage disabled — nothing to restore.
+    if (navigationType !== "REPLACE") {
+      try {
+        const saved = window.sessionStorage.getItem(key);
+        raf = window.requestAnimationFrame(() => {
+          window.scrollTo(0, saved ? parseInt(saved, 10) || 0 : 0);
+        });
+      } catch {
+        // sessionStorage disabled — nothing to restore.
+      }
     }
 
     // Continuously record this entry's scroll while it's the active location,
@@ -269,7 +278,7 @@ export default function AppLayoutRoute() {
       onScroll(); // capture final position for this entry before it changes
       window.removeEventListener("scroll", onScroll);
     };
-  }, [location.key]);
+  }, [location.key, navigationType]);
 
   // Where every routed page actually renders — inside a TabWorkspace iframe
   // (tab mode) or directly in the shell's main column (tabless mode). The


### PR DESCRIPTION
## Bug

Opening a task on the project taskboard scrolled the whole board back to the top. Closing the modal then left you stranded at the top instead of where you were.

## Root cause

Opening a task sets `?task=<id>` via `setSearchParams({ replace: true, preventScrollReset: true })` (`app/projects/components/TaskBoard.tsx`). React Router mints a **fresh `location.key`** even for a `replace`.

The embedded layout (`app/routes/layout.tsx`) runs a custom per-tab scroll restorer keyed on `location.key` (it exists because React Router's `<ScrollRestoration>` can't track scroll across the shell↔iframe boundary). It fired on the new key and unconditionally called `window.scrollTo(0, saved ?? 0)`. Since the new `?task=` entry had no saved offset, it scrolled to `(0, 0)` — **defeating `preventScrollReset` and the Modal's own `focus({ preventScroll: true })` guard** (added in #940).

The same jump also affected board filter changes (epic / sprint / term), which use the same replace-based param updates.

## Fix

Skip the restore/reset when the navigation type is `REPLACE` — an in-place URL update on the same page (opening a task, toggling a filter) — and leave scroll untouched. `POP` still restores back/forward positions; `PUSH` still lands genuinely new pages at the top. One added dependency (`navigationType`) on the existing effect.

## Testing

- `npm run typecheck` — clean for the changed file (pre-existing errors in `scripts/` and `Modal.test.tsx` are unrelated and present on `staging`).
- `npm test` — 2106 passed (250 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/982"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787277337&installation_model_id=21824&pr_number=982&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F982&signature=b69a9a301bdeb37c67962f2211db2f46b7929730d4db99e720a1ea1c108729da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->