### PR TITLE
Task board: create a GitHub issue for an existing task (#981)

### DIFF
--- a/dali-api/app/projects/components/TaskModal.tsx
+++ b/dali-api/app/projects/components/TaskModal.tsx
@@ -159,6 +159,7 @@ export function TaskModal({
   const [linkRepo, setLinkRepo] = useState<string>(githubRepos[0] ?? "");
   const [linkIssueNumber, setLinkIssueNumber] = useState("");
   const [linkBusy, setLinkBusy] = useState(false);
+  const [createBusy, setCreateBusy] = useState(false);
   const [linkError, setLinkError] = useState<string | null>(null);
 
   // Artifacts (edit mode): linked project files. Local so link/unlink/upload
@@ -488,6 +489,38 @@ export function TaskModal({
     }
   }
 
+  // Create a brand-new GitHub issue for this task (no issueNumber → the server
+  // files the issue via createIssueForTask and returns the mirror fields).
+  async function handleCreateGithub() {
+    if (!task) return;
+    if (!linkRepo) {
+      setLinkError("Select a repository.");
+      return;
+    }
+    setCreateBusy(true);
+    setLinkError(null);
+    try {
+      const res = await fetch(`/api/tasks/${task.id}/github`, {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ repo: linkRepo }),
+      });
+      const j = (await res.json().catch(() => ({}))) as {
+        error?: string;
+        githubIssueNumber?: number;
+        githubIssueUrl?: string;
+      };
+      if (!res.ok) throw new Error(j.error ?? `Request failed: ${res.status}`);
+      setGithub({ issueNumber: j.githubIssueNumber ?? null, url: j.githubIssueUrl ?? null });
+      setLinkOpen(false);
+    } catch (err) {
+      setLinkError(err instanceof Error ? err.message : "Couldn't create the issue.");
+    } finally {
+      setCreateBusy(false);
+    }
+  }
+
   async function handleLinkGithub() {
     if (!task) return;
     const num = Number(linkIssueNumber);
@@ -814,21 +847,13 @@ export function TaskModal({
                   ))}
                 </select>
                 <div className="flex items-center gap-2">
-                  <input
-                    type="number"
-                    min={1}
-                    value={linkIssueNumber}
-                    onChange={(e) => setLinkIssueNumber(e.target.value)}
-                    placeholder="Issue #"
-                    className="w-24 px-2 py-1.5 text-sm border border-border rounded-md bg-background text-foreground"
-                  />
                   <Button
                     variant="secondary"
                     size="sm"
-                    onClick={() => void handleLinkGithub()}
-                    disabled={linkBusy || !linkIssueNumber}
+                    onClick={() => void handleCreateGithub()}
+                    disabled={createBusy || linkBusy}
                   >
-                    {linkBusy ? "Linking…" : "Link"}
+                    {createBusy ? "Creating…" : "Create new issue"}
                   </Button>
                   <button
                     type="button"
@@ -841,6 +866,25 @@ export function TaskModal({
                     Cancel
                   </button>
                 </div>
+                <div className="flex items-center gap-2">
+                  <span className="text-muted-foreground">or link existing</span>
+                  <input
+                    type="number"
+                    min={1}
+                    value={linkIssueNumber}
+                    onChange={(e) => setLinkIssueNumber(e.target.value)}
+                    placeholder="Issue #"
+                    className="w-24 px-2 py-1.5 text-sm border border-border rounded-md bg-background text-foreground"
+                  />
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    onClick={() => void handleLinkGithub()}
+                    disabled={linkBusy || createBusy || !linkIssueNumber}
+                  >
+                    {linkBusy ? "Linking…" : "Link"}
+                  </Button>
+                </div>
               </div>
             ) : (
               <button
@@ -848,7 +892,7 @@ export function TaskModal({
                 onClick={() => setLinkOpen(true)}
                 className="self-start text-accent-coral hover:underline"
               >
-                Link GitHub issue
+                Add GitHub issue
               </button>
             )}
             {linkError && <p className="text-accent-coral">{linkError}</p>}

--- a/dali-api/app/projects/lib/__tests__/github-task-sync.test.ts
+++ b/dali-api/app/projects/lib/__tests__/github-task-sync.test.ts
@@ -157,6 +157,53 @@ describe("createIssueForTask", () => {
     expect(body).toContain("<!-- dalios:missing-assignees:");
   });
 
+  it("returns the mirror fields on success", async () => {
+    const { client, issues } = fakeOctokit();
+    __setGitHubClientForTests(client);
+    issues.create.mockResolvedValue({
+      data: { number: 12, html_url: "https://github.com/o/r/issues/12" },
+    });
+
+    mockPrisma.task.findUnique.mockResolvedValue({
+      id: "t4",
+      projectId: "p1",
+      title: "x",
+      status: "Todo",
+      githubRepo: null,
+      githubIssueNumber: null,
+      assignees: [],
+    });
+
+    const result = await createIssueForTask("t4", "o/r");
+
+    expect(result).toEqual({
+      githubRepo: "o/r",
+      githubIssueNumber: 12,
+      githubIssueUrl: "https://github.com/o/r/issues/12",
+    });
+  });
+
+  it("returns null (and doesn't link) when the GitHub create fails", async () => {
+    const { client, issues } = fakeOctokit();
+    __setGitHubClientForTests(client);
+    issues.create.mockRejectedValue(new Error("boom"));
+
+    mockPrisma.task.findUnique.mockResolvedValue({
+      id: "t5",
+      projectId: "p1",
+      title: "x",
+      status: "Todo",
+      githubRepo: null,
+      githubIssueNumber: null,
+      assignees: [],
+    });
+
+    const result = await createIssueForTask("t5", "o/r");
+
+    expect(result).toBeNull();
+    expect(mockPrisma.task.update).not.toHaveBeenCalled();
+  });
+
   it("skips when the task already has a linked issue (re-fire safety)", async () => {
     const { client, issues } = fakeOctokit();
     __setGitHubClientForTests(client);

--- a/dali-api/app/projects/lib/github-task-sync.ts
+++ b/dali-api/app/projects/lib/github-task-sync.ts
@@ -69,16 +69,30 @@ export function wasRecentOutbound(repo: string, num: number): boolean {
 
 // ─── Public surface ─────────────────────────────────────────────────────────
 
-export async function createIssueForTask(taskId: string, repoInput: string): Promise<void> {
+export type TaskGithubMirror = {
+  githubRepo: string;
+  githubIssueNumber: number;
+  githubIssueUrl: string;
+};
+
+// Creates the issue and links it to the task. Returns the stored mirror fields
+// on success, or null when there's nothing to do (bad repo, task gone, already
+// linked) or the GH/DB write fails. Never throws — the fire-and-forget callers
+// (task create) rely on that; the synchronous caller (api.tasks.$id.github,
+// "create" mode) treats null as a failure to surface to the user.
+export async function createIssueForTask(
+  taskId: string,
+  repoInput: string,
+): Promise<TaskGithubMirror | null> {
   const repo = normalizeRepo(repoInput);
   if (!repo) {
     console.error(`github-task-sync: bad repo "${repoInput}" for task ${taskId}`);
-    return;
+    return null;
   }
   try {
     const task = await loadTask(taskId);
-    if (!task) return;
-    if (task.githubIssueNumber !== null) return; // already linked
+    if (!task) return null;
+    if (task.githubIssueNumber !== null) return null; // already linked
 
     const { owner, repo: name } = parseRepo(repo, "createIssueForTask");
     const gh = githubAppClient();
@@ -110,8 +124,15 @@ export async function createIssueForTask(taskId: string, repoInput: string): Pro
     if (missing.length > 0) {
       await postMissingAssigneesComment(owner, name, res.data.number, missing);
     }
+
+    return {
+      githubRepo: repo,
+      githubIssueNumber: res.data.number,
+      githubIssueUrl: res.data.html_url,
+    };
   } catch (err) {
     console.error(`github-task-sync: createIssueForTask(${taskId}) failed`, err);
+    return null;
   }
 }
 

--- a/dali-api/app/projects/routes/__tests__/api.tasks.$id.github.test.ts
+++ b/dali-api/app/projects/routes/__tests__/api.tasks.$id.github.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 
-const { issuesGet } = vi.hoisted(() => ({ issuesGet: vi.fn() }));
+const { issuesGet, createIssueForTask } = vi.hoisted(() => ({
+  issuesGet: vi.fn(),
+  createIssueForTask: vi.fn(),
+}));
 
 vi.mock("~/lib/auth", () => ({ requireProjectEditAccess: vi.fn() }));
 vi.mock("~/lib/db");
@@ -16,6 +19,12 @@ vi.mock("~/lib/github", () => ({
   },
   isNotFound: (err: unknown) => (err as { status?: number } | null)?.status === 404,
 }));
+// Keep the real normalizeRepo (pure); stub createIssueForTask so the create
+// path doesn't reach the GitHub API.
+vi.mock("~/projects/lib/github-task-sync", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("~/projects/lib/github-task-sync")>();
+  return { ...actual, createIssueForTask };
+});
 
 import { requireProjectEditAccess } from "~/lib/auth";
 import { prisma } from "~/lib/db";
@@ -147,6 +156,49 @@ describe("POST /api/tasks/:id/github", () => {
       githubIssueNumber: 42,
       githubIssueUrl: "https://github.com/dali/app/issues/42",
     });
+  });
+});
+
+describe("POST /api/tasks/:id/github (create mode)", () => {
+  it("creates a new issue when no issueNumber is given", async () => {
+    createIssueForTask.mockResolvedValue({
+      githubRepo: "dali/app",
+      githubIssueNumber: 15,
+      githubIssueUrl: "https://github.com/dali/app/issues/15",
+    });
+    const res = await post({ repo: "dali/app" });
+    expect(res.status).toBe(200);
+    expect(createIssueForTask).toHaveBeenCalledWith(TASK_ID, "dali/app");
+    // Create mode never verifies an existing issue.
+    expect(issuesGet).not.toHaveBeenCalled();
+    expect(await res.json()).toEqual({
+      ok: true,
+      githubRepo: "dali/app",
+      githubIssueNumber: 15,
+      githubIssueUrl: "https://github.com/dali/app/issues/15",
+    });
+  });
+
+  it("502s when issue creation fails", async () => {
+    createIssueForTask.mockResolvedValue(null);
+    const res = await post({ repo: "dali/app" });
+    expect(res.status).toBe(502);
+    expect(await res.json()).toMatchObject({
+      error: expect.stringContaining("create"),
+    });
+  });
+
+  it("rejects a repo not in the project's repoUrls before creating", async () => {
+    const res = await post({ repo: "dali/other" });
+    expect(res.status).toBe(400);
+    expect(createIssueForTask).not.toHaveBeenCalled();
+  });
+
+  it("rejects create when the task is already linked", async () => {
+    mockTask({ githubIssueNumber: 7 });
+    const res = await post({ repo: "dali/app" });
+    expect(res.status).toBe(400);
+    expect(createIssueForTask).not.toHaveBeenCalled();
   });
 });
 

--- a/dali-api/app/projects/routes/api.tasks.$id.github.ts
+++ b/dali-api/app/projects/routes/api.tasks.$id.github.ts
@@ -3,30 +3,42 @@ import { prisma } from "~/lib/db";
 import { requireProjectEditAccess } from "~/lib/auth";
 import { withCors, handlePreflight } from "~/lib/cors";
 import { githubAppClient, parseRepo, isNotFound } from "~/lib/github";
-import { normalizeRepo } from "../lib/github-task-sync";
+import { normalizeRepo, createIssueForTask } from "../lib/github-task-sync";
 
-// POST   /api/tasks/:id/github — link an EXISTING GitHub issue to a task
-//        that isn't mirrored yet. Body: { repo, issueNumber }. `repo` must be
-//        one of the project's repoUrls (same validation as MCP
-//        link_task_to_github) and the issue must actually exist — checked
-//        against the GitHub API before the link is written. Unlike the
-//        create-flow mirror toggle, this never creates an issue.
+// POST   /api/tasks/:id/github — attach a GitHub issue mirror to a task that
+//        isn't mirrored yet. `repo` must be one of the project's repoUrls
+//        (same validation as MCP link_task_to_github). Two modes:
+//        - with `issueNumber`: links that EXISTING issue, verified against the
+//          GitHub API before the link is written — never creates.
+//        - without `issueNumber`: CREATES a new issue mirroring the task (via
+//          createIssueForTask) and links it. Same as the create-flow toggle,
+//          but for a task that already exists.
+//        Both return { ok, githubRepo, githubIssueNumber, githubIssueUrl }.
 // DELETE /api/tasks/:id/github — unlink. Mirrors MCP unlink_task_from_github:
 //        clears the three mirror fields; the GH issue itself is untouched.
 //
 // Permission model mirrors the other task routes (Core or project member).
 
-type PostBody = { repo: string; issueNumber: number };
+type PostBody =
+  | { kind: "link"; repo: string; issueNumber: number }
+  | { kind: "create"; repo: string };
 
-function isPostBody(x: unknown): x is PostBody {
-  if (!x || typeof x !== "object") return false;
+function parsePostBody(x: unknown): PostBody | null {
+  if (!x || typeof x !== "object") return null;
   const o = x as Record<string, unknown>;
-  return (
-    typeof o.repo === "string" &&
+  if (typeof o.repo !== "string") return null;
+  // Absent issueNumber = create a new issue. Present must be a positive int.
+  if (o.issueNumber === undefined || o.issueNumber === null) {
+    return { kind: "create", repo: o.repo };
+  }
+  if (
     typeof o.issueNumber === "number" &&
     Number.isInteger(o.issueNumber) &&
     o.issueNumber > 0
-  );
+  ) {
+    return { kind: "link", repo: o.repo, issueNumber: o.issueNumber };
+  }
+  return null;
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
@@ -69,7 +81,8 @@ export async function action({ request, params }: Route.ActionArgs) {
   } catch {
     return withCors(request, Response.json({ error: "Invalid JSON" }, { status: 400 }));
   }
-  if (!isPostBody(body)) {
+  const parsed = parsePostBody(body);
+  if (!parsed) {
     return withCors(request, Response.json({ error: "Invalid body" }, { status: 400 }));
   }
 
@@ -80,7 +93,7 @@ export async function action({ request, params }: Route.ActionArgs) {
     );
   }
 
-  const normalized = normalizeRepo(body.repo);
+  const normalized = normalizeRepo(parsed.repo);
   if (!normalized) {
     return withCors(request, Response.json({ error: "Invalid repo" }, { status: 400 }));
   }
@@ -94,10 +107,24 @@ export async function action({ request, params }: Route.ActionArgs) {
     );
   }
 
+  // Create a fresh issue mirroring the task. createIssueForTask does the GH
+  // write and persists the link; it swallows its own errors and returns null,
+  // which we surface as a 502.
+  if (parsed.kind === "create") {
+    const created = await createIssueForTask(params.id, normalized);
+    if (!created) {
+      return withCors(
+        request,
+        Response.json({ error: "Couldn't create the GitHub issue" }, { status: 502 }),
+      );
+    }
+    return withCors(request, Response.json({ ok: true, ...created }));
+  }
+
   // (githubRepo, githubIssueNumber) is unique across tasks — surface the
   // conflict up front instead of letting the constraint violation 500.
   const alreadyLinked = await prisma.task.findFirst({
-    where: { githubRepo: normalized, githubIssueNumber: body.issueNumber },
+    where: { githubRepo: normalized, githubIssueNumber: parsed.issueNumber },
     select: { id: true },
   });
   if (alreadyLinked) {
@@ -113,7 +140,7 @@ export async function action({ request, params }: Route.ActionArgs) {
     const res = await githubAppClient().rest.issues.get({
       owner,
       repo,
-      issue_number: body.issueNumber,
+      issue_number: parsed.issueNumber,
     });
     issueUrl = res.data.html_url;
   } catch (err) {
@@ -121,7 +148,7 @@ export async function action({ request, params }: Route.ActionArgs) {
       return withCors(
         request,
         Response.json(
-          { error: `Issue #${body.issueNumber} not found in ${normalized}` },
+          { error: `Issue #${parsed.issueNumber} not found in ${normalized}` },
           { status: 400 },
         ),
       );
@@ -137,7 +164,7 @@ export async function action({ request, params }: Route.ActionArgs) {
     where: { id: params.id },
     data: {
       githubRepo: normalized,
-      githubIssueNumber: body.issueNumber,
+      githubIssueNumber: parsed.issueNumber,
       githubIssueUrl: issueUrl,
     },
   });
@@ -147,7 +174,7 @@ export async function action({ request, params }: Route.ActionArgs) {
     Response.json({
       ok: true,
       githubRepo: normalized,
-      githubIssueNumber: body.issueNumber,
+      githubIssueNumber: parsed.issueNumber,
       githubIssueUrl: issueUrl,
     }),
   );


### PR DESCRIPTION
Closes #981.

## Problem
The task↔GitHub mirror could only **create** an issue at task-creation time (the "Create GitHub issue" toggle in the new-task form). For a task that already exists, the modal only offered "Link GitHub issue", which links to an issue that already exists on GitHub — there was no way to file a *new* issue for an existing task from the UI.

## Change
The create-new-issue capability already existed in `createIssueForTask` (used fire-and-forget by the MCP `link_task_to_github` tool); it just wasn't exposed to the web UI. This wires it up:

- **`github-task-sync.ts`** — `createIssueForTask` now returns the stored mirror fields (`{ githubRepo, githubIssueNumber, githubIssueUrl }`) on success, or `null` on skip/failure, so a synchronous caller can report the result. It still swallows its own errors and never throws, so the existing fire-and-forget callers (task create route, MCP create-task, MCP link) are unaffected.
- **`POST /api/tasks/:id/github`** — now two modes on the same endpoint:
  - with `issueNumber`: links that existing issue (verified against the GitHub API first) — unchanged.
  - without `issueNumber`: creates a new issue via `createIssueForTask` and links it.
  - Same `repoUrls` validation and same response shape for both; a GitHub failure surfaces as `502`.
- **`TaskModal`** — the edit-mode GitHub panel now offers **"Create new issue"** alongside **"Link existing"**, sharing the repo picker. Collapsed affordance renamed "Link GitHub issue" → "Add GitHub issue".

## Notes for review
- **Desktop shell:** `POST /api/tasks/:id/github` gains a request shape (omitting `issueNumber`) but the existing link/unlink contract is unchanged, so nothing the desktop app depends on is affected.
- **Notifications/jobs/migrations:** none touched — no schema change (the `Task.githubRepo/githubIssueNumber/githubIssueUrl` fields already exist).
- Create mode is synchronous (a few GitHub API calls) so the modal can show the resulting issue link immediately, consistent with the existing synchronous "link existing" flow.

## Testing
- `npm test` — 2112 unit tests pass (250 files), including new cases:
  - route: create mode files a new issue, `502`s on failure, rejects a repo not in `repoUrls`, rejects when already linked.
  - lib: `createIssueForTask` returns the mirror fields on success and `null` (without linking) on GH failure.
- `npm run typecheck` — no new type errors in changed files (one pre-existing unrelated error in `Modal.test.tsx` on `staging`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/983"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787278158&installation_model_id=21824&pr_number=983&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F983&signature=d3e8262c14e055d3ae245eeeee4a9f2483f1de696e8756120c7e14bc589aac4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->