### PR TITLE
Membership status: stored Active/Alumni derived from Dartmouth signals

### DIFF
--- a/alumni_status_plan.md
+++ b/alumni_status_plan.md
@@ -1,0 +1,202 @@
+# Membership Status — Implementation Plan
+
+Supersedes the derivation approach in PRs #737 / #739 (`alumni_plan.md`). Reuses
+#737's Dartmouth sync clients; replaces #739's per-call `isAlumni()` derivation
+with a **stored, transition-computed status field**.
+
+## Goal
+
+An authoritative record of each lab member's status (`Active` / `Alumni`) that:
+
+- is read O(1) on hot paths (one indexed column — no derivation, no external
+  call, no latency in `getUserRoles`/`tier`);
+- is recomputed only when an input can actually change it (transitions cluster:
+  ~95% at June Commencement, ~5% at off-cycle term ends);
+- is **decoupled from engagement tables** (`ProjectAssignment`,
+  `ExternalMentor`, `StaffingMentorRole`, …) so that (a) an alumnus mentoring a
+  project stays `Alumni`, and (b) the algorithm is immune to the ongoing churn
+  in the staffing/mentor schema;
+- is human-overridable for the cases no signal can resolve.
+
+## Design principles (from review)
+
+1. **Status is a fact about the person (enrollment + graduation), not about
+   their current assignments.** Never infer `Active`/`Alumni` from assignment or
+   mentor rows. This fixes the alumni-mentor case and insulates us from the
+   staffing schema still being in flux.
+2. **Store the answer; recompute at transitions.** Per-call derivation is wasted
+   compute + latency for a value that changes ~once/year per person.
+3. **Fetch authoritative signals at the boundary, not on a rolling window.** The
+   7-day/14-day freshness windows in #737/#739 existed only to keep a cache warm
+   enough for per-call reads. With a stored value refreshed by the Commencement
+   sweep + login, there is no window to tune.
+4. **Name the unresolvable case honestly and hand it to a human.** Dartmouth's
+   `Alum + Student` is identical for a fresh grad (Student lingers) and a BE
+   dual-degree candidate (genuinely enrolled). Don't guess with a time
+   heuristic — pin the rare exceptions via the override.
+
+## Data model — `schema.prisma`
+
+```prisma
+enum MembershipStatus {
+  Active
+  Alumni
+}
+
+model User {
+  // ── Membership status (authoritative, stored) ──────────────────────────
+  membershipStatus           MembershipStatus  @default(Active)
+  // Manual pin. When set, wins over recompute and is never clobbered.
+  // Handles: BE dual-degree candidates (Active while enrolled), non-student
+  // staff members (never graduate), and any misclassification.
+  membershipStatusOverride   MembershipStatus?
+  membershipStatusComputedAt DateTime?         // observability only
+
+  // ── Dartmouth directory signals (cached inputs) — from #737 ─────────────
+  dartmouthAffiliation    String?   // raw IDM code: "DART" | "ALUMNI" | …
+  dartmouthIsAlum         Boolean?  // "Alum" ∈ affiliations — degree conferred
+  dartmouthIsStudent      Boolean?  // "Student" ∈ affiliations (lingers post-grad)
+  dartmouthPeopleSyncedAt DateTime?
+}
+```
+
+`membershipStatus` is only meaningful when a `DALIMember` row is present;
+non-members keep the inert `Active` default. Consumers gate on `DALIMember`
+first (the directory and `tier()` already do).
+
+Migration: additive `ADD COLUMN` (one enum type + 3 columns on User + 4 cache
+columns). **Date it after the latest applied migration** (currently
+`20260720190000`) — do NOT reuse #737's `20260601120000` stamp, which now sorts
+before ~15 applied July migrations.
+
+## The recompute algorithm
+
+```
+recomputeMembershipStatus(userId):
+  load { membershipStatusOverride, dartmouthIsAlum, dartmouthIsStudent,
+         dartmouthAffiliation, graduatedAt, classYear, daliMember? }
+  if no daliMember: return                      // status is member-only
+
+  status =
+    override                                   // manual pin wins
+    ?? Alumni  if dartmouthIsAlum || dartmouthAffiliation == "ALUMNI"   // degree conferred
+    ?? Alumni  if graduatedAt != null && graduatedAt < now             // off-cycle / manual input
+    ?? Active  if dartmouthIsStudent === true    // authoritative still-enrolled (+1 guard, beats classYear)
+    ?? Alumni  if classYear != null && commencement(classYear) <= now  // no-API fallback
+    ?? Active
+
+  write only if changed: membershipStatus = status, membershipStatusComputedAt = now
+```
+
+- **No engagement tables are read.** Alumni-mentor case handled by construction.
+- **No freshness window.** The recompute is always *triggered by* a fresh sync
+  (Commencement sweep / login refresh) or a DB-only input change, so the signals
+  it reads are current by construction; between transitions the stored value
+  simply persists (correct — status doesn't change between transitions).
+- `commencement(classYear)` = June 15 of that year (conservative; Commencement
+  is mid-June).
+- BE dual-degree `Alum + Student`: default lands `Alumni` on the Alum branch;
+  the ~handful of genuine BE candidates get `override = Active`.
+- `graduatedAt` stays a **manual input** — the refresh does NOT auto-stamp it
+  (dropped from #737's orchestrator). `membershipStatus` is now the stored
+  graduation record, so auto-stamping is redundant and its stickiness bug goes
+  away.
+
+## Triggers (replace per-call derivation)
+
+| Trigger | Action | Cadence / cost |
+|---|---|---|
+| **Term-rollover API sweep** (job runner) | on each term change — detected when `currentTerm()` differs from the `lastSweptTermId` held in job state — force-refresh Dartmouth signals for **all active members with a netId**, then recompute. June Commencement is just the highest-volume instance; off-cycle grads at every other term boundary (F/W/X ends) flow through the same path. Not keyed on `classYear == currentYear` (that misses +1s / off-by-one classYears); the whole active lab (~150) is cheap | ~1 min × ~4/yr |
+| **Daily ambiguous-set re-sync** (job runner) | re-pull Dartmouth for the small set that *looks still-enrolled but whose class has graduated*: `Active`, netId present, classYear commencement passed, currently `Student ∧ ¬Alum`. **Self-terminating** — a grace-period grad leaves the set the day "Alum" posts (→ `Alumni`); a genuine +1 correctly stays `Active`. Carries the graduating cohort through the multi-week window where "Alum" lands "within weeks", with no date heuristic | daily, ~tens shrinking to ~few |
+| **Daily recompute pass** (job runner, DB-only) | recompute all members from already-cached signals — applies the formula as the clock advances (classYear / `graduatedAt` crossings), zero API cost | daily, ~hundreds of rows |
+| **Login** (CAS + Google callbacks) | fire-and-forget: `refreshDartmouthSignals` → `recomputeMembershipStatus`; throttled to ≤ once/day/user | per sign-in |
+| **Mutation hooks** | `DALIMember` created → `Active`; `graduatedAt` edited → recompute; override set → recompute | per-event |
+
+We do **NOT** refresh on shell/layout load (the #739 behavior) — the stored
+value removes any need to keep a cache warm for reads, and keeps the hot path
+side-effect-free.
+
+**Why term-rollover, not a fixed June date.** Transitions cluster at *term
+boundaries*, of which Commencement is one; keying the sweep to `currentTerm()`
+changing handles every term end via one code path with no calendar constant to
+drift. The one wrinkle — a fresh grad swept the instant Spring ends can still
+show lingering `Student` before "Alum" posts, and would read `Active` — is
+resolved by the daily ambiguous-set re-sync, which *waits for the authoritative
+`Alum` signal* instead of guessing with a grace-period timeout. That same
+mechanism is what cleanly separates a grace-period grad (Alum eventually posts →
+`Alumni`) from a genuine +1 (Alum won't post for a year → stays `Active`).
+
+All behaviors live as one registry entry (idempotent, bounded under the lease);
+it persists `lastSweptTermId` in job settings so the full sweep fires once per
+rollover. See `app/jobs/registry.ts`.
+
+## What we reuse from #737 / #739
+
+**Reuse ~as-is (from #737):**
+- `app/lib/dartmouth-jwt.ts` — cached JWT exchanger. Clean, no changes needed.
+- `app/lib/dartmouth-people.ts` — People client + `parseDepartmentClass`. As-is.
+- The 4 cache columns + `.env.example` `DARTMOUTH_API_KEY`.
+- Login-callback wiring (resolve the one trivial import-order conflict in
+  `auth.callback.google.ts`).
+
+**Rework (from #737):**
+- `app/lib/dartmouth-refresh.ts` — strip the `graduatedAt` auto-stamp and the
+  `staleAfterDays` trust-window logic; it now just fetches + writes cache
+  columns. Callers chain `recomputeMembershipStatus`.
+
+**Replace (from #739):**
+- `isAlumni()` 5-tier per-call derivation → `recomputeMembershipStatus()` +
+  stored field. `getUserRoles` reads `membershipStatus` and exposes
+  `isAlumni: status === 'Alumni'` (informational only — access suppression and
+  the alumni sidebar/route-guards are **deferred**, see below).
+- `tier()` resolver kept, but composes cheap record checks
+  (`isAdmin`/`isCore`/`PartnerUser`/`DALIMember`) with the **stored** status
+  instead of re-deriving. Unused on staging today; ships ready.
+
+**Directory (from #739, simplified):**
+- `members.tsx` `?status=alumni` tab → `where: { daliMember: { isNot: null },
+  membershipStatus: 'Alumni' }`, class-year sort. The forgiving
+  `alumniWhereClause` and its Tier-0 inconsistency are gone — the stored field
+  is the single source of truth, so the tab and the status agree by
+  construction.
+
+## Deferred to a follow-up (per scope decision)
+
+- Alumni **sidebar variant** (Home / People / Profile only).
+- **`ALUMNI_DENIED_PREFIXES` route guards** + the `getUserRoles` access
+  suppression (`isLabMember`/`isDomainLead`/`isInstructor`/`canViewForms` for
+  pure alumni). Landing these together with the sidebar keeps the access change
+  coherent and testable in one pass.
+- `OnLeave` status value (manual-only; add when needed).
+
+## Migration / CI notes
+
+- One additive migration, re-dated after `20260720190000`. `migration-check.yml`
+  should pass (no drift, no deletions, `ADD COLUMN` is pgfence-safe).
+- Backfill: after deploy, run the sweep once (Admin → Jobs → Run-now, or the
+  daily pass) to populate `membershipStatus` for existing graduated members —
+  the column default leaves them `Active` until first recompute.
+- `DARTMOUTH_API_KEY` must be a Fly secret in staging + prod before the sweep /
+  login refresh does anything (unset → refresh no-ops → status falls back to
+  `graduatedAt` + classYear math, which still works).
+- Every mocked `getUserRoles` in tests gains `isAlumni: false` (there are a few
+  beyond #739's `analytics.test.ts`).
+
+## Test plan
+
+- Unit: `recomputeMembershipStatus` truth table — override wins; Alum→Alumni;
+  graduatedAt→Alumni; Student(¬Alum)→Active beats a lapsed classYear; classYear
+  fallback with no signals; non-member no-op; alumni-with-current-assignment
+  stays Alumni (decoupling proof).
+- Reuse #737's JWT + People client tests as-is.
+- Directory: Alumni tab returns only `membershipStatus == Alumni` members.
+- Job: sweep is idempotent, bounded, date-gates the API pass.
+
+## Known limitations
+
+- **BE dual-degree candidate** (`Alum + Student`): defaults to `Alumni`; requires
+  a manual `override = Active` until they finish. Rare; honest.
+- **+1 student with no netId and no logins**: no Dartmouth data → classYear
+  fallback may read `Alumni` a year early. The annual sweep covers anyone with a
+  netId; a truly netId-less +1 who never logs in is the only gap — override
+  fixes it.

--- a/dali-api/.env.example
+++ b/dali-api/.env.example
@@ -10,6 +10,14 @@ GOOGLE_REDIRECT_URI=http://localhost:5173/auth/google/callback
 # dartmouth sso url
 CAS_BASE_URL="https://login.dartmouth.edu/cas"
 
+# Dartmouth DartAPI key — exchanged for short-lived JWTs against
+# https://api.dartmouth.edu/api/jwt and used for the People API, the source of
+# the graduation + enrollment signals that drive membership status (Active /
+# Alumni). When unset, the sync silently no-ops and status falls back to
+# graduatedAt + classYear math. Provisioned through Dartmouth IT
+# (see developer.dartmouth.edu).
+DARTMOUTH_API_KEY=""
+
 # Gmail send-as address for outbound app email (hiring decision emails, member
 # welcome emails). The actual OAuth refresh token lives in a GmailIntegration
 # DB row created via the one-time /admin/authorize-gmail flow — without that row

--- a/dali-api/app/jobs/membership-status-sync.server.ts
+++ b/dali-api/app/jobs/membership-status-sync.server.ts
@@ -1,0 +1,123 @@
+// Membership-status sync job. Keeps User.membershipStatus current without any
+// per-request derivation. Three phases per run (see alumni_status_plan.md):
+//
+//   A. Term-rollover sweep — force-refresh Dartmouth signals for active members
+//      whose cache predates the current term, then recompute. Rollover is
+//      detected from the data (synced-at < term.startDate), so no extra state
+//      is stored: at a new term everyone qualifies; once swept they drop out
+//      until the next term. Logins that refreshed this term are skipped.
+//   B. Ambiguous re-sync — the small set that looks still-enrolled but whose
+//      class has graduated (Active + Student + ¬Alum + classYear lapsed).
+//      Re-pulled every run until "Alum" posts: a grace-period grad flips to
+//      Alumni the day it lands, a genuine +1 keeps showing Student and stays
+//      Active. No timeout, no guess.
+//   C. DB-only recompute — recompute every member from already-cached signals,
+//      applying the formula as the clock advances (classYear / graduatedAt
+//      crossings) with no API cost. Also backfills status on first run.
+//
+// Idempotent + bounded: writes only when a status changes, the API phases are
+// capped per run and no-op when DARTMOUTH_API_KEY is unset, and force-sync of
+// an already-fresh row is harmless.
+
+import { prisma } from "~/lib/db";
+import type { JobContext, JobResult } from "~/jobs/registry";
+import { currentTerm } from "~/lib/roles";
+import {
+  resolveMembershipStatus,
+  commencementDate,
+  syncAndRecomputeMembershipStatus,
+} from "~/lib/membership-status";
+
+// The classYear whose Commencement has passed as of `now` — a member at or
+// below this class has graduated (used to scope the ambiguous set).
+function graduatedCohortCutoff(now: Date): number {
+  const y = now.getFullYear();
+  const postCommencement =
+    now.getMonth() > 5 || (now.getMonth() === 5 && now.getDate() >= 15);
+  return postCommencement ? y : y - 1;
+}
+
+export async function runMembershipStatusSync({
+  now,
+  settings,
+}: JobContext): Promise<JobResult> {
+  const maxApiPerRun = settings.maxApiPerRun ?? 200;
+  const hasApiKey = !!process.env.DARTMOUTH_API_KEY;
+
+  let synced = 0;
+
+  // ── Phases A + B: API refresh for members that need it ──────────────────
+  // Skipped entirely without an API key — the recompute in Phase C still runs
+  // from graduatedAt + classYear.
+  if (hasApiKey) {
+    const term = await currentTerm();
+    const cutoff = graduatedCohortCutoff(now);
+
+    const candidates = await prisma.user.findMany({
+      where: {
+        daliMember: { isNot: null },
+        netId: { not: null },
+        OR: [
+          // A: never synced, or not synced since this term started.
+          { dartmouthPeopleSyncedAt: null },
+          ...(term
+            ? [{ dartmouthPeopleSyncedAt: { lt: term.startDate } }]
+            : []),
+          // B: ambiguous — looks still-enrolled but class has graduated.
+          {
+            membershipStatus: "Active" as const,
+            dartmouthIsStudent: true,
+            NOT: { dartmouthIsAlum: true },
+            classYear: { lte: cutoff },
+          },
+        ],
+      },
+      select: { id: true },
+      take: maxApiPerRun,
+    });
+
+    for (const u of candidates) {
+      await syncAndRecomputeMembershipStatus(u.id, { force: true });
+      synced++;
+    }
+  }
+
+  // ── Phase C: DB-only recompute of every member (catches time crossings,
+  // reconciles, and backfills on first run) ───────────────────────────────
+  const members = await prisma.user.findMany({
+    where: { daliMember: { isNot: null } },
+    select: {
+      id: true,
+      membershipStatus: true,
+      membershipStatusComputedAt: true,
+      membershipStatusOverride: true,
+      graduatedAt: true,
+      classYear: true,
+      dartmouthIsAlum: true,
+      dartmouthIsStudent: true,
+      dartmouthAffiliation: true,
+    },
+  });
+
+  let recomputed = 0;
+  for (const m of members) {
+    const status = resolveMembershipStatus(m, now);
+    if (status !== m.membershipStatus || m.membershipStatusComputedAt == null) {
+      await prisma.user.update({
+        where: { id: m.id },
+        data: { membershipStatus: status, membershipStatusComputedAt: now },
+      });
+      recomputed++;
+    }
+  }
+
+  const parts: string[] = [];
+  if (synced > 0) parts.push(`${synced} refreshed`);
+  if (recomputed > 0) parts.push(`${recomputed} status change(s)`);
+  if (!hasApiKey) parts.push("API key unset — recompute only");
+
+  return {
+    items: recomputed,
+    note: parts.length > 0 ? parts.join("; ") : undefined,
+  };
+}

--- a/dali-api/app/jobs/registry.ts
+++ b/dali-api/app/jobs/registry.ts
@@ -77,6 +77,7 @@ import { runFormWindows } from "~/jobs/form-windows.server";
 import { runInterviewReminders } from "~/jobs/interview-reminders.server";
 import { runStandupPrompts } from "~/jobs/standup-prompts.server";
 import { runTaskAutoArchive } from "~/jobs/task-auto-archive.server";
+import { runMembershipStatusSync } from "~/jobs/membership-status-sync.server";
 
 export const JOBS: JobDefinition[] = [
   {
@@ -248,6 +249,23 @@ export const JOBS: JobDefinition[] = [
       },
     ],
     handler: runTaskAutoArchive,
+  },
+  {
+    name: "membership-status-sync",
+    description:
+      "Keeps member status (Active/Alumni) current: term-rollover Dartmouth sweep, daily re-sync of the ambiguous graduating cohort, and a DB-only recompute for time crossings. No-ops the API phases when DARTMOUTH_API_KEY is unset.",
+    intervalMinutes: 1440,
+    settings: [
+      {
+        key: "maxApiPerRun",
+        label: "Max Dartmouth API calls per run",
+        unit: "",
+        min: 10,
+        max: 1000,
+        default: 200,
+      },
+    ],
+    handler: runMembershipStatusSync,
   },
 ];
 

--- a/dali-api/app/lib/__tests__/dartmouth-jwt.test.ts
+++ b/dali-api/app/lib/__tests__/dartmouth-jwt.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  getDartmouthJwt,
+  __resetDartmouthJwtCacheForTests,
+} from "~/lib/dartmouth-jwt";
+
+// Build a fake JWT whose middle segment decodes to { exp } at the given
+// epoch seconds. Signature is irrelevant — we never verify it locally.
+function fakeJwt(expSeconds: number): string {
+  const header = Buffer.from(JSON.stringify({ alg: "RS256" })).toString(
+    "base64url",
+  );
+  const payload = Buffer.from(JSON.stringify({ exp: expSeconds })).toString(
+    "base64url",
+  );
+  return `${header}.${payload}.sig`;
+}
+
+describe("getDartmouthJwt", () => {
+  const realFetch = global.fetch;
+  const originalKey = process.env.DARTMOUTH_API_KEY;
+
+  beforeEach(() => {
+    __resetDartmouthJwtCacheForTests();
+    global.fetch = vi.fn();
+    process.env.DARTMOUTH_API_KEY = "test-api-key";
+  });
+
+  afterEach(() => {
+    global.fetch = realFetch;
+    if (originalKey === undefined) delete process.env.DARTMOUTH_API_KEY;
+    else process.env.DARTMOUTH_API_KEY = originalKey;
+  });
+
+  function mockExchange(jwt: string) {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      new Response(JSON.stringify({ jwt }), { status: 200 }),
+    );
+  }
+
+  it("exchanges the API key and returns the JWT", async () => {
+    const jwt = fakeJwt(Math.floor(Date.now() / 1000) + 3600);
+    mockExchange(jwt);
+    const result = await getDartmouthJwt();
+    expect(result).toBe(jwt);
+
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>;
+    const call = fetchMock.mock.calls[0];
+    expect(call[0]).toContain("api.dartmouth.edu/api/jwt");
+    // No optional scope requested — dartmouth_affiliation is in the base
+    // no-scope People payload.
+    expect(call[0]).not.toContain("scope");
+    expect((call[1] as RequestInit).method).toBe("POST");
+    // Raw key — no "Bearer" prefix.
+    expect((call[1] as RequestInit).headers).toEqual({
+      Authorization: "test-api-key",
+    });
+  });
+
+  it("caches subsequent calls until close to expiry", async () => {
+    const jwt = fakeJwt(Math.floor(Date.now() / 1000) + 3600);
+    mockExchange(jwt);
+
+    await getDartmouthJwt();
+    await getDartmouthJwt();
+    await getDartmouthJwt();
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-exchanges once cached JWT is past the refresh buffer", async () => {
+    // First JWT expires in 2 minutes — within the 5-minute refresh buffer,
+    // so the next call must re-exchange.
+    const stale = fakeJwt(Math.floor(Date.now() / 1000) + 120);
+    const fresh = fakeJwt(Math.floor(Date.now() / 1000) + 3600);
+
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>;
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ jwt: stale }), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ jwt: fresh }), { status: 200 }),
+      );
+
+    expect(await getDartmouthJwt()).toBe(stale);
+    expect(await getDartmouthJwt()).toBe(fresh);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws when DARTMOUTH_API_KEY is unset", async () => {
+    delete process.env.DARTMOUTH_API_KEY;
+    await expect(getDartmouthJwt()).rejects.toThrow(/DARTMOUTH_API_KEY/);
+  });
+
+  it("throws on non-OK exchange response", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      new Response("forbidden", { status: 403, statusText: "Forbidden" }),
+    );
+    await expect(getDartmouthJwt()).rejects.toThrow(/403/);
+  });
+});

