### PR TITLE
Align MCP tool RBAC with the web UI

### DIFF
--- a/dali-api/app/mcp/tools/__tests__/create-task.test.ts
+++ b/dali-api/app/mcp/tools/__tests__/create-task.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 vi.mock("~/lib/db");
 vi.mock("~/lib/roles", async (orig) => {
   const real = await orig<typeof import("~/lib/roles")>();
-  return { ...real, isCore: vi.fn() };
+  return { ...real, isCore: vi.fn(), isProjectMember: vi.fn() };
 });
 vi.mock("~/projects/lib/task-notifications.server", () => ({
   notifyTaskAssigned: vi.fn().mockResolvedValue(undefined),
@@ -14,7 +14,7 @@ vi.mock("~/projects/lib/github-task-sync", () => ({
 }));
 
 import { prisma } from "~/lib/db";
-import { isCore } from "~/lib/roles";
+import { isCore, isProjectMember } from "~/lib/roles";
 import { createIssueForTask } from "~/projects/lib/github-task-sync";
 import {
   runCreateTask,
@@ -37,11 +37,29 @@ describe("create_task", () => {
     expect(CREATE_TASK_TOOL.requiredScope).toBe("mcp:write");
   });
 
-  it("rejects non-Core callers", async () => {
+  it("rejects callers without project edit access", async () => {
     vi.mocked(isCore).mockResolvedValue(false);
+    vi.mocked(isProjectMember).mockResolvedValue(false);
     await expect(
       runCreateTask("u1", { projectId: "p1", title: "x" }),
     ).rejects.toMatchObject({ name: "CreateTaskError", status: 403 });
+  });
+
+  it("allows a non-Core project member (web parity)", async () => {
+    vi.mocked(isCore).mockResolvedValue(false);
+    vi.mocked(isProjectMember).mockResolvedValue(true);
+    mockPrisma.project.findUnique.mockResolvedValue({ id: "p1", repoUrls: [] });
+    mockPrisma.task.findFirst.mockResolvedValue(null);
+    mockPrisma.$transaction.mockImplementation(async (fn: unknown) => {
+      const cb = fn as (tx: typeof prisma) => Promise<unknown>;
+      return cb({
+        task: { create: vi.fn().mockResolvedValue({ id: "t-new" }) },
+        taskAssignee: { createMany: vi.fn() },
+      } as unknown as typeof prisma);
+    });
+    const out = await runCreateTask("u1", { projectId: "p1", title: "Build" });
+    expect(out).toMatchObject({ id: "t-new" });
+    expect(isProjectMember).toHaveBeenCalledWith("u1", "p1");
   });
 
   it("rejects when project is missing", async () => {

--- a/dali-api/app/mcp/tools/__tests__/delete-task.test.ts
+++ b/dali-api/app/mcp/tools/__tests__/delete-task.test.ts
@@ -3,11 +3,11 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 vi.mock("~/lib/db");
 vi.mock("~/lib/roles", async (orig) => {
   const real = await orig<typeof import("~/lib/roles")>();
-  return { ...real, isCore: vi.fn() };
+  return { ...real, isCore: vi.fn(), isProjectMember: vi.fn() };
 });
 
 import { prisma } from "~/lib/db";
-import { isCore } from "~/lib/roles";
+import { isCore, isProjectMember } from "~/lib/roles";
 import { runDeleteTask, DELETE_TASK_TOOL, DeleteTaskError } from "~/mcp/tools/delete-task";
 
 const mockPrisma = prisma as unknown as {
@@ -22,8 +22,10 @@ describe("delete_task", () => {
     expect(DELETE_TASK_TOOL.requiredScope).toBe("mcp:write");
   });
 
-  it("rejects non-Core", async () => {
+  it("rejects callers without project edit access", async () => {
     vi.mocked(isCore).mockResolvedValue(false);
+    vi.mocked(isProjectMember).mockResolvedValue(false);
+    mockPrisma.task.findUnique.mockResolvedValue({ id: "t1", projectId: "p1" });
     await expect(runDeleteTask("u1", { taskId: "t1" })).rejects.toMatchObject({ status: 403 });
   });
 
@@ -33,9 +35,9 @@ describe("delete_task", () => {
     await expect(runDeleteTask("u1", { taskId: "x" })).rejects.toBeInstanceOf(DeleteTaskError);
   });
 
-  it("deletes when Core and task exists", async () => {
+  it("deletes when caller can edit and task exists", async () => {
     vi.mocked(isCore).mockResolvedValue(true);
-    mockPrisma.task.findUnique.mockResolvedValue({ id: "t1" });
+    mockPrisma.task.findUnique.mockResolvedValue({ id: "t1", projectId: "p1" });
     mockPrisma.$transaction.mockResolvedValue([]);
     const out = await runDeleteTask("u1", { taskId: "t1" });
     expect(out).toEqual({ ok: true, taskId: "t1" });

--- a/dali-api/app/mcp/tools/__tests__/epics-stories.test.ts
+++ b/dali-api/app/mcp/tools/__tests__/epics-stories.test.ts
@@ -3,11 +3,11 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 vi.mock("~/lib/db");
 vi.mock("~/lib/roles", async (orig) => {
   const real = await orig<typeof import("~/lib/roles")>();
-  return { ...real, isCore: vi.fn() };
+  return { ...real, isCore: vi.fn(), isProjectMember: vi.fn() };
 });
 
 import { prisma } from "~/lib/db";
-import { isCore } from "~/lib/roles";
+import { isCore, isProjectMember } from "~/lib/roles";
 import { runListEpics, LIST_EPICS_TOOL } from "~/mcp/tools/list-epics";
 import {
   runCreateEpic,
@@ -132,16 +132,37 @@ describe("epic + story tools", () => {
 
   it("update_story rejects empty title", async () => {
     vi.mocked(isCore).mockResolvedValue(true);
-    mockPrisma.userStory.findUnique.mockResolvedValue({ id: "us1" });
+    mockPrisma.userStory.findUnique.mockResolvedValue({
+      id: "us1",
+      epic: { projectId: "p1" },
+    });
     await expect(
       runUpdateStory("u1", { storyId: "us1", title: "  " }),
     ).rejects.toMatchObject({ status: 400 });
   });
 
-  it("delete_story is Core-only", async () => {
+  it("delete_story rejects callers without project edit access", async () => {
     vi.mocked(isCore).mockResolvedValue(false);
+    vi.mocked(isProjectMember).mockResolvedValue(false);
+    mockPrisma.userStory.findUnique.mockResolvedValue({
+      id: "us1",
+      epic: { projectId: "p1" },
+    });
     await expect(runDeleteStory("u1", { storyId: "us1" })).rejects.toMatchObject({
       status: 403,
     });
+  });
+
+  it("delete_story allows a non-Core project member (web parity)", async () => {
+    vi.mocked(isCore).mockResolvedValue(false);
+    vi.mocked(isProjectMember).mockResolvedValue(true);
+    mockPrisma.userStory.findUnique.mockResolvedValue({
+      id: "us1",
+      epic: { projectId: "p1" },
+    });
+    mockPrisma.userStory.delete.mockResolvedValue({});
+    const out = await runDeleteStory("u1", { storyId: "us1" });
+    expect(out).toEqual({ ok: true, storyId: "us1" });
+    expect(isProjectMember).toHaveBeenCalledWith("u1", "p1");
   });
 });

--- a/dali-api/app/mcp/tools/__tests__/list-groups.test.ts
+++ b/dali-api/app/mcp/tools/__tests__/list-groups.test.ts
@@ -3,12 +3,19 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 vi.mock("~/lib/groups", () => ({
   listVisibleGroupsForUser: vi.fn(),
 }));
+vi.mock("~/lib/roles", () => ({
+  canViewForms: vi.fn(),
+}));
 
 import { listVisibleGroupsForUser } from "~/lib/groups";
+import { canViewForms } from "~/lib/roles";
 import { runListGroups, LIST_GROUPS_TOOL } from "~/mcp/tools/list-groups";
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // Default: roster-privileged caller (Core/Instructor). Individual tests
+  // override to exercise the non-privileged path.
+  vi.mocked(canViewForms).mockResolvedValue(true);
 });
 
 const ACTIVE_GROUP = {
@@ -52,5 +59,21 @@ describe("list_groups", () => {
     vi.mocked(listVisibleGroupsForUser).mockResolvedValue([ACTIVE_GROUP, ARCHIVED_GROUP]);
     const out = await runListGroups("u1", { includeArchived: true });
     expect(out.groups.map((g) => g.id)).toEqual(["g1", "g2"]);
+  });
+
+  it("returns the full memberIds roster to Core/Instructor callers", async () => {
+    vi.mocked(canViewForms).mockResolvedValue(true);
+    vi.mocked(listVisibleGroupsForUser).mockResolvedValue([ACTIVE_GROUP]);
+    const out = await runListGroups("u1", {});
+    expect(out.groups[0].memberIds).toEqual(["u1", "u2"]);
+    expect(out.groups[0].memberCount).toBe(2);
+  });
+
+  it("omits memberIds for non-privileged callers (keeps the count)", async () => {
+    vi.mocked(canViewForms).mockResolvedValue(false);
+    vi.mocked(listVisibleGroupsForUser).mockResolvedValue([ACTIVE_GROUP]);
+    const out = await runListGroups("u1", {});
+    expect(out.groups[0].memberIds).toBeUndefined();
+    expect(out.groups[0].memberCount).toBe(2);
   });
 });

--- a/dali-api/app/mcp/tools/__tests__/pages-files.test.ts
+++ b/dali-api/app/mcp/tools/__tests__/pages-files.test.ts
@@ -11,10 +11,14 @@ vi.mock("~/collab/export", () => ({
 vi.mock("~/collab/write", () => ({
   replaceCollabDocContent: vi.fn(),
 }));
+vi.mock("~/lib/collabAuth", () => ({
+  authorizeCollabDoc: vi.fn(),
+}));
 
 import { prisma } from "~/lib/db";
 import { isCore, isProjectMember } from "~/lib/roles";
 import { collabDocToProseMirror } from "~/collab/export";
+import { authorizeCollabDoc } from "~/lib/collabAuth";
 import { replaceCollabDocContent } from "~/collab/write";
 import {
   runListProjectPages,
@@ -79,6 +83,7 @@ describe("pages + files tools", () => {
   });
 
   it("read_page derives the doc:{id}:body room for app-created pages", async () => {
+    vi.mocked(authorizeCollabDoc).mockResolvedValue(true);
     mockPrisma.page.findUnique.mockResolvedValue({
       id: "pg1",
       title: "Notes",
@@ -95,11 +100,14 @@ describe("pages + files tools", () => {
       ],
     });
     const out = await runReadPage("u1", { pageId: "pg1" });
+    // Authorization is keyed on the page's own doc room, not any contentDocId.
+    expect(authorizeCollabDoc).toHaveBeenCalledWith("u1", "doc:pg1:body");
     expect(collabDocToProseMirror).toHaveBeenCalledWith("doc:pg1:body");
     expect(out.markdown.startsWith("# Hi")).toBe(true);
   });
 
   it("read_page prefers contentDocId when set (seeded pages)", async () => {
+    vi.mocked(authorizeCollabDoc).mockResolvedValue(true);
     mockPrisma.page.findUnique.mockResolvedValue({
       id: "pg1",
       title: "Handbook",
@@ -118,6 +126,23 @@ describe("pages + files tools", () => {
   it("read_page 404s missing page", async () => {
     mockPrisma.page.findUnique.mockResolvedValue(null);
     await expect(runReadPage("u1", { pageId: "x" })).rejects.toBeInstanceOf(ReadPageError);
+  });
+
+  it("read_page denies callers not authorized on the page's workspace", async () => {
+    vi.mocked(authorizeCollabDoc).mockResolvedValue(false);
+    mockPrisma.page.findUnique.mockResolvedValue({
+      id: "pg1",
+      title: "Secret",
+      kind: "FreeForm",
+      workspaceType: "EducationOffering",
+      workspaceId: "off1",
+      contentDocId: null,
+      iconEmoji: null,
+    });
+    await expect(
+      runReadPage("u1", { pageId: "pg1" }),
+    ).rejects.toMatchObject({ name: "ReadPageError", status: 403 });
+    expect(collabDocToProseMirror).not.toHaveBeenCalled();
   });
 
   it("create_page rejects a non-Folder parent (app nesting rule)", async () => {

--- a/dali-api/app/mcp/tools/__tests__/search-directory.test.ts
+++ b/dali-api/app/mcp/tools/__tests__/search-directory.test.ts
@@ -71,10 +71,37 @@ describe("search_directory", () => {
     expect(out.results).toEqual([]);
   });
 
-  it("scopes user.findMany to DALIMember rows only (privacy)", async () => {
+  it("scopes to current-term members by default (member set + privacy)", async () => {
     mockPrisma.user.findMany.mockResolvedValue([]);
     await runSearchDirectory({ query: "x" });
     const call = mockPrisma.user.findMany.mock.calls[0][0];
-    expect(call.where.daliMember).toEqual({ isNot: null });
+    // Member predicate is AND-ed with the search OR; the member half stays
+    // scoped to DALIMember rows and, by default, current-term-active ones.
+    expect(call.where.AND[0].daliMember).toEqual({ isNot: null });
+    expect(call.where.AND[0].OR).toBeDefined();
+  });
+
+  it("drops the current-term filter when includeInactive is set", async () => {
+    mockPrisma.user.findMany.mockResolvedValue([]);
+    await runSearchDirectory({ query: "x", includeInactive: true });
+    const call = mockPrisma.user.findMany.mock.calls[0][0];
+    expect(call.where.AND[0]).toEqual({ daliMember: { isNot: null } });
+  });
+
+  it("does not expose netId in bulk directory rows", async () => {
+    mockPrisma.user.findMany.mockResolvedValue([
+      {
+        id: "u1",
+        firstName: "Ada",
+        lastName: "Lovelace",
+        daliEmail: "ada@dali.dartmouth.edu",
+        adminMembership: null,
+        coreAssignments: [],
+        domainLeadAssignmentsAsUser: [],
+        domainEligibilities: [],
+      },
+    ]);
+    const out = await runSearchDirectory({ query: "ada" });
+    expect(out.results[0]).not.toHaveProperty("netId");
   });
 });

--- a/dali-api/app/mcp/tools/__tests__/set-task-checklist.test.ts
+++ b/dali-api/app/mcp/tools/__tests__/set-task-checklist.test.ts
@@ -3,11 +3,11 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 vi.mock("~/lib/db");
 vi.mock("~/lib/roles", async (orig) => {
   const real = await orig<typeof import("~/lib/roles")>();
-  return { ...real, isCore: vi.fn() };
+  return { ...real, isCore: vi.fn(), isProjectMember: vi.fn() };
 });
 
 import { prisma } from "~/lib/db";
-import { isCore } from "~/lib/roles";
+import { isCore, isProjectMember } from "~/lib/roles";
 import {
   runSetTaskChecklist,
   SET_TASK_CHECKLIST_TOOL,
@@ -40,14 +40,33 @@ describe("set_task_checklist", () => {
     );
   });
 
-  it("forbids non-assignee non-Core", async () => {
+  it("forbids a non-assignee who can't edit the project", async () => {
     mockPrisma.task.findUnique.mockResolvedValue({
       id: "t1",
+      projectId: "p1",
       assignees: [{ userId: "other" }],
     });
     vi.mocked(isCore).mockResolvedValue(false);
+    vi.mocked(isProjectMember).mockResolvedValue(false);
     await expect(
       runSetTaskChecklist("u1", { taskId: "t1", items: [] }),
     ).rejects.toMatchObject({ status: 403 });
+  });
+
+  it("allows a non-assignee project member (web parity)", async () => {
+    mockPrisma.task.findUnique.mockResolvedValue({
+      id: "t1",
+      projectId: "p1",
+      assignees: [{ userId: "other" }],
+    });
+    vi.mocked(isCore).mockResolvedValue(false);
+    vi.mocked(isProjectMember).mockResolvedValue(true);
+    mockPrisma.task.update.mockResolvedValue({});
+    const out = await runSetTaskChecklist("u1", {
+      taskId: "t1",
+      items: [{ text: "a" }],
+    });
+    expect(out).toMatchObject({ ok: true, count: 1 });
+    expect(isProjectMember).toHaveBeenCalledWith("u1", "p1");
   });
 });

--- a/dali-api/app/mcp/tools/__tests__/sprints.test.ts
+++ b/dali-api/app/mcp/tools/__tests__/sprints.test.ts
@@ -3,11 +3,11 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 vi.mock("~/lib/db");
 vi.mock("~/lib/roles", async (orig) => {
   const real = await orig<typeof import("~/lib/roles")>();
-  return { ...real, isCore: vi.fn() };
+  return { ...real, isCore: vi.fn(), isProjectMember: vi.fn() };
 });
 
 import { prisma } from "~/lib/db";
-import { isCore } from "~/lib/roles";
+import { isCore, isProjectMember } from "~/lib/roles";
 import { runListSprints, LIST_SPRINTS_TOOL } from "~/mcp/tools/list-sprints";
 import {
   runCreateSprint,
@@ -70,8 +70,9 @@ describe("sprint tools", () => {
     });
   });
 
-  it("create_sprint rejects non-Core", async () => {
+  it("create_sprint rejects callers without project edit access", async () => {
     vi.mocked(isCore).mockResolvedValue(false);
+    vi.mocked(isProjectMember).mockResolvedValue(false);
     await expect(
       runCreateSprint("u1", {
         projectId: "p1",

--- a/dali-api/app/mcp/tools/__tests__/update-task-status.test.ts
+++ b/dali-api/app/mcp/tools/__tests__/update-task-status.test.ts
@@ -3,11 +3,11 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 vi.mock("~/lib/db");
 vi.mock("~/lib/roles", async (orig) => {
   const real = await orig<typeof import("~/lib/roles")>();
-  return { ...real, isCore: vi.fn() };
+  return { ...real, isCore: vi.fn(), isProjectMember: vi.fn() };
 });
 
 import { prisma } from "~/lib/db";
-import { isCore } from "~/lib/roles";
+import { isCore, isProjectMember } from "~/lib/roles";
 import {
   runUpdateTaskStatus,
   UPDATE_TASK_STATUS_TOOL,
@@ -81,7 +81,7 @@ describe("update_task_status", () => {
     });
   });
 
-  it("forbids non-assignee non-Core movers", async () => {
+  it("allows a non-assignee project member to move a task (web parity)", async () => {
     mockPrisma.task.findUnique.mockResolvedValue({
       id: "t1",
       status: "Todo",
@@ -89,6 +89,23 @@ describe("update_task_status", () => {
       assignees: [{ userId: "u-other" }],
     });
     vi.mocked(isCore).mockResolvedValue(false);
+    vi.mocked(isProjectMember).mockResolvedValue(true);
+    mockPrisma.task.aggregate.mockResolvedValue({ _max: { position: 0 } });
+    mockPrisma.task.update.mockResolvedValue({});
+    const out = await runUpdateTaskStatus("u1", { taskId: "t1", status: "Done" });
+    expect(out.newStatus).toBe("Done");
+    expect(isProjectMember).toHaveBeenCalledWith("u1", "p1");
+  });
+
+  it("forbids a non-assignee who can't edit the project", async () => {
+    mockPrisma.task.findUnique.mockResolvedValue({
+      id: "t1",
+      status: "Todo",
+      projectId: "p1",
+      assignees: [{ userId: "u-other" }],
+    });
+    vi.mocked(isCore).mockResolvedValue(false);
+    vi.mocked(isProjectMember).mockResolvedValue(false);
     await expect(
       runUpdateTaskStatus("u1", { taskId: "t1", status: "Done" }),
     ).rejects.toMatchObject({ name: "UpdateTaskStatusError", status: 403 });

--- a/dali-api/app/mcp/tools/__tests__/update-task.test.ts
+++ b/dali-api/app/mcp/tools/__tests__/update-task.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 vi.mock("~/lib/db");
 vi.mock("~/lib/roles", async (orig) => {
   const real = await orig<typeof import("~/lib/roles")>();
-  return { ...real, isCore: vi.fn() };
+  return { ...real, isCore: vi.fn(), isProjectMember: vi.fn() };
 });
 vi.mock("~/projects/lib/task-notifications.server", () => ({
   notifyTaskAssigned: vi.fn().mockResolvedValue(undefined),
@@ -13,7 +13,7 @@ vi.mock("~/projects/lib/github-task-sync", () => ({
 }));
 
 import { prisma } from "~/lib/db";
-import { isCore } from "~/lib/roles";
+import { isCore, isProjectMember } from "~/lib/roles";
 import { syncIssueForTask } from "~/projects/lib/github-task-sync";
 import {
   runUpdateTask,
@@ -35,8 +35,15 @@ describe("update_task", () => {
     expect(UPDATE_TASK_TOOL.requiredScope).toBe("mcp:write");
   });
 
-  it("rejects non-Core callers", async () => {
+  it("rejects callers without project edit access", async () => {
     vi.mocked(isCore).mockResolvedValue(false);
+    vi.mocked(isProjectMember).mockResolvedValue(false);
+    mockPrisma.task.findUnique.mockResolvedValue({
+      id: "t1",
+      projectId: "p1",
+      githubIssueNumber: null,
+      assignees: [],
+    });
     await expect(
       runUpdateTask("u1", { taskId: "t1", title: "x" }),
     ).rejects.toMatchObject({ status: 403 });

--- a/dali-api/app/mcp/tools/create-epic.ts
+++ b/dali-api/app/mcp/tools/create-epic.ts
@@ -1,14 +1,15 @@
-// MCP `create_epic` — Core-only. Mirrors api.projects.$id.epics.
+// MCP `create_epic` — Core or project member. Mirrors api.projects.$id.epics.
 
 import { prisma } from "~/lib/db";
-import { isCore } from "~/lib/roles";
+import { canEditProject } from "./access";
 
 const EPIC_STATUSES = ["Backlog", "Open", "InProgress", "Done", "Cancelled"] as const;
 type EpicStatus = (typeof EPIC_STATUSES)[number];
 
 export const CREATE_EPIC_TOOL = {
   name: "create_epic",
-  description: "Create an epic on a project. Core-only.",
+  description:
+    "Create an epic on a project. Requires Core or project-member access.",
   inputSchema: {
     type: "object" as const,
     properties: {
@@ -57,7 +58,7 @@ function parseDate(v: string | undefined): Date | null | "invalid" {
 }
 
 export async function runCreateEpic(callerId: string, input: Input) {
-  if (!(await isCore(callerId))) {
+  if (!(await canEditProject(callerId, input.projectId))) {
     throw new CreateEpicError("Forbidden", 403);
   }
 

--- a/dali-api/app/mcp/tools/create-sprint.ts
+++ b/dali-api/app/mcp/tools/create-sprint.ts
@@ -1,14 +1,15 @@
-// MCP `create_sprint` — Core-only, mirrors api.projects.$id.sprints.
+// MCP `create_sprint` — Core or project member, mirrors api.projects.$id.sprints.
 
 import { prisma } from "~/lib/db";
-import { isCore } from "~/lib/roles";
+import { canEditProject } from "./access";
 
 const SPRINT_STATUSES = ["Planned", "Active", "Closed"] as const;
 type SprintStatus = (typeof SPRINT_STATUSES)[number];
 
 export const CREATE_SPRINT_TOOL = {
   name: "create_sprint",
-  description: "Create a sprint on a project. Core-only.",
+  description:
+    "Create a sprint on a project. Requires Core or project-member access.",
   inputSchema: {
     type: "object" as const,
     properties: {
@@ -49,7 +50,7 @@ export class CreateSprintError extends Error {
 }
 
 export async function runCreateSprint(callerId: string, input: Input) {
-  if (!(await isCore(callerId))) {
+  if (!(await canEditProject(callerId, input.projectId))) {
     throw new CreateSprintError("Forbidden", 403);
   }
 

--- a/dali-api/app/mcp/tools/create-story.ts
+++ b/dali-api/app/mcp/tools/create-story.ts
@@ -1,14 +1,15 @@
-// MCP `create_story` — Core-only. Mirrors api.epics.$id.stories.
+// MCP `create_story` — Core or project member. Mirrors api.epics.$id.stories.
 
 import { prisma } from "~/lib/db";
-import { isCore } from "~/lib/roles";
+import { canEditProject } from "./access";
 
 const STORY_STATUSES = ["Todo", "InProgress", "Done"] as const;
 type StoryStatus = (typeof STORY_STATUSES)[number];
 
 export const CREATE_STORY_TOOL = {
   name: "create_story",
-  description: "Create a user story under an epic. Core-only.",
+  description:
+    "Create a user story under an epic. Requires Core or project-member access.",
   inputSchema: {
     type: "object" as const,
     properties: {
@@ -42,18 +43,18 @@ export class CreateStoryError extends Error {
 }
 
 export async function runCreateStory(callerId: string, input: Input) {
-  if (!(await isCore(callerId))) {
-    throw new CreateStoryError("Forbidden", 403);
-  }
-
   const title = input.title.trim();
   if (!title) throw new CreateStoryError("Title is required", 400);
 
   const epic = await prisma.epic.findUnique({
     where: { id: input.epicId },
-    select: { id: true },
+    select: { id: true, projectId: true },
   });
   if (!epic) throw new CreateStoryError("Epic not found", 404);
+
+  if (!(await canEditProject(callerId, epic.projectId))) {
+    throw new CreateStoryError("Forbidden", 403);
+  }
 
   const last = await prisma.userStory.findFirst({
     where: { epicId: input.epicId },

--- a/dali-api/app/mcp/tools/create-task.ts
+++ b/dali-api/app/mcp/tools/create-task.ts
@@ -1,8 +1,8 @@
 // MCP `create_task` — create a Task on a project. Mirrors
-// api.projects.$id.tasks (Core only). Optionally mirrors to GitHub.
+// api.projects.$id.tasks (Core or project member). Optionally mirrors to GitHub.
 
 import { prisma } from "~/lib/db";
-import { isCore } from "~/lib/roles";
+import { canEditProject } from "./access";
 import { isTaskStatus, TASK_STATUSES } from "~/projects/lib/task-board";
 import { createIssueForTask, normalizeRepo } from "~/projects/lib/github-task-sync";
 import { notifyTaskAssigned } from "~/projects/lib/task-notifications.server";
@@ -13,7 +13,7 @@ type Priority = (typeof PRIORITIES)[number];
 export const CREATE_TASK_TOOL = {
   name: "create_task",
   description:
-    "Create a project task. Core-only. Lands at end of target column. Optionally mirrors to a GitHub issue (`mirrorToGithubRepo` must be one of the project's repoUrls).",
+    "Create a project task. Requires Core or project-member access. Lands at end of target column. Optionally mirrors to a GitHub issue (`mirrorToGithubRepo` must be one of the project's repoUrls).",
   inputSchema: {
     type: "object" as const,
     properties: {
@@ -70,7 +70,7 @@ export class CreateTaskError extends Error {
 }
 
 export async function runCreateTask(callerId: string, input: Input) {
-  if (!(await isCore(callerId))) {
+  if (!(await canEditProject(callerId, input.projectId))) {
     throw new CreateTaskError("Forbidden", 403);
   }
 
@@ -85,6 +85,28 @@ export async function runCreateTask(callerId: string, input: Input) {
     select: { id: true, repoUrls: true },
   });
   if (!project) throw new CreateTaskError("Project not found", 404);
+
+  // A sprint/epic id must belong to this project — a foreign id would let a
+  // member of one project file tasks onto another project's board (matches the
+  // web create route's guard).
+  if (input.sprintId && input.sprintId !== "") {
+    const sprint = await prisma.sprint.findUnique({
+      where: { id: input.sprintId },
+      select: { projectId: true },
+    });
+    if (!sprint || sprint.projectId !== input.projectId) {
+      throw new CreateTaskError("Sprint is not part of this project", 400);
+    }
+  }
+  if (input.epicId && input.epicId !== "") {
+    const epic = await prisma.epic.findUnique({
+      where: { id: input.epicId },
+      select: { projectId: true },
+    });
+    if (!epic || epic.projectId !== input.projectId) {
+      throw new CreateTaskError("Epic is not part of this project", 400);
+    }
+  }
 
   let dueAt: Date | null = null;
   if (input.dueAt && input.dueAt !== "") {

--- a/dali-api/app/mcp/tools/delete-epic.ts
+++ b/dali-api/app/mcp/tools/delete-epic.ts
@@ -1,13 +1,13 @@
-// MCP `delete_epic` — Core-only. Sprints/tasks pointing at the epic have
-// their epicId nulled (mirrors api.epics.$id DELETE).
+// MCP `delete_epic` — Core or project member. Sprints/tasks pointing at the
+// epic have their epicId nulled (mirrors api.epics.$id DELETE).
 
 import { prisma } from "~/lib/db";
-import { isCore } from "~/lib/roles";
+import { canEditProject } from "./access";
 
 export const DELETE_EPIC_TOOL = {
   name: "delete_epic",
   description:
-    "Delete an epic. Sprints and tasks pointing at it have their epicId nulled (no cascade). Core-only.",
+    "Delete an epic. Sprints and tasks pointing at it have their epicId nulled (no cascade). Requires Core or project-member access.",
   inputSchema: {
     type: "object" as const,
     properties: {
@@ -29,15 +29,15 @@ export class DeleteEpicError extends Error {
 }
 
 export async function runDeleteEpic(callerId: string, input: Input) {
-  if (!(await isCore(callerId))) {
-    throw new DeleteEpicError("Forbidden", 403);
-  }
-
   const epic = await prisma.epic.findUnique({
     where: { id: input.epicId },
-    select: { id: true },
+    select: { id: true, projectId: true },
   });
   if (!epic) throw new DeleteEpicError("Epic not found", 404);
+
+  if (!(await canEditProject(callerId, epic.projectId))) {
+    throw new DeleteEpicError("Forbidden", 403);
+  }
 
   await prisma.$transaction([
     prisma.sprint.updateMany({

--- a/dali-api/app/mcp/tools/delete-sprint.ts
+++ b/dali-api/app/mcp/tools/delete-sprint.ts
@@ -1,13 +1,13 @@
 // MCP `delete_sprint` — hard-delete; tasks in the sprint fall back to backlog
-// (sprintId nulled). Core-only. Mirrors api.sprints.$id DELETE.
+// (sprintId nulled). Core or project member. Mirrors api.sprints.$id DELETE.
 
 import { prisma } from "~/lib/db";
-import { isCore } from "~/lib/roles";
+import { canEditProject } from "./access";
 
 export const DELETE_SPRINT_TOOL = {
   name: "delete_sprint",
   description:
-    "Delete a sprint. Tasks pointing at the sprint fall back to backlog (sprintId nulled). Core-only.",
+    "Delete a sprint. Tasks pointing at the sprint fall back to backlog (sprintId nulled). Requires Core or project-member access.",
   inputSchema: {
     type: "object" as const,
     properties: {
@@ -29,15 +29,15 @@ export class DeleteSprintError extends Error {
 }
 
 export async function runDeleteSprint(callerId: string, input: Input) {
-  if (!(await isCore(callerId))) {
-    throw new DeleteSprintError("Forbidden", 403);
-  }
-
   const sprint = await prisma.sprint.findUnique({
     where: { id: input.sprintId },
-    select: { id: true },
+    select: { id: true, projectId: true },
   });
   if (!sprint) throw new DeleteSprintError("Sprint not found", 404);
+
+  if (!(await canEditProject(callerId, sprint.projectId))) {
+    throw new DeleteSprintError("Forbidden", 403);
+  }
 
   await prisma.$transaction([
     prisma.task.updateMany({

--- a/dali-api/app/mcp/tools/delete-story.ts
+++ b/dali-api/app/mcp/tools/delete-story.ts
@@ -1,11 +1,12 @@
-// MCP `delete_story` — Core-only.
+// MCP `delete_story` — Core or project member.
 
 import { prisma } from "~/lib/db";
-import { isCore } from "~/lib/roles";
+import { canEditProject } from "./access";
 
 export const DELETE_STORY_TOOL = {
   name: "delete_story",
-  description: "Delete a user story. Core-only.",
+  description:
+    "Delete a user story. Requires Core or project-member access.",
   inputSchema: {
     type: "object" as const,
     properties: {
@@ -27,15 +28,15 @@ export class DeleteStoryError extends Error {
 }
 
 export async function runDeleteStory(callerId: string, input: Input) {
-  if (!(await isCore(callerId))) {
-    throw new DeleteStoryError("Forbidden", 403);
-  }
-
   const story = await prisma.userStory.findUnique({
     where: { id: input.storyId },
-    select: { id: true },
+    select: { id: true, epic: { select: { projectId: true } } },
   });
   if (!story) throw new DeleteStoryError("Story not found", 404);
+
+  if (!(await canEditProject(callerId, story.epic.projectId))) {
+    throw new DeleteStoryError("Forbidden", 403);
+  }
 
   await prisma.userStory.delete({ where: { id: input.storyId } });
   return { ok: true, storyId: input.storyId };

--- a/dali-api/app/mcp/tools/delete-task.ts
+++ b/dali-api/app/mcp/tools/delete-task.ts
@@ -1,12 +1,12 @@
-// MCP `delete_task` — hard-delete a project task. Core-only.
+// MCP `delete_task` — hard-delete a project task. Core or project member.
 
 import { prisma } from "~/lib/db";
-import { isCore } from "~/lib/roles";
+import { canEditProject } from "./access";
 
 export const DELETE_TASK_TOOL = {
   name: "delete_task",
   description:
-    "Delete a project task (cascades to its assignees and comments). Core-only. Prefer setting status to Cancelled if the task should remain in history.",
+    "Delete a project task (cascades to its assignees and comments). Requires Core or project-member access. Prefer setting status to Cancelled if the task should remain in history.",
   inputSchema: {
     type: "object" as const,
     properties: {
@@ -28,15 +28,15 @@ export class DeleteTaskError extends Error {
 }
 
 export async function runDeleteTask(callerId: string, input: Input) {
-  if (!(await isCore(callerId))) {
-    throw new DeleteTaskError("Forbidden", 403);
-  }
-
   const task = await prisma.task.findUnique({
     where: { id: input.taskId },
-    select: { id: true },
+    select: { id: true, projectId: true },
   });
   if (!task) throw new DeleteTaskError("Task not found", 404);
+
+  if (!(await canEditProject(callerId, task.projectId))) {
+    throw new DeleteTaskError("Forbidden", 403);
+  }
 
   await prisma.$transaction([
     prisma.taskAssignee.deleteMany({ where: { taskId: input.taskId } }),

--- a/dali-api/app/mcp/tools/link-task-to-github.ts
+++ b/dali-api/app/mcp/tools/link-task-to-github.ts
@@ -1,10 +1,10 @@
 // MCP `link_task_to_github` — create a GitHub issue mirror for a task that
-// isn't yet mirrored. Wraps createIssueForTask. Core-only.
+// isn't yet mirrored. Wraps createIssueForTask. Core or project member.
 // (v1: link = create-new-issue. Linking to an existing issue would require
 // new infrastructure; not in scope.)
 
 import { prisma } from "~/lib/db";
-import { isCore } from "~/lib/roles";
+import { canEditProject } from "./access";
 import {
   createIssueForTask,
   normalizeRepo,
@@ -13,7 +13,7 @@ import {
 export const LINK_TASK_TO_GITHUB_TOOL = {
   name: "link_task_to_github",
   description:
-    "Create a GitHub issue mirror for a task. `repo` must be one of the project's repoUrls. Core-only. Returns immediately; the GH write is fire-and-forget.",
+    "Create a GitHub issue mirror for a task. `repo` must be one of the project's repoUrls. Requires Core or project-member access. Returns immediately; the GH write is fire-and-forget.",
   inputSchema: {
     type: "object" as const,
     properties: {
@@ -40,10 +40,6 @@ export class LinkTaskToGithubError extends Error {
 }
 
 export async function runLinkTaskToGithub(callerId: string, input: Input) {
-  if (!(await isCore(callerId))) {
-    throw new LinkTaskToGithubError("Forbidden", 403);
-  }
-
   const normalized = normalizeRepo(input.repo);
   if (!normalized) throw new LinkTaskToGithubError("Invalid repo", 400);
 
@@ -51,11 +47,17 @@ export async function runLinkTaskToGithub(callerId: string, input: Input) {
     where: { id: input.taskId },
     select: {
       id: true,
+      projectId: true,
       githubIssueNumber: true,
       project: { select: { repoUrls: true } },
     },
   });
   if (!task) throw new LinkTaskToGithubError("Task not found", 404);
+
+  if (!(await canEditProject(callerId, task.projectId))) {
+    throw new LinkTaskToGithubError("Forbidden", 403);
+  }
+
   if (task.githubIssueNumber !== null) {
     throw new LinkTaskToGithubError("Task is already linked to a GitHub issue", 400);
   }

--- a/dali-api/app/mcp/tools/list-groups.ts
+++ b/dali-api/app/mcp/tools/list-groups.ts
@@ -1,14 +1,20 @@
 // MCP `list_groups` — lab groups visible to the authenticated member.
 // Static groups they're a member of and Dynamic groups whose resolved
-// membership includes them. Use a returned `id` (member.id) elsewhere, or use
-// `memberIds` to bulk-resolve a group. Requires the `mcp:read` scope.
+// membership includes them. Requires the `mcp:read` scope.
+//
+// The full `memberIds` roster is only returned to callers who can view rosters
+// on the web (Core / Admin / Instructor — the same `canViewForms` gate that
+// guards the web Groups page). Everyone else gets `memberCount` but not the
+// userId list, so a rank-and-file member can't bulk-enumerate a group's
+// membership through MCP when no equivalent web surface would show it.
 
 import { listVisibleGroupsForUser } from "~/lib/groups";
+import { canViewForms } from "~/lib/roles";
 
 export const LIST_GROUPS_TOOL = {
   name: "list_groups",
   description:
-    "List lab groups the authenticated DALI OS member belongs to. Returns each group's id, name, type (Static/Dynamic), and member userIds. Useful for resolving a group into a participant list before calling `schedule_meeting`.",
+    "List lab groups the authenticated DALI OS member belongs to. Returns each group's id, name, type (Static/Dynamic), and memberCount. The full member userId list (`memberIds`) is included only for Core/Admin/Instructor callers, matching the web Groups page.",
   inputSchema: {
     type: "object" as const,
     properties: {
@@ -27,6 +33,7 @@ type Input = { includeArchived?: boolean };
 
 export async function runListGroups(callerId: string, input: Input) {
   const includeArchived = input.includeArchived ?? false;
+  const canSeeRosters = await canViewForms(callerId);
   const visible = await listVisibleGroupsForUser(callerId);
   const groups = visible
     .filter((g) => includeArchived || !g.archived)
@@ -35,7 +42,8 @@ export async function runListGroups(callerId: string, input: Input) {
       name: g.name,
       type: g.type,
       systemKey: g.systemKey,
-      memberIds: g.memberIds,
+      // Roster userIds only for Core/Admin/Instructor; others see the count.
+      memberIds: canSeeRosters ? g.memberIds : undefined,
       memberCount: g.memberIds.length,
       archived: g.archived,
     }));

--- a/dali-api/app/mcp/tools/read-page.ts
+++ b/dali-api/app/mcp/tools/read-page.ts
@@ -2,13 +2,17 @@
 // Yjs binary from CollabDocument, decodes to ProseMirror JSON, and renders to
 // Markdown via export-markdown.ts. The doc name is derived from the page id
 // (doc:{pageId}:body — the room DocumentEditor writes to); Page.contentDocId
-// only overrides for seeded pages that point at a custom doc. Read access is
-// any authenticated member.
+// only overrides for seeded pages that point at a custom doc. Read access
+// mirrors the web `authorizeCollabDoc` gate on the same doc room: Core
+// everywhere, lab members on Lab pages, project members (or partner-visible
+// partners) on Project pages, and the offering's instructors on
+// EducationOffering pages.
 
 import { prisma } from "~/lib/db";
 import { collabDocToProseMirror } from "~/collab/export";
 import { renderMarkdown } from "~/collab/export-markdown";
 import { pageDocName } from "~/collab/roomName";
+import { authorizeCollabDoc } from "~/lib/collabAuth";
 
 export const READ_PAGE_TOOL = {
   name: "read_page",
@@ -34,7 +38,7 @@ export class ReadPageError extends Error {
   }
 }
 
-export async function runReadPage(_callerId: string, input: Input) {
+export async function runReadPage(callerId: string, input: Input) {
   const page = await prisma.page.findUnique({
     where: { id: input.pageId },
     select: {
@@ -48,6 +52,15 @@ export async function runReadPage(_callerId: string, input: Input) {
     },
   });
   if (!page) throw new ReadPageError("Page not found", 404);
+
+  // Gate the body read exactly like the web editor route does — the page's
+  // workspace membership (Core / lab / project / instructor), not merely an
+  // authenticated session. Without this, any mcp:read caller could read a
+  // page's Markdown for a project they aren't on, or an instructor-only
+  // EducationOffering page.
+  if (!(await authorizeCollabDoc(callerId, pageDocName(page.id)))) {
+    throw new ReadPageError("Forbidden", 403);
+  }
 
   const doc = await collabDocToProseMirror(page.contentDocId ?? pageDocName(page.id));
   const markdown = doc.content?.length ? renderMarkdown(doc) : "";

--- a/dali-api/app/mcp/tools/search-directory.ts
+++ b/dali-api/app/mcp/tools/search-directory.ts
@@ -1,14 +1,21 @@
 // MCP `search_directory` — substring search over lab members (User rows with a
 // linked DALIMember marker). Matches against names, daliEmail, netId, domain
 // names, and current-term role titles. Requires the `mcp:read` scope.
+//
+// Scoping mirrors the web People page (members.tsx): by default only members
+// active in the current term are returned (a current-term Core or project
+// assignment), so alumni and inactive members are excluded unless the caller
+// opts into `includeInactive` (the web "All terms" toggle). netId is not
+// returned in bulk rows — the web list view never shows it either; use
+// get_member_profile for a single member's netId.
 
 import { prisma } from "~/lib/db";
-import { currentTerm, isAdminViaEnv } from "~/lib/roles";
+import { currentTerm, currentTermMemberWhere, isAdminViaEnv } from "~/lib/roles";
 
 export const SEARCH_DIRECTORY_TOOL = {
   name: "search_directory",
   description:
-    "Search the DALI member directory. Matches against name fragments, daliEmail, netId, domain names, and role titles. Only returns lab members.",
+    "Search the DALI member directory. Matches against name fragments, daliEmail, netId, domain names, and role titles. Returns current-term-active members by default (set includeInactive to also match alumni / members inactive this term).",
   inputSchema: {
     type: "object" as const,
     properties: {
@@ -24,6 +31,11 @@ export const SEARCH_DIRECTORY_TOOL = {
         maximum: 50,
         description: "Maximum results to return (default 20, max 50).",
       },
+      includeInactive: {
+        type: "boolean",
+        description:
+          "If true, also match members with no current-term assignment (alumni / inactive). Defaults to false — mirrors the web directory's current-term filter.",
+      },
     },
     required: ["query"],
     additionalProperties: false,
@@ -31,14 +43,13 @@ export const SEARCH_DIRECTORY_TOOL = {
   requiredScope: "mcp:read" as const,
 };
 
-type Input = { query: string; limit?: number };
+type Input = { query: string; limit?: number; includeInactive?: boolean };
 
 type DirectoryRow = {
   id: string;
   firstName: string;
   lastName: string;
   daliEmail: string | null;
-  netId: string | null;
   tier: "admin" | "core" | "domain-lead" | "member";
   domains: string[];
   currentTermRoles: string[];
@@ -52,30 +63,41 @@ export async function runSearchDirectory(input: Input): Promise<{ results: Direc
   const term = await currentTerm();
   const termId = term?.id ?? null;
 
+  // Default member set = current-term-active (Core or project assignment this
+  // term), same predicate the web People page uses. `includeInactive` widens
+  // to any lab member (the web "All terms" view).
+  const memberWhere = input.includeInactive
+    ? { daliMember: { isNot: null } }
+    : await currentTermMemberWhere();
+
   const users = await prisma.user.findMany({
     where: {
-      daliMember: { isNot: null },
-      OR: [
-        { firstName: { contains: q, mode: "insensitive" } },
-        { lastName: { contains: q, mode: "insensitive" } },
-        { daliEmail: { contains: q, mode: "insensitive" } },
-        { netId: { contains: q, mode: "insensitive" } },
+      AND: [
+        memberWhere,
         {
-          domainEligibilities: {
-            some: {
-              domain: {
-                OR: [
-                  { displayName: { contains: q, mode: "insensitive" } },
-                  { code: { contains: q, mode: "insensitive" } },
-                ],
+          OR: [
+            { firstName: { contains: q, mode: "insensitive" } },
+            { lastName: { contains: q, mode: "insensitive" } },
+            { daliEmail: { contains: q, mode: "insensitive" } },
+            { netId: { contains: q, mode: "insensitive" } },
+            {
+              domainEligibilities: {
+                some: {
+                  domain: {
+                    OR: [
+                      { displayName: { contains: q, mode: "insensitive" } },
+                      { code: { contains: q, mode: "insensitive" } },
+                    ],
+                  },
+                },
               },
             },
-          },
-        },
-        {
-          coreAssignments: {
-            some: { leadTitle: { contains: q, mode: "insensitive" } },
-          },
+            {
+              coreAssignments: {
+                some: { leadTitle: { contains: q, mode: "insensitive" } },
+              },
+            },
+          ],
         },
       ],
     },
@@ -86,7 +108,6 @@ export async function runSearchDirectory(input: Input): Promise<{ results: Direc
       firstName: true,
       lastName: true,
       daliEmail: true,
-      netId: true,
       adminMembership: { select: { id: true } },
       coreAssignments: termId
         ? { where: { termId }, select: { leadTitle: true } }
@@ -128,7 +149,6 @@ export async function runSearchDirectory(input: Input): Promise<{ results: Direc
       firstName: u.firstName,
       lastName: u.lastName,
       daliEmail: u.daliEmail,
-      netId: u.netId,
       tier,
       domains: u.domainEligibilities.map((e) => e.domain.displayName),
       currentTermRoles,

--- a/dali-api/app/mcp/tools/set-sprint-status.ts
+++ b/dali-api/app/mcp/tools/set-sprint-status.ts
@@ -1,9 +1,10 @@
 // MCP `set_sprint_status` — move a sprint between Planned/Active/Closed.
-// Core-only. Wrapping it as a separate tool (rather than a status field on
-// `update_sprint`) makes the lifecycle transition explicit in tool calls.
+// Core or project member. Wrapping it as a separate tool (rather than a status
+// field on `update_sprint`) makes the lifecycle transition explicit in tool
+// calls.
 
 import { prisma } from "~/lib/db";
-import { isCore } from "~/lib/roles";
+import { canEditProject } from "./access";
 
 const SPRINT_STATUSES = ["Planned", "Active", "Closed"] as const;
 type SprintStatus = (typeof SPRINT_STATUSES)[number];
@@ -11,7 +12,7 @@ type SprintStatus = (typeof SPRINT_STATUSES)[number];
 export const SET_SPRINT_STATUS_TOOL = {
   name: "set_sprint_status",
   description:
-    "Set a sprint's lifecycle status (Planned, Active, Closed). Core-only. Note: parallel sprints can be Active at the same time.",
+    "Set a sprint's lifecycle status (Planned, Active, Closed). Requires Core or project-member access. Note: parallel sprints can be Active at the same time.",
   inputSchema: {
     type: "object" as const,
     properties: {
@@ -37,15 +38,15 @@ export class SetSprintStatusError extends Error {
 }
 
 export async function runSetSprintStatus(callerId: string, input: Input) {
-  if (!(await isCore(callerId))) {
-    throw new SetSprintStatusError("Forbidden", 403);
-  }
-
   const sprint = await prisma.sprint.findUnique({
     where: { id: input.sprintId },
-    select: { id: true, status: true },
+    select: { id: true, projectId: true, status: true },
   });
   if (!sprint) throw new SetSprintStatusError("Sprint not found", 404);
+
+  if (!(await canEditProject(callerId, sprint.projectId))) {
+    throw new SetSprintStatusError("Forbidden", 403);
+  }
 
   await prisma.sprint.update({
     where: { id: input.sprintId },

--- a/dali-api/app/mcp/tools/set-task-checklist.ts
+++ b/dali-api/app/mcp/tools/set-task-checklist.ts
@@ -1,14 +1,15 @@
 // MCP `set_task_checklist` — replace the entire checklist (subtasks) on a
-// task. Stored as JSON `[{text, done}]`. Allowed for task assignees + Core,
-// same as `add_task_comment` and `update_task_status`.
+// task. Stored as JSON `[{text, done}]`. Allowed for the task's assignees and
+// for project editors (Core or project members), matching the web task PATCH
+// route plus the assignee self-service path shared with `update_task_status`.
 
 import { prisma, Prisma } from "~/lib/db";
-import { isCore } from "~/lib/roles";
+import { canEditProject } from "./access";
 
 export const SET_TASK_CHECKLIST_TOOL = {
   name: "set_task_checklist",
   description:
-    "Replace the entire checklist on a project task. Allowed for the task's assignees and for Core members. Pass an empty array to clear.",
+    "Replace the entire checklist on a project task. Allowed for the task's assignees and for project editors (Core or project members). Pass an empty array to clear.",
   inputSchema: {
     type: "object" as const,
     properties: {
@@ -46,12 +47,16 @@ export class SetTaskChecklistError extends Error {
 export async function runSetTaskChecklist(callerId: string, input: Input) {
   const task = await prisma.task.findUnique({
     where: { id: input.taskId },
-    select: { id: true, assignees: { select: { userId: true } } },
+    select: {
+      id: true,
+      projectId: true,
+      assignees: { select: { userId: true } },
+    },
   });
   if (!task) throw new SetTaskChecklistError("Task not found", 404);
 
   const isAssignee = task.assignees.some((a) => a.userId === callerId);
-  if (!isAssignee && !(await isCore(callerId))) {
+  if (!isAssignee && !(await canEditProject(callerId, task.projectId))) {
     throw new SetTaskChecklistError("Forbidden", 403);
   }
 

--- a/dali-api/app/mcp/tools/unlink-task-from-github.ts
+++ b/dali-api/app/mcp/tools/unlink-task-from-github.ts
@@ -1,14 +1,14 @@
 // MCP `unlink_task_from_github` — clear the GitHub mirror fields on a task.
 // Leaves the GH issue itself alone; just severs the dalios↔GH connection so
-// future edits stop syncing. Core-only.
+// future edits stop syncing. Core or project member.
 
 import { prisma } from "~/lib/db";
-import { isCore } from "~/lib/roles";
+import { canEditProject } from "./access";
 
 export const UNLINK_TASK_FROM_GITHUB_TOOL = {
   name: "unlink_task_from_github",
   description:
-    "Clear a task's GitHub issue link. The GitHub issue is left untouched on GH — this only severs dalios's mirror tracking. Core-only.",
+    "Clear a task's GitHub issue link. The GitHub issue is left untouched on GH — this only severs dalios's mirror tracking. Requires Core or project-member access.",
   inputSchema: {
     type: "object" as const,
     properties: {
@@ -30,15 +30,21 @@ export class UnlinkTaskFromGithubError extends Error {
 }
 
 export async function runUnlinkTaskFromGithub(callerId: string, input: Input) {
-  if (!(await isCore(callerId))) {
-    throw new UnlinkTaskFromGithubError("Forbidden", 403);
-  }
-
   const task = await prisma.task.findUnique({
     where: { id: input.taskId },
-    select: { id: true, githubIssueNumber: true, githubRepo: true, githubIssueUrl: true },
+    select: {
+      id: true,
+      projectId: true,
+      githubIssueNumber: true,
+      githubRepo: true,
+      githubIssueUrl: true,
+    },
   });
   if (!task) throw new UnlinkTaskFromGithubError("Task not found", 404);
+
+  if (!(await canEditProject(callerId, task.projectId))) {
+    throw new UnlinkTaskFromGithubError("Forbidden", 403);
+  }
   if (task.githubIssueNumber === null) {
     return { ok: true, taskId: input.taskId, noop: true };
   }

--- a/dali-api/app/mcp/tools/update-epic.ts
+++ b/dali-api/app/mcp/tools/update-epic.ts
@@ -1,7 +1,7 @@
-// MCP `update_epic` — Core-only. Mirrors api.epics.$id POST.
+// MCP `update_epic` — Core or project member. Mirrors api.epics.$id POST.
 
 import { prisma } from "~/lib/db";
-import { isCore } from "~/lib/roles";
+import { canEditProject } from "./access";
 
 const EPIC_STATUSES = ["Backlog", "Open", "InProgress", "Done", "Cancelled"] as const;
 type EpicStatus = (typeof EPIC_STATUSES)[number];
@@ -9,7 +9,7 @@ type EpicStatus = (typeof EPIC_STATUSES)[number];
 export const UPDATE_EPIC_TOOL = {
   name: "update_epic",
   description:
-    "Edit an epic's fields (title, description, status, dates, target term). Core-only. Empty string clears nullable fields.",
+    "Edit an epic's fields (title, description, status, dates, target term). Requires Core or project-member access. Empty string clears nullable fields.",
   inputSchema: {
     type: "object" as const,
     properties: {
@@ -48,15 +48,15 @@ export class UpdateEpicError extends Error {
 }
 
 export async function runUpdateEpic(callerId: string, input: Input) {
-  if (!(await isCore(callerId))) {
-    throw new UpdateEpicError("Forbidden", 403);
-  }
-
   const epic = await prisma.epic.findUnique({
     where: { id: input.epicId },
-    select: { id: true, startsAt: true, endsAt: true },
+    select: { id: true, projectId: true, startsAt: true, endsAt: true },
   });
   if (!epic) throw new UpdateEpicError("Epic not found", 404);
+
+  if (!(await canEditProject(callerId, epic.projectId))) {
+    throw new UpdateEpicError("Forbidden", 403);
+  }
 
   const data: {
     title?: string;

--- a/dali-api/app/mcp/tools/update-sprint.ts
+++ b/dali-api/app/mcp/tools/update-sprint.ts
@@ -1,14 +1,14 @@
-// MCP `update_sprint` — Core-only. Mirrors api.sprints.$id POST. Omit a field
-// to leave it unchanged. Use `set_sprint_status` for status (kept separate for
-// symmetry with `update_task_status`).
+// MCP `update_sprint` — Core or project member. Mirrors api.sprints.$id POST.
+// Omit a field to leave it unchanged. Use `set_sprint_status` for status (kept
+// separate for symmetry with `update_task_status`).
 
 import { prisma } from "~/lib/db";
-import { isCore } from "~/lib/roles";
+import { canEditProject } from "./access";
 
 export const UPDATE_SPRINT_TOOL = {
   name: "update_sprint",
   description:
-    "Edit sprint fields (name, dates, epic link). Core-only. Status changes go through `set_sprint_status`.",
+    "Edit sprint fields (name, dates, epic link). Requires Core or project-member access. Status changes go through `set_sprint_status`.",
   inputSchema: {
     type: "object" as const,
     properties: {
@@ -40,15 +40,15 @@ export class UpdateSprintError extends Error {
 }
 
 export async function runUpdateSprint(callerId: string, input: Input) {
-  if (!(await isCore(callerId))) {
-    throw new UpdateSprintError("Forbidden", 403);
-  }
-
   const sprint = await prisma.sprint.findUnique({
     where: { id: input.sprintId },
-    select: { id: true, startsAt: true, endsAt: true },
+    select: { id: true, projectId: true, startsAt: true, endsAt: true },
   });
   if (!sprint) throw new UpdateSprintError("Sprint not found", 404);
+
+  if (!(await canEditProject(callerId, sprint.projectId))) {
+    throw new UpdateSprintError("Forbidden", 403);
+  }
 
   const data: {
     name?: string;

--- a/dali-api/app/mcp/tools/update-story.ts
+++ b/dali-api/app/mcp/tools/update-story.ts
@@ -1,7 +1,7 @@
-// MCP `update_story` — Core-only. Mirrors api.stories.$id POST.
+// MCP `update_story` — Core or project member. Mirrors api.stories.$id POST.
 
 import { prisma } from "~/lib/db";
-import { isCore } from "~/lib/roles";
+import { canEditProject } from "./access";
 
 const STORY_STATUSES = ["Todo", "InProgress", "Done"] as const;
 type StoryStatus = (typeof STORY_STATUSES)[number];
@@ -9,7 +9,7 @@ type StoryStatus = (typeof STORY_STATUSES)[number];
 export const UPDATE_STORY_TOOL = {
   name: "update_story",
   description:
-    "Edit a user story (title, notes, status). Core-only. Empty string clears notes.",
+    "Edit a user story (title, notes, status). Requires Core or project-member access. Empty string clears notes.",
   inputSchema: {
     type: "object" as const,
     properties: {
@@ -42,15 +42,15 @@ export class UpdateStoryError extends Error {
 }
 
 export async function runUpdateStory(callerId: string, input: Input) {
-  if (!(await isCore(callerId))) {
-    throw new UpdateStoryError("Forbidden", 403);
-  }
-
   const story = await prisma.userStory.findUnique({
     where: { id: input.storyId },
-    select: { id: true },
+    select: { id: true, epic: { select: { projectId: true } } },
   });
   if (!story) throw new UpdateStoryError("Story not found", 404);
+
+  if (!(await canEditProject(callerId, story.epic.projectId))) {
+    throw new UpdateStoryError("Forbidden", 403);
+  }
 
   const data: { title?: string; notes?: string | null; status?: StoryStatus } = {};
 

--- a/dali-api/app/mcp/tools/update-task-status.ts
+++ b/dali-api/app/mcp/tools/update-task-status.ts
@@ -3,13 +3,13 @@
 // drag-to-end of board).
 //
 // Permission: the web board endpoint (`api.tasks.$id.move.ts`) gates moves to
-// Core only. For MCP we additionally allow a task's own assignees to update
-// status — the "list my tasks, mark mine done" flow is the primary value
-// here. Anyone else (incl. non-Core members not assigned to the task) is
-// rejected. Requires the `mcp:write` scope.
+// project editors (Core or a project member). MCP matches that and additionally
+// allows a task's own assignees to update status — the "list my tasks, mark
+// mine done" flow — even when they aren't otherwise project editors. Anyone
+// else is rejected. Requires the `mcp:write` scope.
 
 import { prisma } from "~/lib/db";
-import { isCore } from "~/lib/roles";
+import { canEditProject } from "./access";
 import {
   TASK_STATUSES,
   type TaskStatus,
@@ -19,7 +19,7 @@ import {
 export const UPDATE_TASK_STATUS_TOOL = {
   name: "update_task_status",
   description:
-    "Move a project task to a different status column (e.g. mark a task Done). Allowed for the task's assignees and for Core members.",
+    "Move a project task to a different status column (e.g. mark a task Done). Allowed for the task's assignees and for project editors (Core or project members).",
   inputSchema: {
     type: "object" as const,
     properties: {
@@ -67,8 +67,9 @@ export async function runUpdateTaskStatus(callerId: string, input: Input) {
   if (!task) throw new UpdateTaskStatusError("Task not found", 404);
 
   const isAssignee = task.assignees.some((a) => a.userId === callerId);
-  const callerIsCore = isAssignee ? false : await isCore(callerId);
-  if (!isAssignee && !callerIsCore) {
+  const allowed =
+    isAssignee || (await canEditProject(callerId, task.projectId));
+  if (!allowed) {
     throw new UpdateTaskStatusError("Forbidden", 403);
   }
 

--- a/dali-api/app/mcp/tools/update-task.ts
+++ b/dali-api/app/mcp/tools/update-task.ts
@@ -1,10 +1,10 @@
 // MCP `update_task` — edit fields on a task (title/priority/dueAt/sprintId/
-// epicId/domainId/assignees). Mirrors api.tasks.$id PATCH (Core-only). Use
-// `update_task_status` for status changes (it has special column-rebalance
-// semantics).
+// epicId/domainId/assignees). Mirrors api.tasks.$id PATCH (Core or project
+// member). Use `update_task_status` for status changes (it has special
+// column-rebalance semantics).
 
 import { prisma } from "~/lib/db";
-import { isCore } from "~/lib/roles";
+import { canEditProject } from "./access";
 import { syncIssueForTask } from "~/projects/lib/github-task-sync";
 import { notifyTaskAssigned } from "~/projects/lib/task-notifications.server";
 
@@ -14,7 +14,7 @@ type Priority = (typeof PRIORITIES)[number];
 export const UPDATE_TASK_TOOL = {
   name: "update_task",
   description:
-    "Edit fields on a project task (title, priority, due date, sprint, epic, domain, assignees). Core-only. Status changes go through `update_task_status`. Empty string clears nullable fields; omit a field to leave it unchanged.",
+    "Edit fields on a project task (title, priority, due date, sprint, epic, domain, assignees). Requires Core or project-member access. Status changes go through `update_task_status`. Empty string clears nullable fields; omit a field to leave it unchanged.",
   inputSchema: {
     type: "object" as const,
     properties: {
@@ -68,19 +68,20 @@ export class UpdateTaskError extends Error {
 }
 
 export async function runUpdateTask(callerId: string, input: Input) {
-  if (!(await isCore(callerId))) {
-    throw new UpdateTaskError("Forbidden", 403);
-  }
-
   const task = await prisma.task.findUnique({
     where: { id: input.taskId },
     select: {
       id: true,
+      projectId: true,
       githubIssueNumber: true,
       assignees: { select: { userId: true } },
     },
   });
   if (!task) throw new UpdateTaskError("Task not found", 404);
+
+  if (!(await canEditProject(callerId, task.projectId))) {
+    throw new UpdateTaskError("Forbidden", 403);
+  }
 
   const data: {
     title?: string;
@@ -107,11 +108,36 @@ export async function runUpdateTask(callerId: string, input: Input) {
       data.dueAt = d;
     }
   }
+  // Sprint/epic reassignments are validated against the task's own project so
+  // one project's editor can't attach the task to another project's board
+  // (matches the web PATCH route's guard).
   if (input.sprintId !== undefined) {
-    data.sprintId = input.sprintId === "" ? null : input.sprintId;
+    if (input.sprintId === "") {
+      data.sprintId = null;
+    } else {
+      const sprint = await prisma.sprint.findUnique({
+        where: { id: input.sprintId },
+        select: { projectId: true },
+      });
+      if (!sprint || sprint.projectId !== task.projectId) {
+        throw new UpdateTaskError("Sprint is not part of this project", 400);
+      }
+      data.sprintId = input.sprintId;
+    }
   }
   if (input.epicId !== undefined) {
-    data.epicId = input.epicId === "" ? null : input.epicId;
+    if (input.epicId === "") {
+      data.epicId = null;
+    } else {
+      const epic = await prisma.epic.findUnique({
+        where: { id: input.epicId },
+        select: { projectId: true },
+      });
+      if (!epic || epic.projectId !== task.projectId) {
+        throw new UpdateTaskError("Epic is not part of this project", 400);
+      }
+      data.epicId = input.epicId;
+    }
   }
   if (input.domainId !== undefined) {
     data.domainId = input.domainId === "" ? null : input.domainId;

--- a/dali-api/prisma/migrations/20260721000000_oauth_client_require_membership_default_true/migration.sql
+++ b/dali-api/prisma/migrations/20260721000000_oauth_client_require_membership_default_true/migration.sql
@@ -1,0 +1,6 @@
+-- Fail closed: a client provisioned without an explicit requireMembership now
+-- defaults to true, so a non-member can't reach the MCP surface. Existing rows
+-- are unchanged (the only production client already sets this to true).
+
+-- AlterTable
+ALTER TABLE "OAuthClient" ALTER COLUMN "requireMembership" SET DEFAULT true;

--- a/dali-api/prisma/schema.prisma
+++ b/dali-api/prisma/schema.prisma
@@ -3775,8 +3775,11 @@ model OAuthClient {
   // Dartmouth-student and partner accounts. Null = any.
   requiredAccountType String?
   // If true, /oauth/callback/google verifies a DALIMember row exists for
-  // the authenticated user. MCP clients: true.
-  requireMembership   Boolean  @default(false)
+  // the authenticated user, and mcp-auth re-checks it on every request (the
+  // off-boarding kill switch). Defaults to true so a client provisioned
+  // without an explicit value fails closed — a non-member can't reach the MCP
+  // surface. Set false only for a deliberately public client.
+  requireMembership   Boolean  @default(true)
 
   grants OAuthGrant[]
 


### PR DESCRIPTION
Audit of the MCP tool surface (`app/mcp/tools/`) against the equivalent web routes surfaced six authorization divergences. This PR closes all of them. The MCP dispatcher only checks a coarse `mcp:read`/`mcp:write` scope — every role/ownership check lives inside each tool's `run*` function, and those had drifted from the web.

## Fixes

**🔴 `read_page` had no per-page authorization** — it returned any page's Markdown body to any `mcp:read` caller. Now gated by the web's own `authorizeCollabDoc` (Core / lab member / project member / instructor / partner-visible), matching `documents.$pageId.tsx`. Closes a cross-workspace content leak, most notably instructor-only EducationOffering pages. Its write-twin `set_page_content` already gated correctly.

**🟠 `search_directory`** — now defaults to current-term-active members (`currentTermMemberWhere()`, matching the web People page) with an `includeInactive` opt-in mirroring the "All terms" toggle, and no longer returns `netId` in bulk rows. Single-member netId is still available via `get_member_profile`, matching the web profile page.

**🟠 `list_groups`** — the full `memberIds` roster is returned only to Core/Admin/Instructor callers (`canViewForms`); everyone else gets `memberCount`.

**🟠 `create_task` / `update_task`** — reject a `sprintId`/`epicId` belonging to another project, matching the web routes' cross-project guard.

**🟡 Project writes (14 tools)** — task/sprint/epic/story/github-link tools moved from `isCore` (Core-only) to `canEditProject` (Core **or** project member), resolving each entity's real project — web parity via `requireProjectEditAccess`. `update_task_status` and `set_task_checklist` keep their assignee self-service path *plus* member parity; `add_task_comment` already matched the web (assignee ∨ Core) and is unchanged.

**🟡 `OAuthClient.requireMembership` defaults to `true`** — a client provisioned without an explicit value now fails closed. Additive metadata-only `SET DEFAULT` migration; the only production client already set this explicitly, so existing rows are unchanged.

## Flags / call-outs
- **Behavior change:** `read_page` now returns 403 for pages the caller can't open in the web editor — including **archived pages** (the collab gate treats archived docs as closed). Intentional parity, but noting it.
- **Collab-layer change:** touches `read_page`, one of the additive routes the desktop app depends on indirectly; the route contract is unchanged (same inputs/outputs, just an added auth check).
- **Migration:** `20260721000000_oauth_client_require_membership_default_true` — `ALTER COLUMN ... SET DEFAULT true`, non-data-losing, Prisma-generated (no schema drift).

## Testing
- `npm test` — 2121 unit tests pass (9 new, covering the read_page deny path, directory scoping/netId, group roster gating, and non-Core member write parity).
- `npm run typecheck` — clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/984"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787284582&installation_model_id=21824&pr_number=984&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F984&signature=3ef9c28dc14d6e4ac84c7f21c00a1f1f19a1c5e145e8a1e3531500aed9dc1e19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->