--- a/dali-api/app/lib/__tests__/dartmouth-people.test.ts
+++ b/dali-api/app/lib/__tests__/dartmouth-people.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("~/lib/dartmouth-jwt", () => ({
+  getDartmouthJwt: vi.fn().mockResolvedValue("test-jwt"),
+}));
+
+import {
+  peopleByNetId,
+  parseDepartmentClass,
+} from "~/lib/dartmouth-people";
+
+describe("parseDepartmentClass", () => {
+  it("parses apostrophe-prefixed two-digit class years", () => {
+    expect(parseDepartmentClass("'27")).toBe(2027);
+    expect(parseDepartmentClass("'00")).toBe(2000);
+    expect(parseDepartmentClass("'89")).toBe(2089);
+    expect(parseDepartmentClass("'99")).toBe(1999);
+    expect(parseDepartmentClass(" '26 ")).toBe(2026);
+  });
+
+  it("returns null for department names and junk", () => {
+    expect(parseDepartmentClass("Computer Science")).toBeNull();
+    expect(parseDepartmentClass("27")).toBeNull();
+    expect(parseDepartmentClass("'275")).toBeNull();
+    expect(parseDepartmentClass("")).toBeNull();
+    expect(parseDepartmentClass(null)).toBeNull();
+    expect(parseDepartmentClass(undefined)).toBeNull();
+  });
+});
+
+describe("peopleByNetId", () => {
+  const realFetch = global.fetch;
+
+  beforeEach(() => {
+    global.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    global.fetch = realFetch;
+  });
+
+  function mockPerson(body: unknown, status = 200) {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      new Response(JSON.stringify(body), { status }),
+    );
+  }
+
+  it("sends the JWT as a Bearer token to the person URL", async () => {
+    mockPerson({ dartmouth_affiliation: "DART", affiliations: [] });
+    await peopleByNetId("f006v43");
+
+    const call = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(call[0]).toBe("https://api.dartmouth.edu/api/people/f006v43");
+    expect((call[1] as RequestInit).headers).toMatchObject({
+      Authorization: "Bearer test-jwt",
+    });
+  });
+
+  // The four shapes below are real (anonymized) records observed 2026-07-06,
+  // three weeks after Commencement — see alumni_plan.md.
+
+  it("current student: Student affiliation, class year parsed", async () => {
+    mockPerson({
+      dartmouth_affiliation: "DART",
+      affiliations: [{ name: "Student" }],
+      department_class: "'27",
+    });
+    expect(await peopleByNetId("current")).toEqual({
+      dartmouthAffiliation: "DART",
+      isAlum: false,
+      isStudent: true,
+      classYear: 2027,
+    });
+  });
+
+  it("enrolled +1: classYear past but no Alum affiliation", async () => {
+    mockPerson({
+      dartmouth_affiliation: "DART",
+      affiliations: [{ name: "Student" }],
+      department_class: "'26",
+    });
+    expect(await peopleByNetId("plusone")).toEqual({
+      dartmouthAffiliation: "DART",
+      isAlum: false,
+      isStudent: true,
+      classYear: 2026,
+    });
+  });
+
+  it("fresh grad: Alum appears while Student lingers and IDM still says DART", async () => {
+    mockPerson({
+      dartmouth_affiliation: "DART",
+      affiliations: [{ name: "Alum" }, { name: "Student" }],
+      department_class: "'26",
+    });
+    expect(await peopleByNetId("grad")).toEqual({
+      dartmouthAffiliation: "DART",
+      isAlum: true,
+      isStudent: true,
+      classYear: 2026,
+    });
+  });
+
+  it("long-graduated: IDM flipped to ALUMNI", async () => {
+    mockPerson({
+      dartmouth_affiliation: "ALUMNI",
+      affiliations: [{ name: "Alum" }],
+      department_class: "'20",
+    });
+    expect(await peopleByNetId("old-grad")).toEqual({
+      dartmouthAffiliation: "ALUMNI",
+      isAlum: true,
+      isStudent: false,
+      classYear: 2020,
+    });
+  });
+
+  it("employee: department name is not a class year", async () => {
+    mockPerson({
+      dartmouth_affiliation: "DART",
+      affiliations: [{ name: "Staff" }],
+      department_class: "Computer Science",
+    });
+    expect(await peopleByNetId("staff")).toEqual({
+      dartmouthAffiliation: "DART",
+      isAlum: false,
+      isStudent: false,
+      classYear: null,
+    });
+  });
+
+  it("tolerates missing affiliations and department_class", async () => {
+    mockPerson({ dartmouth_affiliation: "SPON" });
+    expect(await peopleByNetId("spon")).toEqual({
+      dartmouthAffiliation: "SPON",
+      isAlum: false,
+      isStudent: false,
+      classYear: null,
+    });
+  });
+
+  it("returns null on 404 (not a valid identity)", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      new Response("not found", { status: 404 }),
+    );
+    expect(await peopleByNetId("ghost")).toBeNull();
+  });
+
+  it("throws on non-OK, non-404 responses", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      new Response("nope", { status: 503, statusText: "Service Unavailable" }),
+    );
+    await expect(peopleByNetId("x")).rejects.toThrow(/503/);
+  });
+
+  it("URL-encodes the netId", async () => {
+    mockPerson({ affiliations: [] });
+    await peopleByNetId("a/b");
+    const call = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(call[0]).toBe("https://api.dartmouth.edu/api/people/a%2Fb");
+  });
+});

--- a/dali-api/app/lib/__tests__/membership-status.test.ts
+++ b/dali-api/app/lib/__tests__/membership-status.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import {
+  resolveMembershipStatus,
+  commencementDate,
+  type StatusInputs,
+} from "~/lib/membership-status";
+
+// Fixed "now": just past Commencement 2026, before Commencement 2027.
+const NOW = new Date("2026-07-01T00:00:00Z");
+
+// A member with no signals at all — the neutral baseline each case overrides.
+const base: StatusInputs = {
+  membershipStatusOverride: null,
+  graduatedAt: null,
+  classYear: null,
+  dartmouthIsAlum: null,
+  dartmouthIsStudent: null,
+  dartmouthAffiliation: null,
+};
+
+const resolve = (over: Partial<StatusInputs>) =>
+  resolveMembershipStatus({ ...base, ...over }, NOW);
+
+describe("commencementDate", () => {
+  it("is June 15 of the class year", () => {
+    const d = commencementDate(2026);
+    expect(d.getFullYear()).toBe(2026);
+    expect(d.getMonth()).toBe(5); // June, 0-indexed
+    expect(d.getDate()).toBe(15);
+  });
+});
+
+describe("resolveMembershipStatus", () => {
+  it("returns Active when no signal points at graduation (staff / current member)", () => {
+    expect(resolve({})).toBe("Active");
+  });
+
+  it("manual override wins over every derived signal", () => {
+    // Override Active despite a degree-conferred signal (BE dual-degree case).
+    expect(
+      resolve({ membershipStatusOverride: "Active", dartmouthIsAlum: true }),
+    ).toBe("Active");
+    // Override Alumni despite looking like a current student.
+    expect(
+      resolve({
+        membershipStatusOverride: "Alumni",
+        dartmouthIsStudent: true,
+        classYear: 2027,
+      }),
+    ).toBe("Alumni");
+  });
+
+  it("degree conferred (Alum affiliation) => Alumni", () => {
+    expect(resolve({ dartmouthIsAlum: true })).toBe("Alumni");
+  });
+
+  it("IDM ALUMNI affiliation code => Alumni", () => {
+    expect(resolve({ dartmouthAffiliation: "ALUMNI" })).toBe("Alumni");
+  });
+
+  it("explicit past graduatedAt => Alumni", () => {
+    expect(resolve({ graduatedAt: new Date("2026-06-20") })).toBe("Alumni");
+  });
+
+  it("future graduatedAt does not graduate (falls through to Active)", () => {
+    expect(resolve({ graduatedAt: new Date("2027-06-20") })).toBe("Active");
+  });
+
+  it("manual graduatedAt beats a lingering Student affiliation", () => {
+    expect(
+      resolve({ graduatedAt: new Date("2026-06-20"), dartmouthIsStudent: true }),
+    ).toBe("Alumni");
+  });
+
+  it("Student without Alum keeps a lapsed-classYear member Active (+1 guard)", () => {
+    expect(resolve({ dartmouthIsStudent: true, classYear: 2025 })).toBe(
+      "Active",
+    );
+  });
+
+  it("fresh grad with both Alum and lingering Student => Alumni (Alum wins)", () => {
+    expect(resolve({ dartmouthIsAlum: true, dartmouthIsStudent: true })).toBe(
+      "Alumni",
+    );
+  });
+
+  it("classYear past Commencement with no API signals => Alumni (fallback)", () => {
+    expect(resolve({ classYear: 2024 })).toBe("Alumni");
+  });
+
+  it("classYear this year, just past June 15 => Alumni", () => {
+    expect(resolve({ classYear: 2026 })).toBe("Alumni");
+  });
+
+  it("future classYear => Active", () => {
+    expect(resolve({ classYear: 2027 })).toBe("Active");
+  });
+});

--- a/dali-api/app/lib/__tests__/membership-status.test.ts
+++ b/dali-api/app/lib/__tests__/membership-status.test.ts
@@ -1,4 +1,11 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
+
+// membership-status.ts transitively imports ~/lib/db (the Prisma client). These
+// tests only exercise the pure resolver, so mock db to avoid loading the
+// generated client (which the unit-test CI job doesn't build). Mirrors
+// roles.test.ts / search.server.test.ts.
+vi.mock("~/lib/db");
+
 import {
   resolveMembershipStatus,
   commencementDate,

--- a/dali-api/app/lib/__tests__/roles.test.ts
+++ b/dali-api/app/lib/__tests__/roles.test.ts
@@ -26,7 +26,10 @@ const mockPrisma = prisma as unknown as {
   cycleInterviewer: { findFirst: ReturnType<typeof vi.fn> };
   projectAssignment: { findFirst: ReturnType<typeof vi.fn> };
   domainEligibility: { findFirst: ReturnType<typeof vi.fn> };
-  user: { findFirst: ReturnType<typeof vi.fn> };
+  user: {
+    findFirst: ReturnType<typeof vi.fn>;
+    findUnique: ReturnType<typeof vi.fn>;
+  };
   term: {
     findFirst: ReturnType<typeof vi.fn>;
     findMany: ReturnType<typeof vi.fn>;
@@ -46,7 +49,10 @@ beforeEach(() => {
   (mockPrisma as any).cycleInterviewer = { findFirst: vi.fn() };
   (mockPrisma as any).projectAssignment = { findFirst: vi.fn().mockResolvedValue(null) };
   (mockPrisma as any).domainEligibility = { findFirst: vi.fn().mockResolvedValue(null) };
-  (mockPrisma as any).user = { findFirst: vi.fn().mockResolvedValue(null) };
+  (mockPrisma as any).user = {
+    findFirst: vi.fn().mockResolvedValue(null),
+    findUnique: vi.fn().mockResolvedValue(null),
+  };
   // Core access scopes to the active election cycle, looked up via
   // currentTerm (findFirst) → cycle window (findMany). Default to a Spring
   // term so Core checks resolve a non-empty cycle.

--- a/dali-api/app/lib/__tests__/search.server.test.ts
+++ b/dali-api/app/lib/__tests__/search.server.test.ts
@@ -25,6 +25,7 @@ const MEMBER: UserRoles = {
   isDomainLead: false,
   isInstructor: false,
   isInterviewer: false,
+  isAlumni: false,
   canViewForms: false,
   canViewStaffing: false,
 };

--- a/dali-api/app/lib/dartmouth-jwt.ts
+++ b/dali-api/app/lib/dartmouth-jwt.ts
@@ -1,0 +1,101 @@
+// JWT exchanger for api.dartmouth.edu. The DartAPI login service swaps an
+// API key for a short-lived JWT (~6h) which is then passed as
+// `Authorization: Bearer <jwt>` on subsequent People-API calls.
+//
+// Distinct from the session-JWT machinery in `auth.ts` — that signs our own
+// session tokens with `jose`. This module talks to Dartmouth's login service
+// only and never inspects or signs anything itself.
+//
+// Cached in process memory; on cold start or after expiry we re-exchange.
+// Multi-instance Fly deployments each maintain their own cache — that's fine,
+// the cost of a redundant exchange is one extra HTTP call.
+
+// No optional scope is requested. Everything we read from the People API
+// (dartmouth_affiliation) is in the base no-scope payload; the optional
+// scopes (private / read.sensitive / read.highlysensitive) gate FERPA and
+// sensitive fields we never use, and each requires data-steward approval
+// that would otherwise become a silent deployment dependency.
+const JWT_URL = "https://api.dartmouth.edu/api/jwt";
+const REFRESH_BUFFER_MS = 5 * 60 * 1000; // refresh when within 5 min of exp
+
+type CachedJwt = {
+  jwt: string;
+  expiresAtMs: number;
+};
+
+let cached: CachedJwt | null = null;
+let inflight: Promise<CachedJwt> | null = null;
+
+function decodePayloadExpMs(jwt: string): number {
+  // RFC 7519 §4.1.4: `exp` is seconds since epoch. We don't verify the
+  // signature here — Dartmouth verifies it on subsequent calls. We only
+  // need `exp` for cache-staleness.
+  const parts = jwt.split(".");
+  if (parts.length !== 3) {
+    throw new Error("dartmouth-jwt: malformed JWT (expected 3 segments)");
+  }
+  const payload = JSON.parse(
+    Buffer.from(parts[1], "base64url").toString("utf8"),
+  );
+  if (typeof payload.exp !== "number") {
+    throw new Error("dartmouth-jwt: JWT payload missing numeric exp");
+  }
+  return payload.exp * 1000;
+}
+
+async function exchange(): Promise<CachedJwt> {
+  const apiKey = process.env.DARTMOUTH_API_KEY;
+  if (!apiKey) {
+    throw new Error(
+      "dartmouth-jwt: DARTMOUTH_API_KEY is not set; cannot exchange for JWT",
+    );
+  }
+
+  const res = await fetch(JWT_URL, {
+    method: "POST",
+    // DartAPI docs: API key goes in `Authorization` header as the raw key
+    // (no "Bearer " prefix). The returned JWT is what gets used with Bearer
+    // on subsequent People calls.
+    headers: { Authorization: apiKey },
+  });
+
+  if (!res.ok) {
+    throw new Error(
+      `dartmouth-jwt: exchange failed with HTTP ${res.status} ${res.statusText}`,
+    );
+  }
+
+  const body = (await res.json()) as { jwt?: string };
+
+  if (!body.jwt) {
+    throw new Error("dartmouth-jwt: response missing jwt field");
+  }
+
+  return {
+    jwt: body.jwt,
+    expiresAtMs: decodePayloadExpMs(body.jwt),
+  };
+}
+
+export async function getDartmouthJwt(): Promise<string> {
+  const now = Date.now();
+  if (cached && cached.expiresAtMs - REFRESH_BUFFER_MS > now) {
+    return cached.jwt;
+  }
+
+  // Coalesce concurrent callers onto a single in-flight exchange.
+  if (!inflight) {
+    inflight = exchange().finally(() => {
+      inflight = null;
+    });
+  }
+  cached = await inflight;
+  return cached.jwt;
+}
+
+// Test-only reset. Vitest re-imports modules between files but not between
+// tests in the same file; this lets each test start from a clean cache.
+export function __resetDartmouthJwtCacheForTests() {
+  cached = null;
+  inflight = null;
+}

--- a/dali-api/app/lib/dartmouth-people.ts
+++ b/dali-api/app/lib/dartmouth-people.ts
@@ -1,0 +1,97 @@
+// People API client — api.dartmouth.edu/api/people/{netid}.
+//
+// JWT-authenticated. Covers all accounts including alumni, and is the ONLY
+// Dartmouth directory source we use: lookup.dartmouth.edu went behind
+// Dartmouth SSO (verified 2026-07-06 — even GET / 302s to saml2/authenticate)
+// so it is unreachable from our servers.
+//
+// Three signals, all in the base no-scope payload (verified against live
+// records on 2026-07-06 — see alumni_plan.md "Observed API behavior"):
+//
+//   affiliations[]        "Alum" appears within weeks of degree conferral —
+//                         the prompt graduation signal. "Student" LINGERS
+//                         after graduation, so enrolled-right-now is the
+//                         compound (Student present AND Alum absent).
+//   dartmouth_affiliation IDM account code. Stays "DART" for months after
+//                         graduation; the eventual "ALUMNI" flip is the
+//                         long-tail confirmation, not the fresh signal.
+//   department_class      Class identity for students ("'27" → 2027; a
+//                         department name for employees). Note this is the
+//                         CLASS a person identifies with, not their actual
+//                         graduation year — a '25 on a +1 stays "'25".
+//
+// Affiliation codes for dartmouth_affiliation (see developer.dartmouth.edu):
+//   ALUMNI, DART (student/faculty/staff/ex-employee), E-FAC, DEPT, ORG,
+//   P-ADM, SERVICE, SPON, SPONLIM, TRUSTEE.
+
+import { getDartmouthJwt } from "~/lib/dartmouth-jwt";
+
+const PEOPLE_BASE_URL = "https://api.dartmouth.edu/api/people";
+
+export type DartmouthPeopleResult = {
+  /** Raw IDM code, e.g. "DART" | "ALUMNI". */
+  dartmouthAffiliation: string | null;
+  /** "Alum" ∈ affiliations — degree conferred. */
+  isAlum: boolean;
+  /** "Student" ∈ affiliations. Lingers post-graduation; on its own this
+   * does NOT mean currently enrolled — enrolled is isStudent && !isAlum. */
+  isStudent: boolean;
+  /** Parsed from department_class when it is a class year ("'27" → 2027);
+   * null for employees/unparseable. Class identity, not grad year. */
+  classYear: number | null;
+};
+
+// Parse the apostrophe-prefixed two-digit class year format ("'27" → 2027).
+// Returns null when the field is a department string (employees) or
+// otherwise unparseable.
+export function parseDepartmentClass(
+  raw: string | undefined | null,
+): number | null {
+  if (!raw) return null;
+  const m = raw.trim().match(/^'(\d{2})$/);
+  if (!m) return null;
+  const n = parseInt(m[1], 10);
+  // Two-digit window: '00–'89 → 2000-2089, '90–'99 → 1990-1999. Generous on
+  // both sides because Dartmouth currently lists no one outside this band,
+  // and we'd rather be wrong by a century once than miss a real grad.
+  return n >= 90 ? 1900 + n : 2000 + n;
+}
+
+type RawPerson = {
+  dartmouth_affiliation?: string | null;
+  affiliations?: { name?: string | null }[] | null;
+  department_class?: string | null;
+};
+
+export async function peopleByNetId(
+  netId: string,
+): Promise<DartmouthPeopleResult | null> {
+  const jwt = await getDartmouthJwt();
+  const url = `${PEOPLE_BASE_URL}/${encodeURIComponent(netId)}`;
+  const res = await fetch(url, {
+    method: "GET",
+    headers: {
+      Accept: "application/json",
+      Authorization: `Bearer ${jwt}`,
+    },
+  });
+
+  if (res.status === 404) return null;
+  if (!res.ok) {
+    throw new Error(
+      `dartmouth-people: HTTP ${res.status} ${res.statusText} for netId=${netId}`,
+    );
+  }
+
+  const body = (await res.json()) as RawPerson;
+  const names = (body.affiliations ?? [])
+    .map((a) => a?.name)
+    .filter((n): n is string => typeof n === "string");
+
+  return {
+    dartmouthAffiliation: body.dartmouth_affiliation ?? null,
+    isAlum: names.includes("Alum"),
+    isStudent: names.includes("Student"),
+    classYear: parseDepartmentClass(body.department_class),
+  };
+}

--- a/dali-api/app/lib/dartmouth-refresh.ts
+++ b/dali-api/app/lib/dartmouth-refresh.ts
@@ -1,0 +1,83 @@
+// Refresh a user's cached Dartmouth directory signals from
+// api.dartmouth.edu/api/people, writing them onto the User row. These cache
+// columns are INPUTS to membership-status recompute (see
+// app/lib/membership-status.ts) — this module does not derive status itself,
+// and (unlike the abandoned v1) it never stamps graduatedAt.
+//
+// Failure is non-fatal: callers use it fire-and-forget. When DARTMOUTH_API_KEY
+// is unset the People client throws on the JWT exchange; we swallow and leave
+// the last-known cache in place, so status recompute falls back to
+// graduatedAt + classYear math.
+
+import type { Prisma } from "~/generated/prisma/client";
+import { prisma } from "~/lib/db";
+import { peopleByNetId } from "~/lib/dartmouth-people";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export type RefreshOptions = {
+  // Re-fetch even if the cache was refreshed recently. Term-rollover sweeps
+  // and the daily ambiguous-set re-sync pass force; login relies on the
+  // default throttle.
+  force?: boolean;
+  // Skip the network call when the cache is fresher than this. Default 1 day.
+  // This is a politeness throttle against redundant API calls, NOT a
+  // correctness window — status is stored, so a slightly stale cache never
+  // affects a read.
+  throttleMs?: number;
+  // Swallow errors (default true — background/fire-and-forget semantics).
+  swallow?: boolean;
+};
+
+// Returns true when the cache columns were (re)written, false when skipped
+// (throttled / no netId) or on a swallowed failure.
+export async function refreshDartmouthSignals(
+  userId: string,
+  opts: RefreshOptions = {},
+): Promise<boolean> {
+  const { force = false, throttleMs = DAY_MS, swallow = true } = opts;
+
+  try {
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { netId: true, classYear: true, dartmouthPeopleSyncedAt: true },
+    });
+    if (!user || !user.netId) return false;
+
+    if (
+      !force &&
+      user.dartmouthPeopleSyncedAt &&
+      Date.now() - user.dartmouthPeopleSyncedAt.getTime() < throttleMs
+    ) {
+      return false;
+    }
+
+    const people = await peopleByNetId(user.netId);
+    const updates: Prisma.UserUpdateInput = {
+      dartmouthPeopleSyncedAt: new Date(),
+    };
+
+    // 404 (identity gone from the People API) keeps the last-known cached
+    // signals — an account aging out of IDM says nothing about graduation. We
+    // still advance the synced-at stamp so throttling moves forward.
+    if (people) {
+      updates.dartmouthAffiliation = people.dartmouthAffiliation;
+      updates.dartmouthIsAlum = people.isAlum;
+      updates.dartmouthIsStudent = people.isStudent;
+
+      // Populate classYear only when absent — user / Notion input wins and is
+      // never clobbered. department_class is class identity ("'25" for a +1),
+      // which is exactly what the status fallback and display expect.
+      if (people.classYear != null && user.classYear == null) {
+        updates.classYear = people.classYear;
+      }
+    }
+
+    await prisma.user.update({ where: { id: userId }, data: updates });
+    return true;
+  } catch (err) {
+    if (!swallow) throw err;
+    console.warn(`dartmouth-refresh: failed for userId=${userId}: ${err}`);
+    return false;
+  }
+}

--- a/dali-api/app/lib/membership-status.ts
+++ b/dali-api/app/lib/membership-status.ts
@@ -1,0 +1,122 @@
+// Authoritative lab-membership status — stored on User.membershipStatus and
+// recomputed only at transitions (term rollover, login, mutation), never
+// derived per request. See alumni_status_plan.md.
+//
+// The resolver reads NO engagement tables (ProjectAssignment, ExternalMentor,
+// StaffingMentorRole, …): status is a fact about the person's enrollment /
+// graduation, not their current assignments. An alumnus who mentors a project
+// is still Alumni, and the algorithm is immune to churn in the staffing schema.
+
+import type { MembershipStatus } from "~/generated/prisma/client";
+import { prisma } from "~/lib/db";
+import {
+  refreshDartmouthSignals,
+  type RefreshOptions,
+} from "~/lib/dartmouth-refresh";
+
+// Dartmouth Commencement is mid-June. June 15 is the conservative cutoff for
+// treating a classYear as graduated in the no-API fallback path.
+export function commencementDate(classYear: number): Date {
+  return new Date(classYear, 5, 15); // month is 0-indexed; 5 = June
+}
+
+export type StatusInputs = {
+  membershipStatusOverride: MembershipStatus | null;
+  graduatedAt: Date | null;
+  classYear: number | null;
+  dartmouthIsAlum: boolean | null;
+  dartmouthIsStudent: boolean | null;
+  dartmouthAffiliation: string | null;
+};
+
+/**
+ * Pure resolver: map a member's inputs to their status. Ordered so the
+ * strongest, most authoritative signal wins.
+ *
+ *   override            → the manual pin (BE dual-degree, staff, corrections)
+ *   Alum / IDM ALUMNI   → Alumni  (degree conferred)
+ *   graduatedAt < now   → Alumni  (off-cycle / manual)
+ *   Student (¬Alum)     → Active  (+1 guard: genuinely enrolled, beats classYear)
+ *   classYear past      → Alumni  (no-API fallback)
+ *   else                → Active
+ */
+export function resolveMembershipStatus(
+  u: StatusInputs,
+  now: Date,
+): MembershipStatus {
+  if (u.membershipStatusOverride != null) return u.membershipStatusOverride;
+
+  if (u.dartmouthIsAlum === true || u.dartmouthAffiliation === "ALUMNI") {
+    return "Alumni";
+  }
+
+  if (u.graduatedAt != null && u.graduatedAt < now) return "Alumni";
+
+  // "Student" present without "Alum" is the only reliable currently-enrolled
+  // signal. It beats the classYear fallback below — the +1 guard for a member
+  // whose class has lapsed but who is genuinely still enrolled.
+  if (u.dartmouthIsStudent === true) return "Active";
+
+  if (u.classYear != null && commencementDate(u.classYear) <= now) {
+    return "Alumni";
+  }
+
+  return "Active";
+}
+
+/**
+ * Recompute and persist a member's stored membershipStatus from its current
+ * inputs. Member-only: non-members keep the inert Active default. Writes only
+ * when the value changes (or on the first stamp) so the daily sweep stays
+ * cheap. Returns the resolved status, or null for a non-member / missing user.
+ */
+export async function recomputeMembershipStatus(
+  userId: string,
+): Promise<MembershipStatus | null> {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: {
+      membershipStatus: true,
+      membershipStatusComputedAt: true,
+      membershipStatusOverride: true,
+      graduatedAt: true,
+      classYear: true,
+      dartmouthIsAlum: true,
+      dartmouthIsStudent: true,
+      dartmouthAffiliation: true,
+      daliMember: { select: { id: true } },
+    },
+  });
+  if (!user || !user.daliMember) return null;
+
+  const status = resolveMembershipStatus(user, new Date());
+
+  if (
+    status !== user.membershipStatus ||
+    user.membershipStatusComputedAt == null
+  ) {
+    await prisma.user.update({
+      where: { id: userId },
+      data: { membershipStatus: status, membershipStatusComputedAt: new Date() },
+    });
+  }
+  return status;
+}
+
+/**
+ * Refresh Dartmouth signals, then recompute — the unit used by login callbacks
+ * (throttled) and the term-rollover / ambiguous-set sweeps (force). Swallows
+ * its own failures so it is safe to `void` fire-and-forget and so one user's
+ * error never aborts a sweep batch.
+ */
+export async function syncAndRecomputeMembershipStatus(
+  userId: string,
+  opts: RefreshOptions = {},
+): Promise<void> {
+  try {
+    await refreshDartmouthSignals(userId, opts);
+    await recomputeMembershipStatus(userId);
+  } catch (err) {
+    console.warn(`membership-status: sync failed for userId=${userId}: ${err}`);
+  }
+}

--- a/dali-api/app/lib/roles.ts
+++ b/dali-api/app/lib/roles.ts
@@ -34,6 +34,13 @@ export interface UserRoles {
   isInstructor: boolean;
   /** Interviewer on any cycle — mirrors the reviewer/interviewer sidebar convention. */
   isInterviewer: boolean;
+  /**
+   * Graduated former member — reads the stored `User.membershipStatus`
+   * (recomputed at transitions; see membership-status.ts). Informational for
+   * now: access is NOT suppressed here. The alumni sidebar variant + route
+   * guards land in a follow-up, where this flag will gate them.
+   */
+  isAlumni: boolean;
   /** Forms & Groups: Core, Admin, or Instructor. */
   canViewForms: boolean;
   /** Staffing, Intent to Work, Bids, Applications: Core or Admin. */
@@ -49,7 +56,7 @@ export async function getUserRoles(userId: string): Promise<UserRoles> {
 
   const cycleTermIds = await getActiveCoreCycleTermIds();
 
-  const [member, admin, core, domainLead, instructor, interviewer] = await Promise.all([
+  const [member, admin, core, domainLead, instructor, interviewer, userRow] = await Promise.all([
     prisma.dALIMember.findUnique({ where: { userId }, select: { id: true } }),
     prisma.adminMembership.findUnique({ where: { userId }, select: { id: true } }),
     // Core access tracks the active election cycle (Spring N → Winter N+1,
@@ -68,6 +75,9 @@ export async function getUserRoles(userId: string): Promise<UserRoles> {
     // mirrors the domain-lead "any row" convention.
     prisma.instructorAssignment.findFirst({ where: { userId }, select: { id: true } }),
     prisma.cycleInterviewer.findFirst({ where: { userId }, select: { id: true } }),
+    // Stored, authoritative membership status — one indexed column, no
+    // derivation. See membership-status.ts for how it's kept current.
+    prisma.user.findUnique({ where: { id: userId }, select: { membershipStatus: true } }),
   ]);
 
   const isAdminVal = admin !== null || envIds.includes(userId);
@@ -82,6 +92,7 @@ export async function getUserRoles(userId: string): Promise<UserRoles> {
     isDomainLead: domainLead !== null,
     isInstructor: isInstructorVal,
     isInterviewer: interviewer !== null,
+    isAlumni: userRow?.membershipStatus === "Alumni",
     canViewForms: isAdminVal || isCoreVal || isInstructorVal,
     canViewStaffing: isAdminVal || isCoreVal,
   };
@@ -359,6 +370,42 @@ export async function isDomainLead(userId: string): Promise<boolean> {
     select: { id: true },
   });
   return row !== null;
+}
+
+// ─── Tier resolution ─────────────────────────────────────────────────────────
+
+export type Tier =
+  | "Admin"
+  | "Core"
+  | "Member"
+  | "Alumni"
+  | "Partner"
+  | "Student";
+
+/**
+ * Resolve a user's single canonical tier for display. Authority checks win
+ * first (a former member who is now Admin/Core keeps that label); otherwise a
+ * lab member reads their stored `membershipStatus` (Active → Member, Alumni →
+ * Alumni). Reads no engagement tables — the Member/Alumni split is the stored
+ * status, not an assignment lookup.
+ */
+export async function tier(userId: string): Promise<Tier> {
+  if (await isAdmin(userId)) return "Admin";
+  if (await isCore(userId)) return "Core";
+
+  const [userRow, partner] = await Promise.all([
+    prisma.user.findUnique({
+      where: { id: userId },
+      select: { membershipStatus: true, daliMember: { select: { id: true } } },
+    }),
+    prisma.partnerUser.findUnique({ where: { userId }, select: { id: true } }),
+  ]);
+
+  if (userRow?.daliMember) {
+    return userRow.membershipStatus === "Alumni" ? "Alumni" : "Member";
+  }
+  if (partner !== null) return "Partner";
+  return "Student";
 }
 
 /**

--- a/dali-api/app/members/routes/members.tsx
+++ b/dali-api/app/members/routes/members.tsx
@@ -46,6 +46,12 @@ type MemberRow = {
   domainRoles: { domainName: string; level: string }[];
 };
 
+type MemberStatus = "active" | "alumni";
+
+function parseStatus(raw: string | null): MemberStatus {
+  return raw === "alumni" ? "alumni" : "active";
+}
+
 export async function loader({ request }: Route.LoaderArgs) {
   const auth = await requireAuth(request);
   if (!auth.ok) return redirect("/login");
@@ -54,10 +60,14 @@ export async function loader({ request }: Route.LoaderArgs) {
 
   const { terms, selected, termId, isAll } = await resolveTermFilter(request);
 
+  const url = new URL(request.url);
+  const status = parseStatus(url.searchParams.get("status"));
+
   // "Active in a term" = the member held a Core role OR a project assignment
-  // that term. "All terms" drops the constraint and shows every member.
+  // that term. "All terms" drops the constraint and shows every member. The
+  // Alumni view ignores the term filter (term doesn't apply post-grad).
   const activeInTerm =
-    isAll || !termId
+    status === "alumni" || isAll || !termId
       ? {}
       : {
           OR: [
@@ -74,7 +84,6 @@ export async function loader({ request }: Route.LoaderArgs) {
     orderBy: { displayName: "asc" },
     select: { id: true, displayName: true },
   });
-  const url = new URL(request.url);
   const domainParam = url.searchParams.get("domain") ?? "";
   const domainId = domains.some((d) => d.id === domainParam)
     ? domainParam
@@ -86,9 +95,17 @@ export async function loader({ request }: Route.LoaderArgs) {
   // Lab members are Users with a DALIMember row attached. Roles derive from
   // AdminMembership + CoreAssignment per the Phase 2 identity model — see
   // app/admin-console/routes/api.members.ts for the canonical shape.
+  // The Alumni view layers the stored membership status onto the same base set
+  // (still requires a DALIMember row; drops the term filter) and sorts by class
+  // year. membershipStatus is authoritative — no derivation here.
+  const alumniCondition =
+    status === "alumni" ? { membershipStatus: "Alumni" as const } : {};
   const users = await prisma.user.findMany({
-    where: { ...LAB_MEMBER_WHERE, ...activeInTerm, ...inDomain },
-    orderBy: MEMBER_LIST_ORDER_BY,
+    where: { ...LAB_MEMBER_WHERE, ...activeInTerm, ...inDomain, ...alumniCondition },
+    orderBy:
+      status === "alumni"
+        ? [{ classYear: "desc" as const }, ...MEMBER_LIST_ORDER_BY]
+        : MEMBER_LIST_ORDER_BY,
     select: {
       id: true,
       firstName: true,
@@ -140,6 +157,7 @@ export async function loader({ request }: Route.LoaderArgs) {
     selectedDomain: domainId,
     canEdit,
     canSeeGroups,
+    status,
   };
 }
 
@@ -243,7 +261,7 @@ export async function action({ request }: Route.ActionArgs) {
 }
 
 export default function MembersList() {
-  const { rows, terms, selectedTerm, domains, selectedDomain, canEdit, canSeeGroups } =
+  const { rows, terms, selectedTerm, domains, selectedDomain, canEdit, canSeeGroups, status } =
     useLoaderData<typeof loader>();
   const actionData = useActionData<typeof action>();
   const [creating, setCreating] = useState(false);
@@ -335,34 +353,87 @@ export default function MembersList() {
         </Form>
       )}
 
+      <StatusTabs status={status} />
+
       <div className="flex items-center gap-3 flex-wrap">
         <input
           type="search"
           value={query}
           onChange={(e) => setQuery(e.target.value)}
-          placeholder="Search by name or email"
+          placeholder={status === "alumni" ? "Search alumni by name or email" : "Search by name or email"}
           className="flex-1 min-w-[200px] max-w-sm px-3 py-2 text-sm border border-border rounded-md bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-accent-coral/30"
         />
-        <TermFilter terms={terms} selected={selectedTerm} />
+        {status === "active" && <TermFilter terms={terms} selected={selectedTerm} />}
         <DomainFilter domains={domains} selected={selectedDomain} />
         <ViewToggle value={view} onChange={setView} />
         <span className="text-xs text-muted-foreground ml-auto">
-          {filtered.length} {filtered.length === 1 ? "member" : "members"}
+          {filtered.length}{" "}
+          {status === "alumni"
+            ? filtered.length === 1
+              ? "alum"
+              : "alumni"
+            : filtered.length === 1
+              ? "member"
+              : "members"}
           {query && filtered.length !== rows.length ? ` of ${rows.length}` : ""}
         </span>
       </div>
 
       {filtered.length === 0 ? (
         <div className="px-4 py-8 text-center text-sm text-muted-foreground">
-          {query
-            ? "No members match this search."
-            : "No members match these filters."}
+          {status === "alumni"
+            ? query
+              ? "No alumni match this search."
+              : "No alumni yet."
+            : query
+              ? "No members match this search."
+              : "No members match these filters."}
         </div>
       ) : view === "list" ? (
-        <MembersTable rows={filtered} />
+        <MembersTable rows={filtered} status={status} />
       ) : (
         <MembersCards rows={filtered} />
       )}
+    </div>
+  );
+}
+
+// Active ↔ Alumni segmented tab. Drives the loader via `?status=`. Switching to
+// Alumni drops the `?term=` filter (term doesn't apply post-grad) and scopes the
+// list to members whose stored membershipStatus is Alumni.
+function StatusTabs({ status }: { status: MemberStatus }) {
+  const [searchParams, setSearchParams] = useSearchParams();
+  function set(next: MemberStatus) {
+    const params = new URLSearchParams(searchParams);
+    if (next === "alumni") {
+      params.set("status", "alumni");
+      params.delete("term");
+    } else {
+      params.delete("status");
+    }
+    setSearchParams(params);
+  }
+  const tabs: { key: MemberStatus; label: string }[] = [
+    { key: "active", label: "Active" },
+    { key: "alumni", label: "Alumni" },
+  ];
+  return (
+    <div className="inline-flex items-center gap-1 border border-border rounded-md p-1 bg-muted/30 w-fit">
+      {tabs.map((t) => (
+        <button
+          key={t.key}
+          type="button"
+          onClick={() => set(t.key)}
+          aria-pressed={status === t.key}
+          className={`px-3 py-1 text-xs font-medium rounded-sm transition-colors ${
+            status === t.key
+              ? "bg-background text-foreground shadow-sm"
+              : "text-muted-foreground hover:text-foreground"
+          }`}
+        >
+          {t.label}
+        </button>
+      ))}
     </div>
   );
 }
@@ -433,8 +504,11 @@ function DomainFilter({
   );
 }
 
-function MembersTable({ rows }: { rows: MemberRow[] }) {
+function MembersTable({ rows, status }: { rows: MemberRow[]; status: MemberStatus }) {
   const navigate = useNavigate();
+  // Alumni view swaps the Roles column for Class — roles are largely historical
+  // for alumni, and class year is the more useful axis.
+  const showClass = status === "alumni";
   return (
     <div className="overflow-x-auto">
       <table className="w-full text-sm min-w-[640px]">
@@ -442,7 +516,7 @@ function MembersTable({ rows }: { rows: MemberRow[] }) {
           <tr>
             <th className="text-left font-medium px-4 py-2">Name</th>
             <th className="text-left font-medium px-4 py-2">Email</th>
-            <th className="text-left font-medium px-4 py-2">Roles</th>
+            <th className="text-left font-medium px-4 py-2">{showClass ? "Class" : "Roles"}</th>
           </tr>
         </thead>
         <tbody>
@@ -461,7 +535,11 @@ function MembersTable({ rows }: { rows: MemberRow[] }) {
               </td>
               <td className="px-4 py-2 text-muted-foreground">{m.email ?? "—"}</td>
               <td className="px-4 py-2">
-                {m.coreTitles.length === 0 && m.domainRoles.length === 0 ? (
+                {showClass ? (
+                  <span className="text-muted-foreground">
+                    {m.classYear ? `Class of ${m.classYear}` : "—"}
+                  </span>
+                ) : m.coreTitles.length === 0 && m.domainRoles.length === 0 ? (
                   <span className="text-muted-foreground text-xs">—</span>
                 ) : (
                   <RolePills

--- a/dali-api/app/routes/auth.callback.cas.ts
+++ b/dali-api/app/routes/auth.callback.cas.ts
@@ -6,6 +6,7 @@ import { getClientIp } from "~/lib/request-meta";
 import { logAuditEvent } from "~/lib/audit";
 import { upsertUserFromCas } from "~/lib/user-provisioning";
 import { getApiBaseUrl } from "~/lib/app-env";
+import { syncAndRecomputeMembershipStatus } from "~/lib/membership-status";
 
 export async function action() {
   return new Response("Method not allowed", { status: 405 });
@@ -104,6 +105,11 @@ export async function loader({ request }: Route.LoaderArgs) {
   }
 
   const { user } = await upsertUserFromCas(casUser);
+
+  // Fire-and-forget: refresh Dartmouth signals (throttled ≤1/day) and
+  // recompute membership status. CAS just set the netId, so this is the ideal
+  // moment to sync. Never blocks or fails the login.
+  void syncAndRecomputeMembershipStatus(user.id);
 
   const session = await issueSession({
     userId: user.id,

--- a/dali-api/app/routes/auth.callback.google.ts
+++ b/dali-api/app/routes/auth.callback.google.ts
@@ -8,6 +8,7 @@ import { logAuditEvent } from "~/lib/audit";
 import { upsertUserFromGoogle } from "~/lib/user-provisioning";
 import { classifyPartnerEmail } from "~/partners/lib/magic-link.server";
 import { getApiBaseUrl, getCasBaseUrl } from "~/lib/app-env";
+import { syncAndRecomputeMembershipStatus } from "~/lib/membership-status";
 
 const OAUTH_STATE_COOKIE = "__dali_oauth_state";
 
@@ -195,6 +196,11 @@ export async function loader({ request }: Route.LoaderArgs) {
   // unreachable through this route — they live on for the OAuth-provider
   // callback `/oauth/callback/google` which gates on a different signal.
   const { user } = await upsertUserFromGoogle(googleUser);
+
+  // Fire-and-forget membership-status sync (throttled ≤1/day). Members mostly
+  // sign in with Google; without a netId the Dartmouth refresh no-ops and the
+  // recompute still runs from graduatedAt + classYear. Never blocks the login.
+  void syncAndRecomputeMembershipStatus(user.id);
 
   const session = await issueSession({
     userId: user.id,

--- a/dali-api/app/routes/oauth.callback.cas.ts
+++ b/dali-api/app/routes/oauth.callback.cas.ts
@@ -10,6 +10,7 @@ import { prisma } from "~/lib/db";
 import { issueSession } from "~/lib/session";
 import { setSessionCookie } from "~/lib/cookies";
 import { getClientIp } from "~/lib/request-meta";
+import { syncAndRecomputeMembershipStatus } from "~/lib/membership-status";
 import { getApiBaseUrl, getFrontendUrl } from "~/lib/app-env";
 
 export async function action() {
@@ -61,6 +62,9 @@ export async function loader({ request }: Route.LoaderArgs) {
       linkUserId: session.linkUserId ?? undefined,
     });
     finalUser = result.user;
+    // Fire-and-forget membership-status sync (throttled ≤1/day); CAS just set
+    // the netId. Never blocks the OAuth flow.
+    void syncAndRecomputeMembershipStatus(finalUser.id);
   } catch {
     const params = new URLSearchParams({
       error: "server_error",

--- a/dali-api/app/routes/oauth.callback.google.ts
+++ b/dali-api/app/routes/oauth.callback.google.ts
@@ -10,6 +10,7 @@ import { upsertUserFromGoogle } from "~/lib/user-provisioning";
 import { issueSession } from "~/lib/session";
 import { setSessionCookie } from "~/lib/cookies";
 import { getClientIp } from "~/lib/request-meta";
+import { syncAndRecomputeMembershipStatus } from "~/lib/membership-status";
 import { getApiBaseUrl, getCasBaseUrl, getFrontendUrl } from "~/lib/app-env";
 
 export async function action() {
@@ -75,6 +76,9 @@ export async function loader({ request }: Route.LoaderArgs) {
   }
 
   const { user } = await upsertUserFromGoogle(googleUser);
+
+  // Fire-and-forget membership-status sync (throttled ≤1/day). Never blocks.
+  void syncAndRecomputeMembershipStatus(user.id);
 
   // Resolve the OAuthClient policy. requireMembership is a belt-and-suspenders
   // check after the upsert (which already creates a DALIMember marker).

--- a/dali-api/prisma/migrations/20260721140000_add_membership_status/migration.sql
+++ b/dali-api/prisma/migrations/20260721140000_add_membership_status/migration.sql
@@ -1,0 +1,11 @@
+-- CreateEnum
+CREATE TYPE "MembershipStatus" AS ENUM ('Active', 'Alumni');
+
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "membershipStatus" "MembershipStatus" NOT NULL DEFAULT 'Active',
+ADD COLUMN     "membershipStatusOverride" "MembershipStatus",
+ADD COLUMN     "membershipStatusComputedAt" TIMESTAMP(3),
+ADD COLUMN     "dartmouthAffiliation" TEXT,
+ADD COLUMN     "dartmouthIsAlum" BOOLEAN,
+ADD COLUMN     "dartmouthIsStudent" BOOLEAN,
+ADD COLUMN     "dartmouthPeopleSyncedAt" TIMESTAMP(3);

--- a/dali-api/prisma/schema.prisma
+++ b/dali-api/prisma/schema.prisma
@@ -10,6 +10,14 @@ datasource db {
   provider = "postgresql"
 }
 
+// Authoritative lab-membership status. Stored (not derived per-call) and
+// recomputed only at transitions — see membershipStatus below and
+// app/lib/membership-status.ts.
+enum MembershipStatus {
+  Active
+  Alumni
+}
+
 model User {
   // unique identifier
   id String @id @default(cuid())
@@ -44,10 +52,38 @@ model User {
 
   // ─── Profile fields (Phase 1 additions; all nullable) ─────────────────────
   // Dartmouth class year (e.g., 2026). Solves the "took a term off"
-  // ambiguity. Used for alumni derivation + display.
+  // ambiguity. Input to membership-status recompute + display.
   classYear      Int?
-  // Optional explicit graduation override for off-cycle graduations.
+  // Optional explicit graduation override for off-cycle graduations. A manual
+  // input to the status recompute (Alumni once past); never auto-stamped.
   graduatedAt    DateTime?
+
+  // ─── Membership status (authoritative, stored) ────────────────────────────
+  // Recomputed at transitions (term rollover, login, mutation) — never derived
+  // per request. See app/lib/membership-status.ts. Only meaningful when a
+  // DALIMember row is present; non-members keep the inert Active default.
+  membershipStatus           MembershipStatus  @default(Active)
+  // Manual pin. When set it wins over recompute and is never clobbered —
+  // handles BE dual-degree candidates (Active while enrolled), non-student
+  // staff (never graduate), and any misclassification.
+  membershipStatusOverride   MembershipStatus?
+  // Observability: when the stored status was last (re)computed.
+  membershipStatusComputedAt DateTime?
+
+  // ─── Dartmouth directory signals (cached inputs) ──────────────────────────
+  // From api.dartmouth.edu/api/people/{netid} (JWT-authenticated), refreshed
+  // at transitions. Inputs to the status recompute; see dartmouth-people.ts.
+  // dartmouthAffiliation: raw IDM code ("DART" | "ALUMNI" | "E-FAC" | ...).
+  // Stays DART for months post-graduation — the slow long-tail signal.
+  dartmouthAffiliation    String?
+  // "Alum" in the affiliations array — degree conferred; appears within weeks
+  // of Commencement. The prompt graduation signal.
+  dartmouthIsAlum         Boolean?
+  // "Student" in the affiliations array. Lingers after graduation, so
+  // currently-enrolled is the compound: isStudent AND NOT isAlum.
+  dartmouthIsStudent      Boolean?
+  dartmouthPeopleSyncedAt DateTime?
+
   pronouns       String?
   photoUrl       String?
   // Bio stored as a collab doc reference for rich formatting + @mentions.


### PR DESCRIPTION
## Summary

An authoritative, **stored** lab-membership status — `User.membershipStatus` (`Active | Alumni`) — recomputed only at transitions instead of derived on every request. This reworks the stale alumni track (#737 sync foundation + #739 derivation) around three points of review feedback:

1. **Stored, not per-call.** Status transitions cluster (~95% at June Commencement, ~5% at off-cycle term ends), so per-request derivation was wasted compute + latency. `getUserRoles`/`tier` now read one indexed column.
2. **Decoupled from engagement tables.** The resolver reads *no* `ProjectAssignment` / `ExternalMentor` / `StaffingMentorRole` rows — status is a fact about enrollment/graduation. An alumnus who mentors a project stays `Alumni`, and the algorithm is immune to the ongoing churn in the staffing/mentor schema.
3. **No freshness windows.** The 7d/14d "trust windows" from #737/#739 existed only to keep a cache warm for reads. We instead fetch authoritative Dartmouth signals *at the transition boundary* (a term-rollover sweep), so there's nothing to tune.

Design doc: `alumni_status_plan.md`.

## What's here

- **Schema** — `MembershipStatus` enum + `membershipStatus` / `membershipStatusOverride` / `membershipStatusComputedAt` and four Dartmouth cache columns on `User`. One additive migration, re-dated after the July migrations.
- **Dartmouth sync** — salvaged the vetted JWT + People-API clients (+ tests) from #737 unchanged; slimmed `dartmouth-refresh.ts` to write only cache columns (dropped the `graduatedAt` auto-stamp and the staleness window).
- **`membership-status.ts`** — pure `resolveMembershipStatus` (`override` > `Alum`/`ALUMNI` > `graduatedAt` > enrolled-`Student` guard > `classYear` fallback), stored `recomputeMembershipStatus`, and a fire-and-forget `syncAndRecomputeMembershipStatus`.
- **Triggers** — all four login callbacks chain a throttled sync; a new `membership-status-sync` job does a **term-rollover API sweep** + **daily ambiguous-set re-sync** + **DB-only recompute** (which also backfills existing alumni on first run). Rollover is detected from `syncedAt < currentTerm.startDate` — **no `lastSweptTermId` state**.
- **Read surface** — `getUserRoles` exposes `isAlumni` (informational only — see Deferred); `tier()` reads the stored status; People directory gains a `?status=alumni` tab (`where: { membershipStatus: 'Alumni' }`).

## The ambiguous-set re-sync (why there's no BE/+1 heuristic)

Dartmouth's `Alum + Student` is identical for a fresh grad (Student lingers post-grad) and a BE dual-degree candidate (genuinely enrolled). Rather than guess with a time window, the daily job re-pulls only the small set that looks still-enrolled but whose class has graduated, until the `Alum` signal resolves: a grace-period grad flips to `Alumni` the day it posts; a genuine +1 keeps showing `Student` and stays `Active`. The rare unresolvable BE case is pinned via `membershipStatusOverride`.

## Deferred (per scope decision)

- Alumni **sidebar variant** (Home / People / Profile only) + `ALUMNI_DENIED_PREFIXES` route guards + the pure-alumni access suppression in `getUserRoles`. Landing these together keeps the access change coherent and testable in one pass.
- `OnLeave` status value (manual-only; add when needed).

## Test plan

- [x] `npm test` — **2142 pass** (adds a `resolveMembershipStatus` truth-table suite; reuses #737's JWT + People client tests).
- [x] `npm run typecheck` — zero errors in touched files (pre-existing `Modal.test.tsx` / `scripts/` / `seeds/` errors are unrelated).
- [ ] After merge: set `DARTMOUTH_API_KEY` as a Fly secret in **staging + prod**, re-verify the live People-API shape, then Run-now the `membership-status-sync` job to backfill.

## Flags

- **Migration** is additive (`CREATE TYPE` + `ADD COLUMN`), re-dated after `20260720190000`; no backfill in SQL — the job's DB-only recompute stamps existing members on first run.
- **`DARTMOUTH_API_KEY`** is required for the API phases; unset, the sync no-ops and status falls back to `graduatedAt` + classYear math (safe to merge before the secret is set).
- Touches the four auth callbacks (`/auth/callback/*`, `/oauth/callback/*`) with a fire-and-forget hook — no change to their control flow or responses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/dali-os/pr/985"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787286057&installation_model_id=21824&pr_number=985&repository=dali-lab%2Fdali-os&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fdali-os%2Fpull%2F985&signature=4ed82538279e0b9bc2b17ad8542db6e3bea111826d1a88f6f093c10415ed192b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->